### PR TITLE
hc-vite-ssg: Migrate health-calculators from Vue 3 SPA to static site gen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,54 @@
         "@vitejs/plugin-vue": "^6.0.5",
         "tailwindcss": "^4.2.1",
         "vite": "^8.0.0",
+        "vite-ssg": "^28.3.0",
         "vitest": "^4.1.2"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
+      "integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -68,6 +114,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
@@ -100,6 +299,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@intlify/core-base": {
@@ -193,6 +410,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -842,6 +1070,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@unhead/dom": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-2.1.12.tgz",
+      "integrity": "sha512-PpBWWgS3t32qSl60v3UDIhZreuFOAl/Wj2T+bDnlhW/mMGFeVJrHoeJB5pa9UHWJwC1nLyBDn+6XqfCxOftQ2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "unhead": "2.1.12"
+      }
+    },
+    "node_modules/@unhead/vue": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.12.tgz",
+      "integrity": "sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1",
+        "unhead": "2.1.12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.18"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz",
@@ -1088,6 +1346,39 @@
       "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1096,6 +1387,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/chai": {
@@ -1108,6 +1437,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1115,10 +1467,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -1129,6 +1550,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -1220,6 +1652,106 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hookable": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
+      "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.15.1"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html5parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html5parser/-/html5parser-2.0.2.tgz",
+      "integrity": "sha512-L0y+IdTVxHsovmye8MBtFgBvWZnq1C9WnI/SmJszxoQjmUH1psX2uzDk21O5k5et6udxdGjwxkbmT9eVRoG05w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -1228,6 +1760,47 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -1491,6 +2064,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1499,6 +2092,20 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1518,6 +2125,17 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1528,6 +2146,54 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1627,6 +2293,36 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
@@ -1668,12 +2364,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1682,6 +2401,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stackback": {
@@ -1695,6 +2425,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1718,6 +2455,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1763,13 +2526,81 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unhead": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.12.tgz",
+      "integrity": "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.0",
@@ -1846,6 +2677,49 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-ssg": {
+      "version": "28.3.0",
+      "resolved": "https://registry.npmjs.org/vite-ssg/-/vite-ssg-28.3.0.tgz",
+      "integrity": "sha512-dIUjv+scfhJTfYGwf83R0KGAmr/duIo9oln5ZsQOIZZACm3voAON//7oKhtEwaOTtD4QTTab+nhvyn0QiIaFMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/dom": "^2.1.2",
+        "@unhead/vue": "^2.1.2",
+        "ansis": "^4.2.0",
+        "cac": "^6.7.14",
+        "html-minifier-terser": "^7.2.0",
+        "html5parser": "^2.0.2",
+        "jsdom": "^28.0.0"
+      },
+      "bin": {
+        "vite-ssg": "bin/vite-ssg.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "beasties": "^0.3.5",
+        "prettier": "^3.3.0",
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0-0 || ^8.0.0-0",
+        "vue": "^3.2.10",
+        "vue-router": "^4.0.1 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "beasties": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vue-router": {
           "optional": true
         }
       }
@@ -1989,6 +2863,54 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2005,6 +2927,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite-ssg build",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -20,6 +20,7 @@
     "@vitejs/plugin-vue": "^6.0.5",
     "tailwindcss": "^4.2.1",
     "vite": "^8.0.0",
+    "vite-ssg": "^28.3.0",
     "vitest": "^4.1.2"
   }
 }

--- a/src/__tests__/ssg-routes.test.js
+++ b/src/__tests__/ssg-routes.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import routes from '../routes.js'
+
+describe('routes.js exports', () => {
+  it('exports a valid routes array', () => {
+    expect(Array.isArray(routes)).toBe(true)
+    expect(routes.length).toBeGreaterThan(0)
+  })
+
+  it('contains both de and en locale routes', () => {
+    const dePaths = routes.filter(r => r.path?.startsWith('/de/'))
+    const enPaths = routes.filter(r => r.path?.startsWith('/en/'))
+    expect(dePaths.length).toBeGreaterThan(0)
+    expect(enPaths.length).toBeGreaterThan(0)
+  })
+
+  it('has locale meta on all locale routes', () => {
+    const localeRoutes = routes.filter(r => r.path?.startsWith('/de/') || r.path?.startsWith('/en/'))
+    for (const route of localeRoutes) {
+      expect(route.meta?.locale).toMatch(/^(de|en)$/)
+    }
+  })
+
+  it('does not use window.location in any beforeEnter', () => {
+    for (const route of routes) {
+      if (route.beforeEnter) {
+        const src = route.beforeEnter.toString()
+        expect(src).not.toContain('window.location')
+      }
+    }
+  })
+
+  it('contains redirect routes for old paths', () => {
+    const redirectRoutes = routes.filter(r => r.redirect)
+    expect(redirectRoutes.length).toBeGreaterThan(0)
+    const rootRedirect = routes.find(r => r.path === '/')
+    expect(rootRedirect?.redirect).toBe('/de/')
+  })
+})

--- a/src/composables/useHead.js
+++ b/src/composables/useHead.js
@@ -6,6 +6,7 @@ import { localePath as resolveLocalePath, routeMap } from './useLocaleRouter.js'
 const BASE_URL = 'https://jenslaufer.github.io/health-calculators'
 
 function setMeta(attr, key, content) {
+  if (import.meta.env.SSR) return
   let el = document.querySelector(`meta[${attr}="${key}"]`)
   if (!el) {
     el = document.createElement('meta')
@@ -16,6 +17,7 @@ function setMeta(attr, key, content) {
 }
 
 function setCanonical(url) {
+  if (import.meta.env.SSR) return
   let el = document.querySelector('link[rel="canonical"]')
   if (!el) {
     el = document.createElement('link')
@@ -26,6 +28,7 @@ function setCanonical(url) {
 }
 
 function setHreflang(lang, url) {
+  if (import.meta.env.SSR) return
   let el = document.querySelector(`link[hreflang="${lang}"]`)
   if (!el) {
     el = document.createElement('link')
@@ -37,10 +40,12 @@ function setHreflang(lang, url) {
 }
 
 function removeHreflang() {
+  if (import.meta.env.SSR) return
   document.querySelectorAll('link[hreflang]').forEach(el => el.remove())
 }
 
 function setJsonLd(data) {
+  if (import.meta.env.SSR) return
   let el = document.querySelector('script[data-head="jsonld"]')
   if (!el) {
     el = document.createElement('script')
@@ -52,13 +57,14 @@ function setJsonLd(data) {
 }
 
 function removeJsonLd() {
+  if (import.meta.env.SSR) return
   const el = document.querySelector('script[data-head="jsonld"]')
   if (el) el.remove()
 }
 
 export function useHead(getConfig) {
   const resolve = typeof getConfig === 'function' ? getConfig : () => getConfig
-  const prevTitle = document.title
+  const prevTitle = import.meta.env.SSR ? '' : document.title
   const route = useRoute()
   const { locale } = useI18n()
 
@@ -82,7 +88,9 @@ export function useHead(getConfig) {
 
     const url = `${BASE_URL}${currentPath}`
 
-    document.title = title
+    if (!import.meta.env.SSR) {
+      document.title = title
+    }
     setMeta('name', 'description', description)
     setMeta('property', 'og:title', title)
     setMeta('property', 'og:description', description)
@@ -100,7 +108,9 @@ export function useHead(getConfig) {
   })
 
   onUnmounted(() => {
-    document.title = prevTitle
+    if (!import.meta.env.SSR) {
+      document.title = prevTitle
+    }
     removeJsonLd()
     removeHreflang()
   })

--- a/src/main.js
+++ b/src/main.js
@@ -1,30 +1,37 @@
-import { createApp } from 'vue'
+import { ViteSSG } from 'vite-ssg'
 import { createI18n } from 'vue-i18n'
 import './style.css'
 import App from './App.vue'
-import router from './router.js'
+import routes from './routes.js'
 import en from './locales/en.json'
 import de from './locales/de.json'
 
-const i18n = createI18n({
-  legacy: false,
-  locale: 'de',
-  fallbackLocale: 'en',
-  messages: { en, de },
-})
+export const createApp = ViteSSG(
+  App,
+  { routes, base: import.meta.env.BASE_URL },
+  ({ app, router, isClient }) => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'de',
+      fallbackLocale: 'en',
+      messages: { en, de },
+    })
+    app.use(i18n)
 
-router.beforeEach((to) => {
-  const locale = to.meta.locale
-  if (locale && i18n.global.locale.value !== locale) {
-    i18n.global.locale.value = locale
+    router.beforeEach((to) => {
+      const locale = to.meta.locale
+      if (locale && i18n.global.locale.value !== locale) {
+        i18n.global.locale.value = locale
+      }
+    })
+
+    if (isClient) {
+      router.afterEach((to) => {
+        const locale = to.meta.locale
+        if (locale) {
+          document.documentElement.setAttribute('lang', locale)
+        }
+      })
+    }
   }
-})
-
-router.afterEach((to) => {
-  const locale = to.meta.locale
-  if (locale) {
-    document.documentElement.setAttribute('lang', locale)
-  }
-})
-
-createApp(App).use(router).use(i18n).mount('#app')
+)

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,183 @@
+import { routeMap } from './composables/useLocaleRouter.js'
+import Home from './pages/Home.vue'
+import BmiCalculator from './pages/BmiCalculator.vue'
+import WaterIntakeCalculator from './pages/WaterIntakeCalculator.vue'
+import BodyFatCalculator from './pages/BodyFatCalculator.vue'
+import HeartRateZones from './pages/HeartRateZones.vue'
+import IdealWeightCalculator from './pages/IdealWeightCalculator.vue'
+import MacroCalculator from './pages/MacroCalculator.vue'
+import SleepCycleCalculator from './pages/SleepCycleCalculator.vue'
+import TdeeCalculator from './pages/TdeeCalculator.vue'
+import PregnancyCalculator from './pages/PregnancyCalculator.vue'
+import BlogHome from './pages/BlogHome.vue'
+import BmiBerechnen from './pages/blog/BmiBerechnen.vue'
+import TdeeBerechnen from './pages/blog/TdeeBerechnen.vue'
+import SchlafzyklenBerechnen from './pages/blog/SchlafzyklenBerechnen.vue'
+import HerzfrequenzZonenBerechnen from './pages/blog/HerzfrequenzZonenBerechnen.vue'
+import KoerperfettBerechnen from './pages/blog/KoerperfettBerechnen.vue'
+import MakronaehrstoffeBerechnen from './pages/blog/MakronaehrstoffeBerechnen.vue'
+import WasserbedarfBerechnen from './pages/blog/WasserbedarfBerechnen.vue'
+import IdealgewichtBerechnen from './pages/blog/IdealgewichtBerechnen.vue'
+import GeburtsterminBerechnen from './pages/blog/GeburtsterminBerechnen.vue'
+import BloodPressureCalculator from './pages/BloodPressureCalculator.vue'
+import BlutdruckRichtigMessen from './pages/blog/BlutdruckRichtigMessen.vue'
+import CalorieDeficitCalculator from './pages/CalorieDeficitCalculator.vue'
+import KaloriendefizitBerechnen from './pages/blog/KaloriendefizitBerechnen.vue'
+import WaistHipRatioCalculator from './pages/WaistHipRatioCalculator.vue'
+import OvulationCalculator from './pages/OvulationCalculator.vue'
+import ProteinCalculator from './pages/ProteinCalculator.vue'
+import BmrCalculator from './pages/BmrCalculator.vue'
+import TaillenHueftVerhaeltnis from './pages/blog/TaillenHueftVerhaeltnis.vue'
+import EisprungBerechnen from './pages/blog/EisprungBerechnen.vue'
+import ProteinbedarfBerechnen from './pages/blog/ProteinbedarfBerechnen.vue'
+import GrundumsatzBerechnen from './pages/blog/GrundumsatzBerechnen.vue'
+import BlogHomeEn from './pages/BlogHomeEn.vue'
+import CalculateBmi from './pages/blog/en/CalculateBmi.vue'
+import CalculateTdee from './pages/blog/en/CalculateTdee.vue'
+import CalculateSleepCycles from './pages/blog/en/CalculateSleepCycles.vue'
+import CalculateHeartRateZones from './pages/blog/en/CalculateHeartRateZones.vue'
+import CalculateBodyFat from './pages/blog/en/CalculateBodyFat.vue'
+import CalculateMacros from './pages/blog/en/CalculateMacros.vue'
+import CalculateWaterIntake from './pages/blog/en/CalculateWaterIntake.vue'
+import CalculateIdealWeight from './pages/blog/en/CalculateIdealWeight.vue'
+import CalculateDueDate from './pages/blog/en/CalculateDueDate.vue'
+import MeasureBloodPressure from './pages/blog/en/MeasureBloodPressure.vue'
+import CalculateCalorieDeficit from './pages/blog/en/CalculateCalorieDeficit.vue'
+import CalculateWaistHipRatio from './pages/blog/en/CalculateWaistHipRatio.vue'
+import CalculateOvulation from './pages/blog/en/CalculateOvulation.vue'
+import CalculateProteinIntake from './pages/blog/en/CalculateProteinIntake.vue'
+import CalculateBmr from './pages/blog/en/CalculateBmr.vue'
+
+const calculatorComponents = {
+  bmi: BmiCalculator,
+  water: WaterIntakeCalculator,
+  bodyFat: BodyFatCalculator,
+  heartRate: HeartRateZones,
+  idealWeight: IdealWeightCalculator,
+  macro: MacroCalculator,
+  sleep: SleepCycleCalculator,
+  tdee: TdeeCalculator,
+  pregnancy: PregnancyCalculator,
+  bloodPressure: BloodPressureCalculator,
+  calorieDeficit: CalorieDeficitCalculator,
+  waistHipRatio: WaistHipRatioCalculator,
+  ovulation: OvulationCalculator,
+  protein: ProteinCalculator,
+  bmr: BmrCalculator,
+}
+
+const blogComponentsDe = {
+  'bmi-berechnen': BmiBerechnen,
+  'tdee-berechnen': TdeeBerechnen,
+  'schlafzyklen-berechnen': SchlafzyklenBerechnen,
+  'herzfrequenz-zonen-berechnen': HerzfrequenzZonenBerechnen,
+  'koerperfett-berechnen': KoerperfettBerechnen,
+  'makronaehrstoffe-berechnen': MakronaehrstoffeBerechnen,
+  'wasserbedarf-berechnen': WasserbedarfBerechnen,
+  'idealgewicht-berechnen': IdealgewichtBerechnen,
+  'geburtstermin-berechnen': GeburtsterminBerechnen,
+  'blutdruck-richtig-messen': BlutdruckRichtigMessen,
+  'kaloriendefizit-berechnen': KaloriendefizitBerechnen,
+  'taille-hueft-verhaeltnis-berechnen': TaillenHueftVerhaeltnis,
+  'eisprung-berechnen': EisprungBerechnen,
+  'proteinbedarf-berechnen': ProteinbedarfBerechnen,
+  'grundumsatz-berechnen': GrundumsatzBerechnen,
+}
+
+const blogComponentsEn = {
+  'calculate-bmi': CalculateBmi,
+  'calculate-tdee': CalculateTdee,
+  'calculate-sleep-cycles': CalculateSleepCycles,
+  'calculate-heart-rate-zones': CalculateHeartRateZones,
+  'calculate-body-fat': CalculateBodyFat,
+  'calculate-macros': CalculateMacros,
+  'calculate-water-intake': CalculateWaterIntake,
+  'calculate-ideal-weight': CalculateIdealWeight,
+  'calculate-due-date': CalculateDueDate,
+  'measure-blood-pressure': MeasureBloodPressure,
+  'calculate-calorie-deficit': CalculateCalorieDeficit,
+  'calculate-waist-hip-ratio': CalculateWaistHipRatio,
+  'calculate-ovulation': CalculateOvulation,
+  'protein-intake-guide': CalculateProteinIntake,
+  'calculate-bmr': CalculateBmr,
+}
+
+const blogComponentsByLocale = {
+  de: blogComponentsDe,
+  en: blogComponentsEn,
+}
+
+const blogHomeByLocale = {
+  de: BlogHome,
+  en: BlogHomeEn,
+}
+
+function createLocaleRoutes(locale) {
+  const prefix = `/${locale}`
+  const routes = [
+    {
+      path: `${prefix}/`,
+      component: Home,
+      meta: { routeKey: 'home', locale },
+    },
+  ]
+
+  for (const [key, component] of Object.entries(calculatorComponents)) {
+    routes.push({
+      path: `${prefix}/${routeMap[key][locale]}`,
+      component,
+      meta: { routeKey: key, locale },
+    })
+  }
+
+  routes.push({
+    path: `${prefix}/blog`,
+    component: blogHomeByLocale[locale],
+    meta: { routeKey: 'blog', locale },
+  })
+
+  for (const [slug, component] of Object.entries(blogComponentsByLocale[locale])) {
+    routes.push({
+      path: `${prefix}/blog/${slug}`,
+      component,
+      meta: { routeKey: 'blogArticle', locale, slug },
+    })
+  }
+
+  return routes
+}
+
+const oldRouteRedirects = [
+  { path: '/bmi', redirect: `/de/${routeMap.bmi.de}` },
+  { path: '/water', redirect: `/de/${routeMap.water.de}` },
+  { path: '/body-fat', redirect: `/de/${routeMap.bodyFat.de}` },
+  { path: '/heart-rate', redirect: `/de/${routeMap.heartRate.de}` },
+  { path: '/ideal-weight', redirect: `/de/${routeMap.idealWeight.de}` },
+  { path: '/macros', redirect: `/de/${routeMap.macro.de}` },
+  { path: '/sleep', redirect: `/de/${routeMap.sleep.de}` },
+  { path: '/tdee', redirect: `/de/${routeMap.tdee.de}` },
+  { path: '/pregnancy', redirect: `/de/${routeMap.pregnancy.de}` },
+  { path: '/blutdruck-rechner', redirect: `/de/${routeMap.bloodPressure.de}` },
+  { path: '/kaloriendefizit-rechner', redirect: `/de/${routeMap.calorieDeficit.de}` },
+  { path: '/waist-hip-ratio', redirect: `/de/${routeMap.waistHipRatio.de}` },
+  { path: '/ovulation', redirect: `/de/${routeMap.ovulation.de}` },
+  { path: '/protein', redirect: `/de/${routeMap.protein.de}` },
+  { path: '/bmr', redirect: `/de/${routeMap.bmr.de}` },
+  { path: '/blog', redirect: '/de/blog' },
+]
+
+const blogSlugs = Object.keys(blogComponentsDe)
+const oldBlogRedirects = blogSlugs.map(slug => ({
+  path: `/blog/${slug}`,
+  redirect: `/de/blog/${slug}`,
+}))
+
+const routes = [
+  { path: '/', redirect: '/de/' },
+  ...createLocaleRoutes('de'),
+  ...createLocaleRoutes('en'),
+  ...oldRouteRedirects,
+  ...oldBlogRedirects,
+]
+
+export default routes

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,14 @@ import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
-  // Serve from the domain root (custom domain).
   base: '/',
   plugins: [vue(), tailwindcss()],
+  ssgOptions: {
+    dirStyle: 'nested',
+    script: 'async',
+    formatting: 'minify',
+  },
+  ssr: {
+    noExternal: [/vue-i18n/],
+  },
 })

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     exclude: ['e2e/**', 'node_modules/**'],
   },


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-vite-ssg
**Agent:** claude
**Branch:** `agent/hc-vite-ssg-20260331-001503`

### Prompt
> Migrate health-calculators from Vue 3 SPA to static site generation using vite-ssg.

## Goal
Every route gets pre-rendered as a static HTML file at build time. No more 404 for crawlers on GitHub Pages. Switch from createWebHashHistory back to createWebHistory.

## Steps

### 1. Install vite-ssg
```
npm install -D vite-ssg
```

### 2. Extract routes from router.js
- The routes array is built dynamically via `createLocaleRoutes()` — this is fine, vite-ssg just needs the array
- Export the routes array (the `routes` const at line 178) instead of the router instance
- Remove `createRouter` / `createWebHashHistory` usage
- Keep all redirect routes (they work fine with vite-ssg)

### 3. Rewrite src/main.js
```js
import { ViteSSG } from 'vite-ssg'
import { createI18n } from 'vue-i18n'
import './style.css'
import App from './App.vue'
import routes from './routes.js'  // renamed from router.js
import en from './locales/en.json'
import de from './locales/de.json'

export const createApp = ViteSSG(
  App,
  { routes, base: import.meta.env.BASE_URL },
  ({ app, router, isClient }) => {
    const i18n = createI18n({
      legacy: false,
      locale: 'de',
      fallbackLocale: 'en',
      messages: { en, de },
    })
    app.use(i18n)

    router.beforeEach((to) => {
      const locale = to.meta.locale
      if (locale && i18n.global.locale.value !== locale) {
        i18n.global.locale.value = locale
      }
    })

    if (isClient) {
      router.afterEach((to) => {
        const locale = to.meta.locale
        if (locale) {
          document.documentElement.setAttribute('lang', locale)
        }
      })
    }
  }
)
```

### 4. Update package.json
- Change `"build": "vite build"` to `"build": "vite-ssg build"`
- Add vitest to scripts if not present: `"test": "vitest run"`

### 5. Update vite.config.js
```js
import { defineConfig } from 'vite'
import vue from '@vitejs/plugin-vue'
import tailwindcss from '@tailwindcss/vite'

export default defineConfig({
  base: '/',
  plugins: [vue(), tailwindcss()],
  ssgOptions: {
    dirStyle: 'nested',
    script: 'async',
    formatting: 'minify',
  },
  ssr: {
    noExternal: [/vue-i18n/],
  },
})
```

The `ssr.noExternal` for vue-i18n is required — known compatibility issue.

### 6. Guard browser APIs for SSR
These files use `document` or `window`:

**src/composables/useHead.js**: Heavy use of document.* for meta tags, canonical, hreflang, JSON-LD. Wrap all DOM manipulation in `if (typeof document !== 'undefined')` or `if (!import.meta.env.SSR)`. During SSG, these should be no-ops.

**src/main.js**: The `router.afterEach` with `document.documentElement.setAttribute` is already handled by the `isClient` guard in the rewrite above.

### 7. Write tests FIRST
Before implementing, write vitest tests:
- Test that routes.js exports a valid routes array with both locales
- Test that no route uses `window.location` in beforeEnter
- Test that the build script in package.json is "vite-ssg build"
- After implementation: run `npm run build` and verify dist/ contains nested HTML files

### 8. Fix dist/ permissions first
The dist/ directory has root-owned files from a previous Docker build. Run:
```
sudo chown -R $(whoami) dist/ 2>/dev/null || true
rm -rf dist/
```

### 9. Verify build
Run `npm run build`. Verify:
- No SSR errors
- dist/ contains individual HTML files for each route
- Each HTML file contains pre-rendered content
- Existing tests still pass

## DO NOT
- DO NOT delete or modify any calculator pages, blog articles, or locale files
- DO NOT change any calculator logic, styling, or component code (except SSR guards)
- DO NOT remove or modify the composables/useLocaleRouter.js
- DO NOT remove the existing test setup
- DO NOT add Nuxt, VitePress, or any other framework
- DO NOT modify robots.txt, sitemap.xml, or CNAME
- DO NOT change the deploy workflow (.github/workflows/)
- DO NOT delete the dist/ directory ownership fix — document it in the PR

## Create a GitHub issue first
Create issue: "Migrate to vite-ssg for static site generation (SEO fix)"
Reference: Replaces hash routing with pre-rendered static HTML. Each route becomes a real HTML file. Closes #44.