### PR TITLE
hc-102-bsa-calculator: Implement the Body Surface Area (BSA) Calculator as describe

### DIFF
--- a/e2e/bsa.spec.js
+++ b/e2e/bsa.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/koerperoberflaeche-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Körperoberfläche/)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})
+
+test('metric mode — 170 cm, 70 kg → BSA ~1.82 m²', async ({ page }) => {
+  await page.getByRole('button', { name: 'Metrisch' }).click()
+  await page.getByTestId('input-height-cm').fill('170')
+  await page.getByTestId('input-weight-kg').fill('70')
+
+  const result = page.getByTestId('bsa-result')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const bsa = parseFloat(text)
+  expect(bsa).toBeGreaterThanOrEqual(1.75)
+  expect(bsa).toBeLessThanOrEqual(1.90)
+})
+
+test('imperial mode — 5 ft 7 in, 154 lbs → BSA ~1.81 m²', async ({ page }) => {
+  await page.getByRole('button', { name: 'Imperial' }).click()
+  await page.getByTestId('input-height-ft').fill('5')
+  await page.getByTestId('input-height-in').fill('7')
+  await page.getByTestId('input-weight-lbs').fill('154')
+
+  const result = page.getByTestId('bsa-result')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const bsa = parseFloat(text)
+  expect(bsa).toBeGreaterThanOrEqual(1.75)
+  expect(bsa).toBeLessThanOrEqual(1.90)
+})
+
+test('formula selector switches active formula', async ({ page }) => {
+  await page.getByTestId('input-height-cm').fill('170')
+  await page.getByTestId('input-weight-kg').fill('70')
+
+  await page.getByTestId('btn-formula-mosteller').click()
+  await expect(page.getByTestId('btn-formula-mosteller')).toHaveClass(/bg-stone-900/)
+  await expect(page.getByTestId('btn-formula-dubois')).not.toHaveClass(/bg-stone-900/)
+})
+
+test('formula comparison table shows all four formulas', async ({ page }) => {
+  await page.getByTestId('input-height-cm').fill('170')
+  await page.getByTestId('input-weight-kg').fill('70')
+
+  await expect(page.getByText('Du Bois (1916)')).toBeVisible()
+  await expect(page.getByText('Mosteller (1987)')).toBeVisible()
+  await expect(page.getByText('Haycock (1978)')).toBeVisible()
+  await expect(page.getByText('Boyd (1935)')).toBeVisible()
+})
+
+test('no result shown without inputs', async ({ page }) => {
+  await expect(page.getByTestId('bsa-result')).not.toBeVisible()
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -16,7 +16,7 @@ const EXPECTED_KEYS = [
   'waistHipRatio', 'ovulation', 'protein', 'bmr', 'caloriesBurned',
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
-  'leanBodyMass', 'pregnancyWeightGain', 'hba1c',
+  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bsa',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -48,6 +48,7 @@ const EXPECTED_ROUTE_MAP = {
   leanBodyMass: { de: 'magermasse-rechner', en: 'lean-body-mass-calculator' },
   pregnancyWeightGain: { de: 'gewichtszunahme-schwangerschaft', en: 'pregnancy-weight-gain-calculator' },
   hba1c: { de: 'hba1c-konverter', en: 'hba1c-converter' },
+  bsa: { de: 'koerperoberflaeche-rechner', en: 'body-surface-area-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -67,6 +68,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'magermasse-berechnen',
   'gewichtszunahme-schwangerschaft-berechnen',
   'hba1c-umrechnen',
+  'koerperoberflaeche-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -86,19 +88,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-lean-body-mass',
   'pregnancy-weight-gain-guide',
   'hba1c-converter-guide',
+  'body-surface-area-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 28 calculators', () => {
-    expect(calculatorMetas).toHaveLength(28)
+  it('discovers all 29 calculators', () => {
+    expect(calculatorMetas).toHaveLength(29)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 28 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(28)
+  it('builds calculatorComponents map for all 29 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(29)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -121,15 +124,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 28 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(28)
+  it('discovers all 29 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 28 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(28)
+  it('discovers all 29 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -145,10 +148,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 28 calculators with no duplicates', () => {
+  it('groups contain all 29 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(28)
-    expect(new Set(allKeys).size).toBe(28)
+    expect(allKeys).toHaveLength(29)
+    expect(new Set(allKeys).size).toBe(29)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -156,7 +159,7 @@ describe('calculator groups', () => {
 
   it('bodyComposition group has correct calculators in order', () => {
     expect(calculatorGroups[0].calculators).toEqual([
-      'bmi', 'bodyFat', 'idealWeight', 'waistHipRatio', 'leanBodyMass',
+      'bmi', 'bodyFat', 'idealWeight', 'waistHipRatio', 'leanBodyMass', 'bsa',
     ])
   })
 
@@ -217,8 +220,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 174 routes', () => {
-    expect(routes).toHaveLength(174)
+  it('generates exactly 180 routes', () => {
+    expect(routes).toHaveLength(180)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/bsa.test.js
+++ b/src/__tests__/bsa.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+
+// Pure BSA formula functions — mirrored from BsaCalculator.vue
+function dubois(h, w) {
+  return 0.007184 * Math.pow(h, 0.725) * Math.pow(w, 0.425)
+}
+
+function mosteller(h, w) {
+  return Math.sqrt((h * w) / 3600)
+}
+
+function haycock(h, w) {
+  return 0.024265 * Math.pow(h, 0.3964) * Math.pow(w, 0.5378)
+}
+
+function boyd(h, w) {
+  const wg = w * 1000
+  return 0.0003207 * Math.pow(h, 0.3) * Math.pow(wg, 0.7285 - 0.0188 * Math.log10(wg))
+}
+
+// Unit conversion helpers
+function lbsToKg(lbs) { return lbs * 0.453592 }
+function ftInToCm(ft, inches) { return (ft * 12 + inches) * 2.54 }
+
+describe('Du Bois formula', () => {
+  it('170 cm, 70 kg → ~1.81 m²', () => {
+    const bsa = dubois(170, 70)
+    expect(bsa).toBeGreaterThanOrEqual(1.78)
+    expect(bsa).toBeLessThanOrEqual(1.84)
+  })
+
+  it('180 cm, 80 kg → ~1.98 m²', () => {
+    const bsa = dubois(180, 80)
+    expect(bsa).toBeGreaterThanOrEqual(1.95)
+    expect(bsa).toBeLessThanOrEqual(2.02)
+  })
+
+  it('160 cm, 60 kg → ~1.62 m²', () => {
+    const bsa = dubois(160, 60)
+    expect(bsa).toBeGreaterThanOrEqual(1.58)
+    expect(bsa).toBeLessThanOrEqual(1.66)
+  })
+
+  it('50 cm, 3.5 kg (newborn) → ~0.21 m²', () => {
+    const bsa = dubois(50, 3.5)
+    expect(bsa).toBeGreaterThanOrEqual(0.18)
+    expect(bsa).toBeLessThanOrEqual(0.24)
+  })
+})
+
+describe('Mosteller formula', () => {
+  it('170 cm, 70 kg → ~1.82 m²', () => {
+    const bsa = mosteller(170, 70)
+    expect(bsa).toBeCloseTo(Math.sqrt((170 * 70) / 3600), 4)
+    expect(bsa).toBeGreaterThanOrEqual(1.79)
+    expect(bsa).toBeLessThanOrEqual(1.85)
+  })
+
+  it('180 cm, 80 kg → ~2.00 m²', () => {
+    const bsa = mosteller(180, 80)
+    expect(bsa).toBeGreaterThanOrEqual(1.97)
+    expect(bsa).toBeLessThanOrEqual(2.03)
+  })
+
+  it('160 cm, 60 kg → ~1.63 m²', () => {
+    const bsa = mosteller(160, 60)
+    expect(bsa).toBeGreaterThanOrEqual(1.60)
+    expect(bsa).toBeLessThanOrEqual(1.66)
+  })
+
+  it('result equals sqrt(h*w/3600)', () => {
+    expect(mosteller(175, 75)).toBeCloseTo(Math.sqrt((175 * 75) / 3600), 6)
+  })
+})
+
+describe('Haycock formula', () => {
+  it('170 cm, 70 kg → ~1.82 m²', () => {
+    const bsa = haycock(170, 70)
+    expect(bsa).toBeGreaterThanOrEqual(1.79)
+    expect(bsa).toBeLessThanOrEqual(1.86)
+  })
+
+  it('130 cm, 30 kg (child) → ~1.04 m²', () => {
+    const bsa = haycock(130, 30)
+    expect(bsa).toBeGreaterThanOrEqual(0.98)
+    expect(bsa).toBeLessThanOrEqual(1.10)
+  })
+
+  it('180 cm, 80 kg → ~1.99 m²', () => {
+    const bsa = haycock(180, 80)
+    expect(bsa).toBeGreaterThanOrEqual(1.96)
+    expect(bsa).toBeLessThanOrEqual(2.03)
+  })
+})
+
+describe('Boyd formula', () => {
+  it('170 cm, 70 kg → ~1.82 m²', () => {
+    const bsa = boyd(170, 70)
+    expect(bsa).toBeGreaterThanOrEqual(1.78)
+    expect(bsa).toBeLessThanOrEqual(1.86)
+  })
+
+  it('180 cm, 80 kg → ~1.99 m²', () => {
+    const bsa = boyd(180, 80)
+    expect(bsa).toBeGreaterThanOrEqual(1.95)
+    expect(bsa).toBeLessThanOrEqual(2.03)
+  })
+})
+
+describe('formula consistency', () => {
+  it('all four formulas agree within 5% for average adult', () => {
+    const h = 170, w = 70
+    const results = [dubois(h, w), mosteller(h, w), haycock(h, w), boyd(h, w)]
+    const min = Math.min(...results)
+    const max = Math.max(...results)
+    expect((max - min) / min).toBeLessThan(0.05)
+  })
+
+  it('all four formulas agree within 5% for large adult', () => {
+    const h = 190, w = 100
+    const results = [dubois(h, w), mosteller(h, w), haycock(h, w), boyd(h, w)]
+    const min = Math.min(...results)
+    const max = Math.max(...results)
+    expect((max - min) / min).toBeLessThan(0.05)
+  })
+})
+
+describe('unit conversions', () => {
+  it('5 ft 7 in → 170.18 cm', () => {
+    expect(ftInToCm(5, 7)).toBeCloseTo(170.18, 1)
+  })
+
+  it('6 ft 0 in → 182.88 cm', () => {
+    expect(ftInToCm(6, 0)).toBeCloseTo(182.88, 1)
+  })
+
+  it('154 lbs → ~69.85 kg', () => {
+    expect(lbsToKg(154)).toBeCloseTo(69.85, 1)
+  })
+
+  it('BSA same in metric and after imperial conversion (170cm/70kg)', () => {
+    const h = 170
+    const w = 70
+    const hImperial = ftInToCm(5, 6.93) // ~170cm
+    const wImperial = lbsToKg(154.3)   // ~70kg
+    expect(dubois(h, w)).toBeCloseTo(dubois(hImperial, wImperial), 1)
+  })
+})
+
+describe('BSA normal range context', () => {
+  it('average male (178 cm, 78 kg) has BSA ~1.97 m²', () => {
+    const bsa = mosteller(178, 78)
+    expect(bsa).toBeGreaterThanOrEqual(1.9)
+    expect(bsa).toBeLessThanOrEqual(2.1)
+  })
+
+  it('average female (163 cm, 62 kg) has BSA ~1.65 m²', () => {
+    const bsa = mosteller(163, 62)
+    expect(bsa).toBeGreaterThanOrEqual(1.5)
+    expect(bsa).toBeLessThanOrEqual(1.8)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -12,7 +12,7 @@ const EXPECTED_KEYS = [
   'waistHipRatio', 'ovulation', 'protein', 'bmr', 'caloriesBurned',
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
-  'leanBodyMass', 'pregnancyWeightGain', 'hba1c',
+  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bsa',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -32,6 +32,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'magermasse-berechnen',
   'gewichtszunahme-schwangerschaft-berechnen',
   'hba1c-umrechnen',
+  'koerperoberflaeche-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -51,12 +52,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-lean-body-mass',
   'pregnancy-weight-gain-guide',
   'hba1c-converter-guide',
+  'body-surface-area-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 28 calculator meta files', () => {
+  it('discovers all 29 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(28)
+    expect(metas).toHaveLength(29)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -94,19 +96,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 28 DE blog slugs', () => {
+  it('returns all 29 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(28)
+    expect(de).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 28 EN blog slugs', () => {
+  it('returns all 29 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(28)
+    expect(en).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -174,8 +176,8 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en"`)
   })
 
-  it('generates correct total URL count (2 home + 56 calcs + 2 blog index + 56 blog articles = 116)', () => {
+  it('generates correct total URL count (2 home + 58 calcs + 2 blog index + 58 blog articles = 120)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(116)
+    expect(urlCount).toBe(120)
   })
 })

--- a/src/locales/calculators/de/bsa.json
+++ b/src/locales/calculators/de/bsa.json
@@ -1,0 +1,45 @@
+{
+  "home": {
+    "calculators": {
+      "bsa": {
+        "name": "Körperoberfläche-Rechner",
+        "description": "Körperoberfläche nach Du Bois, Mosteller und weiteren Formeln berechnen."
+      }
+    }
+  },
+  "bsa": {
+    "meta": {
+      "title": "Körperoberfläche berechnen — BSA-Rechner | Health Calculators",
+      "description": "Körperoberfläche (BSA) nach Du Bois, Mosteller, Haycock und Boyd berechnen. Wichtig für Chemotherapie-Dosierung und medizinische Berechnungen. Kostenlos."
+    },
+    "title": "Körperoberfläche-Rechner",
+    "description": "Körperoberfläche (BSA) nach verschiedenen Formeln berechnen — relevant für Medikamentendosierung und klinische Bewertungen.",
+    "formula": "Formel",
+    "formulaDubois": "Du Bois (1916)",
+    "formulaMosteller": "Mosteller (1987)",
+    "formulaHaycock": "Haycock (1978)",
+    "formulaBoyd": "Boyd (1935)",
+    "result": "Körperoberfläche",
+    "unit": "m²",
+    "comparison": "Formelvergleich",
+    "comparisonNote": "Alle vier Formeln mit deinen Messwerten:",
+    "selectedLabel": "Ausgewählt",
+    "contextTitle": "Medizinische Bedeutung",
+    "contextDrug": "Medikamentendosierung",
+    "contextDrugText": "Chemotherapeutika und andere Wirkstoffe werden häufig nach Körperoberfläche dosiert (mg/m²), um Über- und Unterdosierungen zu vermeiden.",
+    "contextBurn": "Verbrennungsmedizin",
+    "contextBurnText": "Die Körperoberfläche ist Grundlage der Verbrennungsgrad-Einschätzung (Neuner-Regel) und der Flüssigkeitsersatz-Berechnung.",
+    "contextRenal": "Nierenfunktion",
+    "contextRenalText": "Die glomeruläre Filtrationsrate (GFR) wird auf eine Standardfläche von 1,73 m² normiert, um Patienten unterschiedlicher Größe vergleichen zu können.",
+    "normalRange": "Normalbereich Erwachsene",
+    "normalRangeMale": "Männer: ~1,9 m²",
+    "normalRangeFemale": "Frauen: ~1,6 m²",
+    "heightFt": "Größe (Fuß)",
+    "heightIn": "Zoll",
+    "formulaInfo": "Formel-Referenz",
+    "formulaDuboisDesc": "Älteste und am häufigsten verwendete Formel. Standard in der Chemotherapie.",
+    "formulaMostellerDesc": "Einfachste Berechnung, sehr gute Näherung. Empfohlen vom New England Journal of Medicine.",
+    "formulaHaycockDesc": "Optimiert für Kinder und Erwachsene. Gilt als besonders präzise.",
+    "formulaBoydDesc": "Berücksichtigt nichtlineare Beziehung zwischen Gewicht und BSA. Weniger verbreitet."
+  }
+}

--- a/src/locales/calculators/en/bsa.json
+++ b/src/locales/calculators/en/bsa.json
@@ -1,0 +1,45 @@
+{
+  "home": {
+    "calculators": {
+      "bsa": {
+        "name": "Body Surface Area Calculator",
+        "description": "Calculate body surface area using Du Bois, Mosteller, and other formulas."
+      }
+    }
+  },
+  "bsa": {
+    "meta": {
+      "title": "Body Surface Area Calculator — BSA Calculator | Health Calculators",
+      "description": "Calculate body surface area (BSA) using Du Bois, Mosteller, Haycock, and Boyd formulas. Essential for chemotherapy dosing and clinical assessments. Free."
+    },
+    "title": "Body Surface Area Calculator",
+    "description": "Calculate body surface area (BSA) using multiple validated formulas — essential for drug dosing and clinical assessments.",
+    "formula": "Formula",
+    "formulaDubois": "Du Bois (1916)",
+    "formulaMosteller": "Mosteller (1987)",
+    "formulaHaycock": "Haycock (1978)",
+    "formulaBoyd": "Boyd (1935)",
+    "result": "Body Surface Area",
+    "unit": "m²",
+    "comparison": "Formula Comparison",
+    "comparisonNote": "All four formulas with your measurements:",
+    "selectedLabel": "Selected",
+    "contextTitle": "Medical Significance",
+    "contextDrug": "Drug Dosing",
+    "contextDrugText": "Chemotherapy agents and other drugs are commonly dosed by body surface area (mg/m²) to prevent under- or overdosing across patients of different sizes.",
+    "contextBurn": "Burn Assessment",
+    "contextBurnText": "BSA is the foundation of burn severity assessment (Rule of Nines) and fluid resuscitation calculations in burn patients.",
+    "contextRenal": "Renal Function",
+    "contextRenalText": "Glomerular filtration rate (GFR) is normalized to a standard BSA of 1.73 m² to allow comparison across patients of different body sizes.",
+    "normalRange": "Normal Range Adults",
+    "normalRangeMale": "Males: ~1.9 m²",
+    "normalRangeFemale": "Females: ~1.6 m²",
+    "heightFt": "Height (feet)",
+    "heightIn": "Inches",
+    "formulaInfo": "Formula Reference",
+    "formulaDuboisDesc": "Oldest and most widely used formula. Standard in chemotherapy dosing.",
+    "formulaMostellerDesc": "Simplest calculation, very accurate approximation. Recommended by the New England Journal of Medicine.",
+    "formulaHaycockDesc": "Optimized for children and adults. Considered highly accurate.",
+    "formulaBoydDesc": "Accounts for non-linear relationship between weight and BSA. Less commonly used."
+  }
+}

--- a/src/pages/BsaCalculator.vue
+++ b/src/pages/BsaCalculator.vue
@@ -1,0 +1,269 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t } = useI18n()
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('bsa.meta.title'),
+  description: t('bsa.meta.description'),
+  routeKey: 'bsa',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Body Surface Area Calculator',
+    url: 'https://healthcalculator.app/body-surface-area-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const unit = ref('metric')
+const formula = ref('dubois')
+
+const heightCm = ref(null)
+const weightKg = ref(null)
+const heightFt = ref(null)
+const heightIn = ref(null)
+const weightLbs = ref(null)
+
+const effectiveHeightCm = computed(() => {
+  if (unit.value === 'metric') return heightCm.value
+  const ft = heightFt.value || 0
+  const inches = heightIn.value || 0
+  if (ft === 0 && inches === 0) return null
+  return (ft * 12 + inches) * 2.54
+})
+
+const effectiveWeightKg = computed(() => {
+  if (unit.value === 'metric') return weightKg.value
+  if (!weightLbs.value) return null
+  return weightLbs.value * 0.453592
+})
+
+function dubois(h, w) {
+  return 0.007184 * Math.pow(h, 0.725) * Math.pow(w, 0.425)
+}
+
+function mosteller(h, w) {
+  return Math.sqrt((h * w) / 3600)
+}
+
+function haycock(h, w) {
+  return 0.024265 * Math.pow(h, 0.3964) * Math.pow(w, 0.5378)
+}
+
+function boyd(h, w) {
+  const wg = w * 1000
+  return 0.0003207 * Math.pow(h, 0.3) * Math.pow(wg, 0.7285 - 0.0188 * Math.log10(wg))
+}
+
+const formulaFns = { dubois, mosteller, haycock, boyd }
+const formulaKeys = ['dubois', 'mosteller', 'haycock', 'boyd']
+
+const hasInputs = computed(() => {
+  const h = effectiveHeightCm.value
+  const w = effectiveWeightKg.value
+  return h && w && h > 0 && w > 0
+})
+
+const bsa = computed(() => {
+  if (!hasInputs.value) return null
+  return formulaFns[formula.value](effectiveHeightCm.value, effectiveWeightKg.value)
+})
+
+const allBsa = computed(() => {
+  if (!hasInputs.value) return null
+  const h = effectiveHeightCm.value
+  const w = effectiveWeightKg.value
+  return {
+    dubois: dubois(h, w),
+    mosteller: mosteller(h, w),
+    haycock: haycock(h, w),
+    boyd: boyd(h, w),
+  }
+})
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('bsa.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('bsa.description') }}</p>
+    </div>
+
+    <!-- Inputs -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <!-- Unit toggle -->
+      <div class="flex gap-2 mb-6">
+        <button
+          @click="unit = 'metric'"
+          :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('common.metric') }}</button>
+        <button
+          @click="unit = 'imperial'"
+          :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('common.imperial') }}</button>
+      </div>
+
+      <!-- Height + Weight -->
+      <div class="grid grid-cols-2 gap-4 mb-6">
+        <!-- Metric height -->
+        <div v-if="unit === 'metric'">
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('common.height', { unit: t('common.cm') }) }}
+          </label>
+          <input
+            v-model.number="heightCm"
+            data-testid="input-height-cm"
+            type="number"
+            placeholder="170"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <!-- Imperial height: ft + in -->
+        <div v-else>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('bsa.heightFt') }}
+          </label>
+          <div class="flex gap-2">
+            <input
+              v-model.number="heightFt"
+              data-testid="input-height-ft"
+              type="number"
+              placeholder="5"
+              class="w-1/2 border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+            />
+            <input
+              v-model.number="heightIn"
+              data-testid="input-height-in"
+              type="number"
+              placeholder="7"
+              :title="t('bsa.heightIn')"
+              class="w-1/2 border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+            />
+          </div>
+          <div class="flex text-[10px] text-stone-400 mt-1 gap-2">
+            <span class="w-1/2 pl-1">ft</span>
+            <span class="w-1/2 pl-1">in</span>
+          </div>
+        </div>
+
+        <!-- Weight -->
+        <div>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('common.weight', { unit: t('common.' + (unit === 'metric' ? 'kg' : 'lbs')) }) }}
+          </label>
+          <input
+            v-if="unit === 'metric'"
+            v-model.number="weightKg"
+            data-testid="input-weight-kg"
+            type="number"
+            placeholder="70"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+          <input
+            v-else
+            v-model.number="weightLbs"
+            data-testid="input-weight-lbs"
+            type="number"
+            placeholder="154"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+
+      <!-- Formula selector -->
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('bsa.formula') }}
+        </label>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="key in formulaKeys"
+            :key="key"
+            @click="formula = key"
+            :class="formula === key ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+            :data-testid="`btn-formula-${key}`"
+          >{{ t(`bsa.formula${key.charAt(0).toUpperCase() + key.slice(1)}`) }}</button>
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Result -->
+    <div v-if="bsa" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex items-baseline gap-3 mb-6">
+        <span data-testid="bsa-result" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ bsa.toFixed(2) }}</span>
+        <span class="text-2xl font-light text-stone-500">m²</span>
+        <span class="text-sm font-medium text-stone-400 ml-1">{{ t(`bsa.formula${formula.charAt(0).toUpperCase() + formula.slice(1)}`) }}</span>
+      </div>
+
+      <!-- Formula comparison table -->
+      <div class="border-t border-stone-100 pt-6" v-if="allBsa">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('bsa.comparison') }}</div>
+        <div class="space-y-2.5">
+          <div
+            v-for="key in formulaKeys"
+            :key="key"
+            class="flex items-center justify-between py-2.5 px-3 rounded-lg transition-colors"
+            :class="formula === key ? 'bg-stone-900 text-white' : 'bg-stone-50'"
+          >
+            <span class="text-sm font-medium" :class="formula === key ? 'text-white' : 'text-stone-700'">
+              {{ t(`bsa.formula${key.charAt(0).toUpperCase() + key.slice(1)}`) }}
+              <span v-if="formula === key" class="ml-2 text-[10px] font-semibold uppercase tracking-widest opacity-60">{{ t('bsa.selectedLabel') }}</span>
+            </span>
+            <span class="text-sm font-bold tabular-nums" :class="formula === key ? 'text-white' : 'text-stone-900'">
+              {{ allBsa[key].toFixed(2) }} m²
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Medical context -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('bsa.contextTitle') }}</h2>
+      <div class="space-y-4">
+        <div class="border-b border-stone-100 pb-4">
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t('bsa.contextDrug') }}</div>
+          <p class="text-sm text-stone-500 leading-relaxed">{{ t('bsa.contextDrugText') }}</p>
+        </div>
+        <div class="border-b border-stone-100 pb-4">
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t('bsa.contextBurn') }}</div>
+          <p class="text-sm text-stone-500 leading-relaxed">{{ t('bsa.contextBurnText') }}</p>
+        </div>
+        <div>
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t('bsa.contextRenal') }}</div>
+          <p class="text-sm text-stone-500 leading-relaxed">{{ t('bsa.contextRenalText') }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Normal range + formula reference -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('bsa.formulaInfo') }}</h2>
+      <div class="space-y-3.5">
+        <div v-for="key in formulaKeys" :key="key" class="border-b border-stone-100 pb-3.5 last:border-0">
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t(`bsa.formula${key.charAt(0).toUpperCase() + key.slice(1)}`) }}</div>
+          <p class="text-sm text-stone-500">{{ t(`bsa.formula${key.charAt(0).toUpperCase() + key.slice(1)}Desc`) }}</p>
+        </div>
+      </div>
+    </div>
+
+    <BlogBanner calculator-key="bsa" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/KoerperoberflaeheBerechnen.vue
+++ b/src/pages/blog/KoerperoberflaeheBerechnen.vue
@@ -1,0 +1,196 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Körperoberfläche berechnen — BSA-Formeln und medizinische Bedeutung | Health Calculators',
+  description: 'Körperoberfläche (BSA) nach Du Bois, Mosteller, Haycock und Boyd berechnen. Formeln erklärt, Normalwerte, Bedeutung für Chemotherapie und Verbrennungsmedizin.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Körperoberfläche berechnen — BSA-Formeln und medizinische Bedeutung',
+    description: 'Körperoberfläche (BSA) nach Du Bois, Mosteller, Haycock und Boyd berechnen. Formeln erklärt und medizinische Anwendungen.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-12',
+    dateModified: '2026-04-12',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/koerperoberflaeche-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Körperoberfläche berechnen — BSA-Formeln und medizinische Bedeutung</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">12. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>Körperoberfläche (Body Surface Area, BSA)</strong> ist eine der wichtigsten Größen in der klinischen Medizin. Sie bildet die Basis für die Dosierung von Chemotherapeutika, die Einschätzung von Verbrennungen und die Normierung der Nierenfunktion.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Artikel erfährst du, welche Formeln es gibt, wie sie sich unterscheiden und wann welche verwendet wird.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist die Körperoberfläche?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Körperoberfläche gibt an, wie groß die gesamte Außenfläche des menschlichen Körpers ist — von der Kopfhaut bis zur Fußsohle. Sie wird in Quadratmetern (m²) angegeben.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Für einen durchschnittlichen Erwachsenen liegt sie zwischen <strong>1,6 m² (Frauen)</strong> und <strong>1,9 m² (Männer)</strong>. Kinder haben naturgemäß kleinere Werte — ein Neugeborenes hat etwa 0,2 m².
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base font-semibold text-stone-900 mb-2">Warum ist die BSA wichtiger als das Körpergewicht?</p>
+          <p class="text-sm text-stone-600 leading-relaxed">
+            Das Körpergewicht allein berücksichtigt nicht die Körperzusammensetzung. Eine 80 kg schwere, 1,90 m große Person hat eine deutlich andere Körperoberfläche als eine 80 kg schwere, 1,60 m große Person. Dosierungen nach BSA sind daher individuell präziser.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die vier Standardformeln</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Für die Berechnung der Körperoberfläche existieren mehrere wissenschaftlich validierte Formeln. Sie unterscheiden sich in Präzision, Zielgruppe und Verbreitung.
+        </p>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Formel</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Jahr</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Besonderheit</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Du Bois</td>
+                <td class="px-6 py-3 text-stone-600">1916</td>
+                <td class="px-6 py-3 text-stone-600">Älteste, am meisten verwendete Formel; Standard in der Onkologie</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Mosteller</td>
+                <td class="px-6 py-3 text-stone-600">1987</td>
+                <td class="px-6 py-3 text-stone-600">Einfachste Berechnung; empfohlen vom New England Journal of Medicine</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Haycock</td>
+                <td class="px-6 py-3 text-stone-600">1978</td>
+                <td class="px-6 py-3 text-stone-600">Optimiert für Kinder und Erwachsene; gilt als besonders präzise</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Boyd</td>
+                <td class="px-6 py-3 text-stone-600">1935</td>
+                <td class="px-6 py-3 text-stone-600">Nichtlineare Gewichtsbeziehung; weniger klinisch verbreitet</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Du Bois (1916)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          Die Formel von Du Bois und Du Bois ist die älteste und meistverwendete Formel zur BSA-Berechnung. Sie wurde an einer kleinen Stichprobe entwickelt, hat sich aber in der klinischen Praxis bewährt:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-4">
+          BSA = 0,007184 × Größe (cm)^0,725 × Gewicht (kg)^0,425
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed mb-6">
+          Für einen 170 cm großen, 70 kg schweren Menschen ergibt sich BSA ≈ 1,81 m².
+        </p>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Mosteller (1987)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          Die Mosteller-Formel ist die einfachste Berechnung und liefert sehr gute Ergebnisse. Sie wurde im New England Journal of Medicine veröffentlicht und ist besonders für die schnelle klinische Anwendung geeignet:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-4">
+          BSA = √(Größe (cm) × Gewicht (kg) / 3600)
+        </div>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Haycock (1978)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          Die Haycock-Formel wurde speziell für Kinder entwickelt und gilt auch bei Erwachsenen als sehr präzise:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-4">
+          BSA = 0,024265 × Größe (cm)^0,3964 × Gewicht (kg)^0,5378
+        </div>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Boyd (1935)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          Die Boyd-Formel berücksichtigt eine nichtlineare Beziehung zwischen Gewicht und BSA und wird heute seltener verwendet:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-6">
+          BSA = 0,0003207 × Größe (cm)^0,3 × Gewicht (g)^(0,7285 − 0,0188 × log₁₀(Gewicht (g)))
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Medizinische Anwendungen</h2>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Chemotherapie-Dosierung</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die wichtigste klinische Anwendung der BSA ist die <strong>Dosierung von Chemotherapeutika</strong>. Da viele Krebsmedikamente eine enge therapeutische Breite haben — zu wenig wirkt nicht, zu viel ist giftig — wird die Dosis präzise nach Körperoberfläche berechnet: in <strong>mg/m²</strong>.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Zum Beispiel wird Cisplatin häufig mit 75–100 mg/m² alle 3–4 Wochen dosiert. Bei einer BSA von 1,80 m² entspricht das einer Gesamtdosis von 135–180 mg.
+        </p>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Verbrennungsmedizin</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei Verbrennungsopfern wird der Anteil der verbrannten Körperoberfläche nach der <strong>Neuner-Regel</strong> geschätzt: Kopf 9 %, jeder Arm 9 %, jeder Oberschenkel 9 %, jeder Unterschenkel 9 %, Vorder- und Rücken je 18 %. Die geschätzte Fläche fließt direkt in die Flüssigkeitsersatz-Berechnung ein.
+        </p>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Nierenfunktion (GFR)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Die glomeruläre Filtrationsrate (GFR) wird auf eine Standard-Körperoberfläche von <strong>1,73 m²</strong> normiert. Diese Normierung — bekannt als „BSA-adjustierte GFR" — ermöglicht den Vergleich der Nierenfunktion zwischen Patienten unterschiedlicher Körpergröße.
+        </p>
+      </div>
+
+      <!-- CTA box -->
+      <div class="bg-stone-900 text-white rounded-xl p-8 mb-8">
+        <h2 class="text-xl font-bold mb-2">Körperoberfläche berechnen</h2>
+        <p class="text-stone-300 text-sm mb-4">Berechne deine BSA mit allen vier Formeln und vergleiche die Ergebnisse direkt.</p>
+        <router-link
+          :to="localePath('bsa')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum BSA-Rechner →</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Welche Formel sollte ich verwenden?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In der klinischen Praxis gilt: Die verwendete Formel hängt vom medizinischen Kontext ab.
+        </p>
+        <ul class="space-y-2 text-sm text-stone-600 mb-4">
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>Onkologie / Chemotherapie:</strong> Du Bois ist Standard — historisch bedingt und gut validiert.</span></li>
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>Klinische Entscheidungen allgemein:</strong> Mosteller — einfach und ausreichend präzise.</span></li>
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>Pädiatrie:</strong> Haycock — entwickelt und validiert für Kinder.</span></li>
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>Forschung:</strong> Alle Formeln vergleichen und die Varianz berichten.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Für Laien ist es weniger relevant, welche Formel man verwendet — die Unterschiede sind meist kleiner als 2–3 %. Wichtig ist, den eigenen Wert zu kennen und ihn bei medizinischen Gesprächen parat zu haben.
+        </p>
+      </div>
+
+    </div>
+
+    <RelatedArticles slug="koerperoberflaeche-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/BodySurfaceAreaCalculator.vue
+++ b/src/pages/blog/en/BodySurfaceAreaCalculator.vue
@@ -1,0 +1,193 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Body Surface Area Calculator — BSA Formulas and Medical Uses | Health Calculators',
+  description: 'Calculate body surface area (BSA) using Du Bois, Mosteller, Haycock, and Boyd formulas. Learn why BSA matters for chemotherapy dosing, burn assessment, and kidney function.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Body Surface Area Calculator — BSA Formulas and Medical Uses',
+    description: 'Calculate body surface area using validated formulas. Medical applications: chemotherapy dosing, burn assessment, renal function.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-12',
+    dateModified: '2026-04-12',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/body-surface-area-calculator',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Body Surface Area Calculator — BSA Formulas and Medical Uses</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 12, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Body surface area (BSA)</strong> is one of the most clinically important measurements in medicine. It drives chemotherapy dosing, burn severity assessment, and kidney function normalization.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article explains the four validated BSA formulas, how they differ, and which one to use in different clinical contexts.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is Body Surface Area?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Body surface area is the total external surface of the human body, measured in square meters (m²). For an average adult, BSA ranges from <strong>~1.6 m² (women)</strong> to <strong>~1.9 m² (men)</strong>. A newborn has approximately 0.2 m².
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base font-semibold text-stone-900 mb-2">Why BSA beats body weight for drug dosing</p>
+          <p class="text-sm text-stone-600 leading-relaxed">
+            Two patients can weigh the same but have very different body surface areas depending on their height. BSA-based dosing accounts for this variation, producing more consistent drug concentrations and better clinical outcomes.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The Four Standard Formulas</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Several validated formulas exist for calculating BSA. They differ in precision, target population, and clinical adoption.
+        </p>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Formula</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Year</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Key Feature</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Du Bois</td>
+                <td class="px-6 py-3 text-stone-600">1916</td>
+                <td class="px-6 py-3 text-stone-600">Oldest, most widely used; oncology standard</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Mosteller</td>
+                <td class="px-6 py-3 text-stone-600">1987</td>
+                <td class="px-6 py-3 text-stone-600">Simplest formula; NEJM-endorsed</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Haycock</td>
+                <td class="px-6 py-3 text-stone-600">1978</td>
+                <td class="px-6 py-3 text-stone-600">Best for children and adults; high precision</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-medium text-stone-900">Boyd</td>
+                <td class="px-6 py-3 text-stone-600">1935</td>
+                <td class="px-6 py-3 text-stone-600">Non-linear weight relationship; less common</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Du Bois (1916)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          The oldest BSA formula, still the most widely used in clinical practice — especially in oncology:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-4">
+          BSA = 0.007184 × height (cm)^0.725 × weight (kg)^0.425
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed mb-6">
+          For a 170 cm, 70 kg adult: BSA ≈ 1.81 m².
+        </p>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Mosteller (1987)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          The simplest and most practical formula. Published in the New England Journal of Medicine and recommended for clinical use:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-6">
+          BSA = √(height (cm) × weight (kg) / 3600)
+        </div>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Haycock (1978)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          Developed and validated for pediatric patients, also highly accurate in adults:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-6">
+          BSA = 0.024265 × height (cm)^0.3964 × weight (kg)^0.5378
+        </div>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Boyd (1935)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-3">
+          Accounts for a non-linear relationship between weight and BSA. Less commonly used today:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 mb-6">
+          BSA = 0.0003207 × height (cm)^0.3 × weight (g)^(0.7285 − 0.0188 × log₁₀(weight (g)))
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Medical Applications</h2>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Chemotherapy Dosing</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          BSA is the standard basis for <strong>chemotherapy dosing</strong>. Since many cancer drugs have a narrow therapeutic window — too little fails, too much is toxic — doses are calculated in <strong>mg/m²</strong> to achieve consistent plasma concentrations across patients.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          For example, cisplatin is commonly dosed at 75–100 mg/m² every 3–4 weeks. With a BSA of 1.80 m², that equals 135–180 mg total dose.
+        </p>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Burn Area Assessment</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In burn medicine, the percentage of total body surface area (TBSA) burned is estimated using the <strong>Rule of Nines</strong>: head 9%, each arm 9%, each thigh 9%, each lower leg 9%, front and back trunk 18% each. This percentage drives fluid resuscitation calculations.
+        </p>
+
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Kidney Function (GFR)</h3>
+        <p class="text-base text-stone-600 leading-relaxed mb-6">
+          Glomerular filtration rate (GFR) is normalized to a standard BSA of <strong>1.73 m²</strong>. This BSA-adjusted GFR allows clinicians to compare kidney function across patients with different body sizes and make consistent treatment decisions.
+        </p>
+      </div>
+
+      <!-- CTA box -->
+      <div class="bg-stone-900 text-white rounded-xl p-8 mb-8">
+        <h2 class="text-xl font-bold mb-2">Calculate Your Body Surface Area</h2>
+        <p class="text-stone-300 text-sm mb-4">Compare all four BSA formulas with your own measurements instantly.</p>
+        <router-link
+          :to="localePath('bsa')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Open BSA Calculator →</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Which Formula Should You Use?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The right formula depends on the clinical context:
+        </p>
+        <ul class="space-y-2 text-sm text-stone-600 mb-4">
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>Oncology / chemo dosing:</strong> Du Bois — historical standard, well-validated in this setting.</span></li>
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>General clinical use:</strong> Mosteller — simple and accurate enough for most purposes.</span></li>
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>Pediatrics:</strong> Haycock — developed and validated specifically for children.</span></li>
+          <li class="flex gap-2"><span class="text-stone-400">•</span> <span><strong>Research:</strong> Report all formulas and acknowledge variability.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For personal health awareness, the choice of formula matters little — differences between formulas are typically less than 2–3%. What matters is knowing your approximate BSA and understanding what it means for your health.
+        </p>
+      </div>
+
+    </div>
+
+    <RelatedArticles slug="body-surface-area-calculator" />
+  </article>
+</template>

--- a/src/pages/bsa.meta.js
+++ b/src/pages/bsa.meta.js
@@ -1,0 +1,17 @@
+import Component from './BsaCalculator.vue'
+import BlogDe from './blog/KoerperoberflaeheBerechnen.vue'
+import BlogEn from './blog/en/BodySurfaceAreaCalculator.vue'
+
+export default {
+  key: 'bsa',
+  component: Component,
+  slugs: { de: 'koerperoberflaeche-rechner', en: 'body-surface-area-calculator' },
+  group: 'bodyComposition',
+  groupOrder: 0,
+  order: 5,
+  oldRedirect: '/koerperoberflaeche-rechner',
+  blog: {
+    de: { slug: 'koerperoberflaeche-berechnen', component: BlogDe },
+    en: { slug: 'body-surface-area-calculator', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-102-bsa-calculator
**Agent:** claude
**Branch:** `agent/hc-102-bsa-calculator-20260412-010032`

Closes jenslaufer/health-calculators#102

### Prompt
> Implement the Body Surface Area (BSA) Calculator as described in issue #102.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: Height (cm/ft+in), Weight (kg/lbs), Formula selection (Du Bois, Mosteller, Haycock, Boyd)
- Output: BSA in m², comparison across formulas, medical context (drug dosing, burn area assessment)
- Metric + imperial unit toggle
- Blog articles: DE (/blog/koerperoberflaeche-berechnen) + EN (/blog/body-surface-area-calculator)
- Unit tests for all formulas with known reference values
- E2E test for the calculator page
- SSG pre-rendering must work

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks