### PR TITLE
hc-163-llms-txt: Add auto-generated llms.txt for AI discoverability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite-ssg build && node scripts/generate-sitemap.js",
+    "build": "vite-ssg build && node scripts/generate-sitemap.js && node scripts/generate-llms-txt.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -1,0 +1,102 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BASE_URL = 'https://healthcalculator.app'
+const META_DIR = join(__dirname, '../src/pages')
+const OUTPUT = join(__dirname, '../dist/llms.txt')
+
+function parseMeta(source) {
+  const key = source.match(/key:\s*'([^']+)'/)?.[1]
+
+  const slugsMatch = source.match(/slugs:\s*\{\s*de:\s*'([^']+)',\s*en:\s*'([^']+)'\s*\}/)
+  const slugs = slugsMatch ? { de: slugsMatch[1], en: slugsMatch[2] } : null
+
+  const blogBlock = source.match(/blog:\s*\{([\s\S]*)\},?\s*\}[\s]*$/)?.[1] ?? ''
+  const blogDeSlug = blogBlock.match(/de:\s*\{[^}]*slug:\s*'([^']+)'/)?.[1]
+  const blogEnSlug = blogBlock.match(/en:\s*\{[^}]*slug:\s*'([^']+)'/)?.[1]
+
+  const blogDeFile = source.match(/import BlogDe from '(\.\/blog\/[^']+\.vue)'/)?.[1]
+  const blogEnFile = source.match(/import BlogEn from '(\.\/blog\/(?:en\/)?[^']+\.vue)'/)?.[1]
+
+  const blog = blogDeSlug && blogEnSlug ? {
+    de: { slug: blogDeSlug, file: blogDeFile },
+    en: { slug: blogEnSlug, file: blogEnFile },
+  } : null
+
+  return key && slugs && blog ? { key, slugs, blog } : null
+}
+
+export function discoverMetas(metaDir = META_DIR) {
+  return readdirSync(metaDir)
+    .filter(f => f.endsWith('.meta.js'))
+    .map(f => parseMeta(readFileSync(join(metaDir, f), 'utf-8')))
+    .filter(Boolean)
+}
+
+function loadLocale(key, locale, metaDir) {
+  const localesDir = join(metaDir, '../locales/calculators')
+  const filePath = join(localesDir, locale, `${key}.json`)
+  try {
+    const data = JSON.parse(readFileSync(filePath, 'utf-8'))
+    const rawTitle = data[key]?.meta?.title ?? key
+    return {
+      title: rawTitle.replace(/ \| Health Calculators$/, ''),
+      description: data[key]?.meta?.description ?? '',
+    }
+  } catch {
+    return { title: key, description: '' }
+  }
+}
+
+function extractStr(source, key) {
+  const sq = source.match(new RegExp(`${key}:\\s*'((?:[^'\\\\]|\\\\.)*)'`))
+  if (sq) return sq[1].replace(/\\'/g, "'")
+  const dq = source.match(new RegExp(`${key}:\\s*"((?:[^"\\\\]|\\\\.)*)"`))
+  if (dq) return dq[1].replace(/\\"/g, '"')
+  return ''
+}
+
+function parseBlogComponent(relPath, metaDir) {
+  const absPath = join(metaDir, relPath.replace('./', ''))
+  try {
+    const source = readFileSync(absPath, 'utf-8')
+    const title = extractStr(source, 'title').replace(/ \| Health Calculators$/, '')
+    const description = extractStr(source, 'description')
+    return { title, description }
+  } catch {
+    return { title: '', description: '' }
+  }
+}
+
+export function generateLlmsTxt(metas, baseUrl = BASE_URL, metaDir = META_DIR) {
+  let txt = '# Health Calculators\n\n'
+  txt += '> Free, science-backed health calculators for BMI, BMR, body fat, calories, macros, and more. Available in English and German.\n\n'
+
+  txt += '## Calculators\n\n'
+  for (const meta of metas) {
+    const en = loadLocale(meta.key, 'en', metaDir)
+    const de = loadLocale(meta.key, 'de', metaDir)
+    txt += `- [${en.title}](${baseUrl}/en/${meta.slugs.en}): ${en.description}\n`
+    txt += `- [${de.title}](${baseUrl}/de/${meta.slugs.de}): ${de.description}\n`
+  }
+
+  txt += '\n## Blog\n\n'
+  for (const meta of metas) {
+    const enBlog = meta.blog.en.file ? parseBlogComponent(meta.blog.en.file, metaDir) : { title: '', description: '' }
+    const deBlog = meta.blog.de.file ? parseBlogComponent(meta.blog.de.file, metaDir) : { title: '', description: '' }
+    if (enBlog.title) txt += `- [${enBlog.title}](${baseUrl}/en/blog/${meta.blog.en.slug}): ${enBlog.description}\n`
+    if (deBlog.title) txt += `- [${deBlog.title}](${baseUrl}/de/blog/${meta.blog.de.slug}): ${deBlog.description}\n`
+  }
+
+  return txt
+}
+
+if (process.argv[1]?.endsWith('generate-llms-txt.js')) {
+  const metas = discoverMetas()
+  const content = generateLlmsTxt(metas)
+  writeFileSync(OUTPUT, content)
+  const linkCount = content.split('\n').filter(l => l.startsWith('- [')).length
+  console.log(`llms.txt generated: ${linkCount} links → ${OUTPUT}`)
+}

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { join } from 'node:path'
+import { discoverMetas, generateLlmsTxt } from '../../scripts/generate-llms-txt.js'
+
+const META_DIR = join(import.meta.dirname, '../pages')
+const BASE_URL = 'https://healthcalculator.app'
+
+describe('generateLlmsTxt', () => {
+  let txt
+  let metas
+
+  beforeAll(() => {
+    metas = discoverMetas(META_DIR)
+    txt = generateLlmsTxt(metas, BASE_URL, META_DIR)
+  })
+
+  it('starts with title', () => {
+    expect(txt).toMatch(/^# Health Calculators/)
+  })
+
+  it('has a tagline starting with >', () => {
+    expect(txt).toContain('> ')
+  })
+
+  it('has Calculators section', () => {
+    expect(txt).toContain('## Calculators')
+  })
+
+  it('has Blog section', () => {
+    expect(txt).toContain('## Blog')
+  })
+
+  it('includes EN calculator URLs for all 30 calculators', () => {
+    for (const meta of metas) {
+      expect(txt, `missing EN URL for ${meta.key}`).toContain(`${BASE_URL}/en/${meta.slugs.en}`)
+    }
+  })
+
+  it('includes DE calculator URLs for all 30 calculators', () => {
+    for (const meta of metas) {
+      expect(txt, `missing DE URL for ${meta.key}`).toContain(`${BASE_URL}/de/${meta.slugs.de}`)
+    }
+  })
+
+  it('includes EN blog URLs for all 30 articles', () => {
+    for (const meta of metas) {
+      expect(txt, `missing EN blog URL for ${meta.key}`).toContain(`${BASE_URL}/en/blog/${meta.blog.en.slug}`)
+    }
+  })
+
+  it('includes DE blog URLs for all 30 articles', () => {
+    for (const meta of metas) {
+      expect(txt, `missing DE blog URL for ${meta.key}`).toContain(`${BASE_URL}/de/blog/${meta.blog.de.slug}`)
+    }
+  })
+
+  it('uses - [Title](URL): Description link format', () => {
+    expect(txt).toMatch(/- \[.+\]\(https:\/\/healthcalculator\.app\/en\/bmi-calculator\): .+/)
+  })
+
+  it('every link line has a non-empty description', () => {
+    const lines = txt.split('\n').filter(l => l.startsWith('- ['))
+    for (const line of lines) {
+      expect(line, `missing description in: ${line}`).toMatch(/\): .+$/)
+    }
+  })
+
+  it('generates 120 links (30 calcs × 2 locales + 30 blogs × 2 locales)', () => {
+    const links = txt.split('\n').filter(l => l.startsWith('- ['))
+    expect(links).toHaveLength(120)
+  })
+
+  it('blog titles do not contain "| Health Calculators" suffix', () => {
+    const lines = txt.split('\n').filter(l => l.startsWith('- ['))
+    for (const line of lines) {
+      expect(line).not.toContain('| Health Calculators')
+    }
+  })
+})


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-163-llms-txt
**Agent:** claude
**Branch:** `agent/hc-163-llms-txt-20260412-171003`

Closes jenslaufer/health-calculators#163

### Prompt
> Add auto-generated llms.txt for AI discoverability.

## Context
- HC has no llms.txt — AI models can't discover the 124+ health calculators
- FK (sister site) has one but it's stale and manually maintained
- sitemap.xml is already auto-generated during build (see sitemap generation code)
- llms.txt follows the llms-txt.cloud spec: title, description, then links with descriptions

## Instructions
1. Create a build plugin or script that generates llms.txt from route/sitemap data
   - Follow the same pattern as the existing auto-sitemap generation
   - Include all DE and EN calculator pages with one-line descriptions
   - Include blog pages
   - Use meta.description from route config for descriptions
   - Format: `- [Title](URL): Description`
2. Ensure llms.txt is served at /llms.txt after build
3. Add a test verifying llms.txt is generated with correct format and all pages included
4. Run `npm run test` — all tests must pass
5. Run `npm run build` — verify llms.txt appears in dist/
6. DO NOT DELETE or modify calculator components, blog articles, or unrelated files
7. DO NOT change routing, calculator logic, or visual appearance