### PR TITLE
fix: SSG pages now render unique meta tags (#91)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "temp-app",
       "version": "0.0.0",
       "dependencies": {
+        "@unhead/vue": "^2.1.13",
         "playwright": "^1.58.2",
         "vue": "^3.5.30",
         "vue-i18n": "^11.3.0",
@@ -1084,20 +1085,31 @@
       }
     },
     "node_modules/@unhead/vue": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.12.tgz",
-      "integrity": "sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==",
-      "dev": true,
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.13.tgz",
+      "integrity": "sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1",
-        "unhead": "2.1.12"
+        "unhead": "2.1.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
       },
       "peerDependencies": {
         "vue": ">=3.5.18"
+      }
+    },
+    "node_modules/@unhead/vue/node_modules/unhead": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.13.tgz",
+      "integrity": "sha512-jO9M1sI6b2h/1KpIu4Jeu+ptumLmUKboRRLxys5pYHFeT+lqTzfNHbYUX9bxVDhC1FBszAGuWcUVlmvIPsah8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1656,7 +1668,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
       "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
@@ -2595,6 +2606,7 @@
       "integrity": "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookable": "^6.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@unhead/vue": "^2.1.13",
     "playwright": "^1.58.2",
     "vue": "^3.5.30",
     "vue-i18n": "^11.3.0",

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,0 +1,2 @@
+import { vi } from 'vitest'
+vi.mock('@unhead/vue', () => ({ useHead: vi.fn() }))

--- a/src/__tests__/useHead.test.js
+++ b/src/__tests__/useHead.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock('@unhead/vue', () => ({ useHead: vi.fn() }))
+
+const mockRoute = { path: '/de/bmi-rechner', meta: { slug: 'bmi' } }
+vi.mock('vue-router', () => ({ useRoute: () => mockRoute }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ locale: ref('de') }) }))
+vi.mock('../composables/useLocaleRouter.js', () => ({
+  localePath: (key, locale) => `/${locale}/${key === 'bmi' ? (locale === 'de' ? 'bmi-rechner' : 'bmi-calculator') : key}`,
+  routeMap: { bmi: { de: 'bmi-rechner', en: 'bmi-calculator' } },
+}))
+
+import { useHead as useUnhead } from '@unhead/vue'
+import { useHead } from '../composables/useHead.js'
+
+describe('useHead', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls @unhead/vue useHead with correct structure', () => {
+    useHead(() => ({
+      title: 'BMI Rechner',
+      description: 'Berechne deinen BMI',
+      routeKey: 'bmi',
+    }))
+
+    expect(useUnhead).toHaveBeenCalledTimes(1)
+    const arg = useUnhead.mock.calls[0][0]
+    // arg is a computed ref
+    const head = arg.value
+
+    expect(head.title).toBe('BMI Rechner')
+    expect(head.meta).toEqual(expect.arrayContaining([
+      { name: 'description', content: 'Berechne deinen BMI' },
+      { property: 'og:title', content: 'BMI Rechner' },
+      { property: 'og:description', content: 'Berechne deinen BMI' },
+      { name: 'twitter:title', content: 'BMI Rechner' },
+      { name: 'twitter:description', content: 'Berechne deinen BMI' },
+    ]))
+    expect(head.link).toEqual(expect.arrayContaining([
+      { rel: 'canonical', href: 'https://healthcalculator.app/de/bmi-rechner' },
+      { rel: 'alternate', hreflang: 'de', href: 'https://healthcalculator.app/de/bmi-rechner' },
+      { rel: 'alternate', hreflang: 'en', href: 'https://healthcalculator.app/en/bmi-calculator' },
+    ]))
+  })
+
+  it('accepts a plain object instead of a function', () => {
+    useHead({
+      title: 'Test',
+      description: 'Desc',
+      routeKey: 'bmi',
+    })
+
+    const head = useUnhead.mock.calls[0][0].value
+    expect(head.title).toBe('Test')
+  })
+
+  it('includes jsonLd as script when provided', () => {
+    const jsonLd = { '@type': 'WebPage', name: 'BMI' }
+    useHead(() => ({
+      title: 'BMI',
+      description: 'BMI',
+      routeKey: 'bmi',
+      jsonLd,
+    }))
+
+    const head = useUnhead.mock.calls[0][0].value
+    expect(head.script).toEqual([
+      { type: 'application/ld+json', innerHTML: JSON.stringify(jsonLd) },
+    ])
+  })
+
+  it('omits script when jsonLd is not provided', () => {
+    useHead(() => ({
+      title: 'BMI',
+      description: 'BMI',
+      routeKey: 'bmi',
+    }))
+
+    const head = useUnhead.mock.calls[0][0].value
+    expect(head.script).toBeUndefined()
+  })
+
+  it('sets og:url from routeKey and locale', () => {
+    useHead(() => ({
+      title: 'BMI',
+      description: 'BMI',
+      routeKey: 'bmi',
+    }))
+
+    const head = useUnhead.mock.calls[0][0].value
+    const ogUrl = head.meta.find(m => m.property === 'og:url')
+    expect(ogUrl.content).toBe('https://healthcalculator.app/de/bmi-rechner')
+  })
+})

--- a/src/composables/useHead.js
+++ b/src/composables/useHead.js
@@ -1,74 +1,17 @@
-import { watchEffect, onUnmounted } from 'vue'
+import { computed } from 'vue'
+import { useHead as useUnhead } from '@unhead/vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { localePath as resolveLocalePath, routeMap } from './useLocaleRouter.js'
 
 const BASE_URL = 'https://healthcalculator.app'
 
-function setMeta(attr, key, content) {
-  if (import.meta.env.SSR) return
-  let el = document.querySelector(`meta[${attr}="${key}"]`)
-  if (!el) {
-    el = document.createElement('meta')
-    el.setAttribute(attr, key)
-    document.head.appendChild(el)
-  }
-  el.setAttribute('content', content)
-}
-
-function setCanonical(url) {
-  if (import.meta.env.SSR) return
-  let el = document.querySelector('link[rel="canonical"]')
-  if (!el) {
-    el = document.createElement('link')
-    el.setAttribute('rel', 'canonical')
-    document.head.appendChild(el)
-  }
-  el.setAttribute('href', url)
-}
-
-function setHreflang(lang, url) {
-  if (import.meta.env.SSR) return
-  let el = document.querySelector(`link[hreflang="${lang}"]`)
-  if (!el) {
-    el = document.createElement('link')
-    el.setAttribute('rel', 'alternate')
-    el.setAttribute('hreflang', lang)
-    document.head.appendChild(el)
-  }
-  el.setAttribute('href', url)
-}
-
-function removeHreflang() {
-  if (import.meta.env.SSR) return
-  document.querySelectorAll('link[hreflang]').forEach(el => el.remove())
-}
-
-function setJsonLd(data) {
-  if (import.meta.env.SSR) return
-  let el = document.querySelector('script[data-head="jsonld"]')
-  if (!el) {
-    el = document.createElement('script')
-    el.setAttribute('type', 'application/ld+json')
-    el.setAttribute('data-head', 'jsonld')
-    document.head.appendChild(el)
-  }
-  el.textContent = JSON.stringify(data)
-}
-
-function removeJsonLd() {
-  if (import.meta.env.SSR) return
-  const el = document.querySelector('script[data-head="jsonld"]')
-  if (el) el.remove()
-}
-
 export function useHead(getConfig) {
   const resolve = typeof getConfig === 'function' ? getConfig : () => getConfig
-  const prevTitle = import.meta.env.SSR ? '' : document.title
   const route = useRoute()
   const { locale } = useI18n()
 
-  watchEffect(() => {
+  const headData = computed(() => {
     const { title, description, routeKey, jsonLd } = resolve()
     const currentLocale = locale.value
     const otherLocale = currentLocale === 'de' ? 'en' : 'de'
@@ -88,30 +31,31 @@ export function useHead(getConfig) {
 
     const url = `${BASE_URL}${currentPath}`
 
-    if (!import.meta.env.SSR) {
-      document.title = title
+    const head = {
+      title,
+      meta: [
+        { name: 'description', content: description },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: description },
+        { property: 'og:url', content: url },
+        { name: 'twitter:title', content: title },
+        { name: 'twitter:description', content: description },
+      ],
+      link: [
+        { rel: 'canonical', href: url },
+        { rel: 'alternate', hreflang: currentLocale, href: `${BASE_URL}${currentPath}` },
+        { rel: 'alternate', hreflang: otherLocale, href: `${BASE_URL}${otherPath}` },
+      ],
     }
-    setMeta('name', 'description', description)
-    setMeta('property', 'og:title', title)
-    setMeta('property', 'og:description', description)
-    setMeta('property', 'og:url', url)
-    setMeta('name', 'twitter:title', title)
-    setMeta('name', 'twitter:description', description)
-    setCanonical(url)
-
-    setHreflang(currentLocale, `${BASE_URL}${currentPath}`)
-    setHreflang(otherLocale, `${BASE_URL}${otherPath}`)
 
     if (jsonLd) {
-      setJsonLd(jsonLd)
+      head.script = [
+        { type: 'application/ld+json', innerHTML: JSON.stringify(jsonLd) },
+      ]
     }
+
+    return head
   })
 
-  onUnmounted(() => {
-    if (!import.meta.env.SSR) {
-      document.title = prevTitle
-    }
-    removeJsonLd()
-    removeHreflang()
-  })
+  useUnhead(headData)
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,9 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   base: '/',
   plugins: [vue(), tailwindcss()],
+  test: {
+    setupFiles: ['./src/__tests__/setup.js'],
+  },
   ssgOptions: {
     dirStyle: 'nested',
     script: 'async',


### PR DESCRIPTION
## Summary
- Replaced manual DOM manipulation in `src/composables/useHead.js` with `@unhead/vue`'s `useHead()` — removes all `if (import.meta.env.SSR) return` guards that prevented meta tags from rendering during SSG
- Each static HTML page now has unique `<title>`, description, og:*, twitter:*, canonical, hreflang, and JSON-LD tags
- Added unit tests for the rewritten composable

## Test plan
- [x] `npx vitest run` — all 334 tests pass
- [x] `npm run build` — verified unique `<title>` tags across SSG pages (de/en BMI, water, index)
- [x] Verified meta tags (description, og:title, og:description, og:url, twitter:*, canonical, hreflang) in built HTML

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)