### PR TITLE
hc-affiliate-all-calculators: TASK: Add AffiliateBanner to all calculator pages and restru

### DIFF
--- a/src/__tests__/affiliate-layout.test.js
+++ b/src/__tests__/affiliate-layout.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const pagesDir = resolve(__dirname, '../pages')
+
+/**
+ * Verifies that AffiliateBanner appears between the input card and the results
+ * section in the template of each calculator page.
+ *
+ * Strategy: extract the <template> block, then check that:
+ * 1. <AffiliateBanner appears in the template
+ * 2. The AffiliateBanner comes AFTER the input card closing </div>
+ * 3. The AffiliateBanner comes BEFORE the results section (v-if on result data)
+ */
+function getTemplate(fileName) {
+  const content = readFileSync(resolve(pagesDir, fileName), 'utf-8')
+  const match = content.match(/<template>([\s\S]*)<\/template>/)
+  return match ? match[1] : ''
+}
+
+function getAffiliateBannerIndex(template) {
+  return template.indexOf('<AffiliateBanner')
+}
+
+const calculators = [
+  { file: 'BmiCalculator.vue', resultMarker: 'v-if="bmi"' },
+  { file: 'BloodPressureCalculator.vue', resultMarker: 'v-if="result"' },
+  { file: 'BodyFatCalculator.vue', resultMarker: 'v-if="bodyFat"' },
+  { file: 'BmrCalculator.vue', resultMarker: 'v-if="bmr"' },
+  { file: 'CalorieDeficitCalculator.vue', resultMarker: 'v-if="hasResult"' },
+  { file: 'HeartRateZones.vue', resultMarker: 'v-if="hrMax"' },
+  { file: 'IdealWeightCalculator.vue', resultMarker: 'data-testid="results"' },
+  { file: 'MacroCalculator.vue', resultMarker: 'v-if="targetCalories"' },
+  { file: 'OvulationCalculator.vue', resultMarker: 'v-if="hasResults"' },
+  { file: 'PregnancyCalculator.vue', resultMarker: 'v-if="hasResults"' },
+  { file: 'ProteinCalculator.vue', resultMarker: 'v-if="dailyProtein"' },
+  { file: 'SleepCycleCalculator.vue', resultMarker: 'v-if="options.length"' },
+  { file: 'TdeeCalculator.vue', resultMarker: 'v-if="tdee"' },
+  { file: 'WaistHipRatioCalculator.vue', resultMarker: 'v-if="whr"' },
+  { file: 'WaterIntakeCalculator.vue', resultMarker: 'v-if="liters"' },
+]
+
+describe('AffiliateBanner layout order — all calculators', () => {
+  it.each(calculators)(
+    '$file: AffiliateBanner appears between input and results',
+    ({ file, resultMarker }) => {
+      const template = getTemplate(file)
+
+      const bannerIdx = getAffiliateBannerIndex(template)
+      expect(bannerIdx, `${file} must contain <AffiliateBanner`).toBeGreaterThan(-1)
+
+      // The results section (identified by its v-if) must come AFTER the banner
+      const resultsIdx = template.indexOf(resultMarker)
+      expect(resultsIdx, `${file} must contain ${resultMarker}`).toBeGreaterThan(-1)
+      expect(bannerIdx, `${file}: AffiliateBanner must appear before results section`).toBeLessThan(resultsIdx)
+    }
+  )
+
+  it.each(calculators)(
+    '$file: AffiliateBanner is NOT inside input card',
+    ({ file }) => {
+      const template = getTemplate(file)
+      const bannerIdx = getAffiliateBannerIndex(template)
+
+      // The banner should be a top-level element, not nested inside the first card.
+      // Check that the banner is preceded by a closing </div> (end of input card)
+      // within the last 50 characters before it.
+      const before = template.substring(Math.max(0, bannerIdx - 100), bannerIdx)
+      expect(before, `${file}: AffiliateBanner should follow a closing </div>`).toMatch(/<\/div>/)
+    }
+  )
+
+  it.each(calculators)(
+    '$file: BlogBanner and AdSlot come after results section',
+    ({ file, resultMarker }) => {
+      const template = getTemplate(file)
+      const resultsIdx = template.indexOf(resultMarker)
+      const blogIdx = template.indexOf('<BlogBanner')
+      const adIdx = template.indexOf('<AdSlot')
+
+      expect(blogIdx, `${file}: BlogBanner must come after results`).toBeGreaterThan(resultsIdx)
+      expect(adIdx, `${file}: AdSlot must come after results`).toBeGreaterThan(resultsIdx)
+    }
+  )
+})

--- a/src/pages/BloodPressureCalculator.vue
+++ b/src/pages/BloodPressureCalculator.vue
@@ -82,40 +82,40 @@ const recommendationKeys = {
             class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
         </div>
       </div>
-
-      <div v-if="result" class="pt-5 border-t border-stone-100">
-        <div class="flex items-baseline gap-3 mb-4">
-          <span data-testid="systolic-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ systolic }}</span>
-          <span class="text-2xl text-stone-400 font-light">/</span>
-          <span data-testid="diastolic-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ diastolic }}</span>
-          <span class="text-sm text-stone-400 ml-1">mmHg</span>
-        </div>
-        <p data-testid="category" :class="result.color" class="text-lg font-semibold mb-4">{{ t('bloodPressure.' + result.key) }}</p>
-
-        <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-1.5">
-          <div class="absolute inset-0 flex">
-            <div class="flex-1 bg-green-600"></div>
-            <div class="flex-1 bg-yellow-500"></div>
-            <div class="flex-1 bg-orange-500"></div>
-            <div class="flex-1 bg-red-500"></div>
-            <div class="flex-[0.5] bg-red-700"></div>
-          </div>
-        </div>
-        <div class="flex text-[10px] text-stone-400 tabular-nums mb-6">
-          <div class="flex-1">{{ t('bloodPressure.scaleNormal') }}</div>
-          <div class="flex-1 text-center">{{ t('bloodPressure.scaleElevated') }}</div>
-          <div class="flex-1 text-center">{{ t('bloodPressure.scaleStage1') }}</div>
-          <div class="flex-1 text-center">{{ t('bloodPressure.scaleStage2') }}</div>
-          <div class="flex-[0.5] text-right">{{ t('bloodPressure.scaleCrisis') }}</div>
-        </div>
-
-        <div data-testid="recommendation" class="bg-stone-50 border border-stone-200 rounded-lg p-4">
-          <p class="text-sm text-stone-600 leading-relaxed">{{ t(recommendationKeys[result.key]) }}</p>
-        </div>
-      </div>
     </div>
 
     <AffiliateBanner class="my-6" />
+
+    <div v-if="result" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex items-baseline gap-3 mb-4">
+        <span data-testid="systolic-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ systolic }}</span>
+        <span class="text-2xl text-stone-400 font-light">/</span>
+        <span data-testid="diastolic-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ diastolic }}</span>
+        <span class="text-sm text-stone-400 ml-1">mmHg</span>
+      </div>
+      <p data-testid="category" :class="result.color" class="text-lg font-semibold mb-4">{{ t('bloodPressure.' + result.key) }}</p>
+
+      <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-1.5">
+        <div class="absolute inset-0 flex">
+          <div class="flex-1 bg-green-600"></div>
+          <div class="flex-1 bg-yellow-500"></div>
+          <div class="flex-1 bg-orange-500"></div>
+          <div class="flex-1 bg-red-500"></div>
+          <div class="flex-[0.5] bg-red-700"></div>
+        </div>
+      </div>
+      <div class="flex text-[10px] text-stone-400 tabular-nums mb-6">
+        <div class="flex-1">{{ t('bloodPressure.scaleNormal') }}</div>
+        <div class="flex-1 text-center">{{ t('bloodPressure.scaleElevated') }}</div>
+        <div class="flex-1 text-center">{{ t('bloodPressure.scaleStage1') }}</div>
+        <div class="flex-1 text-center">{{ t('bloodPressure.scaleStage2') }}</div>
+        <div class="flex-[0.5] text-right">{{ t('bloodPressure.scaleCrisis') }}</div>
+      </div>
+
+      <div data-testid="recommendation" class="bg-stone-50 border border-stone-200 rounded-lg p-4">
+        <p class="text-sm text-stone-600 leading-relaxed">{{ t(recommendationKeys[result.key]) }}</p>
+      </div>
+    </div>
 
     <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
       <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('bloodPressure.categoriesTitle') }}</h2>

--- a/src/pages/BmiCalculator.vue
+++ b/src/pages/BmiCalculator.vue
@@ -101,35 +101,35 @@ const barPosition = computed(() => {
           />
         </div>
       </div>
-
-      <div v-if="bmi" class="pt-5 border-t border-stone-100">
-        <div class="flex items-baseline gap-3 mb-4">
-          <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ bmiFormatted }}</span>
-          <span :class="category.color" class="text-lg font-semibold">{{ t(category.label) }}</span>
-        </div>
-
-        <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-1.5">
-          <div class="absolute inset-0 flex">
-            <div class="flex-1 bg-blue-400/8"></div>
-            <div class="flex-1 bg-green-600"></div>
-            <div class="flex-1 bg-yellow-500"></div>
-            <div class="flex-1 bg-red-500"></div>
-          </div>
-          <div
-            class="absolute top-0 w-1 h-full bg-stone-900 rounded-full transform"
-            :style="{ left: barPosition + '%' }"
-          ></div>
-        </div>
-        <div class="flex text-[10px] text-stone-400 tabular-nums">
-          <div class="flex-1">18.5</div>
-          <div class="flex-1 text-center">25</div>
-          <div class="flex-1 text-center">30</div>
-          <div class="flex-1 text-right">40</div>
-        </div>
-      </div>
     </div>
 
     <AffiliateBanner class="my-6" />
+
+    <div v-if="bmi" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex items-baseline gap-3 mb-4">
+        <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ bmiFormatted }}</span>
+        <span :class="category.color" class="text-lg font-semibold">{{ t(category.label) }}</span>
+      </div>
+
+      <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-1.5">
+        <div class="absolute inset-0 flex">
+          <div class="flex-1 bg-blue-400/8"></div>
+          <div class="flex-1 bg-green-600"></div>
+          <div class="flex-1 bg-yellow-500"></div>
+          <div class="flex-1 bg-red-500"></div>
+        </div>
+        <div
+          class="absolute top-0 w-1 h-full bg-stone-900 rounded-full transform"
+          :style="{ left: barPosition + '%' }"
+        ></div>
+      </div>
+      <div class="flex text-[10px] text-stone-400 tabular-nums">
+        <div class="flex-1">18.5</div>
+        <div class="flex-1 text-center">25</div>
+        <div class="flex-1 text-center">30</div>
+        <div class="flex-1 text-right">40</div>
+      </div>
+    </div>
 
     <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
       <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('bmi.categories') }}</h2>

--- a/src/pages/BmrCalculator.vue
+++ b/src/pages/BmrCalculator.vue
@@ -130,7 +130,12 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
       </select>
     </div>
 
-    <div v-if="bmr" class="text-center py-6 border-t border-stone-100">
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="bmr" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="text-center py-6">
       <div class="text-5xl font-bold text-stone-900 tabular-nums" data-testid="bmr-result">{{ formatNumber(bmr) }}</div>
       <div class="text-sm text-stone-500 mt-1">{{ t('common.kcalPerDay') }}</div>
 

--- a/src/pages/BodyFatCalculator.vue
+++ b/src/pages/BodyFatCalculator.vue
@@ -170,41 +170,43 @@ const unitLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'cm' :
           class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
       </div>
     </div>
+  </div>
 
-    <div v-if="bodyFat" class="pt-5 border-t border-stone-100">
-      <div class="flex items-baseline gap-3 mb-4">
-        <span data-testid="body-fat-result" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ bodyFatFormatted }}</span>
-        <span class="text-2xl text-stone-400">%</span>
-        <span v-if="category" :class="category.color" data-testid="body-fat-category" class="text-lg font-semibold">{{ t(category.label) }}</span>
-      </div>
+  <AffiliateBanner class="my-6" />
 
-      <div class="relative h-2.5 bg-stone-200 rounded-full overflow-hidden mb-1.5">
-        <div class="absolute inset-0 flex">
-          <div class="flex-1 bg-blue-500"></div>
-          <div class="flex-1 bg-green-600"></div>
-          <div class="flex-1 bg-green-500"></div>
-          <div class="flex-1 bg-yellow-500"></div>
-          <div class="flex-1 bg-red-500"></div>
-        </div>
-        <div class="absolute top-0 w-1 h-full bg-stone-900 rounded-full transform" :style="{ left: barPosition + '%' }"></div>
-      </div>
-      <div class="flex text-[10px] text-stone-400 tabular-nums">
-        <div class="flex-1">5%</div>
-        <div class="flex-1 text-center">15%</div>
-        <div class="flex-1 text-center">25%</div>
-        <div class="flex-1 text-center">35%</div>
-        <div class="flex-1 text-right">50%</div>
-      </div>
+  <div v-if="bodyFat" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-4">
+      <span data-testid="body-fat-result" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ bodyFatFormatted }}</span>
+      <span class="text-2xl text-stone-400">%</span>
+      <span v-if="category" :class="category.color" data-testid="body-fat-category" class="text-lg font-semibold">{{ t(category.label) }}</span>
+    </div>
 
-      <div v-if="fatMass !== null" class="grid grid-cols-2 gap-4 mt-5">
-        <div class="bg-stone-50 rounded-lg p-4">
-          <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('bodyFat.fatMass') }}</div>
-          <div data-testid="fat-mass" class="text-2xl font-bold text-stone-900 tabular-nums">{{ fatMass.toFixed(1) }} <span class="text-sm text-stone-400">{{ massUnit }}</span></div>
-        </div>
-        <div class="bg-stone-50 rounded-lg p-4">
-          <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('bodyFat.leanMass') }}</div>
-          <div data-testid="lean-mass" class="text-2xl font-bold text-stone-900 tabular-nums">{{ leanMass.toFixed(1) }} <span class="text-sm text-stone-400">{{ massUnit }}</span></div>
-        </div>
+    <div class="relative h-2.5 bg-stone-200 rounded-full overflow-hidden mb-1.5">
+      <div class="absolute inset-0 flex">
+        <div class="flex-1 bg-blue-500"></div>
+        <div class="flex-1 bg-green-600"></div>
+        <div class="flex-1 bg-green-500"></div>
+        <div class="flex-1 bg-yellow-500"></div>
+        <div class="flex-1 bg-red-500"></div>
+      </div>
+      <div class="absolute top-0 w-1 h-full bg-stone-900 rounded-full transform" :style="{ left: barPosition + '%' }"></div>
+    </div>
+    <div class="flex text-[10px] text-stone-400 tabular-nums">
+      <div class="flex-1">5%</div>
+      <div class="flex-1 text-center">15%</div>
+      <div class="flex-1 text-center">25%</div>
+      <div class="flex-1 text-center">35%</div>
+      <div class="flex-1 text-right">50%</div>
+    </div>
+
+    <div v-if="fatMass !== null" class="grid grid-cols-2 gap-4 mt-5">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('bodyFat.fatMass') }}</div>
+        <div data-testid="fat-mass" class="text-2xl font-bold text-stone-900 tabular-nums">{{ fatMass.toFixed(1) }} <span class="text-sm text-stone-400">{{ massUnit }}</span></div>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('bodyFat.leanMass') }}</div>
+        <div data-testid="lean-mass" class="text-2xl font-bold text-stone-900 tabular-nums">{{ leanMass.toFixed(1) }} <span class="text-sm text-stone-400">{{ massUnit }}</span></div>
       </div>
     </div>
   </div>

--- a/src/pages/CalorieDeficitCalculator.vue
+++ b/src/pages/CalorieDeficitCalculator.vue
@@ -152,7 +152,12 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
       </select>
     </div>
 
-    <div v-if="hasResult" class="text-center py-6 border-t border-stone-100">
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="hasResult" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="text-center py-6">
       <div class="text-5xl font-bold text-stone-900 tabular-nums" data-testid="daily-calories">{{ formatNumber(dailyCalories) }}</div>
       <div class="text-sm text-stone-500 mt-1">{{ t('calorieDeficit.resultLabel') }}</div>
 

--- a/src/pages/HeartRateZones.vue
+++ b/src/pages/HeartRateZones.vue
@@ -106,6 +106,8 @@ const zones = computed(() => {
     </div>
   </div>
 
+  <AffiliateBanner class="my-6" />
+
   <div v-if="hrMax" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8">
     <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('heartRate.maxHr') }}</p>
     <p class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ hrMax }}</p>

--- a/src/pages/IdealWeightCalculator.vue
+++ b/src/pages/IdealWeightCalculator.vue
@@ -126,13 +126,16 @@ const fmt = (v) => v?.toFixed(1)
       </div>
     </div>
 
-    <div v-if="formulas" data-testid="results" class="pt-5 border-t border-stone-100">
-      <div class="mb-4">
-        <span class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ fmt(average) }}</span>
-        <span class="text-lg text-stone-500 ml-2">{{ weightUnit }}</span>
-      </div>
-      <p class="text-sm text-stone-500 mb-6">{{ fmt(range.min) }} – {{ fmt(range.max) }} {{ weightUnit }}</p>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="formulas" data-testid="results" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ fmt(average) }}</span>
+      <span class="text-lg text-stone-500 ml-2">{{ weightUnit }}</span>
     </div>
+    <p class="text-sm text-stone-500 mb-6">{{ fmt(range.min) }} – {{ fmt(range.max) }} {{ weightUnit }}</p>
   </div>
 
   <div v-if="formulas" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">

--- a/src/pages/MacroCalculator.vue
+++ b/src/pages/MacroCalculator.vue
@@ -177,39 +177,42 @@ const macros = computed(() => {
       </div>
     </div>
 
-    <div v-if="targetCalories" class="pt-5 border-t border-stone-100">
-      <div class="mb-6">
-        <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('macro.targetCalories') }}</p>
-        <span class="text-5xl font-bold text-stone-900 tabular-nums leading-none" data-testid="target-calories">{{ targetCalories }}</span>
-        <span class="text-lg text-stone-400 ml-1">{{ t('common.kcal') }}</span>
-      </div>
+  </div>
 
-      <div class="grid grid-cols-3 gap-4 mb-6">
-        <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
-          <div class="w-2.5 h-2.5 rounded-full bg-blue-500 mx-auto mb-2"></div>
-          <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="protein-grams">{{ macros.protein.grams }}</p>
-          <p class="text-xs text-stone-500 font-medium">{{ t('macro.protein') }}</p>
-          <p class="text-xs text-stone-400 mt-1" data-testid="protein-pct">{{ macros.protein.pct }}%</p>
-        </div>
-        <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
-          <div class="w-2.5 h-2.5 rounded-full bg-amber-500 mx-auto mb-2"></div>
-          <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="carbs-grams">{{ macros.carbs.grams }}</p>
-          <p class="text-xs text-stone-500 font-medium">{{ t('macro.carbs') }}</p>
-          <p class="text-xs text-stone-400 mt-1" data-testid="carbs-pct">{{ macros.carbs.pct }}%</p>
-        </div>
-        <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
-          <div class="w-2.5 h-2.5 rounded-full bg-rose-500 mx-auto mb-2"></div>
-          <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="fat-grams">{{ macros.fat.grams }}</p>
-          <p class="text-xs text-stone-500 font-medium">{{ t('macro.fat') }}</p>
-          <p class="text-xs text-stone-400 mt-1" data-testid="fat-pct">{{ macros.fat.pct }}%</p>
-        </div>
-      </div>
+  <AffiliateBanner class="my-6" />
 
-      <div class="rounded-full overflow-hidden flex" style="height: 12px" role="img" aria-label="Macro ratio" data-testid="macro-bar">
-        <div class="bg-blue-500" :style="{ width: macros.protein.pct + '%', height: '100%' }"></div>
-        <div class="bg-amber-500" :style="{ width: macros.carbs.pct + '%', height: '100%' }"></div>
-        <div class="bg-rose-500" :style="{ width: macros.fat.pct + '%', height: '100%' }"></div>
+  <div v-if="targetCalories" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="mb-6">
+      <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('macro.targetCalories') }}</p>
+      <span class="text-5xl font-bold text-stone-900 tabular-nums leading-none" data-testid="target-calories">{{ targetCalories }}</span>
+      <span class="text-lg text-stone-400 ml-1">{{ t('common.kcal') }}</span>
+    </div>
+
+    <div class="grid grid-cols-3 gap-4 mb-6">
+      <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
+        <div class="w-2.5 h-2.5 rounded-full bg-blue-500 mx-auto mb-2"></div>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="protein-grams">{{ macros.protein.grams }}</p>
+        <p class="text-xs text-stone-500 font-medium">{{ t('macro.protein') }}</p>
+        <p class="text-xs text-stone-400 mt-1" data-testid="protein-pct">{{ macros.protein.pct }}%</p>
       </div>
+      <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
+        <div class="w-2.5 h-2.5 rounded-full bg-amber-500 mx-auto mb-2"></div>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="carbs-grams">{{ macros.carbs.grams }}</p>
+        <p class="text-xs text-stone-500 font-medium">{{ t('macro.carbs') }}</p>
+        <p class="text-xs text-stone-400 mt-1" data-testid="carbs-pct">{{ macros.carbs.pct }}%</p>
+      </div>
+      <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
+        <div class="w-2.5 h-2.5 rounded-full bg-rose-500 mx-auto mb-2"></div>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="fat-grams">{{ macros.fat.grams }}</p>
+        <p class="text-xs text-stone-500 font-medium">{{ t('macro.fat') }}</p>
+        <p class="text-xs text-stone-400 mt-1" data-testid="fat-pct">{{ macros.fat.pct }}%</p>
+      </div>
+    </div>
+
+    <div class="rounded-full overflow-hidden flex" style="height: 12px" role="img" aria-label="Macro ratio" data-testid="macro-bar">
+      <div class="bg-blue-500" :style="{ width: macros.protein.pct + '%', height: '100%' }"></div>
+      <div class="bg-amber-500" :style="{ width: macros.carbs.pct + '%', height: '100%' }"></div>
+      <div class="bg-rose-500" :style="{ width: macros.fat.pct + '%', height: '100%' }"></div>
     </div>
   </div>
 

--- a/src/pages/OvulationCalculator.vue
+++ b/src/pages/OvulationCalculator.vue
@@ -98,60 +98,63 @@ const hasResults = computed(() => !!lmpDate.value)
       </div>
     </div>
 
-    <div v-if="hasResults">
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-6">
-        <div class="rounded-xl border border-stone-200 p-5 text-center">
-          <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('ovulation.ovulationDate') }}</div>
-          <div class="text-xl font-bold text-stone-900" data-testid="ovulation-date">{{ formatDate(ovulationDate) }}</div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="hasResults" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-6">
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('ovulation.ovulationDate') }}</div>
+        <div class="text-xl font-bold text-stone-900" data-testid="ovulation-date">{{ formatDate(ovulationDate) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('ovulation.fertileWindow') }}</div>
+        <div class="text-base font-bold text-stone-900" data-testid="fertile-window">{{ formatDate(fertileStart) }} – {{ formatDate(fertileEnd) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('ovulation.cycleDay') }}</div>
+        <div class="text-xl font-bold text-stone-900" data-testid="cycle-day">{{ t('ovulation.dayN', { n: cycleDay }) }}</div>
+      </div>
+    </div>
+
+    <!-- Cycle timeline -->
+    <div class="mb-6" data-testid="cycle-timeline">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('ovulation.currentCycle') }}</h2>
+      <div class="flex rounded-lg overflow-hidden h-8">
+        <div class="bg-stone-400 flex items-center justify-center text-xs text-white font-medium" :style="{ width: (5 / cycleLength * 100) + '%' }">
+          {{ t('ovulation.phaseMenstruation') }}
         </div>
-        <div class="rounded-xl border border-stone-200 p-5 text-center">
-          <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('ovulation.fertileWindow') }}</div>
-          <div class="text-base font-bold text-stone-900" data-testid="fertile-window">{{ formatDate(fertileStart) }} – {{ formatDate(fertileEnd) }}</div>
+        <div class="bg-stone-200 flex items-center justify-center text-xs text-stone-600 font-medium" :style="{ width: ((cycleLength - 14 - 5 - 5) / cycleLength * 100) + '%' }">
+          {{ t('ovulation.phaseFollicular') }}
         </div>
-        <div class="rounded-xl border border-stone-200 p-5 text-center">
-          <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('ovulation.cycleDay') }}</div>
-          <div class="text-xl font-bold text-stone-900" data-testid="cycle-day">{{ t('ovulation.dayN', { n: cycleDay }) }}</div>
+        <div class="bg-stone-700 flex items-center justify-center text-xs text-white font-medium" :style="{ width: (7 / cycleLength * 100) + '%' }">
+          {{ t('ovulation.phaseFertile') }}
+        </div>
+        <div class="bg-stone-300 flex items-center justify-center text-xs text-stone-700 font-medium" :style="{ width: ((cycleLength - (cycleLength - 14) - 1) / cycleLength * 100) + '%' }">
+          {{ t('ovulation.phaseLuteal') }}
         </div>
       </div>
-
-      <!-- Cycle timeline -->
-      <div class="mb-6" data-testid="cycle-timeline">
-        <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('ovulation.currentCycle') }}</h2>
-        <div class="flex rounded-lg overflow-hidden h-8">
-          <div class="bg-stone-400 flex items-center justify-center text-xs text-white font-medium" :style="{ width: (5 / cycleLength * 100) + '%' }">
-            {{ t('ovulation.phaseMenstruation') }}
-          </div>
-          <div class="bg-stone-200 flex items-center justify-center text-xs text-stone-600 font-medium" :style="{ width: ((cycleLength - 14 - 5 - 5) / cycleLength * 100) + '%' }">
-            {{ t('ovulation.phaseFollicular') }}
-          </div>
-          <div class="bg-stone-700 flex items-center justify-center text-xs text-white font-medium" :style="{ width: (7 / cycleLength * 100) + '%' }">
-            {{ t('ovulation.phaseFertile') }}
-          </div>
-          <div class="bg-stone-300 flex items-center justify-center text-xs text-stone-700 font-medium" :style="{ width: ((cycleLength - (cycleLength - 14) - 1) / cycleLength * 100) + '%' }">
-            {{ t('ovulation.phaseLuteal') }}
-          </div>
-        </div>
-        <div class="mt-2 text-sm text-stone-500">
-          {{ t('ovulation.currentPhaseLabel') }}:
-          <span class="font-semibold text-stone-700">{{ t('ovulation.phase_' + currentPhase) }}</span>
-        </div>
+      <div class="mt-2 text-sm text-stone-500">
+        {{ t('ovulation.currentPhaseLabel') }}:
+        <span class="font-semibold text-stone-700">{{ t('ovulation.phase_' + currentPhase) }}</span>
       </div>
+    </div>
 
-      <!-- Next 3 predicted cycles -->
-      <div>
-        <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('ovulation.nextCycles') }}</h2>
-        <div class="space-y-3">
-          <div
-            v-for="(cycle, i) in nextCycles"
-            :key="i"
-            data-testid="next-cycle"
-            class="flex items-center gap-4 rounded-lg border border-stone-200 px-4 py-3"
-          >
-            <span class="w-3 h-3 rounded-full shrink-0 bg-stone-300"></span>
-            <span class="text-sm font-semibold text-stone-700 w-20">{{ t('ovulation.cycleN', { n: i + 2 }) }}</span>
-            <span class="text-sm text-stone-600 flex-1">{{ t('ovulation.periodLabel') }}: {{ formatDate(cycle.periodStart) }}</span>
-            <span class="text-sm text-stone-600">{{ t('ovulation.ovulationLabel') }}: {{ formatDate(cycle.ovulationDate) }}</span>
-          </div>
+    <!-- Next 3 predicted cycles -->
+    <div>
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('ovulation.nextCycles') }}</h2>
+      <div class="space-y-3">
+        <div
+          v-for="(cycle, i) in nextCycles"
+          :key="i"
+          data-testid="next-cycle"
+          class="flex items-center gap-4 rounded-lg border border-stone-200 px-4 py-3"
+        >
+          <span class="w-3 h-3 rounded-full shrink-0 bg-stone-300"></span>
+          <span class="text-sm font-semibold text-stone-700 w-20">{{ t('ovulation.cycleN', { n: i + 2 }) }}</span>
+          <span class="text-sm text-stone-600 flex-1">{{ t('ovulation.periodLabel') }}: {{ formatDate(cycle.periodStart) }}</span>
+          <span class="text-sm text-stone-600">{{ t('ovulation.ovulationLabel') }}: {{ formatDate(cycle.ovulationDate) }}</span>
         </div>
       </div>
     </div>

--- a/src/pages/PregnancyCalculator.vue
+++ b/src/pages/PregnancyCalculator.vue
@@ -110,50 +110,53 @@ const hasResults = computed(() => !!lmpDate.value)
       </div>
     </div>
 
-    <div v-if="hasResults">
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-6">
-        <div class="rounded-xl border border-stone-200 p-5 text-center">
-          <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.dueDate') }}</div>
-          <div class="text-xl font-bold text-stone-900" data-testid="due-date">{{ formatDate(dueDate) }}</div>
-        </div>
-        <div class="rounded-xl border border-stone-200 p-5 text-center">
-          <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.gestationalAge') }}</div>
-          <div class="text-xl font-bold text-stone-900" data-testid="gestational-age">{{ t('pregnancy.weeksAndDays', { weeks: gestationalWeeks, days: gestationalRemainderDays }) }}</div>
-        </div>
-        <div class="rounded-xl border border-stone-200 p-5 text-center">
-          <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.trimester') }}</div>
-          <div class="text-xl font-bold text-stone-900" data-testid="trimester">{{ trimester }}</div>
-        </div>
-        <div class="rounded-xl border border-stone-200 p-5 text-center">
-          <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.conceptionDate') }}</div>
-          <div class="text-xl font-bold text-stone-900" data-testid="conception-date">{{ formatDate(conceptionDate) }}</div>
-        </div>
-      </div>
+  </div>
 
-      <div class="mb-6">
-        <div class="flex justify-between text-xs text-stone-400 mb-1">
-          <span>{{ t('pregnancy.complete', { pct: progressPercent }) }}</span>
-          <span>{{ t('pregnancy.daysLeft', { n: daysUntilDue }) }}</span>
-        </div>
-        <div class="w-full bg-stone-100 rounded-full h-3" data-testid="progress-bar">
-          <div role="progressbar" class="bg-stone-700 h-3 rounded-full transition-all duration-300" :style="{ width: progressPercent + '%' }"></div>
-        </div>
-      </div>
+  <AffiliateBanner class="my-6" />
 
-      <div>
-        <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('pregnancy.milestones') }}</h2>
-        <div class="space-y-3">
-          <div
-            v-for="m in milestones"
-            :key="m.week"
-            data-testid="milestone"
-            :class="['flex items-center gap-4 rounded-lg border px-4 py-3 transition-colors', m.date <= today ? 'passed border-stone-400 bg-stone-50' : 'border-stone-200']"
-          >
-            <span :class="['w-3 h-3 rounded-full shrink-0', m.date <= today ? 'bg-stone-700' : 'bg-stone-300']"></span>
-            <span class="text-sm font-semibold text-stone-700 w-16">{{ t('pregnancy.week', { n: m.week }) }}</span>
-            <span class="text-sm text-stone-600 flex-1">{{ t(m.labelKey) }}</span>
-            <span class="text-xs text-stone-400">{{ formatDate(m.date) }}</span>
-          </div>
+  <div v-if="hasResults" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-6">
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.dueDate') }}</div>
+        <div class="text-xl font-bold text-stone-900" data-testid="due-date">{{ formatDate(dueDate) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.gestationalAge') }}</div>
+        <div class="text-xl font-bold text-stone-900" data-testid="gestational-age">{{ t('pregnancy.weeksAndDays', { weeks: gestationalWeeks, days: gestationalRemainderDays }) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.trimester') }}</div>
+        <div class="text-xl font-bold text-stone-900" data-testid="trimester">{{ trimester }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('pregnancy.conceptionDate') }}</div>
+        <div class="text-xl font-bold text-stone-900" data-testid="conception-date">{{ formatDate(conceptionDate) }}</div>
+      </div>
+    </div>
+
+    <div class="mb-6">
+      <div class="flex justify-between text-xs text-stone-400 mb-1">
+        <span>{{ t('pregnancy.complete', { pct: progressPercent }) }}</span>
+        <span>{{ t('pregnancy.daysLeft', { n: daysUntilDue }) }}</span>
+      </div>
+      <div class="w-full bg-stone-100 rounded-full h-3" data-testid="progress-bar">
+        <div role="progressbar" class="bg-stone-700 h-3 rounded-full transition-all duration-300" :style="{ width: progressPercent + '%' }"></div>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('pregnancy.milestones') }}</h2>
+      <div class="space-y-3">
+        <div
+          v-for="m in milestones"
+          :key="m.week"
+          data-testid="milestone"
+          :class="['flex items-center gap-4 rounded-lg border px-4 py-3 transition-colors', m.date <= today ? 'passed border-stone-400 bg-stone-50' : 'border-stone-200']"
+        >
+          <span :class="['w-3 h-3 rounded-full shrink-0', m.date <= today ? 'bg-stone-700' : 'bg-stone-300']"></span>
+          <span class="text-sm font-semibold text-stone-700 w-16">{{ t('pregnancy.week', { n: m.week }) }}</span>
+          <span class="text-sm text-stone-600 flex-1">{{ t(m.labelKey) }}</span>
+          <span class="text-xs text-stone-400">{{ formatDate(m.date) }}</span>
         </div>
       </div>
     </div>

--- a/src/pages/ProteinCalculator.vue
+++ b/src/pages/ProteinCalculator.vue
@@ -222,62 +222,65 @@ const foodSources = computed(() => {
       </div>
     </div>
 
-    <div v-if="dailyProtein" class="pt-5 border-t border-stone-100">
-      <div class="mb-6">
-        <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('protein.dailyProtein') }}</p>
-        <span class="text-5xl font-bold text-stone-900 tabular-nums leading-none" data-testid="protein-total">{{ dailyProtein }}</span>
-        <span class="text-lg text-stone-400 ml-1">{{ t('protein.gramsPerDay') }}</span>
-      </div>
+  </div>
 
-      <div class="grid grid-cols-2 gap-4 mb-6">
-        <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
-          <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="protein-per-kg">{{ proteinPerKg.toFixed(1) }}</p>
-          <p class="text-xs text-stone-500 font-medium">{{ t('protein.perKg') }}</p>
-        </div>
-        <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
-          <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="protein-per-meal">{{ proteinPerMeal }}</p>
-          <p class="text-xs text-stone-500 font-medium">{{ t('protein.grams') }} {{ t('protein.perMeal') }}</p>
-        </div>
-      </div>
+  <AffiliateBanner class="my-6" />
 
-      <!-- Goal comparison chart -->
-      <div class="mb-6">
-        <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-3">{{ t('protein.goalComparison') }}</p>
-        <div class="space-y-3">
-          <div v-for="item in goalComparison" :key="item.key" class="flex items-center gap-3">
-            <span class="text-sm text-stone-600 w-28 shrink-0">{{ t(goalLabels[item.key]) }}</span>
-            <div class="flex-1 bg-stone-100 rounded-full overflow-hidden" style="height: 24px">
-              <div
-                :class="goalColors[item.key]"
-                class="h-full rounded-full flex items-center justify-end pr-2 transition-all duration-300"
-                :style="{ width: (item.grams / maxGoalGrams * 100) + '%' }"
-              >
-                <span class="text-xs font-bold text-white">{{ item.grams }} g</span>
-              </div>
+  <div v-if="dailyProtein" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="mb-6">
+      <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('protein.dailyProtein') }}</p>
+      <span class="text-5xl font-bold text-stone-900 tabular-nums leading-none" data-testid="protein-total">{{ dailyProtein }}</span>
+      <span class="text-lg text-stone-400 ml-1">{{ t('protein.gramsPerDay') }}</span>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="protein-per-kg">{{ proteinPerKg.toFixed(1) }}</p>
+        <p class="text-xs text-stone-500 font-medium">{{ t('protein.perKg') }}</p>
+      </div>
+      <div class="bg-white rounded-xl border border-stone-200 shadow-sm p-4 text-center">
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="protein-per-meal">{{ proteinPerMeal }}</p>
+        <p class="text-xs text-stone-500 font-medium">{{ t('protein.grams') }} {{ t('protein.perMeal') }}</p>
+      </div>
+    </div>
+
+    <!-- Goal comparison chart -->
+    <div class="mb-6">
+      <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-3">{{ t('protein.goalComparison') }}</p>
+      <div class="space-y-3">
+        <div v-for="item in goalComparison" :key="item.key" class="flex items-center gap-3">
+          <span class="text-sm text-stone-600 w-28 shrink-0">{{ t(goalLabels[item.key]) }}</span>
+          <div class="flex-1 bg-stone-100 rounded-full overflow-hidden" style="height: 24px">
+            <div
+              :class="goalColors[item.key]"
+              class="h-full rounded-full flex items-center justify-end pr-2 transition-all duration-300"
+              :style="{ width: (item.grams / maxGoalGrams * 100) + '%' }"
+            >
+              <span class="text-xs font-bold text-white">{{ item.grams }} g</span>
             </div>
           </div>
         </div>
       </div>
+    </div>
 
-      <!-- Food sources table -->
-      <div data-testid="food-sources">
-        <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-3">{{ t('protein.foodSources') }}</p>
-        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="bg-stone-50 border-b border-stone-200">
-                <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('protein.food') }}</th>
-                <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('protein.proteinPer100g') }}</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-stone-100">
-              <tr v-for="food in foodSources" :key="food.name">
-                <td class="px-6 py-3 text-stone-600">{{ food.name }}</td>
-                <td class="px-6 py-3 text-stone-900 font-medium">{{ food.protein }} g</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+    <!-- Food sources table -->
+    <div data-testid="food-sources">
+      <p class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-3">{{ t('protein.foodSources') }}</p>
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="bg-stone-50 border-b border-stone-200">
+              <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('protein.food') }}</th>
+              <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('protein.proteinPer100g') }}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-stone-100">
+            <tr v-for="food in foodSources" :key="food.name">
+              <td class="px-6 py-3 text-stone-600">{{ food.name }}</td>
+              <td class="px-6 py-3 text-stone-900 font-medium">{{ food.protein }} g</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/src/pages/SleepCycleCalculator.vue
+++ b/src/pages/SleepCycleCalculator.vue
@@ -102,25 +102,28 @@ const options = computed(() => {
       />
     </div>
 
-    <div v-if="options.length" class="grid gap-4 sm:grid-cols-3">
-      <div
-        v-for="opt in options"
-        :key="opt.cycles"
-        data-testid="cycle-option"
-        :class="[
-          'rounded-xl border p-5 text-center',
-          opt.recommended
-            ? 'border-green-600 bg-green-50'
-            : 'border-stone-200'
-        ]"
-      >
-        <span
-          v-if="opt.recommended"
-          class="inline-block text-xs font-semibold text-green-700 bg-green-100 rounded-full px-2.5 py-0.5 mb-2"
-        >{{ t('sleep.recommended') }}</span>
-        <div class="text-3xl font-bold text-stone-900 tabular-nums mb-1">{{ opt.time }}</div>
-        <div class="text-sm text-stone-500">{{ t('sleep.cycles', { n: opt.cycles }) }} &middot; {{ opt.duration }}</div>
-      </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="options.length" class="grid gap-4 sm:grid-cols-3 mb-6">
+    <div
+      v-for="opt in options"
+      :key="opt.cycles"
+      data-testid="cycle-option"
+      :class="[
+        'rounded-xl border p-5 text-center bg-white shadow-sm',
+        opt.recommended
+          ? 'border-green-600 bg-green-50'
+          : 'border-stone-200'
+      ]"
+    >
+      <span
+        v-if="opt.recommended"
+        class="inline-block text-xs font-semibold text-green-700 bg-green-100 rounded-full px-2.5 py-0.5 mb-2"
+      >{{ t('sleep.recommended') }}</span>
+      <div class="text-3xl font-bold text-stone-900 tabular-nums mb-1">{{ opt.time }}</div>
+      <div class="text-sm text-stone-500">{{ t('sleep.cycles', { n: opt.cycles }) }} &middot; {{ opt.duration }}</div>
     </div>
   </div>
 

--- a/src/pages/TdeeCalculator.vue
+++ b/src/pages/TdeeCalculator.vue
@@ -129,7 +129,12 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
       </select>
     </div>
 
-    <div v-if="tdee" class="text-center py-6 border-t border-stone-100">
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="tdee" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="text-center py-6">
       <div class="text-5xl font-bold text-stone-900 tabular-nums" data-testid="tdee-result">{{ formatNumber(tdee) }}</div>
       <div class="text-sm text-stone-500 mt-1">{{ t('common.kcalPerDay') }}</div>
       <div class="text-sm text-stone-400 mt-3" data-testid="bmr-result">{{ t('tdee.bmr', { value: formatNumber(bmr) }) }}</div>

--- a/src/pages/WaistHipRatioCalculator.vue
+++ b/src/pages/WaistHipRatioCalculator.vue
@@ -112,29 +112,32 @@ const recColors = { low: 'text-green-600', moderate: 'text-yellow-600', high: 't
       </div>
     </div>
 
-    <div v-if="whr" class="pt-5 border-t border-stone-100">
-      <div class="flex items-baseline gap-3 mb-4">
-        <span data-testid="whr-result" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ whrFormatted }}</span>
-        <span v-if="category" :class="category.color" data-testid="whr-category" class="text-lg font-semibold">{{ t(categoryLabels[category.key]) }}</span>
-      </div>
+  </div>
 
-      <div class="relative h-2.5 bg-stone-200 rounded-full overflow-hidden mb-1.5">
-        <div class="absolute inset-0 flex">
-          <div class="flex-1 bg-green-600"></div>
-          <div class="flex-1 bg-yellow-500"></div>
-          <div class="flex-1 bg-red-500"></div>
-        </div>
-        <div class="absolute top-0 w-1 h-full bg-stone-900 rounded-full transform" :style="{ left: barPosition + '%' }"></div>
-      </div>
-      <div class="flex text-[10px] text-stone-400 tabular-nums">
-        <div class="flex-1">0.50</div>
-        <div class="flex-1 text-center">0.80</div>
-        <div class="flex-1 text-right">1.20</div>
-      </div>
+  <AffiliateBanner class="my-6" />
 
-      <div class="bg-stone-50 rounded-lg p-4 mt-5">
-        <p v-if="category" class="text-sm text-stone-600 leading-relaxed" v-html="t(recKeys[category.key], { start: `<strong class='${recColors[category.key]}'>`, end: '</strong>' })"></p>
+  <div v-if="whr" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-4">
+      <span data-testid="whr-result" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ whrFormatted }}</span>
+      <span v-if="category" :class="category.color" data-testid="whr-category" class="text-lg font-semibold">{{ t(categoryLabels[category.key]) }}</span>
+    </div>
+
+    <div class="relative h-2.5 bg-stone-200 rounded-full overflow-hidden mb-1.5">
+      <div class="absolute inset-0 flex">
+        <div class="flex-1 bg-green-600"></div>
+        <div class="flex-1 bg-yellow-500"></div>
+        <div class="flex-1 bg-red-500"></div>
       </div>
+      <div class="absolute top-0 w-1 h-full bg-stone-900 rounded-full transform" :style="{ left: barPosition + '%' }"></div>
+    </div>
+    <div class="flex text-[10px] text-stone-400 tabular-nums">
+      <div class="flex-1">0.50</div>
+      <div class="flex-1 text-center">0.80</div>
+      <div class="flex-1 text-right">1.20</div>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 mt-5">
+      <p v-if="category" class="text-sm text-stone-600 leading-relaxed" v-html="t(recKeys[category.key], { start: `<strong class='${recColors[category.key]}'>`, end: '</strong>' })"></p>
     </div>
   </div>
 

--- a/src/pages/WaterIntakeCalculator.vue
+++ b/src/pages/WaterIntakeCalculator.vue
@@ -119,27 +119,30 @@ const glassRatio = computed(() => {
       </div>
     </div>
 
-    <div v-if="liters" class="pt-5 border-t border-stone-100">
-      <div class="flex items-baseline gap-3 mb-1">
-        <span data-testid="liters" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ litersFormatted }}</span>
-        <span class="text-lg text-stone-500">{{ t('water.litersPerDay') }}</span>
-      </div>
-      <div class="flex items-baseline gap-4 mb-5">
-        <span class="text-lg text-stone-500"><span data-testid="glasses">{{ glasses }}</span> {{ t('water.glasses') }}</span>
-        <span v-if="unit === 'imperial'" class="text-lg text-stone-500"><span data-testid="oz">{{ oz }}</span> {{ t('water.oz') }}</span>
-      </div>
+  </div>
 
-      <div class="flex gap-2 mb-5">
-        <div
-          v-for="i in 8"
-          :key="i"
-          class="w-8 h-10 rounded-md transition-colors duration-300"
-          :class="i <= filledCount ? 'bg-blue-400' : 'bg-stone-200'"
-        ></div>
-      </div>
+  <AffiliateBanner class="my-6" />
 
-      <p class="text-sm text-stone-400">{{ t('water.tip') }}</p>
+  <div v-if="liters" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-1">
+      <span data-testid="liters" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ litersFormatted }}</span>
+      <span class="text-lg text-stone-500">{{ t('water.litersPerDay') }}</span>
     </div>
+    <div class="flex items-baseline gap-4 mb-5">
+      <span class="text-lg text-stone-500"><span data-testid="glasses">{{ glasses }}</span> {{ t('water.glasses') }}</span>
+      <span v-if="unit === 'imperial'" class="text-lg text-stone-500"><span data-testid="oz">{{ oz }}</span> {{ t('water.oz') }}</span>
+    </div>
+
+    <div class="flex gap-2 mb-5">
+      <div
+        v-for="i in 8"
+        :key="i"
+        class="w-8 h-10 rounded-md transition-colors duration-300"
+        :class="i <= filledCount ? 'bg-blue-400' : 'bg-stone-200'"
+      ></div>
+    </div>
+
+    <p class="text-sm text-stone-400">{{ t('water.tip') }}</p>
   </div>
 
 


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-affiliate-all-calculators
**Agent:** claude
**Branch:** `agent/hc-affiliate-all-calculators-20260402-065524`

### Prompt
> TASK: Add AffiliateBanner to all calculator pages and restructure layout.

CONTEXT: HC calculators currently have input fields and results display in ONE card.
Jens wants the layout to match FC (finanzkalkulatoren): affiliate between calculator inputs
and results display.

CURRENT LAYOUT (most calculators):
1. Back link + Title + Description
2. Single card: input fields + results display (both in one card)
3. Info/reference card
4. BlogBanner
5. AdSlot

DESIRED LAYOUT:
1. Back link + Title + Description
2. Input section card (inputs only)
3. AffiliateBanner (between input and results)
4. Results section card (results display, conditional on calculation being done)
5. Info/reference card (if exists)
6. BlogBanner
7. AdSlot

The AffiliateBanner import already exists in all 15 calculator files.
Only BmiCalculator.vue and BloodPressureCalculator.vue currently render it in template.

CALCULATORS TO UPDATE (13 files in src/pages/):
- BodyFatCalculator.vue
- BmrCalculator.vue
- CalorieDeficitCalculator.vue
- HeartRateZones.vue
- IdealWeightCalculator.vue
- MacroCalculator.vue
- OvulationCalculator.vue
- PregnancyCalculator.vue
- ProteinCalculator.vue
- SleepCycleCalculator.vue
- TdeeCalculator.vue
- WaistHipRatioCalculator.vue
- WaterIntakeCalculator.vue

ALSO UPDATE BmiCalculator.vue and BloodPressureCalculator.vue to match the new layout
(split input+results into separate cards with AffiliateBanner between them).

IMPORTANT: The AffiliateBanner component (src/components/AffiliateBanner.vue) now hides
itself when the URL is '#'. All current HC affiliate URLs are '#', so the banner won't
be visible yet. But the HTML structure must be correct for when real programs are added.

Branch to work from: main (NOT feature/ads-affiliate-adsense — that branch has
the AffiliateBanner.vue fix which should be merged first, or cherry-pick commit c3baeae).

DO NOT modify or delete:
- src/components/AffiliateBanner.vue (already updated)
- src/components/AdSlot.vue
- src/ads/config.js
- src/pages/Home.vue, BlogHome.vue, BlogHomeEn.vue
- Any blog files
- public/sitemap.xml
- Any files not listed above

TESTS: Write tests verifying AffiliateBanner appears between input and results sections
in DOM order for at least 3 calculators. Run all existing tests.