### PR TITLE
Switch to hash-based routing for GitHub Pages

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import { routeMap } from './composables/useLocaleRouter.js'
 import Home from './pages/Home.vue'
 import BmiCalculator from './pages/BmiCalculator.vue'
@@ -184,6 +184,6 @@ const routes = [
 ]
 
 export default createRouter({
-  history: createWebHistory('/health-calculators/'),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes,
 })

--- a/tests/router.test.js
+++ b/tests/router.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const routerSource = readFileSync(
+  resolve(import.meta.dirname, '..', 'src', 'router.js'),
+  'utf-8'
+)
+
+describe('router history mode', () => {
+  it('imports createWebHashHistory, not createWebHistory', () => {
+    expect(routerSource).toContain('createWebHashHistory')
+    expect(routerSource).not.toMatch(/\bcreateWebHistory\b/)
+  })
+
+  it('uses createWebHashHistory in router creation', () => {
+    expect(routerSource).toMatch(/history:\s*createWebHashHistory\(/)
+  })
+})


### PR DESCRIPTION
## Summary
- Replace `createWebHistory` with `createWebHashHistory` in `src/router.js` to fix HTTP 404 on direct URL access and page refresh on GitHub Pages
- Add `tests/router.test.js` to verify hash-based history mode is used

Closes #44

## Test plan
- [x] New router test verifies `createWebHashHistory` import and usage
- [x] All 26 existing tests pass
- [ ] Manual: verify routes work with `/#/de/`, `/#/en/` paths after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)