### PR TITLE
fix: replace GitHub Pages URLs with healthcalculator.app (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Health Calculators
 
-Live: https://jenslaufer.github.io/health-calculators/
+Live: https://healthcalculator.app/
 
 Vue 3 + Vite health calculator collection. Uses `<script setup>` SFCs with Tailwind CSS.
 

--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Free online health calculators: BMI, TDEE, body fat, macros, ideal weight, water intake, heart rate zones, and sleep cycles. Science-backed formulas, instant results, no sign-up." />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://jenslaufer.github.io/health-calculators/" />
+    <link rel="canonical" href="https://healthcalculator.app/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Health Calculators" />
     <meta property="og:title" content="Health Calculators — Free, Science-Backed Health Tools" />
     <meta property="og:description" content="Free online health calculators: BMI, TDEE, body fat, macros, ideal weight, water intake, heart rate zones, and sleep cycles. Science-backed formulas, instant results, no sign-up." />
-    <meta property="og:url" content="https://jenslaufer.github.io/health-calculators/" />
+    <meta property="og:url" content="https://healthcalculator.app/" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />

--- a/public/404.html
+++ b/public/404.html
@@ -6,14 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Free online health calculators: BMI, TDEE, body fat, macros, ideal weight, water intake, heart rate zones, and sleep cycles. Science-backed formulas, instant results, no sign-up." />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://jenslaufer.github.io/health-calculators/" />
+    <link rel="canonical" href="https://healthcalculator.app/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Health Calculators" />
     <meta property="og:title" content="Health Calculators — Free, Science-Backed Health Tools" />
     <meta property="og:description" content="Free online health calculators: BMI, TDEE, body fat, macros, ideal weight, water intake, heart rate zones, and sleep cycles. Science-backed formulas, instant results, no sign-up." />
-    <meta property="og:url" content="https://jenslaufer.github.io/health-calculators/" />
+    <meta property="og:url" content="https://healthcalculator.app/" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://jenslaufer.github.io/health-calculators/sitemap.xml
+Sitemap: https://healthcalculator.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,327 +1,327 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/</loc>
+    <loc>https://healthcalculator.app/</loc>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <!-- German calculator routes -->
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/bmi-rechner</loc>
+    <loc>https://healthcalculator.app/de/bmi-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/wasser-rechner</loc>
+    <loc>https://healthcalculator.app/de/wasser-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/koerperfett-rechner</loc>
+    <loc>https://healthcalculator.app/de/koerperfett-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/herzfrequenz-zonen</loc>
+    <loc>https://healthcalculator.app/de/herzfrequenz-zonen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/idealgewicht-rechner</loc>
+    <loc>https://healthcalculator.app/de/idealgewicht-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/makro-rechner</loc>
+    <loc>https://healthcalculator.app/de/makro-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/schlafzyklen-rechner</loc>
+    <loc>https://healthcalculator.app/de/schlafzyklen-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/tdee-rechner</loc>
+    <loc>https://healthcalculator.app/de/tdee-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/schwangerschafts-rechner</loc>
+    <loc>https://healthcalculator.app/de/schwangerschafts-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blutdruck-rechner</loc>
+    <loc>https://healthcalculator.app/de/blutdruck-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/kaloriendefizit-rechner</loc>
+    <loc>https://healthcalculator.app/de/kaloriendefizit-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/taille-hueft-verhaeltnis</loc>
+    <loc>https://healthcalculator.app/de/taille-hueft-verhaeltnis</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/eisprung-rechner</loc>
+    <loc>https://healthcalculator.app/de/eisprung-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/protein-rechner</loc>
+    <loc>https://healthcalculator.app/de/protein-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/bmr-rechner</loc>
+    <loc>https://healthcalculator.app/de/bmr-rechner</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <!-- English calculator routes -->
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/bmi-calculator</loc>
+    <loc>https://healthcalculator.app/en/bmi-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/water-intake-calculator</loc>
+    <loc>https://healthcalculator.app/en/water-intake-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/body-fat-calculator</loc>
+    <loc>https://healthcalculator.app/en/body-fat-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/heart-rate-zones</loc>
+    <loc>https://healthcalculator.app/en/heart-rate-zones</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/ideal-weight-calculator</loc>
+    <loc>https://healthcalculator.app/en/ideal-weight-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/macro-calculator</loc>
+    <loc>https://healthcalculator.app/en/macro-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/sleep-cycle-calculator</loc>
+    <loc>https://healthcalculator.app/en/sleep-cycle-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/tdee-calculator</loc>
+    <loc>https://healthcalculator.app/en/tdee-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/pregnancy-calculator</loc>
+    <loc>https://healthcalculator.app/en/pregnancy-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blood-pressure-calculator</loc>
+    <loc>https://healthcalculator.app/en/blood-pressure-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/calorie-deficit-calculator</loc>
+    <loc>https://healthcalculator.app/en/calorie-deficit-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/waist-hip-ratio-calculator</loc>
+    <loc>https://healthcalculator.app/en/waist-hip-ratio-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/ovulation-calculator</loc>
+    <loc>https://healthcalculator.app/en/ovulation-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/protein-calculator</loc>
+    <loc>https://healthcalculator.app/en/protein-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/bmr-calculator</loc>
+    <loc>https://healthcalculator.app/en/bmr-calculator</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <!-- Blog index pages -->
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog</loc>
+    <loc>https://healthcalculator.app/de/blog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog</loc>
+    <loc>https://healthcalculator.app/en/blog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <!-- German blog articles -->
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/bmi-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/bmi-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/idealgewicht-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/idealgewicht-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/koerperfett-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/koerperfett-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/tdee-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/tdee-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/makronaehrstoffe-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/makronaehrstoffe-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/wasserbedarf-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/wasserbedarf-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/schlafzyklen-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/schlafzyklen-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/geburtstermin-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/geburtstermin-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/kaloriendefizit-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/kaloriendefizit-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/herzfrequenz-zonen-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/herzfrequenz-zonen-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/taille-hueft-verhaeltnis-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/taille-hueft-verhaeltnis-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/blutdruck-richtig-messen</loc>
+    <loc>https://healthcalculator.app/de/blog/blutdruck-richtig-messen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/eisprung-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/eisprung-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/proteinbedarf-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/proteinbedarf-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/de/blog/grundumsatz-berechnen</loc>
+    <loc>https://healthcalculator.app/de/blog/grundumsatz-berechnen</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
 
   <!-- English blog articles -->
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-bmi</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-bmi</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-ideal-weight</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-ideal-weight</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-body-fat</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-body-fat</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-tdee</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-tdee</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-macros</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-macros</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-water-intake</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-water-intake</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-sleep-cycles</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-sleep-cycles</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-due-date</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-due-date</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-calorie-deficit</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-calorie-deficit</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-heart-rate-zones</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-heart-rate-zones</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-waist-hip-ratio</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-waist-hip-ratio</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/measure-blood-pressure</loc>
+    <loc>https://healthcalculator.app/en/blog/measure-blood-pressure</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-ovulation</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-ovulation</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/protein-intake-guide</loc>
+    <loc>https://healthcalculator.app/en/blog/protein-intake-guide</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jenslaufer.github.io/health-calculators/en/blog/calculate-bmr</loc>
+    <loc>https://healthcalculator.app/en/blog/calculate-bmr</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/composables/useHead.js
+++ b/src/composables/useHead.js
@@ -3,7 +3,7 @@ import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { localePath as resolveLocalePath, routeMap } from './useLocaleRouter.js'
 
-const BASE_URL = 'https://jenslaufer.github.io/health-calculators'
+const BASE_URL = 'https://healthcalculator.app'
 
 function setMeta(attr, key, content) {
   if (import.meta.env.SSR) return

--- a/src/pages/BloodPressureCalculator.vue
+++ b/src/pages/BloodPressureCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Blutdruck-Rechner',
-    url: 'https://jenslaufer.github.io/health-calculators/blutdruck-rechner',
+    url: 'https://healthcalculator.app/blutdruck-rechner',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/BmiCalculator.vue
+++ b/src/pages/BmiCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'BMI Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/bmi',
+    url: 'https://healthcalculator.app/bmi',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/BmrCalculator.vue
+++ b/src/pages/BmrCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'BMR Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/bmr',
+    url: 'https://healthcalculator.app/bmr',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/BodyFatCalculator.vue
+++ b/src/pages/BodyFatCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Body Fat Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/body-fat',
+    url: 'https://healthcalculator.app/body-fat',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/CalorieDeficitCalculator.vue
+++ b/src/pages/CalorieDeficitCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Kaloriendefizit-Rechner',
-    url: 'https://jenslaufer.github.io/health-calculators/kaloriendefizit-rechner',
+    url: 'https://healthcalculator.app/kaloriendefizit-rechner',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/HeartRateZones.vue
+++ b/src/pages/HeartRateZones.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Heart Rate Zone Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/heart-rate',
+    url: 'https://healthcalculator.app/heart-rate',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -15,7 +15,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name: t('nav.brand'),
-    url: 'https://jenslaufer.github.io/health-calculators/',
+    url: 'https://healthcalculator.app/',
     description: t('home.meta.description'),
   },
 }))

--- a/src/pages/IdealWeightCalculator.vue
+++ b/src/pages/IdealWeightCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Ideal Weight Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/ideal-weight',
+    url: 'https://healthcalculator.app/ideal-weight',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/MacroCalculator.vue
+++ b/src/pages/MacroCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Macro Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/macros',
+    url: 'https://healthcalculator.app/macros',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/OvulationCalculator.vue
+++ b/src/pages/OvulationCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'MedicalWebPage',
     name: 'Ovulation Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/ovulation',
+    url: 'https://healthcalculator.app/ovulation',
     about: { '@type': 'MedicalCondition', name: 'Ovulation' },
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   },

--- a/src/pages/PregnancyCalculator.vue
+++ b/src/pages/PregnancyCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'MedicalWebPage',
     name: 'Pregnancy Due Date Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/pregnancy',
+    url: 'https://healthcalculator.app/pregnancy',
     about: { '@type': 'MedicalCondition', name: 'Pregnancy' },
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   },

--- a/src/pages/ProteinCalculator.vue
+++ b/src/pages/ProteinCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Protein Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/protein',
+    url: 'https://healthcalculator.app/protein',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/SleepCycleCalculator.vue
+++ b/src/pages/SleepCycleCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Sleep Cycle Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/sleep',
+    url: 'https://healthcalculator.app/sleep',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/TdeeCalculator.vue
+++ b/src/pages/TdeeCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'TDEE Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/tdee',
+    url: 'https://healthcalculator.app/tdee',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/WaistHipRatioCalculator.vue
+++ b/src/pages/WaistHipRatioCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Waist-to-Hip Ratio Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/waist-hip-ratio',
+    url: 'https://healthcalculator.app/waist-hip-ratio',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/WaterIntakeCalculator.vue
+++ b/src/pages/WaterIntakeCalculator.vue
@@ -16,7 +16,7 @@ useHead(() => ({
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name: 'Water Intake Calculator',
-    url: 'https://jenslaufer.github.io/health-calculators/water',
+    url: 'https://healthcalculator.app/water',
     applicationCategory: 'HealthApplication',
     operatingSystem: 'Any',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },

--- a/src/pages/blog/BlutdruckRichtigMessen.vue
+++ b/src/pages/blog/BlutdruckRichtigMessen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/blutdruck-richtig-messen',
+      '@id': 'https://healthcalculator.app/blog/blutdruck-richtig-messen',
     },
   },
 })

--- a/src/pages/blog/BmiBerechnen.vue
+++ b/src/pages/blog/BmiBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/bmi-berechnen',
+      '@id': 'https://healthcalculator.app/blog/bmi-berechnen',
     },
   },
 })

--- a/src/pages/blog/EisprungBerechnen.vue
+++ b/src/pages/blog/EisprungBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-29',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/eisprung-berechnen',
+      '@id': 'https://healthcalculator.app/blog/eisprung-berechnen',
     },
   },
 })

--- a/src/pages/blog/GeburtsterminBerechnen.vue
+++ b/src/pages/blog/GeburtsterminBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/geburtstermin-berechnen',
+      '@id': 'https://healthcalculator.app/blog/geburtstermin-berechnen',
     },
   },
 })

--- a/src/pages/blog/GrundumsatzBerechnen.vue
+++ b/src/pages/blog/GrundumsatzBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-30',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/grundumsatz-berechnen',
+      '@id': 'https://healthcalculator.app/blog/grundumsatz-berechnen',
     },
   },
 })

--- a/src/pages/blog/HerzfrequenzZonenBerechnen.vue
+++ b/src/pages/blog/HerzfrequenzZonenBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/herzfrequenz-zonen-berechnen',
+      '@id': 'https://healthcalculator.app/blog/herzfrequenz-zonen-berechnen',
     },
   },
 })

--- a/src/pages/blog/IdealgewichtBerechnen.vue
+++ b/src/pages/blog/IdealgewichtBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/idealgewicht-berechnen',
+      '@id': 'https://healthcalculator.app/blog/idealgewicht-berechnen',
     },
   },
 })

--- a/src/pages/blog/KaloriendefizitBerechnen.vue
+++ b/src/pages/blog/KaloriendefizitBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/kaloriendefizit-berechnen',
+      '@id': 'https://healthcalculator.app/blog/kaloriendefizit-berechnen',
     },
   },
 })

--- a/src/pages/blog/KoerperfettBerechnen.vue
+++ b/src/pages/blog/KoerperfettBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/koerperfett-berechnen',
+      '@id': 'https://healthcalculator.app/blog/koerperfett-berechnen',
     },
   },
 })

--- a/src/pages/blog/MakronaehrstoffeBerechnen.vue
+++ b/src/pages/blog/MakronaehrstoffeBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/makronaehrstoffe-berechnen',
+      '@id': 'https://healthcalculator.app/blog/makronaehrstoffe-berechnen',
     },
   },
 })

--- a/src/pages/blog/ProteinbedarfBerechnen.vue
+++ b/src/pages/blog/ProteinbedarfBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-30',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/proteinbedarf-berechnen',
+      '@id': 'https://healthcalculator.app/blog/proteinbedarf-berechnen',
     },
   },
 })

--- a/src/pages/blog/SchlafzyklenBerechnen.vue
+++ b/src/pages/blog/SchlafzyklenBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/schlafzyklen-berechnen',
+      '@id': 'https://healthcalculator.app/blog/schlafzyklen-berechnen',
     },
   },
 })

--- a/src/pages/blog/TaillenHueftVerhaeltnis.vue
+++ b/src/pages/blog/TaillenHueftVerhaeltnis.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/taille-hueft-verhaeltnis-berechnen',
+      '@id': 'https://healthcalculator.app/blog/taille-hueft-verhaeltnis-berechnen',
     },
   },
 })

--- a/src/pages/blog/TdeeBerechnen.vue
+++ b/src/pages/blog/TdeeBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/tdee-berechnen',
+      '@id': 'https://healthcalculator.app/blog/tdee-berechnen',
     },
   },
 })

--- a/src/pages/blog/WasserbedarfBerechnen.vue
+++ b/src/pages/blog/WasserbedarfBerechnen.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/blog/wasserbedarf-berechnen',
+      '@id': 'https://healthcalculator.app/blog/wasserbedarf-berechnen',
     },
   },
 })

--- a/src/pages/blog/en/CalculateBmi.vue
+++ b/src/pages/blog/en/CalculateBmi.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-bmi',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-bmi',
     },
   },
 })

--- a/src/pages/blog/en/CalculateBmr.vue
+++ b/src/pages/blog/en/CalculateBmr.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-30',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-bmr',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-bmr',
     },
   },
 })

--- a/src/pages/blog/en/CalculateBodyFat.vue
+++ b/src/pages/blog/en/CalculateBodyFat.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-body-fat',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-body-fat',
     },
   },
 })

--- a/src/pages/blog/en/CalculateCalorieDeficit.vue
+++ b/src/pages/blog/en/CalculateCalorieDeficit.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-calorie-deficit',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-calorie-deficit',
     },
   },
 })

--- a/src/pages/blog/en/CalculateDueDate.vue
+++ b/src/pages/blog/en/CalculateDueDate.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-due-date',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-due-date',
     },
   },
 })

--- a/src/pages/blog/en/CalculateHeartRateZones.vue
+++ b/src/pages/blog/en/CalculateHeartRateZones.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-heart-rate-zones',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-heart-rate-zones',
     },
   },
 })

--- a/src/pages/blog/en/CalculateIdealWeight.vue
+++ b/src/pages/blog/en/CalculateIdealWeight.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-ideal-weight',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-ideal-weight',
     },
   },
 })

--- a/src/pages/blog/en/CalculateMacros.vue
+++ b/src/pages/blog/en/CalculateMacros.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-macros',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-macros',
     },
   },
 })

--- a/src/pages/blog/en/CalculateOvulation.vue
+++ b/src/pages/blog/en/CalculateOvulation.vue
@@ -20,7 +20,7 @@ useHead({
     dateModified: '2026-03-29',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-ovulation',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-ovulation',
     },
   },
 })

--- a/src/pages/blog/en/CalculateProteinIntake.vue
+++ b/src/pages/blog/en/CalculateProteinIntake.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-30',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/protein-intake-guide',
+      '@id': 'https://healthcalculator.app/en/blog/protein-intake-guide',
     },
   },
 })

--- a/src/pages/blog/en/CalculateSleepCycles.vue
+++ b/src/pages/blog/en/CalculateSleepCycles.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-sleep-cycles',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-sleep-cycles',
     },
   },
 })

--- a/src/pages/blog/en/CalculateTdee.vue
+++ b/src/pages/blog/en/CalculateTdee.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-tdee',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-tdee',
     },
   },
 })

--- a/src/pages/blog/en/CalculateWaistHipRatio.vue
+++ b/src/pages/blog/en/CalculateWaistHipRatio.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-waist-hip-ratio',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-waist-hip-ratio',
     },
   },
 })

--- a/src/pages/blog/en/CalculateWaterIntake.vue
+++ b/src/pages/blog/en/CalculateWaterIntake.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-25',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/calculate-water-intake',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-water-intake',
     },
   },
 })

--- a/src/pages/blog/en/MeasureBloodPressure.vue
+++ b/src/pages/blog/en/MeasureBloodPressure.vue
@@ -17,7 +17,7 @@ useHead({
     dateModified: '2026-03-27',
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://jenslaufer.github.io/health-calculators/en/blog/measure-blood-pressure',
+      '@id': 'https://healthcalculator.app/en/blog/measure-blood-pressure',
     },
   },
 })

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
-const BASE_URL = 'https://jenslaufer.github.io/health-calculators'
+const BASE_URL = 'https://healthcalculator.app'
 const publicDir = resolve(import.meta.dirname, '..', 'public')
 
 describe('404.html', () => {


### PR DESCRIPTION
## Summary
- Replaced all `jenslaufer.github.io/health-calculators` references with `healthcalculator.app` across 53 files
- Updated sitemap.xml, robots.txt, canonical URLs, og:url meta tags, structured data `@id` fields, test assertions, and README
- No logic, style, or functionality changes — URL-only replacement

## Test plan
- [x] All 29 existing tests pass (3 test files)
- [ ] Verify sitemap.xml URLs resolve correctly
- [ ] Verify canonical/og:url tags in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)