### PR TITLE
hc-100-pregnancy-weight-gain: Implement the Pregnancy Weight Gain Calculator as described 

### DIFF
--- a/e2e/pregnancy-weight-gain.spec.js
+++ b/e2e/pregnancy-weight-gain.spec.js
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Pregnancy Weight Gain Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/gewichtszunahme-schwangerschaft')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Gewichtszunahme Schwangerschaft/)
+  })
+
+  test('h1 contains Schwangerschaft', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Schwangerschaft')
+  })
+
+  test('back link navigates to home page', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('singleton is selected by default', async ({ page }) => {
+    const singletonBtn = page.getByTestId('btn-singleton')
+    await expect(singletonBtn).toHaveClass(/bg-stone-900/)
+  })
+
+  test('results hidden before input', async ({ page }) => {
+    await expect(page.getByTestId('bmi-result')).not.toBeVisible()
+    await expect(page.getByTestId('total-gain-range')).not.toBeVisible()
+  })
+
+  test('normal weight woman shows correct gain range', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('65')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    await expect(page.getByTestId('bmi-result')).toBeVisible()
+    await expect(page.getByTestId('bmi-category')).toContainText('Normalgewicht')
+    const range = await page.getByTestId('total-gain-range').textContent()
+    expect(range).toContain('11.5')
+    expect(range).toContain('16')
+  })
+
+  test('overweight woman shows correct gain range', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('78')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    await expect(page.getByTestId('bmi-category')).toContainText('Übergewicht')
+    const range = await page.getByTestId('total-gain-range').textContent()
+    expect(range).toContain('7')
+    expect(range).toContain('11.5')
+  })
+
+  test('obese woman shows correct gain range', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('95')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    await expect(page.getByTestId('bmi-category')).toContainText('Adipositas')
+    const range = await page.getByTestId('total-gain-range').textContent()
+    expect(range).toContain('5')
+    expect(range).toContain('9')
+  })
+
+  test('underweight woman shows correct gain range', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('48')
+    await page.getByTestId('height').fill('165')
+    await page.getByTestId('current-week').fill('20')
+
+    await expect(page.getByTestId('bmi-category')).toContainText('Untergewicht')
+    const range = await page.getByTestId('total-gain-range').textContent()
+    expect(range).toContain('12.5')
+    expect(range).toContain('18')
+  })
+
+  test('switching to twins changes gain range', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('65')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    // Singleton: 11.5–16 kg
+    const singletonRange = await page.getByTestId('total-gain-range').textContent()
+    expect(singletonRange).toContain('11.5')
+
+    // Switch to twins
+    await page.getByTestId('btn-twins').click()
+    await expect(page.getByTestId('btn-twins')).toHaveClass(/bg-stone-900/)
+
+    // Twins normal weight: 17–25 kg
+    const twinsRange = await page.getByTestId('total-gain-range').textContent()
+    expect(twinsRange).toContain('17')
+    expect(twinsRange).toContain('25')
+  })
+
+  test('gain-by-week is shown and changes with week input', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('65')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    const gain20 = await page.getByTestId('gain-by-week').textContent()
+    expect(gain20).toBeTruthy()
+
+    await page.getByTestId('current-week').fill('40')
+    const gain40 = await page.getByTestId('gain-by-week').textContent()
+    // Week 40 gain should be higher than week 20 gain
+    const min20 = parseFloat(gain20)
+    const min40 = parseFloat(gain40)
+    expect(min40).toBeGreaterThan(min20)
+  })
+
+  test('chart is visible after input', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('65')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    await expect(page.getByTestId('weight-chart')).toBeVisible()
+    await expect(page.getByTestId('chart-dot')).toBeVisible()
+  })
+
+  test('BMI result is a number', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('65')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    const bmiText = await page.getByTestId('bmi-result').textContent()
+    const bmi = parseFloat(bmiText)
+    expect(bmi).toBeGreaterThan(10)
+    expect(bmi).toBeLessThan(100)
+  })
+})
+
+test.describe('Pregnancy Weight Gain Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/pregnancy-weight-gain-calculator')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Pregnancy Weight Gain/)
+  })
+
+  test('h1 contains Pregnancy', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Pregnancy')
+  })
+
+  test('normal weight woman shows correct category in EN', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('65')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    await expect(page.getByTestId('bmi-category')).toContainText('Normal weight')
+  })
+
+  test('twins button switches range in EN', async ({ page }) => {
+    await page.getByTestId('pre-weight').fill('65')
+    await page.getByTestId('height').fill('170')
+    await page.getByTestId('current-week').fill('20')
+
+    await page.getByTestId('btn-twins').click()
+    const twinsRange = await page.getByTestId('total-gain-range').textContent()
+    expect(twinsRange).toContain('17')
+    expect(twinsRange).toContain('25')
+  })
+})

--- a/src/__tests__/pregnancy-weight-gain.test.js
+++ b/src/__tests__/pregnancy-weight-gain.test.js
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest'
+
+// Pure calculation functions — mirroring PregnancyWeightGainCalculator.vue logic
+
+const IOM_GUIDELINES = {
+  singleton: {
+    underweight: { min: 12.5, max: 18 },
+    normal:      { min: 11.5, max: 16 },
+    overweight:  { min: 7,    max: 11.5 },
+    obese:       { min: 5,    max: 9 },
+  },
+  twins: {
+    underweight: { min: 12.5, max: 18 },
+    normal:      { min: 17,   max: 25 },
+    overweight:  { min: 14,   max: 23 },
+    obese:       { min: 11,   max: 19 },
+  },
+}
+
+function calcBmi(weightKg, heightCm) {
+  return weightKg / Math.pow(heightCm / 100, 2)
+}
+
+function getBmiCategory(bmi) {
+  if (bmi < 18.5) return 'underweight'
+  if (bmi < 25)   return 'normal'
+  if (bmi < 30)   return 'overweight'
+  return 'obese'
+}
+
+function getGainRange(bmiCategory, isTwins) {
+  const type = isTwins ? 'twins' : 'singleton'
+  return IOM_GUIDELINES[type][bmiCategory]
+}
+
+function getGainAtWeek(gainRange, week) {
+  const w = Math.min(Math.max(week, 0), 40)
+  return {
+    min: (gainRange.min / 40) * w,
+    max: (gainRange.max / 40) * w,
+  }
+}
+
+// ---- BMI calculation ----
+
+describe('BMI calculation', () => {
+  it('65kg, 170cm → BMI ~22.5', () => {
+    expect(calcBmi(65, 170)).toBeCloseTo(22.49, 1)
+  })
+
+  it('50kg, 165cm → BMI ~18.4 (underweight boundary)', () => {
+    expect(calcBmi(50, 165)).toBeCloseTo(18.37, 1)
+  })
+
+  it('90kg, 170cm → BMI ~31.1 (obese)', () => {
+    expect(calcBmi(90, 170)).toBeCloseTo(31.14, 1)
+  })
+
+  it('75kg, 170cm → BMI ~26.0 (overweight)', () => {
+    expect(calcBmi(75, 170)).toBeCloseTo(25.95, 1)
+  })
+})
+
+// ---- BMI category ----
+
+describe('BMI category classification', () => {
+  it('BMI 17.5 → underweight', () => {
+    expect(getBmiCategory(17.5)).toBe('underweight')
+  })
+
+  it('BMI 18.5 → normal', () => {
+    expect(getBmiCategory(18.5)).toBe('normal')
+  })
+
+  it('BMI 24.9 → normal', () => {
+    expect(getBmiCategory(24.9)).toBe('normal')
+  })
+
+  it('BMI 25.0 → overweight', () => {
+    expect(getBmiCategory(25.0)).toBe('overweight')
+  })
+
+  it('BMI 29.9 → overweight', () => {
+    expect(getBmiCategory(29.9)).toBe('overweight')
+  })
+
+  it('BMI 30.0 → obese', () => {
+    expect(getBmiCategory(30.0)).toBe('obese')
+  })
+
+  it('BMI 35.0 → obese', () => {
+    expect(getBmiCategory(35.0)).toBe('obese')
+  })
+})
+
+// ---- Gain range (singleton) ----
+
+describe('IOM 2009 gain range — singleton', () => {
+  it('underweight: 12.5–18 kg', () => {
+    const range = getGainRange('underweight', false)
+    expect(range.min).toBe(12.5)
+    expect(range.max).toBe(18)
+  })
+
+  it('normal: 11.5–16 kg', () => {
+    const range = getGainRange('normal', false)
+    expect(range.min).toBe(11.5)
+    expect(range.max).toBe(16)
+  })
+
+  it('overweight: 7–11.5 kg', () => {
+    const range = getGainRange('overweight', false)
+    expect(range.min).toBe(7)
+    expect(range.max).toBe(11.5)
+  })
+
+  it('obese: 5–9 kg', () => {
+    const range = getGainRange('obese', false)
+    expect(range.min).toBe(5)
+    expect(range.max).toBe(9)
+  })
+})
+
+// ---- Gain range (twins) ----
+
+describe('IOM 2009 gain range — twins', () => {
+  it('normal twins: 17–25 kg', () => {
+    const range = getGainRange('normal', true)
+    expect(range.min).toBe(17)
+    expect(range.max).toBe(25)
+  })
+
+  it('overweight twins: 14–23 kg', () => {
+    const range = getGainRange('overweight', true)
+    expect(range.min).toBe(14)
+    expect(range.max).toBe(23)
+  })
+
+  it('obese twins: 11–19 kg', () => {
+    const range = getGainRange('obese', true)
+    expect(range.min).toBe(11)
+    expect(range.max).toBe(19)
+  })
+
+  it('twins range is higher than singleton for normal weight', () => {
+    const twin = getGainRange('normal', true)
+    const single = getGainRange('normal', false)
+    expect(twin.min).toBeGreaterThan(single.min)
+    expect(twin.max).toBeGreaterThan(single.max)
+  })
+
+  it('twins range is higher than singleton for overweight', () => {
+    const twin = getGainRange('overweight', true)
+    const single = getGainRange('overweight', false)
+    expect(twin.min).toBeGreaterThan(single.min)
+    expect(twin.max).toBeGreaterThan(single.max)
+  })
+})
+
+// ---- Week-by-week interpolation ----
+
+describe('Week-by-week gain interpolation', () => {
+  it('week 0 → 0 kg gain', () => {
+    const range = getGainRange('normal', false)
+    const gain = getGainAtWeek(range, 0)
+    expect(gain.min).toBeCloseTo(0, 2)
+    expect(gain.max).toBeCloseTo(0, 2)
+  })
+
+  it('week 40 → full total gain for normal weight', () => {
+    const range = getGainRange('normal', false)
+    const gain = getGainAtWeek(range, 40)
+    expect(gain.min).toBeCloseTo(11.5, 1)
+    expect(gain.max).toBeCloseTo(16, 1)
+  })
+
+  it('week 20 → half of total gain (linear interpolation)', () => {
+    const range = getGainRange('normal', false)
+    const gain = getGainAtWeek(range, 20)
+    expect(gain.min).toBeCloseTo(11.5 / 2, 1)
+    expect(gain.max).toBeCloseTo(16 / 2, 1)
+  })
+
+  it('week 10 → quarter of total gain', () => {
+    const range = getGainRange('obese', false)
+    const gain = getGainAtWeek(range, 10)
+    expect(gain.min).toBeCloseTo(5 / 4, 1)
+    expect(gain.max).toBeCloseTo(9 / 4, 1)
+  })
+
+  it('week > 40 is capped at 40', () => {
+    const range = getGainRange('normal', false)
+    const gain40 = getGainAtWeek(range, 40)
+    const gain42 = getGainAtWeek(range, 42)
+    expect(gain42.min).toBeCloseTo(gain40.min, 2)
+    expect(gain42.max).toBeCloseTo(gain40.max, 2)
+  })
+
+  it('min is always less than max', () => {
+    const categories = ['underweight', 'normal', 'overweight', 'obese']
+    for (const cat of categories) {
+      const range = getGainRange(cat, false)
+      for (const week of [1, 10, 20, 30, 40]) {
+        const gain = getGainAtWeek(range, week)
+        expect(gain.min).toBeLessThan(gain.max)
+      }
+    }
+  })
+
+  it('week-by-week gain increases monotonically', () => {
+    const range = getGainRange('normal', false)
+    let prev = getGainAtWeek(range, 0)
+    for (let w = 1; w <= 40; w++) {
+      const curr = getGainAtWeek(range, w)
+      expect(curr.min).toBeGreaterThanOrEqual(prev.min)
+      expect(curr.max).toBeGreaterThanOrEqual(prev.max)
+      prev = curr
+    }
+  })
+})
+
+// ---- End-to-end scenarios ----
+
+describe('Full calculation scenarios', () => {
+  it('normal weight woman, week 20, singleton', () => {
+    const bmi = calcBmi(65, 170)
+    const cat = getBmiCategory(bmi)
+    expect(cat).toBe('normal')
+    const range = getGainRange(cat, false)
+    const gain = getGainAtWeek(range, 20)
+    expect(gain.min).toBeCloseTo(5.75, 1)
+    expect(gain.max).toBeCloseTo(8, 1)
+  })
+
+  it('overweight woman, week 30, singleton', () => {
+    const bmi = calcBmi(78, 170)
+    const cat = getBmiCategory(bmi)
+    expect(cat).toBe('overweight')
+    const range = getGainRange(cat, false)
+    const gain = getGainAtWeek(range, 30)
+    expect(gain.min).toBeCloseTo(5.25, 1)
+    expect(gain.max).toBeCloseTo(8.625, 1)
+  })
+
+  it('obese woman, week 36, singleton', () => {
+    const bmi = calcBmi(95, 170)
+    const cat = getBmiCategory(bmi)
+    expect(cat).toBe('obese')
+    const range = getGainRange(cat, false)
+    expect(range.min).toBe(5)
+    expect(range.max).toBe(9)
+    const gain = getGainAtWeek(range, 36)
+    expect(gain.min).toBeCloseTo(4.5, 1)
+    expect(gain.max).toBeCloseTo(8.1, 1)
+  })
+
+  it('underweight woman, week 15, singleton', () => {
+    const bmi = calcBmi(48, 165)
+    const cat = getBmiCategory(bmi)
+    expect(cat).toBe('underweight')
+    const range = getGainRange(cat, false)
+    expect(range.min).toBe(12.5)
+    expect(range.max).toBe(18)
+    const gain = getGainAtWeek(range, 15)
+    expect(gain.min).toBeCloseTo(4.6875, 1)
+    expect(gain.max).toBeCloseTo(6.75, 1)
+  })
+
+  it('normal weight woman, twins, week 20', () => {
+    const bmi = calcBmi(65, 170)
+    const cat = getBmiCategory(bmi)
+    expect(cat).toBe('normal')
+    const range = getGainRange(cat, true)
+    expect(range.min).toBe(17)
+    expect(range.max).toBe(25)
+    const gain = getGainAtWeek(range, 20)
+    expect(gain.min).toBeCloseTo(8.5, 1)
+    expect(gain.max).toBeCloseTo(12.5, 1)
+  })
+})

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -227,6 +227,15 @@ slug: 'period-calculator-guide',
     calculatorKey: 'leanBodyMass',
     related: ['calculate-body-fat', 'calculate-bmi'],
   },
+  {
+    slug: 'pregnancy-weight-gain-guide',
+    title: 'Pregnancy Weight Gain Calculator — IOM 2009 Guidelines',
+    description: 'How much weight should you gain during pregnancy? IOM 2009 recommendations by pre-pregnancy BMI, week-by-week breakdown, and twin pregnancies explained.',
+    date: '2026-04-09',
+    readTime: '8 min',
+    calculatorKey: 'pregnancyWeightGain',
+    related: ['calculate-due-date', 'calculate-bmi'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -227,6 +227,15 @@ slug: 'zyklusrechner-guide',
     calculatorKey: 'leanBodyMass',
     related: ['koerperfett-berechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'gewichtszunahme-schwangerschaft-berechnen',
+    title: 'Gewichtszunahme in der Schwangerschaft berechnen — IOM-Leitlinien',
+    description: 'Empfohlene Gewichtszunahme in der Schwangerschaft nach IOM 2009. Richtwerte nach BMI-Kategorie, Wochenverlauf und Zwillingsschwangerschaften verständlich erklärt.',
+    date: '2026-04-09',
+    readTime: '8 min',
+    calculatorKey: 'pregnancyWeightGain',
+    related: ['geburtstermin-berechnen', 'bmi-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/pregnancyWeightGain.json
+++ b/src/locales/calculators/de/pregnancyWeightGain.json
@@ -1,0 +1,40 @@
+{
+  "home": {
+    "calculators": {
+      "pregnancyWeightGain": {
+        "name": "Gewichtszunahme Schwangerschaft",
+        "description": "Empfohlene Gewichtszunahme in der Schwangerschaft nach IOM-Leitlinien."
+      }
+    }
+  },
+  "pregnancyWeightGain": {
+    "meta": {
+      "title": "Gewichtszunahme Schwangerschaft berechnen — IOM-Empfehlungen",
+      "description": "Berechne deine empfohlene Gewichtszunahme in der Schwangerschaft nach IOM 2009 Leitlinien. Individuell angepasst an deinen BMI, Schwangerschaftswoche und Mehrlinge."
+    },
+    "title": "Gewichtszunahme in der Schwangerschaft",
+    "description": "Empfohlene Gewichtszunahme nach IOM 2009 Leitlinien — basierend auf deinem Vor-Schwangerschafts-BMI.",
+    "preWeight": "Gewicht vor der Schwangerschaft (kg)",
+    "height": "Körpergröße (cm)",
+    "currentWeek": "Aktuelle Schwangerschaftswoche",
+    "twinsLabel": "Mehrlingsschwangerschaft",
+    "singleton": "Einling",
+    "twins": "Zwillinge",
+    "totalGainRange": "Empfohlene Gesamtzunahme",
+    "gainByWeek": "Zunahme bis SSW {week}",
+    "chartTitle": "Wochenverlauf der Gewichtszunahme",
+    "weekShort": "SSW {w}",
+    "legendMax": "Maximale Empfehlung",
+    "legendMin": "Minimale Empfehlung",
+    "legendCurrent": "Aktuelle Woche",
+    "source": "Leitlinien: Institute of Medicine (IOM) 2009",
+    "linkBmi": "BMI-Rechner",
+    "linkPregnancy": "Schwangerschafts-Rechner",
+    "categories": {
+      "underweight": "Untergewicht",
+      "normal": "Normalgewicht",
+      "overweight": "Übergewicht",
+      "obese": "Adipositas"
+    }
+  }
+}

--- a/src/locales/calculators/en/pregnancyWeightGain.json
+++ b/src/locales/calculators/en/pregnancyWeightGain.json
@@ -1,0 +1,40 @@
+{
+  "home": {
+    "calculators": {
+      "pregnancyWeightGain": {
+        "name": "Pregnancy Weight Gain",
+        "description": "Recommended weight gain during pregnancy based on IOM guidelines."
+      }
+    }
+  },
+  "pregnancyWeightGain": {
+    "meta": {
+      "title": "Pregnancy Weight Gain Calculator — IOM 2009 Guidelines",
+      "description": "Calculate your recommended pregnancy weight gain based on IOM 2009 guidelines. Personalized for your pre-pregnancy BMI, current week, and twin pregnancies."
+    },
+    "title": "Pregnancy Weight Gain Calculator",
+    "description": "Recommended weight gain based on IOM 2009 guidelines — tailored to your pre-pregnancy BMI.",
+    "preWeight": "Pre-pregnancy weight (kg)",
+    "height": "Height (cm)",
+    "currentWeek": "Current pregnancy week",
+    "twinsLabel": "Multiple pregnancy",
+    "singleton": "Single",
+    "twins": "Twins",
+    "totalGainRange": "Recommended total gain",
+    "gainByWeek": "Gain by week {week}",
+    "chartTitle": "Week-by-week weight gain",
+    "weekShort": "Wk {w}",
+    "legendMax": "Upper recommendation",
+    "legendMin": "Lower recommendation",
+    "legendCurrent": "Current week",
+    "source": "Guidelines: Institute of Medicine (IOM) 2009",
+    "linkBmi": "BMI Calculator",
+    "linkPregnancy": "Pregnancy Calculator",
+    "categories": {
+      "underweight": "Underweight",
+      "normal": "Normal weight",
+      "overweight": "Overweight",
+      "obese": "Obese"
+    }
+  }
+}

--- a/src/pages/PregnancyWeightGainCalculator.vue
+++ b/src/pages/PregnancyWeightGainCalculator.vue
@@ -1,0 +1,338 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t } = useI18n()
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('pregnancyWeightGain.meta.title'),
+  description: t('pregnancyWeightGain.meta.description'),
+  routeKey: 'pregnancyWeightGain',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Pregnancy Weight Gain Calculator',
+    url: 'https://healthcalculator.app/pregnancy-weight-gain-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+// IOM 2009 guidelines: { min, max } total weight gain in kg
+const IOM_GUIDELINES = {
+  singleton: {
+    underweight: { min: 12.5, max: 18 },
+    normal:      { min: 11.5, max: 16 },
+    overweight:  { min: 7,    max: 11.5 },
+    obese:       { min: 5,    max: 9 },
+  },
+  twins: {
+    underweight: { min: 12.5, max: 18 },  // IOM 2009 has no specific guideline; use singleton underweight as proxy
+    normal:      { min: 17,   max: 25 },
+    overweight:  { min: 14,   max: 23 },
+    obese:       { min: 11,   max: 19 },
+  },
+}
+
+const preWeight = ref(null)
+const heightCm = ref(null)
+const currentWeek = ref(null)
+const twins = ref(false)
+
+const bmi = computed(() => {
+  if (!preWeight.value || !heightCm.value) return null
+  return preWeight.value / Math.pow(heightCm.value / 100, 2)
+})
+
+const bmiCategory = computed(() => {
+  if (!bmi.value) return null
+  if (bmi.value < 18.5) return 'underweight'
+  if (bmi.value < 25)   return 'normal'
+  if (bmi.value < 30)   return 'overweight'
+  return 'obese'
+})
+
+const gainRange = computed(() => {
+  if (!bmiCategory.value) return null
+  const type = twins.value ? 'twins' : 'singleton'
+  return IOM_GUIDELINES[type][bmiCategory.value]
+})
+
+const gainAtWeek = computed(() => {
+  if (!gainRange.value || !currentWeek.value) return null
+  const week = Math.min(Math.max(currentWeek.value, 0), 40)
+  return {
+    min: (gainRange.value.min / 40) * week,
+    max: (gainRange.value.max / 40) * week,
+  }
+})
+
+const hasResults = computed(() => bmi.value !== null && currentWeek.value !== null)
+
+// Chart: week-by-week recommended gain range
+const CHART_WEEKS = 40
+const chartWidth = 400
+const chartHeight = 160
+const paddingLeft = 32
+const paddingRight = 8
+const paddingTop = 8
+const paddingBottom = 24
+
+const maxGain = computed(() => {
+  if (!gainRange.value) return 20
+  return Math.ceil(gainRange.value.max * 1.1)
+})
+
+function weekToX(week) {
+  return paddingLeft + (week / CHART_WEEKS) * (chartWidth - paddingLeft - paddingRight)
+}
+
+function gainToY(gain) {
+  return paddingTop + chartHeight - paddingBottom - (gain / maxGain.value) * (chartHeight - paddingTop - paddingBottom)
+}
+
+const shadedPath = computed(() => {
+  if (!gainRange.value) return ''
+  const minRate = gainRange.value.min / 40
+  const maxRate = gainRange.value.max / 40
+  // Build top edge (max) forward, bottom edge (min) backward
+  const topPoints = []
+  const bottomPoints = []
+  for (let w = 0; w <= CHART_WEEKS; w++) {
+    topPoints.push(`${weekToX(w)},${gainToY(maxRate * w)}`)
+    bottomPoints.push(`${weekToX(w)},${gainToY(minRate * w)}`)
+  }
+  return `M ${topPoints[0]} L ${topPoints.join(' L ')} L ${bottomPoints.reverse().join(' L ')} Z`
+})
+
+const minLine = computed(() => {
+  if (!gainRange.value) return ''
+  const rate = gainRange.value.min / 40
+  return Array.from({ length: CHART_WEEKS + 1 }, (_, w) => `${weekToX(w)},${gainToY(rate * w)}`).join(' ')
+})
+
+const maxLine = computed(() => {
+  if (!gainRange.value) return ''
+  const rate = gainRange.value.max / 40
+  return Array.from({ length: CHART_WEEKS + 1 }, (_, w) => `${weekToX(w)},${gainToY(rate * w)}`).join(' ')
+})
+
+const currentDot = computed(() => {
+  if (!gainAtWeek.value || !currentWeek.value) return null
+  const w = Math.min(currentWeek.value, CHART_WEEKS)
+  const midGain = (gainAtWeek.value.min + gainAtWeek.value.max) / 2
+  return { x: weekToX(w), y: gainToY(midGain) }
+})
+
+const yAxisTicks = computed(() => {
+  if (!gainRange.value) return []
+  const step = maxGain.value <= 10 ? 2 : maxGain.value <= 20 ? 4 : 5
+  const ticks = []
+  for (let g = 0; g <= maxGain.value; g += step) {
+    ticks.push({ g, y: gainToY(g) })
+  }
+  return ticks
+})
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('pregnancyWeightGain.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('pregnancyWeightGain.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div>
+        <label for="pre-weight" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('pregnancyWeightGain.preWeight') }}
+        </label>
+        <input
+          id="pre-weight"
+          v-model.number="preWeight"
+          type="number"
+          placeholder="65"
+          min="30"
+          max="250"
+          data-testid="pre-weight"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+      <div>
+        <label for="height" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('pregnancyWeightGain.height') }}
+        </label>
+        <input
+          id="height"
+          v-model.number="heightCm"
+          type="number"
+          placeholder="170"
+          min="100"
+          max="250"
+          data-testid="height"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <label for="week" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('pregnancyWeightGain.currentWeek') }}
+        </label>
+        <input
+          id="week"
+          v-model.number="currentWeek"
+          type="number"
+          placeholder="20"
+          min="1"
+          max="42"
+          data-testid="current-week"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+      <div class="flex flex-col justify-end pb-0.5">
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('pregnancyWeightGain.twinsLabel') }}
+        </label>
+        <div class="flex gap-2">
+          <button
+            @click="twins = false"
+            :class="!twins ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+            data-testid="btn-singleton"
+          >{{ t('pregnancyWeightGain.singleton') }}</button>
+          <button
+            @click="twins = true"
+            :class="twins ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+            data-testid="btn-twins"
+          >{{ t('pregnancyWeightGain.twins') }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="hasResults" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <!-- BMI & Category -->
+    <div class="flex items-baseline gap-3 mb-6">
+      <span data-testid="bmi-result" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ bmi.toFixed(1) }}</span>
+      <span class="text-2xl text-stone-400">BMI</span>
+      <span data-testid="bmi-category" class="text-lg font-medium"
+        :class="{
+          'text-blue-600':   bmiCategory === 'underweight',
+          'text-emerald-600': bmiCategory === 'normal',
+          'text-yellow-600':  bmiCategory === 'overweight',
+          'text-red-600':     bmiCategory === 'obese',
+        }"
+      >{{ t('pregnancyWeightGain.categories.' + bmiCategory) }}</span>
+    </div>
+
+    <!-- Total gain recommendation -->
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('pregnancyWeightGain.totalGainRange') }}</div>
+        <div class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="total-gain-range">
+          {{ gainRange.min }}–{{ gainRange.max }} <span class="text-sm text-stone-400">kg</span>
+        </div>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <div class="text-xs font-semibold text-stone-500 tracking-wide uppercase mb-1">{{ t('pregnancyWeightGain.gainByWeek', { week: currentWeek }) }}</div>
+        <div class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="gain-by-week">
+          {{ gainAtWeek.min.toFixed(1) }}–{{ gainAtWeek.max.toFixed(1) }} <span class="text-sm text-stone-400">kg</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Chart -->
+    <div>
+      <h2 class="text-sm font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('pregnancyWeightGain.chartTitle') }}</h2>
+      <div class="overflow-x-auto">
+        <svg
+          :viewBox="`0 0 ${chartWidth} ${chartHeight}`"
+          :width="chartWidth"
+          :height="chartHeight"
+          class="w-full max-w-full"
+          aria-label="Pregnancy weight gain chart"
+          data-testid="weight-chart"
+        >
+          <!-- Y-axis ticks -->
+          <g v-for="tick in yAxisTicks" :key="tick.g">
+            <line :x1="paddingLeft - 4" :y1="tick.y" :x2="chartWidth - paddingRight" :y2="tick.y"
+              stroke="#e7e5e4" stroke-width="1" />
+            <text :x="paddingLeft - 6" :y="tick.y + 4" text-anchor="end" class="text-xs" fill="#a8a29e" font-size="9">
+              {{ tick.g }}
+            </text>
+          </g>
+
+          <!-- X-axis labels -->
+          <text v-for="w in [0, 10, 20, 30, 40]" :key="w"
+            :x="weekToX(w)" :y="chartHeight - 2" text-anchor="middle" fill="#a8a29e" font-size="9">
+            {{ w === 0 ? t('pregnancyWeightGain.weekShort', { w: 0 }) : w }}
+          </text>
+
+          <!-- Shaded range -->
+          <path :d="shadedPath" fill="#10b981" fill-opacity="0.12" />
+
+          <!-- Min line -->
+          <polyline :points="minLine" fill="none" stroke="#10b981" stroke-width="1.5" stroke-dasharray="4 2" />
+
+          <!-- Max line -->
+          <polyline :points="maxLine" fill="none" stroke="#10b981" stroke-width="1.5" />
+
+          <!-- Current week vertical line -->
+          <line v-if="currentDot && currentWeek <= CHART_WEEKS"
+            :x1="currentDot.x" :y1="paddingTop"
+            :x2="currentDot.x" :y2="chartHeight - paddingBottom"
+            stroke="#292524" stroke-width="1" stroke-dasharray="3 3" />
+
+          <!-- Current position dot -->
+          <circle v-if="currentDot && currentWeek <= CHART_WEEKS"
+            :cx="currentDot.x" :cy="currentDot.y"
+            r="5" fill="#292524" data-testid="chart-dot" />
+        </svg>
+      </div>
+      <div class="flex items-center gap-4 mt-2 text-xs text-stone-400">
+        <span class="flex items-center gap-1">
+          <span class="inline-block w-4 border-t-2 border-emerald-500"></span>
+          {{ t('pregnancyWeightGain.legendMax') }}
+        </span>
+        <span class="flex items-center gap-1">
+          <span class="inline-block w-4 border-t-2 border-emerald-500 border-dashed"></span>
+          {{ t('pregnancyWeightGain.legendMin') }}
+        </span>
+        <span class="flex items-center gap-1">
+          <span class="inline-block w-2 h-2 rounded-full bg-stone-900"></span>
+          {{ t('pregnancyWeightGain.legendCurrent') }}
+        </span>
+      </div>
+    </div>
+
+    <!-- IOM source note -->
+    <p class="text-xs text-stone-400 mt-4">{{ t('pregnancyWeightGain.source') }}</p>
+  </div>
+
+  <!-- Links to related calculators -->
+  <div v-if="hasResults" class="flex flex-wrap gap-3 mb-6 text-sm">
+    <router-link :to="localePath('bmi')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('pregnancyWeightGain.linkBmi') }}
+    </router-link>
+    <span class="text-stone-300">&middot;</span>
+    <router-link :to="localePath('pregnancy')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('pregnancyWeightGain.linkPregnancy') }}
+    </router-link>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <BlogBanner calculator-key="pregnancyWeightGain" />
+</template>

--- a/src/pages/blog/GewichtszunahmeSchwanerschaft.vue
+++ b/src/pages/blog/GewichtszunahmeSchwanerschaft.vue
@@ -1,0 +1,246 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Gewichtszunahme in der Schwangerschaft berechnen — IOM-Leitlinien | Health Calculators',
+  description: 'Empfohlene Gewichtszunahme in der Schwangerschaft nach IOM 2009. Richtwerte nach BMI-Kategorie, Wochenverlauf und Zwillingsschwangerschaften verständlich erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Gewichtszunahme in der Schwangerschaft berechnen — IOM-Leitlinien',
+    description: 'Empfohlene Gewichtszunahme in der Schwangerschaft nach IOM 2009. Richtwerte nach BMI-Kategorie, Wochenverlauf und Zwillingsschwangerschaften verständlich erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-09',
+    dateModified: '2026-04-09',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/gewichtszunahme-schwangerschaft-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Gewichtszunahme in der Schwangerschaft berechnen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">9. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wie viel Gewicht solltest du in der Schwangerschaft zunehmen? Die Antwort hängt von deinem
+          <strong>Vor-Schwangerschafts-BMI</strong> ab. Das Institute of Medicine (IOM) hat 2009 evidenzbasierte
+          Leitlinien veröffentlicht, die bis heute weltweit als Goldstandard gelten.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Zu wenig Gewichtszunahme erhöht das Risiko für Frühgeburt und geringes Geburtsgewicht. Zu viel
+          erhöht das Risiko für Schwangerschaftsdiabetes, Kaiserschnitt und spätere Gewichtsprobleme des Kindes.
+          Der richtige Bereich schützt Mutter und Kind.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">IOM 2009 Leitlinien nach BMI-Kategorie</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Berechne zuerst deinen <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Vor-Schwangerschafts-BMI</router-link>.
+          Dieser bestimmt, in welcher Kategorie du bist:
+        </p>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">BMI vor der Schwangerschaft</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfohlene Zunahme</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">&lt; 18,5</td>
+                <td class="px-6 py-3 font-medium text-blue-700">Untergewicht</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">12,5 – 18 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">18,5 – 24,9</td>
+                <td class="px-6 py-3 font-medium text-emerald-700">Normalgewicht</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">11,5 – 16 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">25 – 29,9</td>
+                <td class="px-6 py-3 font-medium text-yellow-700">Übergewicht</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">7 – 11,5 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">≥ 30</td>
+                <td class="px-6 py-3 font-medium text-red-700">Adipositas</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">5 – 9 kg</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="bg-stone-50 rounded-xl p-6 mb-6">
+          <h3 class="text-base font-bold text-stone-900 mb-2">Zwillingsschwangerschaften</h3>
+          <p class="text-sm text-stone-600 mb-3">
+            Bei Zwillingen empfiehlt das IOM eine höhere Gesamtzunahme:
+          </p>
+          <div class="space-y-1 text-sm text-stone-700">
+            <div class="flex justify-between"><span>Normalgewicht (BMI 18,5–24,9)</span><span class="font-semibold tabular-nums">17 – 25 kg</span></div>
+            <div class="flex justify-between"><span>Übergewicht (BMI 25–29,9)</span><span class="font-semibold tabular-nums">14 – 23 kg</span></div>
+            <div class="flex justify-between"><span>Adipositas (BMI ≥ 30)</span><span class="font-semibold tabular-nums">11 – 19 kg</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wie verteilt sich die Gewichtszunahme?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Gewichtszunahme verläuft nicht gleichmäßig. Im ersten Trimester (bis Woche 13) nehmen die meisten
+          Frauen nur wenig zu — oft 0,5 bis 2 kg. Der Großteil der Zunahme findet im zweiten und dritten
+          Trimester statt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Als grobe Orientierung gilt für Normalgewichtige nach dem ersten Trimester eine wöchentliche Zunahme
+          von etwa 0,35–0,5 kg. Für Übergewichtige sind es 0,23–0,33 kg/Woche, für Adipöse 0,17–0,27 kg/Woche.
+        </p>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">1. Trimester</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">2./3. Trimester (pro Woche)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 font-medium text-blue-700">Untergewicht</td>
+                <td class="px-6 py-3 text-stone-600">~1–2 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0,44–0,58 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-emerald-700">Normalgewicht</td>
+                <td class="px-6 py-3 text-stone-600">~1–2 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0,35–0,50 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-yellow-700">Übergewicht</td>
+                <td class="px-6 py-3 text-stone-600">~0,5–1 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0,23–0,33 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-red-700">Adipositas</td>
+                <td class="px-6 py-3 text-stone-600">~0,5–1 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0,17–0,27 kg</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Deine persönliche Empfehlung berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Gewichtszunahme nach IOM-Leitlinien — kostenlos und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('pregnancyWeightGain')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Woraus setzt sich das Mehrgewicht zusammen?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Gewichtszunahme in der Schwangerschaft kommt nicht nur vom Baby selbst. Bei einer Gesamtzunahme
+          von 12 kg entfallen ungefähr:
+        </p>
+        <div class="grid grid-cols-2 gap-3 mb-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~3,3 kg</div>
+            <div class="text-sm text-stone-500">Baby</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~0,7 kg</div>
+            <div class="text-sm text-stone-500">Plazenta</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~0,8 kg</div>
+            <div class="text-sm text-stone-500">Fruchtwasser</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~1,8 kg</div>
+            <div class="text-sm text-stone-500">Gebärmutter & Brustgewebe</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~1,8 kg</div>
+            <div class="text-sm text-stone-500">Blutvolumen</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~3,5 kg</div>
+            <div class="text-sm text-stone-500">Mütterliche Fettreserven</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Was, wenn ich außerhalb des empfohlenen Bereichs liege?</h3>
+            <p class="text-sm text-stone-600">
+              Einzelne Schwankungen sind normal. Wichtig ist der Trend über mehrere Wochen. Sprich bei
+              deutlichen Abweichungen mit deiner Gynäkologin oder deinem Gynäkologen.
+            </p>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Gilt der Richtwert für alle Frauen?</h3>
+            <p class="text-sm text-stone-600">
+              Die IOM-Leitlinien sind evidenzbasierte Empfehlungen für gesunde Einlings- und Zwillingsschwangerschaften.
+              Bei Erkrankungen wie Schwangerschaftsdiabetes oder Bluthochdruck gelten individuelle Empfehlungen.
+            </p>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Zählt Wassereinlagerung zur Gewichtszunahme?</h3>
+            <p class="text-sm text-stone-600">
+              Ja. Leichte Ödeme in Beinen und Füßen sind normal und Teil der empfohlenen Zunahme.
+              Plötzlich starke Schwellungen sollten ärztlich abgeklärt werden.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die empfohlene Gewichtszunahme in der Schwangerschaft hängt vom Vor-Schwangerschafts-BMI ab.
+          Nutze unseren <router-link :to="localePath('pregnancyWeightGain')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Rechner für die Gewichtszunahme in der Schwangerschaft</router-link>,
+          um deine individuelle Empfehlung zu berechnen — und vergleiche deinen BMI mit dem
+          <router-link :to="localePath('bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner</router-link>.
+          Den errechneten Geburtstermin und die Schwangerschaftswoche kannst du mit dem
+          <router-link :to="localePath('pregnancy')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Schwangerschafts-Rechner</router-link> ermitteln.
+        </p>
+      </div>
+
+      <RelatedArticles slug="gewichtszunahme-schwangerschaft-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/PregnancyWeightGainGuide.vue
+++ b/src/pages/blog/en/PregnancyWeightGainGuide.vue
@@ -1,0 +1,244 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Pregnancy Weight Gain Calculator — IOM 2009 Guidelines | Health Calculators',
+  description: 'How much weight should you gain during pregnancy? IOM 2009 recommendations by pre-pregnancy BMI, week-by-week breakdown, and twin pregnancies explained.',
+  path: '/en/blog/pregnancy-weight-gain-guide',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Pregnancy Weight Gain Calculator — IOM 2009 Guidelines',
+    description: 'How much weight should you gain during pregnancy? IOM 2009 recommendations by pre-pregnancy BMI, week-by-week breakdown, and twin pregnancies explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-09',
+    dateModified: '2026-04-09',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/pregnancy-weight-gain-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Pregnancy Weight Gain — How Much Is Right for You?</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 9, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          How much weight should you gain during pregnancy? The answer depends on your
+          <strong>pre-pregnancy BMI</strong>. The Institute of Medicine (IOM) published evidence-based
+          guidelines in 2009 that remain the gold standard worldwide.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Too little weight gain raises the risk of preterm birth and low birth weight. Too much increases
+          the risk of gestational diabetes, cesarean delivery, and childhood obesity. The right range
+          protects both mother and child.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">IOM 2009 Guidelines by BMI Category</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          First, calculate your <router-link :to="localeBlogPath('calculate-bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">pre-pregnancy BMI</router-link>.
+          This determines which category applies to you:
+        </p>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Pre-pregnancy BMI</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Recommended gain</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">&lt; 18.5</td>
+                <td class="px-6 py-3 font-medium text-blue-700">Underweight</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">12.5 – 18 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">18.5 – 24.9</td>
+                <td class="px-6 py-3 font-medium text-emerald-700">Normal weight</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">11.5 – 16 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">25 – 29.9</td>
+                <td class="px-6 py-3 font-medium text-yellow-700">Overweight</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">7 – 11.5 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">≥ 30</td>
+                <td class="px-6 py-3 font-medium text-red-700">Obese</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">5 – 9 kg</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="bg-stone-50 rounded-xl p-6 mb-6">
+          <h3 class="text-base font-bold text-stone-900 mb-2">Twin pregnancies</h3>
+          <p class="text-sm text-stone-600 mb-3">
+            For twins, the IOM recommends a higher total weight gain:
+          </p>
+          <div class="space-y-1 text-sm text-stone-700">
+            <div class="flex justify-between"><span>Normal weight (BMI 18.5–24.9)</span><span class="font-semibold tabular-nums">17 – 25 kg</span></div>
+            <div class="flex justify-between"><span>Overweight (BMI 25–29.9)</span><span class="font-semibold tabular-nums">14 – 23 kg</span></div>
+            <div class="flex justify-between"><span>Obese (BMI ≥ 30)</span><span class="font-semibold tabular-nums">11 – 19 kg</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How Does Weight Gain Distribute Over Weeks?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Weight gain does not happen evenly. In the first trimester (up to week 13), most women gain very
+          little — often just 0.5 to 2 kg. Most of the gain happens in the second and third trimesters.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          As a rough guide for normal-weight women after the first trimester: about 0.35–0.50 kg per week.
+          For overweight: 0.23–0.33 kg/week, for obese: 0.17–0.27 kg/week.
+        </p>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">1st trimester</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">2nd/3rd trimester (per week)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 font-medium text-blue-700">Underweight</td>
+                <td class="px-6 py-3 text-stone-600">~1–2 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0.44–0.58 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-emerald-700">Normal weight</td>
+                <td class="px-6 py-3 text-stone-600">~1–2 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0.35–0.50 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-yellow-700">Overweight</td>
+                <td class="px-6 py-3 text-stone-600">~0.5–1 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0.23–0.33 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-red-700">Obese</td>
+                <td class="px-6 py-3 text-stone-600">~0.5–1 kg</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">~0.17–0.27 kg</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your personal recommendation</h3>
+        <p class="text-stone-300 text-sm mb-5">IOM-based weight gain calculator — free and no sign-up required.</p>
+        <router-link
+          :to="localePath('pregnancyWeightGain')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free now &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Where Does the Extra Weight Come From?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The weight gained during pregnancy is not just the baby. For a total gain of 12 kg, approximately:
+        </p>
+        <div class="grid grid-cols-2 gap-3 mb-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~3.3 kg</div>
+            <div class="text-sm text-stone-500">Baby</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~0.7 kg</div>
+            <div class="text-sm text-stone-500">Placenta</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~0.8 kg</div>
+            <div class="text-sm text-stone-500">Amniotic fluid</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~1.8 kg</div>
+            <div class="text-sm text-stone-500">Uterus & breast tissue</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~1.8 kg</div>
+            <div class="text-sm text-stone-500">Blood volume</div>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-4">
+            <div class="text-lg font-bold text-stone-900 tabular-nums mb-1">~3.5 kg</div>
+            <div class="text-sm text-stone-500">Maternal fat stores</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Common Questions</h2>
+
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">What if I'm outside the recommended range?</h3>
+            <p class="text-sm text-stone-600">
+              Individual fluctuations are normal. What matters is the trend over several weeks. Talk to your
+              OB-GYN if you notice significant deviations.
+            </p>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Do these guidelines apply to everyone?</h3>
+            <p class="text-sm text-stone-600">
+              The IOM guidelines are evidence-based recommendations for healthy singleton and twin pregnancies.
+              Individual conditions like gestational diabetes or hypertension may require different targets.
+            </p>
+          </div>
+
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Does water retention count toward weight gain?</h3>
+            <p class="text-sm text-stone-600">
+              Yes. Mild swelling in legs and feet is normal and part of the recommended gain.
+              Sudden severe swelling should be assessed by a doctor.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conclusion</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Recommended pregnancy weight gain depends on your pre-pregnancy BMI.
+          Use our <router-link :to="localePath('pregnancyWeightGain')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Pregnancy Weight Gain Calculator</router-link>
+          to get your personalized recommendation — and check your BMI with the
+          <router-link :to="localePath('bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI Calculator</router-link>.
+          Find your due date and current week with the
+          <router-link :to="localePath('pregnancy')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Pregnancy Calculator</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="pregnancy-weight-gain-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/pregnancyWeightGain.meta.js
+++ b/src/pages/pregnancyWeightGain.meta.js
@@ -1,0 +1,17 @@
+import Component from './PregnancyWeightGainCalculator.vue'
+import BlogDe from './blog/GewichtszunahmeSchwanerschaft.vue'
+import BlogEn from './blog/en/PregnancyWeightGainGuide.vue'
+
+export default {
+  key: 'pregnancyWeightGain',
+  component: Component,
+  slugs: { de: 'gewichtszunahme-schwangerschaft', en: 'pregnancy-weight-gain-calculator' },
+  group: 'pregnancy',
+  groupOrder: 3,
+  order: 1,
+  oldRedirect: '/pregnancy-weight-gain',
+  blog: {
+    de: { slug: 'gewichtszunahme-schwangerschaft-berechnen', component: BlogDe },
+    en: { slug: 'pregnancy-weight-gain-guide', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-100-pregnancy-weight-gain
**Agent:** claude
**Branch:** `agent/hc-100-pregnancy-weight-gain-20260409-060002`

Closes jenslaufer/health-calculators#100

### Prompt
> Implement the Pregnancy Weight Gain Calculator as described in issue #100.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: Pre-pregnancy weight (kg), Height (cm), Current pregnancy week (1-42), Twins (yes/no)
- Output: Pre-pregnancy BMI category, Recommended total gain range (IOM 2009 guidelines), Recommended gain by current week, Visual chart showing week-by-week recommended range
- IOM 2009 guidelines: Underweight (<18.5): 12.5-18kg, Normal (18.5-24.9): 11.5-16kg, Overweight (25-29.9): 7-11.5kg, Obese (≥30): 5-9kg. Twins: Normal 17-25kg, Overweight 14-23kg, Obese 11-19kg
- Blog articles: DE + EN (SEO optimized, structured data)
- DE title: "Gewichtszunahme in der Schwangerschaft berechnen"
- Internal links to BMI-Rechner, Schwangerschafts-Rechner
- Unit tests for calculation logic (all BMI categories, twins, week-by-week interpolation)
- E2E test for the calculator page
- SSG pre-rendering must work

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks