### PR TITLE
hc-94-lean-body-mass: Implement GitHub issue #94: Lean Body Mass Calculator + Blog

### DIFF
--- a/e2e/lean-body-mass.spec.js
+++ b/e2e/lean-body-mass.spec.js
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/magermasse-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Magermasse/)
+})
+
+test('male is selected by default', async ({ page }) => {
+  const maleBtn = page.getByRole('button', { name: 'Mann', exact: true })
+  await expect(maleBtn).toHaveClass(/bg-stone-900/)
+})
+
+test('metric and imperial unit switching works', async ({ page }) => {
+  await page.getByRole('button', { name: 'Imperial' }).click()
+  const weightLabel = page.getByLabel(/Gewicht/i)
+  await expect(weightLabel).toBeVisible()
+})
+
+test('male 80kg, 180cm → LBM ~60 kg', async ({ page }) => {
+  await page.getByRole('button', { name: 'Mann', exact: true }).click()
+  await page.getByRole('button', { name: 'Metrisch' }).click()
+  await page.getByLabel(/Gewicht/i).fill('80')
+  await page.getByLabel(/Größe/i).fill('180')
+
+  const result = page.getByTestId('lbm-result')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const lbm = parseFloat(text)
+  expect(lbm).toBeGreaterThanOrEqual(55)
+  expect(lbm).toBeLessThanOrEqual(66)
+})
+
+test('female 60kg, 165cm → LBM ~44 kg', async ({ page }) => {
+  await page.getByRole('button', { name: 'Frau' }).click()
+  await page.getByRole('button', { name: 'Metrisch' }).click()
+  await page.getByLabel(/Gewicht/i).fill('60')
+  await page.getByLabel(/Größe/i).fill('165')
+
+  const result = page.getByTestId('lbm-result')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const lbm = parseFloat(text)
+  expect(lbm).toBeGreaterThanOrEqual(40)
+  expect(lbm).toBeLessThanOrEqual(48)
+})
+
+test('formula comparison table shows three results', async ({ page }) => {
+  await page.getByRole('button', { name: 'Mann', exact: true }).click()
+  await page.getByLabel(/Gewicht/i).fill('80')
+  await page.getByLabel(/Größe/i).fill('180')
+
+  await expect(page.getByTestId('boer-result')).toBeVisible()
+  await expect(page.getByTestId('james-result')).toBeVisible()
+  await expect(page.getByTestId('hume-result')).toBeVisible()
+})
+
+test('fat mass and lean percentage are shown', async ({ page }) => {
+  await page.getByRole('button', { name: 'Mann', exact: true }).click()
+  await page.getByLabel(/Gewicht/i).fill('80')
+  await page.getByLabel(/Größe/i).fill('180')
+
+  await expect(page.getByTestId('fat-mass')).toBeVisible()
+  await expect(page.getByTestId('lean-percent')).toBeVisible()
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/lean-body-mass.test.js
+++ b/src/__tests__/lean-body-mass.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+
+// Pure calculation functions — extracted from LeanBodyMassCalculator.vue to be testable
+
+function calcLBMBoer(weightKg, heightCm, gender) {
+  if (gender === 'male') return 0.407 * weightKg + 0.267 * heightCm - 19.2
+  return 0.252 * weightKg + 0.473 * heightCm - 48.3
+}
+
+function calcLBMJames(weightKg, heightCm, gender) {
+  if (gender === 'male') return 1.1 * weightKg - 128 * Math.pow(weightKg / heightCm, 2)
+  return 1.07 * weightKg - 148 * Math.pow(weightKg / heightCm, 2)
+}
+
+function calcLBMHume(weightKg, heightCm, gender) {
+  if (gender === 'male') return 0.3281 * weightKg + 0.33929 * heightCm - 29.5336
+  return 0.29569 * weightKg + 0.41813 * heightCm - 43.2933
+}
+
+function calcLBMAverage(weightKg, heightCm, gender) {
+  const boer = calcLBMBoer(weightKg, heightCm, gender)
+  const james = calcLBMJames(weightKg, heightCm, gender)
+  const hume = calcLBMHume(weightKg, heightCm, gender)
+  return (boer + james + hume) / 3
+}
+
+function toKg(lbs) {
+  return lbs * 0.453592
+}
+
+function toCm(inches) {
+  return inches * 2.54
+}
+
+describe('Boer formula — male', () => {
+  it('80kg, 180cm → ~61.4 kg LBM', () => {
+    const lbm = calcLBMBoer(80, 180, 'male')
+    expect(lbm).toBeCloseTo(61.42, 1)
+  })
+
+  it('70kg, 175cm → ~57.7 kg LBM', () => {
+    const lbm = calcLBMBoer(70, 175, 'male')
+    expect(lbm).toBeGreaterThanOrEqual(55)
+    expect(lbm).toBeLessThanOrEqual(61)
+  })
+
+  it('100kg, 190cm → ~72.9 kg LBM', () => {
+    const lbm = calcLBMBoer(100, 190, 'male')
+    expect(lbm).toBeGreaterThanOrEqual(70)
+    expect(lbm).toBeLessThanOrEqual(76)
+  })
+})
+
+describe('Boer formula — female', () => {
+  it('60kg, 165cm → ~44.9 kg LBM', () => {
+    const lbm = calcLBMBoer(60, 165, 'female')
+    expect(lbm).toBeCloseTo(44.865, 1)
+  })
+
+  it('55kg, 160cm → ~40.9 kg LBM', () => {
+    const lbm = calcLBMBoer(55, 160, 'female')
+    expect(lbm).toBeGreaterThanOrEqual(38)
+    expect(lbm).toBeLessThanOrEqual(44)
+  })
+
+  it('75kg, 170cm → ~49.2 kg LBM', () => {
+    const lbm = calcLBMBoer(75, 170, 'female')
+    expect(lbm).toBeGreaterThanOrEqual(46)
+    expect(lbm).toBeLessThanOrEqual(53)
+  })
+})
+
+describe('James formula — male', () => {
+  it('80kg, 180cm → ~62.7 kg LBM', () => {
+    const lbm = calcLBMJames(80, 180, 'male')
+    expect(lbm).toBeCloseTo(62.716, 1)
+  })
+
+  it('70kg, 175cm → ~56.5 kg LBM', () => {
+    const lbm = calcLBMJames(70, 175, 'male')
+    expect(lbm).toBeGreaterThanOrEqual(54)
+    expect(lbm).toBeLessThanOrEqual(59)
+  })
+})
+
+describe('James formula — female', () => {
+  it('60kg, 165cm → ~44.6 kg LBM', () => {
+    const lbm = calcLBMJames(60, 165, 'female')
+    expect(lbm).toBeCloseTo(44.627, 1)
+  })
+
+  it('55kg, 160cm → ~41.3 kg LBM', () => {
+    const lbm = calcLBMJames(55, 160, 'female')
+    expect(lbm).toBeGreaterThanOrEqual(38)
+    expect(lbm).toBeLessThanOrEqual(44)
+  })
+})
+
+describe('Hume formula — male', () => {
+  it('80kg, 180cm → ~57.8 kg LBM', () => {
+    const lbm = calcLBMHume(80, 180, 'male')
+    expect(lbm).toBeCloseTo(57.787, 1)
+  })
+
+  it('70kg, 175cm → ~52.8 kg LBM', () => {
+    const lbm = calcLBMHume(70, 175, 'male')
+    expect(lbm).toBeGreaterThanOrEqual(50)
+    expect(lbm).toBeLessThanOrEqual(56)
+  })
+})
+
+describe('Hume formula — female', () => {
+  it('60kg, 165cm → ~43.4 kg LBM', () => {
+    const lbm = calcLBMHume(60, 165, 'female')
+    expect(lbm).toBeCloseTo(43.44, 1)
+  })
+
+  it('55kg, 160cm → ~40.0 kg LBM', () => {
+    const lbm = calcLBMHume(55, 160, 'female')
+    expect(lbm).toBeGreaterThanOrEqual(37)
+    expect(lbm).toBeLessThanOrEqual(43)
+  })
+})
+
+describe('Average of all three formulas', () => {
+  it('80kg male, 180cm → average ~60.6 kg', () => {
+    const avg = calcLBMAverage(80, 180, 'male')
+    expect(avg).toBeGreaterThanOrEqual(58)
+    expect(avg).toBeLessThanOrEqual(64)
+  })
+
+  it('60kg female, 165cm → average ~44.3 kg', () => {
+    const avg = calcLBMAverage(60, 165, 'female')
+    expect(avg).toBeGreaterThanOrEqual(42)
+    expect(avg).toBeLessThanOrEqual(47)
+  })
+
+  it('average is between min and max formula result', () => {
+    const w = 75
+    const h = 175
+    const g = 'male'
+    const boer = calcLBMBoer(w, h, g)
+    const james = calcLBMJames(w, h, g)
+    const hume = calcLBMHume(w, h, g)
+    const avg = calcLBMAverage(w, h, g)
+    expect(avg).toBeGreaterThanOrEqual(Math.min(boer, james, hume))
+    expect(avg).toBeLessThanOrEqual(Math.max(boer, james, hume))
+  })
+})
+
+describe('Imperial unit conversion', () => {
+  it('converts lbs to kg correctly', () => {
+    expect(toKg(1)).toBeCloseTo(0.4536, 3)
+    expect(toKg(176)).toBeCloseTo(79.83, 1)
+    expect(toKg(132)).toBeCloseTo(59.87, 1)
+  })
+
+  it('converts inches to cm correctly', () => {
+    expect(toCm(1)).toBeCloseTo(2.54, 2)
+    expect(toCm(70.87)).toBeCloseTo(180, 0)
+    expect(toCm(65)).toBeCloseTo(165.1, 0)
+  })
+
+  it('imperial inputs produce same result as metric equivalents', () => {
+    const metricLbm = calcLBMBoer(80, 180, 'male')
+    const imperialLbm = calcLBMBoer(toKg(176.37), toCm(70.87), 'male')
+    expect(Math.abs(metricLbm - imperialLbm)).toBeLessThan(1)
+  })
+})
+
+describe('Fat mass and lean mass percentage', () => {
+  it('80kg male with ~60.6kg LBM → ~19.4kg fat, ~75.8% lean', () => {
+    const weight = 80
+    const lbm = calcLBMAverage(80, 180, 'male')
+    const fatMass = weight - lbm
+    const leanPercent = (lbm / weight) * 100
+    expect(fatMass).toBeGreaterThanOrEqual(14)
+    expect(fatMass).toBeLessThanOrEqual(26)
+    expect(leanPercent).toBeGreaterThanOrEqual(70)
+    expect(leanPercent).toBeLessThanOrEqual(85)
+  })
+
+  it('60kg female with ~44.3kg LBM → ~15.7kg fat, ~73.8% lean', () => {
+    const weight = 60
+    const lbm = calcLBMAverage(60, 165, 'female')
+    const fatMass = weight - lbm
+    const leanPercent = (lbm / weight) * 100
+    expect(fatMass).toBeGreaterThanOrEqual(12)
+    expect(fatMass).toBeLessThanOrEqual(20)
+    expect(leanPercent).toBeGreaterThanOrEqual(68)
+    expect(leanPercent).toBeLessThanOrEqual(80)
+  })
+})

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -218,6 +218,15 @@ slug: 'period-calculator-guide',
     calculatorKey: 'caffeine',
     related: ['calculate-sleep-cycles', 'calculate-water-intake'],
   },
+  {
+    slug: 'calculate-lean-body-mass',
+    title: 'Lean Body Mass Calculator — What It Tells You About Your Fitness',
+    description: 'Calculate lean body mass using three scientific formulas: Boer, James and Hume. What LBM reveals about your fitness and why it matters more than body weight.',
+    date: '2026-04-08',
+    readTime: '7 min',
+    calculatorKey: 'leanBodyMass',
+    related: ['calculate-body-fat', 'calculate-bmi'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -218,6 +218,15 @@ slug: 'zyklusrechner-guide',
     calculatorKey: 'caffeine',
     related: ['schlafzyklen-berechnen', 'wasserbedarf-berechnen'],
   },
+  {
+    slug: 'magermasse-berechnen',
+    title: 'Fettfreie Körpermasse berechnen — was sie über deine Fitness verrät',
+    description: 'Fettfreie Körpermasse (Magermasse) berechnen mit drei wissenschaftlichen Formeln: Boer, James und Hume. Was LBM über deine Fitness verrät.',
+    date: '2026-04-08',
+    readTime: '7 min',
+    calculatorKey: 'leanBodyMass',
+    related: ['koerperfett-berechnen', 'bmi-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/leanBodyMass.json
+++ b/src/locales/calculators/de/leanBodyMass.json
@@ -1,0 +1,25 @@
+{
+  "home": {
+    "calculators": {
+      "leanBodyMass": {
+        "name": "Magermasse-Rechner",
+        "description": "Berechne deine fettfreie Körpermasse."
+      }
+    }
+  },
+  "leanBodyMass": {
+    "meta": {
+      "title": "Magermasse-Rechner — Boer, James & Hume Formeln",
+      "description": "Berechne deine fettfreie Körpermasse (Lean Body Mass) mit drei wissenschaftlichen Formeln: Boer, James und Hume."
+    },
+    "title": "Magermasse-Rechner",
+    "description": "Berechne deine fettfreie Körpermasse mit drei wissenschaftlichen Formeln.",
+    "fatMass": "Fettmasse",
+    "leanPercent": "Magermasse-Anteil",
+    "formulaComparison": "Formelvergleich",
+    "boer": "Boer",
+    "james": "James",
+    "hume": "Hume",
+    "average": "Durchschnitt"
+  }
+}

--- a/src/locales/calculators/en/leanBodyMass.json
+++ b/src/locales/calculators/en/leanBodyMass.json
@@ -1,0 +1,25 @@
+{
+  "home": {
+    "calculators": {
+      "leanBodyMass": {
+        "name": "Lean Body Mass Calculator",
+        "description": "Calculate your lean body mass."
+      }
+    }
+  },
+  "leanBodyMass": {
+    "meta": {
+      "title": "Lean Body Mass Calculator — Boer, James & Hume Formulas",
+      "description": "Calculate your lean body mass using three scientific formulas: Boer, James and Hume."
+    },
+    "title": "Lean Body Mass Calculator",
+    "description": "Calculate your lean body mass using three scientific formulas.",
+    "fatMass": "Fat Mass",
+    "leanPercent": "Lean Mass %",
+    "formulaComparison": "Formula Comparison",
+    "boer": "Boer",
+    "james": "James",
+    "hume": "Hume",
+    "average": "Average"
+  }
+}

--- a/src/pages/LeanBodyMassCalculator.vue
+++ b/src/pages/LeanBodyMassCalculator.vue
@@ -1,0 +1,175 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t } = useI18n()
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('leanBodyMass.meta.title'),
+  description: t('leanBodyMass.meta.description'),
+  routeKey: 'leanBodyMass',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Lean Body Mass Calculator',
+    url: 'https://healthcalculator.app/lean-body-mass',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const gender = ref('male')
+const unit = ref('metric')
+const weight = ref(null)
+const height = ref(null)
+
+const toKg = (val) => unit.value === 'imperial' ? val * 0.453592 : val
+const toCm = (val) => unit.value === 'imperial' ? val * 2.54 : val
+
+const lbmBoer = computed(() => {
+  if (!weight.value || !height.value) return null
+  const w = toKg(weight.value)
+  const h = toCm(height.value)
+  if (gender.value === 'male') return 0.407 * w + 0.267 * h - 19.2
+  return 0.252 * w + 0.473 * h - 48.3
+})
+
+const lbmJames = computed(() => {
+  if (!weight.value || !height.value) return null
+  const w = toKg(weight.value)
+  const h = toCm(height.value)
+  if (gender.value === 'male') return 1.1 * w - 128 * Math.pow(w / h, 2)
+  return 1.07 * w - 148 * Math.pow(w / h, 2)
+})
+
+const lbmHume = computed(() => {
+  if (!weight.value || !height.value) return null
+  const w = toKg(weight.value)
+  const h = toCm(height.value)
+  if (gender.value === 'male') return 0.3281 * w + 0.33929 * h - 29.5336
+  return 0.29569 * w + 0.41813 * h - 43.2933
+})
+
+const lbmAverage = computed(() => {
+  if (!lbmBoer.value || !lbmJames.value || !lbmHume.value) return null
+  return (lbmBoer.value + lbmJames.value + lbmHume.value) / 3
+})
+
+const fatMass = computed(() => {
+  if (!lbmAverage.value || !weight.value) return null
+  const w = toKg(weight.value)
+  return Math.max(0, w - lbmAverage.value)
+})
+
+const leanPercent = computed(() => {
+  if (!lbmAverage.value || !weight.value) return null
+  const w = toKg(weight.value)
+  return Math.min(100, (lbmAverage.value / w) * 100)
+})
+
+const massUnit = computed(() => 'kg')
+const weightLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'kg' : 'lbs')))
+const heightLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'cm' : 'inches')))
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('leanBodyMass.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('leanBodyMass.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="gender = 'male'"
+        :class="gender === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.male') }}</button>
+      <button
+        @click="gender = 'female'"
+        :class="gender === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.female') }}</button>
+    </div>
+
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="unit = 'metric'"
+        :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.metric') }}</button>
+      <button
+        @click="unit = 'imperial'"
+        :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.imperial') }}</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <label for="weight" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('common.weight', { unit: weightLabel }) }}
+        </label>
+        <input id="weight" v-model.number="weight" type="number" :placeholder="unit === 'metric' ? '80' : '176'"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label for="height" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('common.height', { unit: heightLabel }) }}
+        </label>
+        <input id="height" v-model.number="height" type="number" :placeholder="unit === 'metric' ? '180' : '71'"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="lbmAverage" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-6">
+      <span data-testid="lbm-result" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ lbmAverage.toFixed(1) }}</span>
+      <span class="text-2xl text-stone-400">{{ massUnit }}</span>
+      <span class="text-lg text-stone-500 font-medium">{{ t('leanBodyMass.average') }}</span>
+    </div>
+
+    <div class="grid grid-cols-3 gap-4 mb-6">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('leanBodyMass.fatMass') }}</div>
+        <div data-testid="fat-mass" class="text-2xl font-bold text-stone-900 tabular-nums">{{ fatMass.toFixed(1) }} <span class="text-sm text-stone-400">{{ massUnit }}</span></div>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('leanBodyMass.leanPercent') }}</div>
+        <div data-testid="lean-percent" class="text-2xl font-bold text-stone-900 tabular-nums">{{ leanPercent.toFixed(1) }} <span class="text-sm text-stone-400">%</span></div>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="text-sm font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('leanBodyMass.formulaComparison') }}</h2>
+      <div class="space-y-3">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3">
+          <span class="text-sm text-stone-600">{{ t('leanBodyMass.boer') }}</span>
+          <span data-testid="boer-result" class="text-sm font-semibold text-stone-900 tabular-nums">{{ lbmBoer.toFixed(1) }} {{ massUnit }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3">
+          <span class="text-sm text-stone-600">{{ t('leanBodyMass.james') }}</span>
+          <span data-testid="james-result" class="text-sm font-semibold text-stone-900 tabular-nums">{{ lbmJames.toFixed(1) }} {{ massUnit }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <span class="text-sm text-stone-600">{{ t('leanBodyMass.hume') }}</span>
+          <span data-testid="hume-result" class="text-sm font-semibold text-stone-900 tabular-nums">{{ lbmHume.toFixed(1) }} {{ massUnit }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <BlogBanner calculator-key="leanBodyMass" />
+</template>

--- a/src/pages/blog/MagermassBerechnen.vue
+++ b/src/pages/blog/MagermassBerechnen.vue
@@ -1,0 +1,158 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Fettfreie Körpermasse berechnen: Boer, James & Hume im Vergleich | Health Calculators',
+  description: 'Fettfreie Körpermasse (Magermasse) berechnen mit drei wissenschaftlichen Formeln. Was LBM über deine Fitness verrät und warum sie wichtiger ist als das Körpergewicht.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Fettfreie Körpermasse berechnen — was sie über deine Fitness verrät',
+    description: 'Fettfreie Körpermasse (Magermasse) berechnen mit drei wissenschaftlichen Formeln. Was LBM über deine Fitness verrät und warum sie wichtiger ist als das Körpergewicht.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-08',
+    dateModified: '2026-04-08',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/magermasse-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Fettfreie Körpermasse berechnen — was sie über deine Fitness verrät</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">8. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>fettfreie Körpermasse</strong> (Lean Body Mass, LBM) ist die Masse deines Körpers ohne Fett — also Muskeln, Knochen, Organe und Wasser. Sie ist eine der aussagekräftigsten Kennzahlen für Fitness und Gesundheit.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Anders als das Körpergewicht allein zeigt die LBM, wie viel „funktionale" Masse du trägst. Sportler mit hoher Muskelmasse haben eine hohe LBM, auch wenn ihr <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> erhöht erscheint.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die drei wissenschaftlichen Formeln</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Es gibt drei etablierte Formeln zur Berechnung der Magermasse — jede mit leicht unterschiedlichem Ansatz:
+        </p>
+
+        <div class="space-y-4 mb-6">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Boer-Formel (1984)</h3>
+            <p class="text-sm text-stone-600 mb-3">Basiert auf Gewicht und Körpergröße, einfach und weit verbreitet.</p>
+            <div class="bg-stone-50 rounded-lg p-3 font-mono text-sm text-stone-700">
+              <div>Männer: 0,407 × W + 0,267 × H − 19,2</div>
+              <div>Frauen: 0,252 × W + 0,473 × H − 48,3</div>
+            </div>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">James-Formel (1976)</h3>
+            <p class="text-sm text-stone-600 mb-3">Berücksichtigt das Verhältnis von Gewicht zu Körpergröße — reagiert stärker auf Übergewicht.</p>
+            <div class="bg-stone-50 rounded-lg p-3 font-mono text-sm text-stone-700">
+              <div>Männer: 1,1 × W − 128 × (W/H)²</div>
+              <div>Frauen: 1,07 × W − 148 × (W/H)²</div>
+            </div>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Hume-Formel (1966)</h3>
+            <p class="text-sm text-stone-600 mb-3">Eine der ältesten Formeln, abgeleitet aus Messungen an Leichen — konservativere Schätzungen.</p>
+            <div class="bg-stone-50 rounded-lg p-3 font-mono text-sm text-stone-700">
+              <div>Männer: 0,3281 × W + 0,33929 × H − 29,5336</div>
+              <div>Frauen: 0,29569 × W + 0,41813 × H − 43,2933</div>
+            </div>
+          </div>
+        </div>
+        <p class="text-sm text-stone-500">W = Gewicht in kg, H = Körpergröße in cm</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Typische Richtwerte</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Profil</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Gewicht</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Magermasse (Ø)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Magermasse %</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Mann, 180 cm, aktiv</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">80 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~61 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~76 %</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Frau, 165 cm, aktiv</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">60 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~44 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~74 %</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Mann, 175 cm, Sportler</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">75 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~58 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~77 %</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deine Magermasse berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Drei Formeln im Vergleich — kostenlos und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('leanBodyMass')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum die Magermasse wichtiger ist als das Gewicht</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Zwei Personen mit gleichem Gewicht können einen sehr unterschiedlichen Gesundheitszustand haben. Wer regelmäßig trainiert, baut Muskelmasse auf — das Gewicht steigt, aber die LBM steigt ebenfalls. Das ist ein positives Zeichen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Umgekehrt: Wer abnimmt, ohne zu trainieren, verliert nicht nur Fett, sondern auch Muskeln. Die LBM sinkt — ein Warnsignal, das das Gewicht allein nicht zeigt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Kombiniere die LBM mit dem <router-link :to="localeBlogPath('koerperfett-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Körperfettanteil</router-link> für ein vollständiges Bild deiner Körperzusammensetzung.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die fettfreie Körpermasse ist eine präzisere Kennzahl als das Körpergewicht. Nutze unseren <router-link :to="localePath('leanBodyMass')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Magermasse-Rechner</router-link> und ergänze das Ergebnis mit dem <router-link :to="localePath('bodyFat')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Körperfett-Rechner</router-link> und dem <router-link :to="localePath('bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticles slug="magermasse-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/CalculateLeanBodyMass.vue
+++ b/src/pages/blog/en/CalculateLeanBodyMass.vue
@@ -1,0 +1,158 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Lean Body Mass Calculator — What It Tells You About Your Fitness | Health Calculators',
+  description: 'Calculate lean body mass using three scientific formulas: Boer, James and Hume. What LBM reveals about your fitness and why it matters more than body weight.',
+  path: '/en/blog/calculate-lean-body-mass',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Lean Body Mass Calculator — What It Tells You About Your Fitness',
+    description: 'Calculate lean body mass using three scientific formulas: Boer, James and Hume. What LBM reveals about your fitness and why it matters more than body weight.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-08',
+    dateModified: '2026-04-08',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-lean-body-mass',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Lean Body Mass Calculator — What It Tells You About Your Fitness</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 8, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Lean body mass</strong> (LBM) is your body weight minus fat — muscles, bones, organs and water. It is one of the most meaningful metrics for fitness and health.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Unlike body weight alone, LBM shows how much "functional" mass you carry. Athletes with high muscle mass have a high LBM even if their <router-link :to="localeBlogPath('calculate-bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> appears elevated.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The Three Scientific Formulas</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Three established formulas exist for calculating lean body mass — each with a slightly different approach:
+        </p>
+
+        <div class="space-y-4 mb-6">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Boer Formula (1984)</h3>
+            <p class="text-sm text-stone-600 mb-3">Based on weight and height — simple and widely used.</p>
+            <div class="bg-stone-50 rounded-lg p-3 font-mono text-sm text-stone-700">
+              <div>Male: 0.407 × W + 0.267 × H − 19.2</div>
+              <div>Female: 0.252 × W + 0.473 × H − 48.3</div>
+            </div>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">James Formula (1976)</h3>
+            <p class="text-sm text-stone-600 mb-3">Accounts for the weight-to-height ratio — more sensitive to overweight.</p>
+            <div class="bg-stone-50 rounded-lg p-3 font-mono text-sm text-stone-700">
+              <div>Male: 1.1 × W − 128 × (W/H)²</div>
+              <div>Female: 1.07 × W − 148 × (W/H)²</div>
+            </div>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Hume Formula (1966)</h3>
+            <p class="text-sm text-stone-600 mb-3">One of the oldest formulas, derived from cadaver measurements — more conservative estimates.</p>
+            <div class="bg-stone-50 rounded-lg p-3 font-mono text-sm text-stone-700">
+              <div>Male: 0.3281 × W + 0.33929 × H − 29.5336</div>
+              <div>Female: 0.29569 × W + 0.41813 × H − 43.2933</div>
+            </div>
+          </div>
+        </div>
+        <p class="text-sm text-stone-500">W = weight in kg, H = height in cm</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Typical Reference Values</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Profile</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Weight</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">LBM (avg)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">LBM %</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Male, 180 cm, active</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">80 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~61 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~76%</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Female, 165 cm, active</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">60 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~44 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~74%</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Male, 175 cm, athlete</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">75 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~58 kg</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~77%</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your lean body mass now</h3>
+        <p class="text-stone-300 text-sm mb-5">Three formulas compared — free and no sign-up required.</p>
+        <router-link
+          :to="localePath('leanBodyMass')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free now &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why LBM Matters More Than Body Weight</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Two people with the same weight can have very different health profiles. Regular training builds muscle mass — weight rises, but LBM rises too. That is a positive sign.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Conversely, losing weight without training means losing not just fat but also muscle. LBM drops — a warning sign that body weight alone does not reveal.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Combine LBM with your <router-link :to="localeBlogPath('calculate-body-fat')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">body fat percentage</router-link> for a complete picture of your body composition.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conclusion</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Lean body mass is a more precise metric than body weight. Use our <router-link :to="localePath('leanBodyMass')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Lean Body Mass Calculator</router-link> and complement the result with the <router-link :to="localePath('bodyFat')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Body Fat Calculator</router-link> and the <router-link :to="localePath('bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI Calculator</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="calculate-lean-body-mass" />
+    </div>
+  </article>
+</template>

--- a/src/pages/leanBodyMass.meta.js
+++ b/src/pages/leanBodyMass.meta.js
@@ -1,0 +1,17 @@
+import Component from './LeanBodyMassCalculator.vue'
+import BlogDe from './blog/MagermassBerechnen.vue'
+import BlogEn from './blog/en/CalculateLeanBodyMass.vue'
+
+export default {
+  key: 'leanBodyMass',
+  component: Component,
+  slugs: { de: 'magermasse-rechner', en: 'lean-body-mass-calculator' },
+  group: 'bodyComposition',
+  groupOrder: 0,
+  order: 4,
+  oldRedirect: '/lean-body-mass',
+  blog: {
+    de: { slug: 'magermasse-berechnen', component: BlogDe },
+    en: { slug: 'calculate-lean-body-mass', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-94-lean-body-mass
**Agent:** claude
**Branch:** `agent/hc-94-lean-body-mass-20260408-140031`

Closes jenslaufer/health-calculators#94

### Prompt
> Implement GitHub issue #94: Lean Body Mass Calculator + Blog (DE+EN).

## Context
This is a Vue 3 + Vite + Tailwind CSS health calculator site. Look at an existing calculator (e.g. src/pages/BodyFatCalculator.vue) for the exact pattern: page component, composable, meta file, route registration, home page link, blog article, tests.

## Calculator
- Input: weight (kg/lbs), height (cm/ft+in), gender (male/female)
- Formulas:
  - Boer: Male: 0.407W + 0.267H - 19.2 | Female: 0.252W + 0.473H - 48.3
  - James: Male: 1.1W - 128(W/H)² | Female: 1.07W - 148(W/H)²
  - Hume: Male: 0.3281W + 0.33929H - 29.5336 | Female: 0.29569W + 0.41813H - 43.2933
- Output: lean body mass (kg), body fat mass (kg), lean mass %, comparison across formulas
- DE + EN versions (follow existing i18n pattern)
- Place in "Body Composition" category on home page

## Blog
- DE: "Fettfreie Körpermasse berechnen — was sie über deine Fitness verrät"
- EN: "Lean Body Mass Calculator — What It Tells You About Your Fitness"
- Follow existing blog pattern in the repo

## Tests
- Write tests FIRST, then implement
- Unit tests for all three formulas
- E2E test for the calculator page

## CRITICAL CONSTRAINTS
- DO NOT delete or modify any existing calculator files
- DO NOT modify any file you don't need to change
- Follow the EXACT pattern of existing calculators
- Register the new calculator in router and home page