### PR TITLE
hc-103-blood-sugar-converter: Implement the Blood Sugar Converter as described in issue #1

### DIFF
--- a/e2e/bloodSugar.spec.js
+++ b/e2e/bloodSugar.spec.js
@@ -1,0 +1,187 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Blood Sugar Converter (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/blutzucker-umrechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Blutzucker umrechnen/)
+  })
+
+  test('h1 contains Blutzucker', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Blutzucker')
+  })
+
+  test('back link navigates to home page', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('mg/dL unit is selected by default', async ({ page }) => {
+    await expect(page.getByTestId('btn-mgdl')).toHaveClass(/bg-stone-900/)
+  })
+
+  test('fasting context is selected by default', async ({ page }) => {
+    await expect(page.getByTestId('btn-fasting')).toHaveClass(/bg-stone-900/)
+  })
+
+  test('results hidden before input', async ({ page }) => {
+    await expect(page.getByTestId('result-converted')).not.toBeVisible()
+  })
+
+  test('95 mg/dL fasting → normal, ~5.27 mmol/L', async ({ page }) => {
+    await page.getByTestId('input-value').fill('95')
+    await expect(page.getByTestId('result-converted')).toBeVisible()
+    const converted = await page.getByTestId('result-converted').textContent()
+    expect(parseFloat(converted)).toBeCloseTo(5.27, 1)
+    await expect(page.getByTestId('risk-badge')).toContainText('Normal')
+  })
+
+  test('115 mg/dL fasting → Prädiabetes', async ({ page }) => {
+    await page.getByTestId('input-value').fill('115')
+    await expect(page.getByTestId('risk-badge')).toContainText('Prädiabetes')
+  })
+
+  test('130 mg/dL fasting → Diabetes', async ({ page }) => {
+    await page.getByTestId('input-value').fill('130')
+    await expect(page.getByTestId('risk-badge')).toContainText('Diabetes')
+  })
+
+  test('100 mg/dL fasting → Prädiabetes (lower boundary)', async ({ page }) => {
+    await page.getByTestId('input-value').fill('100')
+    await expect(page.getByTestId('risk-badge')).toContainText('Prädiabetes')
+  })
+
+  test('126 mg/dL fasting → Diabetes (lower boundary)', async ({ page }) => {
+    await page.getByTestId('input-value').fill('126')
+    await expect(page.getByTestId('risk-badge')).toContainText('Diabetes')
+  })
+
+  test('switching to postprandial context changes classification', async ({ page }) => {
+    await page.getByTestId('input-value').fill('90')
+    await expect(page.getByTestId('risk-badge')).toContainText('Normal')
+    await page.getByTestId('btn-postprandial').click()
+    await expect(page.getByTestId('btn-postprandial')).toHaveClass(/bg-stone-900/)
+    await expect(page.getByTestId('risk-badge')).toContainText('Normal')
+  })
+
+  test('150 mg/dL postprandial → Prädiabetes', async ({ page }) => {
+    await page.getByTestId('btn-postprandial').click()
+    await page.getByTestId('input-value').fill('150')
+    await expect(page.getByTestId('risk-badge')).toContainText('Prädiabetes')
+  })
+
+  test('200 mg/dL postprandial → Diabetes (lower boundary)', async ({ page }) => {
+    await page.getByTestId('btn-postprandial').click()
+    await page.getByTestId('input-value').fill('200')
+    await expect(page.getByTestId('risk-badge')).toContainText('Diabetes')
+  })
+
+  test('switching to mmol/L unit clears input', async ({ page }) => {
+    await page.getByTestId('input-value').fill('95')
+    await page.getByTestId('btn-mmol').click()
+    await expect(page.getByTestId('btn-mmol')).toHaveClass(/bg-stone-900/)
+    await expect(page.getByTestId('result-converted')).not.toBeVisible()
+  })
+
+  test('5.3 mmol/L → normal fasting, ~95.5 mg/dL', async ({ page }) => {
+    await page.getByTestId('btn-mmol').click()
+    await page.getByTestId('input-value').fill('5.3')
+    await expect(page.getByTestId('result-converted')).toBeVisible()
+    const converted = await page.getByTestId('result-converted').textContent()
+    expect(parseFloat(converted)).toBeCloseTo(95.5, 0)
+    await expect(page.getByTestId('risk-badge')).toContainText('Normal')
+  })
+
+  test('7.0 mmol/L fasting → Diabetes', async ({ page }) => {
+    await page.getByTestId('btn-mmol').click()
+    await page.getByTestId('input-value').fill('7.0')
+    await expect(page.getByTestId('risk-badge')).toContainText('Diabetes')
+  })
+
+  test('risk category chart is visible after input', async ({ page }) => {
+    await page.getByTestId('input-value').fill('95')
+    await expect(page.getByTestId('risk-category')).toBeVisible()
+  })
+
+  test('reference ranges table is always visible', async ({ page }) => {
+    await expect(page.getByText('Referenzbereiche')).toBeVisible()
+  })
+
+  test('formula is displayed after input', async ({ page }) => {
+    await page.getByTestId('input-value').fill('95')
+    await expect(page.getByText(/18,018/)).toBeVisible()
+  })
+})
+
+test.describe('Blood Sugar Converter (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/blood-sugar-converter')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Blood Sugar/)
+  })
+
+  test('h1 contains Blood Sugar', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Blood Sugar')
+  })
+
+  test('95 mg/dL fasting → Normal', async ({ page }) => {
+    await page.getByTestId('input-value').fill('95')
+    await expect(page.getByTestId('risk-badge')).toContainText('Normal')
+  })
+
+  test('115 mg/dL fasting → Prediabetes', async ({ page }) => {
+    await page.getByTestId('input-value').fill('115')
+    await expect(page.getByTestId('risk-badge')).toContainText('Prediabetes')
+  })
+
+  test('130 mg/dL fasting → Diabetes', async ({ page }) => {
+    await page.getByTestId('input-value').fill('130')
+    await expect(page.getByTestId('risk-badge')).toContainText('Diabetes')
+  })
+
+  test('reference ranges table is always visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Reference Ranges' })).toBeVisible()
+  })
+})
+
+test.describe('Blood Sugar DE blog article', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/blog/blutzucker-umrechnen')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Blutzucker umrechnen/)
+  })
+
+  test('h1 contains Blutzucker', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Blutzucker')
+  })
+
+  test('CTA link navigates to calculator', async ({ page }) => {
+    await page.getByRole('link', { name: /Blutzucker-Umrechner/ }).click()
+    await expect(page).toHaveURL(/blutzucker-umrechner/)
+  })
+})
+
+test.describe('Blood Sugar EN blog article', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/blog/blood-sugar-converter-guide')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Blood Sugar/)
+  })
+
+  test('h1 contains Blood Sugar', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Blood Sugar')
+  })
+
+  test('CTA link navigates to calculator', async ({ page }) => {
+    await page.getByRole('link', { name: /Blood Sugar Converter/ }).click()
+    await expect(page).toHaveURL(/blood-sugar-converter/)
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -16,7 +16,7 @@ const EXPECTED_KEYS = [
   'waistHipRatio', 'ovulation', 'protein', 'bmr', 'caloriesBurned',
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
-  'leanBodyMass', 'pregnancyWeightGain', 'hba1c',
+  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -48,6 +48,7 @@ const EXPECTED_ROUTE_MAP = {
   leanBodyMass: { de: 'magermasse-rechner', en: 'lean-body-mass-calculator' },
   pregnancyWeightGain: { de: 'gewichtszunahme-schwangerschaft', en: 'pregnancy-weight-gain-calculator' },
   hba1c: { de: 'hba1c-konverter', en: 'hba1c-converter' },
+  bloodSugar: { de: 'blutzucker-umrechner', en: 'blood-sugar-converter' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -67,6 +68,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'magermasse-berechnen',
   'gewichtszunahme-schwangerschaft-berechnen',
   'hba1c-umrechnen',
+  'blutzucker-umrechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -86,19 +88,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-lean-body-mass',
   'pregnancy-weight-gain-guide',
   'hba1c-converter-guide',
+  'blood-sugar-converter-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 28 calculators', () => {
-    expect(calculatorMetas).toHaveLength(28)
+  it('discovers all 29 calculators', () => {
+    expect(calculatorMetas).toHaveLength(29)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 28 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(28)
+  it('builds calculatorComponents map for all 29 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(29)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -121,15 +124,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 28 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(28)
+  it('discovers all 29 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 28 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(28)
+  it('discovers all 29 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -145,10 +148,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 28 calculators with no duplicates', () => {
+  it('groups contain all 29 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(28)
-    expect(new Set(allKeys).size).toBe(28)
+    expect(allKeys).toHaveLength(29)
+    expect(new Set(allKeys).size).toBe(29)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -169,7 +172,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar',
     ])
   })
 
@@ -217,8 +220,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 174 routes', () => {
-    expect(routes).toHaveLength(174)
+  it('generates exactly 180 routes', () => {
+    expect(routes).toHaveLength(180)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/bloodSugar.test.js
+++ b/src/__tests__/bloodSugar.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+
+// Mirror the calculation logic from BloodSugarConverter.vue
+
+const FACTOR = 18.018
+
+function mgToMmol(mg) {
+  return mg / FACTOR
+}
+
+function mmolToMg(mmol) {
+  return mmol * FACTOR
+}
+
+function getFastingCategory(mg) {
+  if (mg < 100) return 'normal'
+  if (mg < 126) return 'prediabetes'
+  return 'diabetes'
+}
+
+function getPostprandialCategory(mg) {
+  if (mg < 140) return 'normal'
+  if (mg < 200) return 'prediabetes'
+  return 'diabetes'
+}
+
+// ---- Unit conversion ----
+
+describe('mgToMmol', () => {
+  it('95 mg/dL → ~5.27 mmol/L', () => {
+    expect(mgToMmol(95)).toBeCloseTo(5.27, 1)
+  })
+
+  it('100 mg/dL → ~5.55 mmol/L', () => {
+    expect(mgToMmol(100)).toBeCloseTo(5.55, 1)
+  })
+
+  it('126 mg/dL → ~6.99 mmol/L', () => {
+    expect(mgToMmol(126)).toBeCloseTo(6.99, 1)
+  })
+
+  it('140 mg/dL → ~7.77 mmol/L', () => {
+    expect(mgToMmol(140)).toBeCloseTo(7.77, 1)
+  })
+
+  it('200 mg/dL → ~11.10 mmol/L', () => {
+    expect(mgToMmol(200)).toBeCloseTo(11.10, 1)
+  })
+})
+
+describe('mmolToMg', () => {
+  it('5.6 mmol/L → ~101 mg/dL', () => {
+    expect(mmolToMg(5.6)).toBeCloseTo(100.9, 0)
+  })
+
+  it('7.0 mmol/L → ~126.1 mg/dL', () => {
+    expect(mmolToMg(7.0)).toBeCloseTo(126.1, 0)
+  })
+
+  it('7.8 mmol/L → ~140.5 mg/dL', () => {
+    expect(mmolToMg(7.8)).toBeCloseTo(140.5, 0)
+  })
+
+  it('roundtrip: 95 mg/dL → mmol → mg/dL', () => {
+    expect(mmolToMg(mgToMmol(95))).toBeCloseTo(95, 5)
+  })
+
+  it('roundtrip: 200 mg/dL → mmol → mg/dL', () => {
+    expect(mmolToMg(mgToMmol(200))).toBeCloseTo(200, 5)
+  })
+})
+
+// ---- Fasting classification ----
+
+describe('getFastingCategory', () => {
+  it('70 mg/dL → normal', () => {
+    expect(getFastingCategory(70)).toBe('normal')
+  })
+
+  it('99 mg/dL → normal (upper boundary)', () => {
+    expect(getFastingCategory(99)).toBe('normal')
+  })
+
+  it('100 mg/dL → prediabetes (lower boundary)', () => {
+    expect(getFastingCategory(100)).toBe('prediabetes')
+  })
+
+  it('115 mg/dL → prediabetes', () => {
+    expect(getFastingCategory(115)).toBe('prediabetes')
+  })
+
+  it('125 mg/dL → prediabetes (upper boundary)', () => {
+    expect(getFastingCategory(125)).toBe('prediabetes')
+  })
+
+  it('126 mg/dL → diabetes (lower boundary)', () => {
+    expect(getFastingCategory(126)).toBe('diabetes')
+  })
+
+  it('200 mg/dL → diabetes', () => {
+    expect(getFastingCategory(200)).toBe('diabetes')
+  })
+})
+
+// ---- Postprandial classification ----
+
+describe('getPostprandialCategory', () => {
+  it('100 mg/dL → normal', () => {
+    expect(getPostprandialCategory(100)).toBe('normal')
+  })
+
+  it('139 mg/dL → normal (upper boundary)', () => {
+    expect(getPostprandialCategory(139)).toBe('normal')
+  })
+
+  it('140 mg/dL → prediabetes (lower boundary)', () => {
+    expect(getPostprandialCategory(140)).toBe('prediabetes')
+  })
+
+  it('170 mg/dL → prediabetes', () => {
+    expect(getPostprandialCategory(170)).toBe('prediabetes')
+  })
+
+  it('199 mg/dL → prediabetes (upper boundary)', () => {
+    expect(getPostprandialCategory(199)).toBe('prediabetes')
+  })
+
+  it('200 mg/dL → diabetes (lower boundary)', () => {
+    expect(getPostprandialCategory(200)).toBe('diabetes')
+  })
+
+  it('350 mg/dL → diabetes', () => {
+    expect(getPostprandialCategory(350)).toBe('diabetes')
+  })
+})
+
+// ---- Combined: mmol/L input classification ----
+
+describe('mmol/L input → fasting classification', () => {
+  it('5.5 mmol/L → normal fasting', () => {
+    expect(getFastingCategory(mmolToMg(5.5))).toBe('normal')
+  })
+
+  it('5.6 mmol/L → prediabetes fasting (lower boundary)', () => {
+    expect(getFastingCategory(mmolToMg(5.6))).toBe('prediabetes')
+  })
+
+  it('7.0 mmol/L → diabetes fasting (lower boundary)', () => {
+    expect(getFastingCategory(mmolToMg(7.0))).toBe('diabetes')
+  })
+})
+
+describe('mmol/L input → postprandial classification', () => {
+  it('7.7 mmol/L → normal postprandial', () => {
+    expect(getPostprandialCategory(mmolToMg(7.7))).toBe('normal')
+  })
+
+  it('7.8 mmol/L → prediabetes postprandial (lower boundary)', () => {
+    expect(getPostprandialCategory(mmolToMg(7.8))).toBe('prediabetes')
+  })
+
+  it('11.2 mmol/L → diabetes postprandial', () => {
+    expect(getPostprandialCategory(mmolToMg(11.2))).toBe('diabetes')
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -12,7 +12,7 @@ const EXPECTED_KEYS = [
   'waistHipRatio', 'ovulation', 'protein', 'bmr', 'caloriesBurned',
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
-  'leanBodyMass', 'pregnancyWeightGain', 'hba1c',
+  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -32,6 +32,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'magermasse-berechnen',
   'gewichtszunahme-schwangerschaft-berechnen',
   'hba1c-umrechnen',
+  'blutzucker-umrechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -51,12 +52,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-lean-body-mass',
   'pregnancy-weight-gain-guide',
   'hba1c-converter-guide',
+  'blood-sugar-converter-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 28 calculator meta files', () => {
+  it('discovers all 29 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(28)
+    expect(metas).toHaveLength(29)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -94,19 +96,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 28 DE blog slugs', () => {
+  it('returns all 29 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(28)
+    expect(de).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 28 EN blog slugs', () => {
+  it('returns all 29 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(28)
+    expect(en).toHaveLength(29)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -174,8 +176,8 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en"`)
   })
 
-  it('generates correct total URL count (2 home + 56 calcs + 2 blog index + 56 blog articles = 116)', () => {
+  it('generates correct total URL count (2 home + 58 calcs + 2 blog index + 58 blog articles = 120)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(116)
+    expect(urlCount).toBe(120)
   })
 })

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -236,6 +236,15 @@ slug: 'period-calculator-guide',
     calculatorKey: 'pregnancyWeightGain',
     related: ['calculate-due-date', 'calculate-bmi'],
   },
+  {
+    slug: 'blood-sugar-converter-guide',
+    title: 'Blood Sugar Converter — mg/dL to mmol/L Guide',
+    description: 'Convert blood sugar between mg/dL and mmol/L. Understand fasting and postprandial reference ranges. Normal, Prediabetes, Diabetes explained with free calculator.',
+    date: '2026-04-12',
+    readTime: '7 min',
+    calculatorKey: 'bloodSugar',
+    related: ['hba1c-converter-guide', 'calculate-water-intake'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -236,6 +236,15 @@ slug: 'zyklusrechner-guide',
     calculatorKey: 'pregnancyWeightGain',
     related: ['geburtstermin-berechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'blutzucker-umrechnen',
+    title: 'Blutzucker umrechnen — mg/dL und mmol/L verstehen',
+    description: 'Blutzucker zwischen mg/dL und mmol/L umrechnen. Nüchternwert und postprandialen Wert einordnen: Normal, Prädiabetes, Diabetes. Kostenloser Rechner.',
+    date: '2026-04-12',
+    readTime: '7 min',
+    calculatorKey: 'bloodSugar',
+    related: ['hba1c-umrechnen', 'wasserbedarf-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/bloodSugar.json
+++ b/src/locales/calculators/de/bloodSugar.json
@@ -1,0 +1,55 @@
+{
+  "home": {
+    "calculators": {
+      "bloodSugar": {
+        "name": "Blutzucker-Umrechner",
+        "description": "Blutzucker zwischen mg/dL und mmol/L umrechnen und Wert einordnen."
+      }
+    }
+  },
+  "bloodSugar": {
+    "meta": {
+      "title": "Blutzucker umrechnen — mg/dL in mmol/L | Health Calculators",
+      "description": "Blutzucker zwischen mg/dL und mmol/L umrechnen. Nüchternwert und postprandialen Wert einordnen: Normal, Prädiabetes, Diabetes. Kostenloser Rechner."
+    },
+    "title": "Blutzucker umrechnen — mg/dL und mmol/L",
+    "description": "Blutzuckerwert zwischen mg/dL und mmol/L umrechnen und sofort in Normalbereich, Prädiabetes oder Diabetes einordnen.",
+    "unitLabel": "Einheit des eingegebenen Werts",
+    "contextLabel": "Messzeitpunkt",
+    "fasting": "Nüchtern",
+    "postprandial": "Nach der Mahlzeit (2h)",
+    "valuePlaceholderMg": "z.B. 95",
+    "valuePlaceholderMmol": "z.B. 5,3",
+    "valueLabel": "Blutzuckerwert",
+    "resultLabel": "Umgerechneter Wert",
+    "category": "Einordnung",
+    "formula": "Umrechnungsformel",
+    "formulaMgToMmol": "mmol/L = mg/dL ÷ 18,018",
+    "formulaMmolToMg": "mg/dL = mmol/L × 18,018",
+    "normal": "Normal",
+    "prediabetes": "Prädiabetes",
+    "diabetes": "Diabetes",
+    "categoriesTitle": "Referenzbereiche",
+    "fastingRangesTitle": "Nüchternblutzucker",
+    "postprandialRangesTitle": "Postprandialer Blutzucker (2h nach Mahlzeit)",
+    "rangeCategory": "Kategorie",
+    "rangeMg": "mg/dL",
+    "rangeMmol": "mmol/L",
+    "normalFastingRange": "< 100",
+    "normalFastingRangeMmol": "< 5,6",
+    "prediabeticFastingRange": "100 – 125",
+    "prediabeticFastingRangeMmol": "5,6 – 6,9",
+    "diabeticFastingRange": "≥ 126",
+    "diabeticFastingRangeMmol": "≥ 7,0",
+    "normalPostprandialRange": "< 140",
+    "normalPostprandialRangeMmol": "< 7,8",
+    "prediabeticPostprandialRange": "140 – 199",
+    "prediabeticPostprandialRangeMmol": "7,8 – 11,0",
+    "diabeticPostprandialRange": "≥ 200",
+    "diabeticPostprandialRangeMmol": "≥ 11,1",
+    "normalDesc": "Kein erhöhtes Risiko.",
+    "prediabetesDesc": "Erhöhtes Risiko. Lebensstiländerungen empfohlen.",
+    "diabetesDesc": "Diabetes-Bereich. Arzt aufsuchen.",
+    "contextNote": "Werte können je nach Messzeitpunkt, Tageszeit und Ernährung variieren. Kein Ersatz für ärztliche Beratung."
+  }
+}

--- a/src/locales/calculators/en/bloodSugar.json
+++ b/src/locales/calculators/en/bloodSugar.json
@@ -1,0 +1,55 @@
+{
+  "home": {
+    "calculators": {
+      "bloodSugar": {
+        "name": "Blood Sugar Converter",
+        "description": "Convert blood sugar between mg/dL and mmol/L and classify your reading."
+      }
+    }
+  },
+  "bloodSugar": {
+    "meta": {
+      "title": "Blood Sugar Converter — mg/dL to mmol/L | Health Calculators",
+      "description": "Convert blood sugar between mg/dL and mmol/L. Classify fasting and postprandial readings: Normal, Prediabetes, Diabetes. Free online calculator."
+    },
+    "title": "Blood Sugar Converter — mg/dL and mmol/L",
+    "description": "Convert your blood sugar value between mg/dL and mmol/L and instantly classify it as Normal, Prediabetes, or Diabetes.",
+    "unitLabel": "Unit of entered value",
+    "contextLabel": "Measurement context",
+    "fasting": "Fasting",
+    "postprandial": "After meal (2h)",
+    "valuePlaceholderMg": "e.g. 95",
+    "valuePlaceholderMmol": "e.g. 5.3",
+    "valueLabel": "Blood sugar value",
+    "resultLabel": "Converted value",
+    "category": "Classification",
+    "formula": "Conversion formula",
+    "formulaMgToMmol": "mmol/L = mg/dL ÷ 18.018",
+    "formulaMmolToMg": "mg/dL = mmol/L × 18.018",
+    "normal": "Normal",
+    "prediabetes": "Prediabetes",
+    "diabetes": "Diabetes",
+    "categoriesTitle": "Reference Ranges",
+    "fastingRangesTitle": "Fasting Blood Sugar",
+    "postprandialRangesTitle": "Postprandial Blood Sugar (2h after meal)",
+    "rangeCategory": "Category",
+    "rangeMg": "mg/dL",
+    "rangeMmol": "mmol/L",
+    "normalFastingRange": "< 100",
+    "normalFastingRangeMmol": "< 5.6",
+    "prediabeticFastingRange": "100 – 125",
+    "prediabeticFastingRangeMmol": "5.6 – 6.9",
+    "diabeticFastingRange": "≥ 126",
+    "diabeticFastingRangeMmol": "≥ 7.0",
+    "normalPostprandialRange": "< 140",
+    "normalPostprandialRangeMmol": "< 7.8",
+    "prediabeticPostprandialRange": "140 – 199",
+    "prediabeticPostprandialRangeMmol": "7.8 – 11.0",
+    "diabeticPostprandialRange": "≥ 200",
+    "diabeticPostprandialRangeMmol": "≥ 11.1",
+    "normalDesc": "No elevated risk.",
+    "prediabetesDesc": "Elevated risk. Lifestyle changes recommended.",
+    "diabetesDesc": "Diabetes range. Consult a doctor.",
+    "contextNote": "Values can vary depending on measurement time, time of day, and diet. Not a substitute for medical advice."
+  }
+}

--- a/src/pages/BloodSugarConverter.vue
+++ b/src/pages/BloodSugarConverter.vue
@@ -1,0 +1,277 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t } = useI18n()
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('bloodSugar.meta.title'),
+  description: t('bloodSugar.meta.description'),
+  routeKey: 'bloodSugar',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Blood Sugar Converter',
+    url: 'https://healthcalculator.app/blood-sugar-converter',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const FACTOR = 18.018
+
+// unit: 'mg' = mg/dL input | 'mmol' = mmol/L input
+const unit = ref('mg')
+// context: 'fasting' | 'postprandial'
+const context = ref('fasting')
+const inputValue = ref(null)
+
+function switchUnit(u) {
+  unit.value = u
+  inputValue.value = null
+}
+
+function switchContext(c) {
+  context.value = c
+}
+
+const valueMg = computed(() => {
+  if (!inputValue.value) return null
+  return unit.value === 'mg' ? inputValue.value : inputValue.value * FACTOR
+})
+
+const convertedValue = computed(() => {
+  if (valueMg.value === null) return null
+  return unit.value === 'mg' ? valueMg.value / FACTOR : valueMg.value
+})
+
+const riskCategory = computed(() => {
+  if (valueMg.value === null) return null
+  const v = valueMg.value
+  if (context.value === 'fasting') {
+    if (v < 100) return { key: 'normal', color: 'text-green-600', bg: 'bg-green-600' }
+    if (v < 126) return { key: 'prediabetes', color: 'text-yellow-500', bg: 'bg-yellow-500' }
+    return { key: 'diabetes', color: 'text-red-500', bg: 'bg-red-500' }
+  } else {
+    if (v < 140) return { key: 'normal', color: 'text-green-600', bg: 'bg-green-600' }
+    if (v < 200) return { key: 'prediabetes', color: 'text-yellow-500', bg: 'bg-yellow-500' }
+    return { key: 'diabetes', color: 'text-red-500', bg: 'bg-red-500' }
+  }
+})
+
+const hasResult = computed(() => valueMg.value !== null)
+
+const outputUnit = computed(() => (unit.value === 'mg' ? 'mmol/L' : 'mg/dL'))
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('bloodSugar.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('bloodSugar.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <!-- Unit + context toggles -->
+      <div class="flex flex-wrap gap-2 mb-6">
+        <button
+          data-testid="btn-mgdl"
+          @click="switchUnit('mg')"
+          :class="unit === 'mg' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >mg/dL</button>
+        <button
+          data-testid="btn-mmol"
+          @click="switchUnit('mmol')"
+          :class="unit === 'mmol' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >mmol/L</button>
+
+        <div class="ml-auto flex gap-2">
+          <button
+            data-testid="btn-fasting"
+            @click="switchContext('fasting')"
+            :class="context === 'fasting' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('bloodSugar.fasting') }}</button>
+          <button
+            data-testid="btn-postprandial"
+            @click="switchContext('postprandial')"
+            :class="context === 'postprandial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('bloodSugar.postprandial') }}</button>
+        </div>
+      </div>
+
+      <!-- Input -->
+      <label for="input-value" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+        {{ t('bloodSugar.valueLabel') }} ({{ unit === 'mg' ? 'mg/dL' : 'mmol/L' }})
+      </label>
+      <input
+        id="input-value"
+        v-model.number="inputValue"
+        data-testid="input-value"
+        type="number"
+        step="0.1"
+        min="0"
+        :placeholder="unit === 'mg' ? t('bloodSugar.valuePlaceholderMg') : t('bloodSugar.valuePlaceholderMmol')"
+        class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+      />
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Results -->
+    <div v-if="hasResult" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <!-- Risk badge -->
+      <div class="flex items-center gap-3 mb-6">
+        <span
+          data-testid="risk-badge"
+          :class="[riskCategory.bg, 'text-white text-sm font-semibold px-3 py-1 rounded-full']"
+        >{{ t('bloodSugar.' + riskCategory.key) }}</span>
+        <span class="text-sm text-stone-500">{{ t('bloodSugar.category') }}</span>
+      </div>
+
+      <!-- Result values -->
+      <div class="grid grid-cols-2 gap-6 mb-6">
+        <div class="space-y-5">
+          <div>
+            <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('bloodSugar.resultLabel') }} ({{ outputUnit }})</div>
+            <div data-testid="result-converted" class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight">
+              {{ unit === 'mg' ? convertedValue.toFixed(2) : convertedValue.toFixed(1) }}
+              <span class="text-base font-normal text-stone-500">{{ outputUnit }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Visual risk indicator -->
+        <div data-testid="risk-category" class="flex flex-col items-center justify-center">
+          <div class="relative w-28 h-28">
+            <svg viewBox="0 0 100 100" class="w-full h-full -rotate-90">
+              <circle cx="50" cy="50" r="38" fill="none" stroke="#e7e5e4" stroke-width="10"/>
+              <circle
+                cx="50" cy="50" r="38" fill="none"
+                :stroke="riskCategory.key === 'normal' ? '#16a34a' : riskCategory.key === 'prediabetes' ? '#eab308' : '#ef4444'"
+                stroke-width="10"
+                stroke-linecap="round"
+                :stroke-dasharray="`${riskCategory.key === 'normal' ? 79 : riskCategory.key === 'prediabetes' ? 159 : 239} 239`"
+              />
+            </svg>
+            <div class="absolute inset-0 flex items-center justify-center">
+              <span :class="[riskCategory.color, 'text-xs font-bold text-center leading-tight px-2']">
+                {{ t('bloodSugar.' + riskCategory.key) }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Formula -->
+      <div class="border-t border-stone-100 pt-4">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('bloodSugar.formula') }}</div>
+        <div class="bg-stone-50 rounded-lg px-4 py-3 text-sm font-mono text-stone-700">
+          {{ unit === 'mg' ? t('bloodSugar.formulaMgToMmol') : t('bloodSugar.formulaMmolToMg') }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Reference ranges table -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('bloodSugar.categoriesTitle') }}</h2>
+
+      <div class="mb-6">
+        <div class="text-sm font-semibold text-stone-700 mb-3">{{ t('bloodSugar.fastingRangesTitle') }}</div>
+        <div class="space-y-3">
+          <div class="flex items-center justify-between border-b border-stone-100 pb-3">
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-green-600 shrink-0"></div>
+              <div>
+                <span class="text-sm text-stone-900 font-medium">{{ t('bloodSugar.normal') }}</span>
+                <p class="text-xs text-stone-500">{{ t('bloodSugar.normalDesc') }}</p>
+              </div>
+            </div>
+            <div class="text-right shrink-0 ml-4">
+              <div class="text-sm font-medium text-stone-900 tabular-nums">{{ t('bloodSugar.normalFastingRange') }} mg/dL</div>
+              <div class="text-xs text-stone-500 tabular-nums">{{ t('bloodSugar.normalFastingRangeMmol') }} mmol/L</div>
+            </div>
+          </div>
+          <div class="flex items-center justify-between border-b border-stone-100 pb-3">
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-yellow-500 shrink-0"></div>
+              <div>
+                <span class="text-sm text-stone-900 font-medium">{{ t('bloodSugar.prediabetes') }}</span>
+                <p class="text-xs text-stone-500">{{ t('bloodSugar.prediabetesDesc') }}</p>
+              </div>
+            </div>
+            <div class="text-right shrink-0 ml-4">
+              <div class="text-sm font-medium text-stone-900 tabular-nums">{{ t('bloodSugar.prediabeticFastingRange') }} mg/dL</div>
+              <div class="text-xs text-stone-500 tabular-nums">{{ t('bloodSugar.prediabeticFastingRangeMmol') }} mmol/L</div>
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-red-500 shrink-0"></div>
+              <div>
+                <span class="text-sm text-stone-900 font-medium">{{ t('bloodSugar.diabetes') }}</span>
+                <p class="text-xs text-stone-500">{{ t('bloodSugar.diabetesDesc') }}</p>
+              </div>
+            </div>
+            <div class="text-right shrink-0 ml-4">
+              <div class="text-sm font-medium text-stone-900 tabular-nums">{{ t('bloodSugar.diabeticFastingRange') }} mg/dL</div>
+              <div class="text-xs text-stone-500 tabular-nums">{{ t('bloodSugar.diabeticFastingRangeMmol') }} mmol/L</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="text-sm font-semibold text-stone-700 mb-3">{{ t('bloodSugar.postprandialRangesTitle') }}</div>
+        <div class="space-y-3">
+          <div class="flex items-center justify-between border-b border-stone-100 pb-3">
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-green-600 shrink-0"></div>
+              <span class="text-sm text-stone-900 font-medium">{{ t('bloodSugar.normal') }}</span>
+            </div>
+            <div class="text-right shrink-0 ml-4">
+              <div class="text-sm font-medium text-stone-900 tabular-nums">{{ t('bloodSugar.normalPostprandialRange') }} mg/dL</div>
+              <div class="text-xs text-stone-500 tabular-nums">{{ t('bloodSugar.normalPostprandialRangeMmol') }} mmol/L</div>
+            </div>
+          </div>
+          <div class="flex items-center justify-between border-b border-stone-100 pb-3">
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-yellow-500 shrink-0"></div>
+              <span class="text-sm text-stone-900 font-medium">{{ t('bloodSugar.prediabetes') }}</span>
+            </div>
+            <div class="text-right shrink-0 ml-4">
+              <div class="text-sm font-medium text-stone-900 tabular-nums">{{ t('bloodSugar.prediabeticPostprandialRange') }} mg/dL</div>
+              <div class="text-xs text-stone-500 tabular-nums">{{ t('bloodSugar.prediabeticPostprandialRangeMmol') }} mmol/L</div>
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-red-500 shrink-0"></div>
+              <span class="text-sm text-stone-900 font-medium">{{ t('bloodSugar.diabetes') }}</span>
+            </div>
+            <div class="text-right shrink-0 ml-4">
+              <div class="text-sm font-medium text-stone-900 tabular-nums">{{ t('bloodSugar.diabeticPostprandialRange') }} mg/dL</div>
+              <div class="text-xs text-stone-500 tabular-nums">{{ t('bloodSugar.diabeticPostprandialRangeMmol') }} mmol/L</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p class="text-xs text-stone-400 mt-6 italic">{{ t('bloodSugar.contextNote') }}</p>
+    </div>
+
+    <BlogBanner calculator-key="bloodSugar" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/BlutzuckerUmrechnen.vue
+++ b/src/pages/blog/BlutzuckerUmrechnen.vue
@@ -1,0 +1,254 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Blutzucker umrechnen — mg/dL und mmol/L verstehen | Health Calculators',
+  description: 'Blutzucker zwischen mg/dL und mmol/L umrechnen. Nüchternwert und postprandialen Wert einordnen. Referenzbereiche, Formel und kostenloser Rechner.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Blutzucker umrechnen — mg/dL und mmol/L verstehen',
+    description: 'Blutzucker zwischen mg/dL und mmol/L umrechnen. Referenzbereiche für Nüchtern- und postprandiale Werte einfach erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-12',
+    dateModified: '2026-04-12',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/blutzucker-umrechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Blutzucker umrechnen — mg/dL und mmol/L verstehen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">12. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ob auf dem Blutzuckermessgerät, im Arztbericht oder in einer amerikanischen Studie — Blutzuckerwerte erscheinen in zwei Einheiten: <strong>mg/dL</strong> (Milligramm pro Deziliter) und <strong>mmol/L</strong> (Millimol pro Liter). In Europa ist mg/dL Standard, in vielen anderen Ländern mmol/L.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Artikel erfährst du, wie die Umrechnung funktioniert, was die Referenzbereiche bedeuten und wie du deinen Wert richtig einordnest.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Umrechnungsformel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Blutzucker lässt sich mit einem festen Faktor zwischen beiden Einheiten umrechnen. Der Faktor basiert auf dem Molekulargewicht von Glukose (180,18 g/mol):
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Richtung</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Formel</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">mg/dL → mmol/L</td>
+                <td class="px-6 py-3 font-mono text-stone-900">mmol/L = mg/dL ÷ 18,018</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">mmol/L → mg/dL</td>
+                <td class="px-6 py-3 font-mono text-stone-900">mg/dL = mmol/L × 18,018</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-sm text-stone-700 font-semibold mb-2">Beispiel</p>
+          <p class="text-sm text-stone-600">Ein Nüchternblutzucker von <strong>95 mg/dL</strong> entspricht <strong>5,27 mmol/L</strong> (95 ÷ 18,018 ≈ 5,27).</p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Nüchternblutzucker — Referenzbereiche</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Den Nüchternblutzucker misst man nach mindestens 8 Stunden ohne Essen. Er ist der wichtigste Basiswert zur Diagnose von Diabetes und Prädiabetes.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mg/dL</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mmol/L</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-green-600 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Normal</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">&lt; 100</td>
+                <td class="px-6 py-3 text-stone-600">&lt; 5,6</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-yellow-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Prädiabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">100 – 125</td>
+                <td class="px-6 py-3 text-stone-600">5,6 – 6,9</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-red-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Diabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">≥ 126</td>
+                <td class="px-6 py-3 text-stone-600">≥ 7,0</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500 italic">Quelle: American Diabetes Association (ADA) Standards of Care 2024.</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Postprandialer Blutzucker — Referenzbereiche</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Den postprandialen Blutzucker misst man 2 Stunden nach einer Mahlzeit. Er zeigt, wie gut der Körper Kohlenhydrate verarbeitet, und kann erhöht sein, während der Nüchternwert noch normal ist.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mg/dL</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mmol/L</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-green-600 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Normal</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">&lt; 140</td>
+                <td class="px-6 py-3 text-stone-600">&lt; 7,8</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-yellow-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Prädiabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">140 – 199</td>
+                <td class="px-6 py-3 text-stone-600">7,8 – 11,0</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-red-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Diabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">≥ 200</td>
+                <td class="px-6 py-3 text-stone-600">≥ 11,1</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Nüchternwert vs. postprandialer Wert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Beide Messungen geben unterschiedliche Einblicke in die Blutzuckerregulation:
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Nüchternwert</strong> zeigt die Basisfunktion der Bauchspeicheldrüse und Insulinresistenz im Ruhezustand.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Postprandialer Wert</strong> zeigt die Reaktion auf Kohlenhydrate und ist oft früher erhöht als der Nüchternwert.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base">Ein erhöhter postprandialer Wert bei normalem Nüchternwert kann auf Prädiabetes hindeuten.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Zusammenhang mit HbA1c</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der HbA1c-Wert spiegelt den durchschnittlichen Blutzucker der letzten 2–3 Monate wider — er ist der Langzeit-Gegenstück zum aktuellen Blutzucker. Ein einzelner Blutzuckerwert zeigt den Momentanzustand; der HbA1c zeigt das Gesamtbild.
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6">
+          <p class="text-sm text-stone-600">Ein HbA1c von 6,5 % entspricht einem geschätzten mittleren Blutzucker von ca. <strong>140 mg/dL (7,8 mmol/L)</strong>.</p>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Blutzucker jetzt umrechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Gib deinen Wert ein und sieh sofort die Einordnung für Nüchtern- oder postprandialen Wert.</p>
+        <router-link
+          :to="localePath('bloodSugar')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum Blutzucker-Umrechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Warum gibt es zwei verschiedene Einheiten?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Historisch haben verschiedene Länder unterschiedliche Messsysteme eingeführt. Deutschland, Österreich und die Schweiz verwenden mg/dL, während viele andere Länder (UK, Kanada, Australien) mmol/L bevorzugen. Medizinische Geräte können oft zwischen beiden umschalten.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Kann ein einzelner Wert Diabetes diagnostizieren?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Nein. Ein einzelner erhöhter Wert allein genügt nicht für eine Diagnose. Die ADA fordert mindestens zwei abnormale Messungen an verschiedenen Tagen oder einen oralen Glukosetoleranztest. Wende dich immer an einen Arzt.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Was beeinflusst den Blutzucker?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Mahlzeiten (besonders Kohlenhydrate), körperliche Aktivität, Stress, Schlafmangel, Medikamente und Krankheiten können den Blutzucker kurzfristig stark beeinflussen. Für verlässliche Werte ist eine standardisierte Messbedingung wichtig.
+            </p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/pages/blog/en/BloodSugarConverterGuide.vue
+++ b/src/pages/blog/en/BloodSugarConverterGuide.vue
@@ -1,0 +1,254 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Blood Sugar Converter — mg/dL to mmol/L Guide | Health Calculators',
+  description: 'Convert blood sugar between mg/dL and mmol/L. Understand fasting and postprandial reference ranges. Normal, Prediabetes, Diabetes explained with free calculator.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Blood Sugar Converter — mg/dL to mmol/L Guide',
+    description: 'Convert blood sugar between mg/dL and mmol/L. Reference ranges for fasting and postprandial readings explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-12',
+    dateModified: '2026-04-12',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/blood-sugar-converter-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Blood Sugar Converter — mg/dL to mmol/L Guide</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 12, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Blood sugar values appear in two units depending on where you are: <strong>mg/dL</strong> (milligrams per deciliter) used in the US and Germany, and <strong>mmol/L</strong> (millimoles per liter) used in the UK, Canada, Australia, and most of the world.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how to convert between units, what the reference ranges mean, and how to interpret your reading as fasting or postprandial.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conversion Formula</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Blood sugar converts between units using a fixed factor based on the molecular weight of glucose (180.18 g/mol):
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Direction</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Formula</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">mg/dL → mmol/L</td>
+                <td class="px-6 py-3 font-mono text-stone-900">mmol/L = mg/dL ÷ 18.018</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">mmol/L → mg/dL</td>
+                <td class="px-6 py-3 font-mono text-stone-900">mg/dL = mmol/L × 18.018</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-sm text-stone-700 font-semibold mb-2">Example</p>
+          <p class="text-sm text-stone-600">A fasting blood sugar of <strong>95 mg/dL</strong> equals <strong>5.27 mmol/L</strong> (95 ÷ 18.018 ≈ 5.27).</p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fasting Blood Sugar Reference Ranges</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Fasting blood sugar is measured after at least 8 hours without eating. It is the primary value for diagnosing diabetes and prediabetes.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mg/dL</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mmol/L</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-green-600 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Normal</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">&lt; 100</td>
+                <td class="px-6 py-3 text-stone-600">&lt; 5.6</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-yellow-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Prediabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">100 – 125</td>
+                <td class="px-6 py-3 text-stone-600">5.6 – 6.9</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-red-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Diabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">≥ 126</td>
+                <td class="px-6 py-3 text-stone-600">≥ 7.0</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500 italic">Source: American Diabetes Association (ADA) Standards of Care 2024.</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Postprandial Blood Sugar Reference Ranges</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Postprandial blood sugar is measured 2 hours after a meal. It shows how well the body processes carbohydrates and can be elevated even when fasting values are still normal.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mg/dL</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">mmol/L</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-green-600 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Normal</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">&lt; 140</td>
+                <td class="px-6 py-3 text-stone-600">&lt; 7.8</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-yellow-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Prediabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">140 – 199</td>
+                <td class="px-6 py-3 text-stone-600">7.8 – 11.0</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-red-500 shrink-0"></span>
+                    <span class="text-stone-900 font-medium">Diabetes</span>
+                  </span>
+                </td>
+                <td class="px-6 py-3 text-stone-600">≥ 200</td>
+                <td class="px-6 py-3 text-stone-600">≥ 11.1</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fasting vs. Postprandial</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Both measurements reveal different aspects of blood sugar regulation:
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Fasting</strong> shows baseline pancreatic function and insulin resistance at rest.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Postprandial</strong> shows the response to carbohydrates and is often elevated earlier than fasting values.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base">Elevated postprandial values with normal fasting values can indicate prediabetes.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Relationship to HbA1c</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          While blood sugar gives a snapshot, HbA1c reflects the average blood sugar over the past 2–3 months. Both tests together provide the most complete picture of glucose metabolism.
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6">
+          <p class="text-sm text-stone-600">An HbA1c of 6.5% corresponds to an estimated average glucose of approximately <strong>140 mg/dL (7.8 mmol/L)</strong>.</p>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Convert Your Blood Sugar Now</h3>
+        <p class="text-stone-300 text-sm mb-5">Enter your value and instantly see the conversion and classification for fasting or postprandial readings.</p>
+        <router-link
+          :to="localePath('bloodSugar')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Open Blood Sugar Converter &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequently Asked Questions</h2>
+
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Why are there two different units?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Different countries adopted different measurement systems historically. The US and Germany use mg/dL, while most other countries use mmol/L. Modern glucose meters often support both units.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Can a single reading diagnose diabetes?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              No. A single elevated reading alone is not sufficient for diagnosis. The ADA requires at least two abnormal measurements on different days, or an oral glucose tolerance test. Always consult a doctor.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">What affects blood sugar levels?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Meals (especially carbohydrates), physical activity, stress, poor sleep, medications, and illness can all significantly affect blood sugar in the short term. Standardized measurement conditions are important for reliable readings.
+            </p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <RelatedArticlesEn />
+  </article>
+</template>

--- a/src/pages/bloodSugar.meta.js
+++ b/src/pages/bloodSugar.meta.js
@@ -1,0 +1,17 @@
+import Component from './BloodSugarConverter.vue'
+import BlogDe from './blog/BlutzuckerUmrechnen.vue'
+import BlogEn from './blog/en/BloodSugarConverterGuide.vue'
+
+export default {
+  key: 'bloodSugar',
+  component: Component,
+  slugs: { de: 'blutzucker-umrechner', en: 'blood-sugar-converter' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 8,
+  oldRedirect: '/blutzucker-umrechner',
+  blog: {
+    de: { slug: 'blutzucker-umrechnen', component: BlogDe },
+    en: { slug: 'blood-sugar-converter-guide', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-103-blood-sugar-converter
**Agent:** claude
**Branch:** `agent/hc-103-blood-sugar-converter-20260412-030032`

Closes jenslaufer/health-calculators#103

### Prompt
> Implement the Blood Sugar Converter as described in issue #103.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: Blood sugar value, unit selection (mg/dL or mmol/L)
- Output: Converted value, reference range classification (normal/pre-diabetic/diabetic), fasting vs postprandial context
- Conversion factor: mmol/L = mg/dL / 18.018
- Visual color-coded range indicator (green/yellow/red)
- Blog articles: DE (/blog/blutzucker-umrechnen) + EN (/blog/blood-sugar-converter-guide)
- Unit tests for conversion accuracy, range classification
- E2E test for the calculator page
- SSG pre-rendering must work

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks