### PR TITLE
hc-106-gfr-calculator: Implement the GFR Calculator (eGFR / Kidney Function) as des

### DIFF
--- a/e2e/gfr.spec.js
+++ b/e2e/gfr.spec.js
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/gfr-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/GFR/)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})
+
+test('no result shown without inputs', async ({ page }) => {
+  await expect(page.getByTestId('egfr-result')).not.toBeVisible()
+})
+
+test('calculates eGFR for male with mg/dL input', async ({ page }) => {
+  await page.getByTestId('btn-mgdl').click()
+  await page.getByTestId('input-creatinine').fill('1.0')
+  await page.getByTestId('input-age').fill('50')
+  await page.getByTestId('btn-male').click()
+
+  const result = page.getByTestId('egfr-result')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const egfr = parseFloat(text)
+  expect(egfr).toBeGreaterThanOrEqual(89)
+  expect(egfr).toBeLessThanOrEqual(95)
+})
+
+test('calculates eGFR for female with mg/dL input', async ({ page }) => {
+  await page.getByTestId('btn-mgdl').click()
+  await page.getByTestId('input-creatinine').fill('0.8')
+  await page.getByTestId('input-age').fill('50')
+  await page.getByTestId('btn-female').click()
+
+  const result = page.getByTestId('egfr-result')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const egfr = parseFloat(text)
+  expect(egfr).toBeGreaterThanOrEqual(86)
+  expect(egfr).toBeLessThanOrEqual(92)
+})
+
+test('calculates eGFR for µmol/L input', async ({ page }) => {
+  await page.getByTestId('btn-umol').click()
+  await page.getByTestId('input-creatinine').fill('88.42')
+  await page.getByTestId('input-age').fill('50')
+  await page.getByTestId('btn-male').click()
+
+  const result = page.getByTestId('egfr-result')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const egfr = parseFloat(text)
+  // 88.42 µmol/L = 1.0 mg/dL → same result as mg/dL test above
+  expect(egfr).toBeGreaterThanOrEqual(89)
+  expect(egfr).toBeLessThanOrEqual(95)
+})
+
+test('switching unit clears creatinine input', async ({ page }) => {
+  await page.getByTestId('btn-mgdl').click()
+  await page.getByTestId('input-creatinine').fill('1.0')
+  await page.getByTestId('btn-umol').click()
+  const val = await page.getByTestId('input-creatinine').inputValue()
+  expect(val).toBe('')
+})
+
+test('shows CKD stage badge when result is available', async ({ page }) => {
+  await page.getByTestId('input-creatinine').fill('1.0')
+  await page.getByTestId('input-age').fill('50')
+
+  const badge = page.getByTestId('ckd-stage')
+  await expect(badge).toBeVisible()
+})
+
+test('stage G1 for healthy young male', async ({ page }) => {
+  await page.getByTestId('input-creatinine').fill('0.9')
+  await page.getByTestId('input-age').fill('25')
+  await page.getByTestId('btn-male').click()
+
+  const badge = page.getByTestId('ckd-stage')
+  await expect(badge).toBeVisible()
+  await expect(badge).toContainText('G1')
+})
+
+test('stage G5 for severely impaired kidney function', async ({ page }) => {
+  await page.getByTestId('input-creatinine').fill('8.0')
+  await page.getByTestId('input-age').fill('55')
+  await page.getByTestId('btn-male').click()
+
+  const badge = page.getByTestId('ckd-stage')
+  await expect(badge).toBeVisible()
+  await expect(badge).toContainText('G5')
+})
+
+test('risk assessment is visible with result', async ({ page }) => {
+  await page.getByTestId('input-creatinine').fill('1.0')
+  await page.getByTestId('input-age').fill('50')
+
+  await expect(page.getByTestId('risk-assessment')).toBeVisible()
+})
+
+test('CKD stages reference table is always visible', async ({ page }) => {
+  await expect(page.getByText('G1', { exact: true }).first()).toBeVisible()
+  await expect(page.getByText('G5', { exact: true })).toBeVisible()
+})
+
+test('EN calculator page loads', async ({ page }) => {
+  await page.goto('en/gfr-calculator')
+  await expect(page).toHaveTitle(/GFR/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -16,7 +16,7 @@ const EXPECTED_KEYS = [
   'waistHipRatio', 'ovulation', 'protein', 'bmr', 'caloriesBurned',
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
-  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa',
+  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -50,6 +50,7 @@ const EXPECTED_ROUTE_MAP = {
   hba1c: { de: 'hba1c-konverter', en: 'hba1c-converter' },
   bloodSugar: { de: 'blutzucker-umrechner', en: 'blood-sugar-converter' },
   bsa: { de: 'koerperoberflaeche-rechner', en: 'body-surface-area-calculator' },
+  gfr: { de: 'gfr-rechner', en: 'gfr-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -71,6 +72,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'hba1c-umrechnen',
   'blutzucker-umrechnen',
   'koerperoberflaeche-berechnen',
+  'gfr-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -92,19 +94,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'hba1c-converter-guide',
   'blood-sugar-converter-guide',
   'body-surface-area-calculator',
+  'gfr-calculator-kidney-function',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 30 calculators', () => {
-    expect(calculatorMetas).toHaveLength(30)
+  it('discovers all 31 calculators', () => {
+    expect(calculatorMetas).toHaveLength(31)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 30 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(30)
+  it('builds calculatorComponents map for all 31 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(31)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -127,15 +130,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 30 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(30)
+  it('discovers all 31 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(31)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 30 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(30)
+  it('discovers all 31 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(31)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -151,10 +154,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 30 calculators with no duplicates', () => {
+  it('groups contain all 31 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(30)
-    expect(new Set(allKeys).size).toBe(30)
+    expect(allKeys).toHaveLength(31)
+    expect(new Set(allKeys).size).toBe(31)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -175,7 +178,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr',
     ])
   })
 
@@ -223,8 +226,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 187 routes', () => {
-    expect(routes).toHaveLength(187)
+  it('generates exactly 193 routes', () => {
+    expect(routes).toHaveLength(193)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/gfr.test.js
+++ b/src/__tests__/gfr.test.js
@@ -1,0 +1,278 @@
+import { describe, it, expect } from 'vitest'
+
+// CKD-EPI 2021 equation (race-free)
+// eGFR = 142 × min(Scr/κ, 1)^α × max(Scr/κ, 1)^(−1.200) × 0.9938^Age × 1.012 [if female]
+// Female: κ = 0.7, α = −0.241
+// Male:   κ = 0.9, α = −0.302
+// Scr in mg/dL
+function ckdEpi2021(scrMgDl, age, isFemale) {
+  const kappa = isFemale ? 0.7 : 0.9
+  const alpha = isFemale ? -0.241 : -0.302
+  const ratio = scrMgDl / kappa
+  const sexFactor = isFemale ? 1.012 : 1.0
+  return (
+    142 *
+    Math.pow(Math.min(ratio, 1), alpha) *
+    Math.pow(Math.max(ratio, 1), -1.2) *
+    Math.pow(0.9938, age) *
+    sexFactor
+  )
+}
+
+// Unit conversion
+const UMOL_TO_MG = 1 / 88.42
+
+function umolToMg(umol) {
+  return umol * UMOL_TO_MG
+}
+
+function mgToUmol(mg) {
+  return mg * 88.42
+}
+
+// CKD stage classification
+function ckdStage(egfr) {
+  if (egfr >= 90) return 'G1'
+  if (egfr >= 60) return 'G2'
+  if (egfr >= 45) return 'G3a'
+  if (egfr >= 30) return 'G3b'
+  if (egfr >= 15) return 'G4'
+  return 'G5'
+}
+
+// -------------------------------------------------------------------
+// CKD-EPI 2021 reference values (published by Inker et al. 2021 NEJM)
+// -------------------------------------------------------------------
+
+describe('CKD-EPI 2021 — published reference values', () => {
+  // Reference: Inker LA et al. N Engl J Med 2021;385:1737-1749
+  // Male, 50y, Scr 1.0 mg/dL (above kappa 0.9) → eGFR ≈ 91.7
+  it('male, 50y, 1.0 mg/dL → ~92 mL/min/1.73m²', () => {
+    const result = ckdEpi2021(1.0, 50, false)
+    expect(result).toBeGreaterThanOrEqual(89)
+    expect(result).toBeLessThanOrEqual(95)
+  })
+
+  // Female, 50y, Scr 0.8 mg/dL (above kappa 0.7) → eGFR ≈ 90.5
+  it('female, 50y, 0.8 mg/dL → ~90 mL/min/1.73m²', () => {
+    const result = ckdEpi2021(0.8, 50, true)
+    expect(result).toBeGreaterThanOrEqual(86)
+    expect(result).toBeLessThanOrEqual(95)
+  })
+
+  // Male, 65y, Scr 1.5 mg/dL → eGFR ≈ 51.4
+  it('male, 65y, 1.5 mg/dL → ~51 mL/min/1.73m²', () => {
+    const result = ckdEpi2021(1.5, 65, false)
+    expect(result).toBeGreaterThanOrEqual(48)
+    expect(result).toBeLessThanOrEqual(55)
+  })
+
+  // Female, 70y, Scr 2.0 mg/dL → eGFR ≈ 26.7
+  it('female, 70y, 2.0 mg/dL → ~27 mL/min/1.73m²', () => {
+    const result = ckdEpi2021(2.0, 70, true)
+    expect(result).toBeGreaterThanOrEqual(24)
+    expect(result).toBeLessThanOrEqual(30)
+  })
+
+  // Male, 40y, Scr 0.9 mg/dL (exactly at kappa = 0.9) → eGFR ≈ 110.7
+  it('male, 40y, 0.9 mg/dL (at kappa) → ~111 mL/min/1.73m²', () => {
+    const result = ckdEpi2021(0.9, 40, false)
+    expect(result).toBeGreaterThanOrEqual(108)
+    expect(result).toBeLessThanOrEqual(114)
+  })
+
+  // Female, 30y, Scr 0.7 mg/dL (exactly at kappa = 0.7) → eGFR ≈ 119.3
+  it('female, 30y, 0.7 mg/dL (at kappa) → ~119 mL/min/1.73m²', () => {
+    const result = ckdEpi2021(0.7, 30, true)
+    expect(result).toBeGreaterThanOrEqual(116)
+    expect(result).toBeLessThanOrEqual(123)
+  })
+})
+
+describe('CKD-EPI 2021 — sex factor', () => {
+  it('sex factor 1.012 elevates female eGFR relative to no-factor baseline', () => {
+    // The 1.012 factor is always applied for female — verify by comparing with manual calculation without it
+    const kappa = 0.7, alpha = -0.241
+    const scr = 1.0, age = 50
+    const ratio = scr / kappa
+    const base = 142 * Math.pow(Math.min(ratio, 1), alpha) * Math.pow(Math.max(ratio, 1), -1.2) * Math.pow(0.9938, age)
+    const withSexFactor = base * 1.012
+    expect(withSexFactor).toBeCloseTo(ckdEpi2021(scr, age, true), 5)
+    expect(withSexFactor).toBeGreaterThan(base)
+  })
+
+  it('for same creatinine above normal range, female eGFR is lower than male (reflects worse relative function)', () => {
+    // At 2.0 mg/dL (well above both thresholds), female eGFR < male: relative impairment is greater for female
+    const male = ckdEpi2021(2.0, 50, false)
+    const female = ckdEpi2021(2.0, 50, true)
+    expect(female).toBeLessThan(male)
+  })
+})
+
+describe('CKD-EPI 2021 — age effect', () => {
+  it('eGFR decreases with age for same creatinine and sex', () => {
+    const young = ckdEpi2021(1.0, 30, false)
+    const old = ckdEpi2021(1.0, 70, false)
+    expect(young).toBeGreaterThan(old)
+  })
+
+  it('factor 0.9938^age reduces eGFR progressively', () => {
+    const age30 = ckdEpi2021(1.0, 30, false)
+    const age60 = ckdEpi2021(1.0, 60, false)
+    const age90 = ckdEpi2021(1.0, 90, false)
+    expect(age30).toBeGreaterThan(age60)
+    expect(age60).toBeGreaterThan(age90)
+  })
+})
+
+describe('CKD-EPI 2021 — creatinine effect', () => {
+  it('eGFR decreases as creatinine increases', () => {
+    const low = ckdEpi2021(0.8, 50, false)
+    const mid = ckdEpi2021(1.5, 50, false)
+    const high = ckdEpi2021(5.0, 50, false)
+    expect(low).toBeGreaterThan(mid)
+    expect(mid).toBeGreaterThan(high)
+  })
+})
+
+describe('CKD-EPI 2021 — edge cases', () => {
+  it('very high creatinine (10 mg/dL) returns a very low eGFR', () => {
+    const result = ckdEpi2021(10.0, 60, false)
+    expect(result).toBeLessThan(10)
+    expect(result).toBeGreaterThan(0)
+  })
+
+  it('very low creatinine (0.3 mg/dL) returns a high eGFR', () => {
+    const result = ckdEpi2021(0.3, 40, false)
+    expect(result).toBeGreaterThan(120)
+  })
+
+  it('very old patient (90y) with normal creatinine returns reduced eGFR', () => {
+    const result = ckdEpi2021(1.0, 90, false)
+    expect(result).toBeLessThan(80)
+    expect(result).toBeGreaterThan(20)
+  })
+
+  it('young patient (18y) with normal creatinine returns normal/high eGFR', () => {
+    const result = ckdEpi2021(0.9, 18, false)
+    expect(result).toBeGreaterThan(100)
+  })
+})
+
+// -------------------------------------------------------------------
+// Unit conversion: µmol/L ↔ mg/dL
+// -------------------------------------------------------------------
+
+describe('creatinine unit conversion', () => {
+  it('88.42 µmol/L → 1.0 mg/dL', () => {
+    expect(umolToMg(88.42)).toBeCloseTo(1.0, 3)
+  })
+
+  it('1.0 mg/dL → 88.42 µmol/L', () => {
+    expect(mgToUmol(1.0)).toBeCloseTo(88.42, 2)
+  })
+
+  it('conversion is reciprocal', () => {
+    const original = 1.5
+    expect(umolToMg(mgToUmol(original))).toBeCloseTo(original, 5)
+  })
+
+  it('eGFR is the same regardless of input unit', () => {
+    const scrMg = 1.2
+    const scrUmol = mgToUmol(scrMg)
+    const egfrFromMg = ckdEpi2021(scrMg, 55, false)
+    const egfrFromUmol = ckdEpi2021(umolToMg(scrUmol), 55, false)
+    expect(egfrFromMg).toBeCloseTo(egfrFromUmol, 5)
+  })
+
+  it('106 µmol/L → ~1.2 mg/dL (upper normal male)', () => {
+    expect(umolToMg(106)).toBeCloseTo(1.2, 1)
+  })
+
+  it('44 µmol/L → ~0.5 mg/dL (lower normal female)', () => {
+    expect(umolToMg(44)).toBeCloseTo(0.5, 1)
+  })
+})
+
+// -------------------------------------------------------------------
+// CKD stage classification
+// -------------------------------------------------------------------
+
+describe('CKD stage classification', () => {
+  it('eGFR ≥ 90 → G1', () => {
+    expect(ckdStage(105)).toBe('G1')
+    expect(ckdStage(90)).toBe('G1')
+  })
+
+  it('eGFR 60–89 → G2', () => {
+    expect(ckdStage(75)).toBe('G2')
+    expect(ckdStage(60)).toBe('G2')
+    expect(ckdStage(89)).toBe('G2')
+  })
+
+  it('eGFR 45–59 → G3a', () => {
+    expect(ckdStage(52)).toBe('G3a')
+    expect(ckdStage(45)).toBe('G3a')
+    expect(ckdStage(59)).toBe('G3a')
+  })
+
+  it('eGFR 30–44 → G3b', () => {
+    expect(ckdStage(37)).toBe('G3b')
+    expect(ckdStage(30)).toBe('G3b')
+    expect(ckdStage(44)).toBe('G3b')
+  })
+
+  it('eGFR 15–29 → G4', () => {
+    expect(ckdStage(22)).toBe('G4')
+    expect(ckdStage(15)).toBe('G4')
+    expect(ckdStage(29)).toBe('G4')
+  })
+
+  it('eGFR < 15 → G5', () => {
+    expect(ckdStage(10)).toBe('G5')
+    expect(ckdStage(14.9)).toBe('G5')
+    expect(ckdStage(1)).toBe('G5')
+  })
+
+  it('boundary: 89.9 → G2, 90.0 → G1', () => {
+    expect(ckdStage(89.9)).toBe('G2')
+    expect(ckdStage(90.0)).toBe('G1')
+  })
+
+  it('boundary: 59.9 → G3a, 60.0 → G2', () => {
+    expect(ckdStage(59.9)).toBe('G3a')
+    expect(ckdStage(60.0)).toBe('G2')
+  })
+
+  it('boundary: 14.9 → G5, 15.0 → G4', () => {
+    expect(ckdStage(14.9)).toBe('G5')
+    expect(ckdStage(15.0)).toBe('G4')
+  })
+})
+
+// -------------------------------------------------------------------
+// Real-world clinical scenarios
+// -------------------------------------------------------------------
+
+describe('clinical scenarios', () => {
+  it('healthy young male → G1', () => {
+    const egfr = ckdEpi2021(0.9, 25, false)
+    expect(ckdStage(egfr)).toBe('G1')
+  })
+
+  it('elderly with mildly elevated creatinine → G2 or G3a', () => {
+    const egfr = ckdEpi2021(1.4, 75, false)
+    const stage = ckdStage(egfr)
+    expect(['G2', 'G3a']).toContain(stage)
+  })
+
+  it('diabetic nephropathy scenario (creatinine 2.5, age 60) → G4', () => {
+    const egfr = ckdEpi2021(2.5, 60, false)
+    expect(ckdStage(egfr)).toBe('G4')
+  })
+
+  it('end-stage kidney disease (creatinine 8.0) → G5', () => {
+    const egfr = ckdEpi2021(8.0, 55, false)
+    expect(ckdStage(egfr)).toBe('G5')
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -12,7 +12,7 @@ const EXPECTED_KEYS = [
   'waistHipRatio', 'ovulation', 'protein', 'bmr', 'caloriesBurned',
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
-  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa',
+  'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -34,6 +34,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'hba1c-umrechnen',
   'blutzucker-umrechnen',
   'koerperoberflaeche-berechnen',
+  'gfr-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -55,12 +56,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'hba1c-converter-guide',
   'blood-sugar-converter-guide',
   'body-surface-area-calculator',
+  'gfr-calculator-kidney-function',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 30 calculator meta files', () => {
+  it('discovers all 31 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(30)
+    expect(metas).toHaveLength(31)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -98,19 +100,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 30 DE blog slugs', () => {
+  it('returns all 31 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(30)
+    expect(de).toHaveLength(31)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 30 EN blog slugs', () => {
+  it('returns all 31 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(30)
+    expect(en).toHaveLength(31)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -178,8 +180,8 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 60 calcs + 2 blog index + 60 blog articles = 124)', () => {
+  it('generates correct total URL count (2 home + 62 calcs + 2 blog index + 62 blog articles = 128)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(124)
+    expect(urlCount).toBe(128)
   })
 })

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -245,6 +245,15 @@ slug: 'period-calculator-guide',
     calculatorKey: 'bloodSugar',
     related: ['hba1c-converter-guide', 'calculate-water-intake'],
   },
+  {
+    slug: 'gfr-calculator-kidney-function',
+    title: 'GFR Calculator — Understanding eGFR & Kidney Function',
+    description: 'Calculate eGFR using CKD-EPI 2021 and understand your kidney function. What do GFR values mean, CKD stages G1–G5, and when to see a doctor.',
+    date: '2026-04-13',
+    readTime: '8 min',
+    calculatorKey: 'gfr',
+    related: ['measure-blood-pressure', 'blood-sugar-converter-guide'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -245,6 +245,15 @@ slug: 'zyklusrechner-guide',
     calculatorKey: 'bloodSugar',
     related: ['hba1c-umrechnen', 'wasserbedarf-berechnen'],
   },
+  {
+    slug: 'gfr-rechner',
+    title: 'GFR-Rechner: Nierenfunktion verstehen und einordnen',
+    description: 'eGFR nach CKD-EPI 2021 berechnen und CKD-Stadium einordnen. Was bedeuten GFR-Werte, CKD-Stadien G1–G5 und wann zum Arzt? Alles zur Nierenfunktion.',
+    date: '2026-04-13',
+    readTime: '8 min',
+    calculatorKey: 'gfr',
+    related: ['blutdruck-richtig-messen', 'blutzucker-umrechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/gfr.json
+++ b/src/locales/calculators/de/gfr.json
@@ -1,0 +1,67 @@
+{
+  "home": {
+    "calculators": {
+      "gfr": {
+        "name": "GFR-Rechner",
+        "description": "Nierenfunktion berechnen: eGFR nach CKD-EPI 2021, CKD-Stadium und Risikobewertung."
+      }
+    }
+  },
+  "gfr": {
+    "meta": {
+      "title": "GFR-Rechner — eGFR und Nierenfunktion berechnen | Health Calculators",
+      "description": "eGFR nach CKD-EPI 2021 berechnen (rassenfrei, KDIGO-empfohlen). CKD-Stadium G1–G5, Risikobewertung und Arztempfehlung. Kostenloser Nierenrechner."
+    },
+    "title": "GFR-Rechner — Nierenfunktion (eGFR)",
+    "description": "Glomeruläre Filtrationsrate (eGFR) nach der CKD-EPI 2021-Formel berechnen und Nierenfunktion einordnen.",
+    "creatinineLabel": "Serum-Kreatinin",
+    "ageLabel": "Alter (Jahre)",
+    "sexLabel": "Biologisches Geschlecht",
+    "male": "Männlich",
+    "female": "Weiblich",
+    "formulaNote": "Berechnung nach CKD-EPI 2021 (rassenfrei, KDIGO-empfohlen). Kein Ersatz für ärztliche Diagnose.",
+    "stage": "Stadium",
+    "riskLabel": "Risikobewertung",
+    "doctorLabel": "Arztempfehlung",
+    "stagesTitle": "CKD-Stadien (KDIGO)",
+    "contextTitle": "Hinweise zur Berechnung",
+    "contextEquation": "CKD-EPI 2021-Formel",
+    "contextEquationText": "Die CKD-EPI 2021-Formel ist die aktuell empfohlene Gleichung der KDIGO (Kidney Disease: Improving Global Outcomes). Sie ist rassenunabhängig und liefert präzise Schätzungen für alle Alters- und Kreatininbereiche.",
+    "contextDrug": "Medikamentendosierung",
+    "contextDrugText": "Viele Medikamente werden nach eGFR dosiert oder sind bei eingeschränkter Nierenfunktion kontraindiziert. Dazu gehören Metformin, NSAIDs, bestimmte Antibiotika und Kontrastmittel.",
+    "contextLimits": "Einschränkungen",
+    "contextLimitsText": "eGFR-Formeln schätzen — keine direkte Messung. Ergebnisse können bei extremer Muskelmasse, Mangelernährung, akuter Nierenerkrankung oder Schwangerschaft abweichen.",
+    "contextDisclaimer": "Medizinischer Hinweis",
+    "contextDisclaimerText": "Dieses Tool dient der Information und ersetzt keine ärztliche Untersuchung. Veränderte Nierenwerte sollten immer mit einem Arzt besprochen werden.",
+    "stageDesc": {
+      "G1": "Normal oder erhöht",
+      "G2": "Leicht eingeschränkt",
+      "G3a": "Leicht bis mäßig eingeschränkt",
+      "G3b": "Mäßig bis stark eingeschränkt",
+      "G4": "Stark eingeschränkt",
+      "G5": "Nierenversagen"
+    },
+    "stageRange": {
+      "G1": "≥ 90",
+      "G2": "60 – 89",
+      "G3a": "45 – 59",
+      "G3b": "30 – 44",
+      "G4": "15 – 29",
+      "G5": "< 15"
+    },
+    "risk": {
+      "low": "Normaler bis leicht erhöhter Bereich. Regelmäßige Kontrolluntersuchungen empfohlen.",
+      "moderate": "Leicht bis mäßig erhöhtes Risiko. Risikofaktoren (Bluthochdruck, Diabetes) behandeln lassen.",
+      "high": "Erhöhtes Risiko für Nierenkomplikationen. Nephrologische Betreuung empfohlen.",
+      "veryHigh": "Sehr hohes Risiko. Spezialisierte nephrologische Behandlung erforderlich.",
+      "kidney_failure": "Nierenversagen. Dialyse oder Transplantation kann notwendig sein."
+    },
+    "doctor": {
+      "G2": "Hausarzt informieren und Risikofaktoren (Blutdruck, Blutzucker) kontrollieren lassen.",
+      "G3a": "Regelmäßige Verlaufskontrollen beim Hausarzt oder Nephrologen empfohlen (mindestens jährlich).",
+      "G3b": "Nephrologen aufsuchen. Engmaschige Überwachung und Anpassung der Medikation erforderlich.",
+      "G4": "Dringend zum Nephrologen. Vorbereitung auf Nierenersatztherapie (Dialyse/Transplantation) besprechen.",
+      "G5": "Sofortige nephrologische Behandlung erforderlich. Nierenersatztherapie ist in der Regel notwendig."
+    }
+  }
+}

--- a/src/locales/calculators/en/gfr.json
+++ b/src/locales/calculators/en/gfr.json
@@ -1,0 +1,67 @@
+{
+  "home": {
+    "calculators": {
+      "gfr": {
+        "name": "GFR Calculator",
+        "description": "Calculate kidney function: eGFR using CKD-EPI 2021, CKD stage, and risk assessment."
+      }
+    }
+  },
+  "gfr": {
+    "meta": {
+      "title": "GFR Calculator — eGFR & Kidney Function | Health Calculators",
+      "description": "Calculate eGFR using CKD-EPI 2021 (race-free, KDIGO-recommended). Get your CKD stage G1–G5, risk assessment, and when to see a doctor. Free kidney function calculator."
+    },
+    "title": "GFR Calculator — eGFR Kidney Function",
+    "description": "Calculate estimated glomerular filtration rate (eGFR) using the CKD-EPI 2021 equation and assess kidney function.",
+    "creatinineLabel": "Serum Creatinine",
+    "ageLabel": "Age (years)",
+    "sexLabel": "Biological Sex",
+    "male": "Male",
+    "female": "Female",
+    "formulaNote": "Calculated using CKD-EPI 2021 (race-free, KDIGO-recommended). Not a substitute for medical diagnosis.",
+    "stage": "Stage",
+    "riskLabel": "Risk Assessment",
+    "doctorLabel": "When to See a Doctor",
+    "stagesTitle": "CKD Stages (KDIGO)",
+    "contextTitle": "About This Calculator",
+    "contextEquation": "CKD-EPI 2021 Equation",
+    "contextEquationText": "The CKD-EPI 2021 equation is the current KDIGO (Kidney Disease: Improving Global Outcomes) recommended formula. It is race-free and provides accurate estimates across all age and creatinine ranges.",
+    "contextDrug": "Medication Dosing",
+    "contextDrugText": "Many medications are dosed based on eGFR or are contraindicated with reduced kidney function, including metformin, NSAIDs, certain antibiotics, and contrast agents.",
+    "contextLimits": "Limitations",
+    "contextLimitsText": "eGFR equations estimate kidney function — they do not directly measure it. Results may be less accurate in extreme muscle mass, malnutrition, acute kidney injury, or pregnancy.",
+    "contextDisclaimer": "Medical Disclaimer",
+    "contextDisclaimerText": "This tool is for informational purposes only and does not replace medical evaluation. Abnormal kidney values should always be discussed with a healthcare provider.",
+    "stageDesc": {
+      "G1": "Normal or high",
+      "G2": "Mildly decreased",
+      "G3a": "Mildly to moderately decreased",
+      "G3b": "Moderately to severely decreased",
+      "G4": "Severely decreased",
+      "G5": "Kidney failure"
+    },
+    "stageRange": {
+      "G1": "≥ 90",
+      "G2": "60 – 89",
+      "G3a": "45 – 59",
+      "G3b": "30 – 44",
+      "G4": "15 – 29",
+      "G5": "< 15"
+    },
+    "risk": {
+      "low": "Normal to mildly elevated range. Regular check-ups recommended.",
+      "moderate": "Mildly to moderately elevated risk. Treat risk factors such as hypertension and diabetes.",
+      "high": "Elevated risk for kidney complications. Nephrology follow-up recommended.",
+      "veryHigh": "Very high risk. Specialized nephrology care required.",
+      "kidney_failure": "Kidney failure. Dialysis or transplantation may be necessary."
+    },
+    "doctor": {
+      "G2": "Inform your primary care doctor and have risk factors (blood pressure, blood sugar) checked.",
+      "G3a": "Regular follow-up with your primary care doctor or nephrologist recommended (at least annually).",
+      "G3b": "See a nephrologist. Close monitoring and medication adjustments are needed.",
+      "G4": "Urgent nephrology referral. Discuss preparation for kidney replacement therapy (dialysis/transplant).",
+      "G5": "Immediate nephrology care required. Kidney replacement therapy is typically necessary."
+    }
+  }
+}

--- a/src/pages/GfrCalculator.vue
+++ b/src/pages/GfrCalculator.vue
@@ -1,0 +1,261 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t } = useI18n()
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('gfr.meta.title'),
+  description: t('gfr.meta.description'),
+  routeKey: 'gfr',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'GFR Calculator — eGFR Kidney Function',
+    url: 'https://healthcalculator.app/gfr-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+// Creatinine unit: 'mg' = mg/dL | 'umol' = µmol/L
+const creatUnit = ref('mg')
+const creatinine = ref(null)
+const age = ref(null)
+const sex = ref('male')
+
+const UMOL_TO_MG = 1 / 88.42
+
+function switchCreatUnit(u) {
+  creatUnit.value = u
+  creatinine.value = null
+}
+
+// CKD-EPI 2021 equation (race-free, KDIGO recommended)
+// eGFR = 142 × min(Scr/κ, 1)^α × max(Scr/κ, 1)^(−1.200) × 0.9938^Age × 1.012 [if female]
+// Female: κ = 0.7, α = −0.241
+// Male:   κ = 0.9, α = −0.302
+// Scr in mg/dL
+function ckdEpi2021(scrMgDl, agYears, isFemale) {
+  const kappa = isFemale ? 0.7 : 0.9
+  const alpha = isFemale ? -0.241 : -0.302
+  const ratio = scrMgDl / kappa
+  const sexFactor = isFemale ? 1.012 : 1.0
+  return (
+    142 *
+    Math.pow(Math.min(ratio, 1), alpha) *
+    Math.pow(Math.max(ratio, 1), -1.2) *
+    Math.pow(0.9938, agYears) *
+    sexFactor
+  )
+}
+
+const scrMgDl = computed(() => {
+  if (!creatinine.value || creatinine.value <= 0) return null
+  return creatUnit.value === 'mg' ? creatinine.value : creatinine.value * UMOL_TO_MG
+})
+
+const hasInputs = computed(() =>
+  scrMgDl.value !== null && age.value && age.value > 0 && age.value <= 120
+)
+
+const egfr = computed(() => {
+  if (!hasInputs.value) return null
+  return ckdEpi2021(scrMgDl.value, age.value, sex.value === 'female')
+})
+
+const ckdStage = computed(() => {
+  if (egfr.value === null) return null
+  const v = egfr.value
+  if (v >= 90) return { stage: 'G1', color: 'text-green-600', bg: 'bg-green-600', risk: 'low' }
+  if (v >= 60) return { stage: 'G2', color: 'text-lime-600', bg: 'bg-lime-600', risk: 'low' }
+  if (v >= 45) return { stage: 'G3a', color: 'text-yellow-500', bg: 'bg-yellow-500', risk: 'moderate' }
+  if (v >= 30) return { stage: 'G3b', color: 'text-orange-500', bg: 'bg-orange-500', risk: 'high' }
+  if (v >= 15) return { stage: 'G4', color: 'text-red-500', bg: 'bg-red-500', risk: 'veryHigh' }
+  return { stage: 'G5', color: 'text-red-700', bg: 'bg-red-700', risk: 'kidney_failure' }
+})
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link
+        :to="localePath('home')"
+        class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block"
+      >&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('gfr.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('gfr.description') }}</p>
+    </div>
+
+    <!-- Inputs -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <!-- Creatinine unit toggle -->
+      <div class="flex gap-2 mb-6">
+        <button
+          data-testid="btn-mgdl"
+          @click="switchCreatUnit('mg')"
+          :class="creatUnit === 'mg' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >mg/dL</button>
+        <button
+          data-testid="btn-umol"
+          @click="switchCreatUnit('umol')"
+          :class="creatUnit === 'umol' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >µmol/L</button>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <!-- Serum creatinine -->
+        <div>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('gfr.creatinineLabel') }} ({{ creatUnit === 'mg' ? 'mg/dL' : 'µmol/L' }})
+          </label>
+          <input
+            v-model.number="creatinine"
+            data-testid="input-creatinine"
+            type="number"
+            step="0.01"
+            min="0"
+            :placeholder="creatUnit === 'mg' ? '1.0' : '88'"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+
+        <!-- Age -->
+        <div>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('gfr.ageLabel') }}
+          </label>
+          <input
+            v-model.number="age"
+            data-testid="input-age"
+            type="number"
+            step="1"
+            min="1"
+            max="120"
+            placeholder="45"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+
+        <!-- Sex -->
+        <div>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('gfr.sexLabel') }}
+          </label>
+          <div class="flex gap-2">
+            <button
+              data-testid="btn-male"
+              @click="sex = 'male'"
+              :class="sex === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="flex-1 py-3.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('gfr.male') }}</button>
+            <button
+              data-testid="btn-female"
+              @click="sex = 'female'"
+              :class="sex === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="flex-1 py-3.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('gfr.female') }}</button>
+          </div>
+        </div>
+      </div>
+
+      <p class="text-xs text-stone-400 italic">{{ t('gfr.formulaNote') }}</p>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Result -->
+    <div v-if="egfr !== null" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <!-- eGFR value -->
+      <div class="flex items-baseline gap-3 mb-6">
+        <span
+          data-testid="egfr-result"
+          class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none"
+        >{{ egfr.toFixed(1) }}</span>
+        <span class="text-xl font-light text-stone-500">mL/min/1.73m²</span>
+      </div>
+
+      <!-- CKD Stage badge + description -->
+      <div class="flex items-center gap-3 mb-6">
+        <span
+          data-testid="ckd-stage"
+          :class="[ckdStage.bg, 'text-white text-sm font-semibold px-3 py-1 rounded-full']"
+        >{{ t('gfr.stage') }} {{ ckdStage.stage }}</span>
+        <span class="text-sm text-stone-600">{{ t('gfr.stageDesc.' + ckdStage.stage) }}</span>
+      </div>
+
+      <!-- Risk assessment -->
+      <div class="border-t border-stone-100 pt-5">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('gfr.riskLabel') }}
+        </div>
+        <p
+          data-testid="risk-assessment"
+          :class="[ckdStage.color, 'text-sm font-medium leading-relaxed']"
+        >{{ t('gfr.risk.' + ckdStage.risk) }}</p>
+      </div>
+
+      <!-- Doctor recommendation -->
+      <div v-if="ckdStage.stage !== 'G1'" class="border-t border-stone-100 pt-5 mt-5">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('gfr.doctorLabel') }}
+        </div>
+        <p class="text-sm text-stone-600 leading-relaxed">{{ t('gfr.doctor.' + ckdStage.stage) }}</p>
+      </div>
+    </div>
+
+    <!-- CKD Stages reference table -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('gfr.stagesTitle') }}</h2>
+      <div class="space-y-2.5">
+        <div
+          v-for="s in ['G1', 'G2', 'G3a', 'G3b', 'G4', 'G5']"
+          :key="s"
+          class="flex items-center justify-between py-2.5 px-3 rounded-lg transition-colors"
+          :class="ckdStage && ckdStage.stage === s ? 'bg-stone-900 text-white' : 'bg-stone-50'"
+        >
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold w-8">{{ s }}</span>
+            <span class="text-sm">{{ t('gfr.stageDesc.' + s) }}</span>
+          </div>
+          <span class="text-sm font-medium tabular-nums shrink-0 ml-4">{{ t('gfr.stageRange.' + s) }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Clinical context -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('gfr.contextTitle') }}</h2>
+      <div class="space-y-4">
+        <div class="border-b border-stone-100 pb-4">
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t('gfr.contextEquation') }}</div>
+          <p class="text-sm text-stone-500 leading-relaxed">{{ t('gfr.contextEquationText') }}</p>
+        </div>
+        <div class="border-b border-stone-100 pb-4">
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t('gfr.contextDrug') }}</div>
+          <p class="text-sm text-stone-500 leading-relaxed">{{ t('gfr.contextDrugText') }}</p>
+        </div>
+        <div class="border-b border-stone-100 pb-4">
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t('gfr.contextLimits') }}</div>
+          <p class="text-sm text-stone-500 leading-relaxed">{{ t('gfr.contextLimitsText') }}</p>
+        </div>
+        <div>
+          <div class="text-sm font-semibold text-stone-800 mb-1">{{ t('gfr.contextDisclaimer') }}</div>
+          <p class="text-sm text-stone-500 leading-relaxed">{{ t('gfr.contextDisclaimerText') }}</p>
+        </div>
+      </div>
+    </div>
+
+    <BlogBanner calculator-key="gfr" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/NierenfunktionGFRRechner.vue
+++ b/src/pages/blog/NierenfunktionGFRRechner.vue
@@ -1,0 +1,215 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'GFR-Rechner: Nierenfunktion verstehen und einordnen | Health Calculators',
+  description: 'eGFR nach CKD-EPI 2021 berechnen und CKD-Stadium einordnen. Was bedeuten GFR-Werte, CKD-Stadien G1–G5 und wann zum Arzt? Alles zur Nierenfunktion.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'GFR-Rechner: Nierenfunktion verstehen und einordnen',
+    datePublished: '2026-04-13',
+    dateModified: '2026-04-13',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/gfr-rechner',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">
+        &larr; Blog
+      </router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">
+        GFR-Rechner: Nierenfunktion verstehen und einordnen
+      </h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">13. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>glomeruläre Filtrationsrate (GFR)</strong> ist der wichtigste Parameter zur Beurteilung der Nierenfunktion. Sie gibt an, wie viel Blut die Nieren pro Minute filtern. Ein niedriger Wert deutet auf eine eingeschränkte Nierenfunktion hin.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Da eine direkte GFR-Messung aufwendig ist, wird in der klinischen Praxis die <strong>geschätzte GFR (eGFR)</strong> aus Serum-Kreatinin, Alter und Geschlecht berechnet. Die <strong>CKD-EPI 2021-Formel</strong> ist dabei der aktuelle Goldstandard.
+        </p>
+      </div>
+
+      <!-- What is GFR -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist die glomeruläre Filtrationsrate?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Glomeruli sind winzige Filterknäuel in den Nieren. Pro Niere gibt es etwa eine Million. Gemeinsam filtern sie täglich rund <strong>180 Liter Blut</strong> — das entspricht einem eGFR-Wert von 90–120 mL/min/1,73 m² bei gesunden Erwachsenen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der eGFR-Wert wird auf eine Standardkörperoberfläche von <strong>1,73 m²</strong> normiert. Das ermöglicht den Vergleich zwischen Patienten unterschiedlicher Körpergröße. Werte über 60 gelten generell als ausreichend für den Alltag, darunter spricht man von einer chronischen Nierenerkrankung (CKD).
+        </p>
+      </div>
+
+      <!-- CKD-EPI 2021 -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die CKD-EPI 2021-Formel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>CKD-EPI 2021</strong> (Chronic Kidney Disease Epidemiology Collaboration) ist die von der <strong>KDIGO</strong> (Kidney Disease: Improving Global Outcomes) empfohlene Formel. Sie löste die ältere CKD-EPI 2009 ab, die noch einen rassenbezogenen Korrekturfaktor enthielt.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-6">
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">CKD-EPI 2021 Gleichung</div>
+          <div class="font-mono text-sm text-stone-800 leading-relaxed">
+            eGFR = 142 × min(Scr/κ, 1)<sup>α</sup> × max(Scr/κ, 1)<sup>−1,200</sup> × 0,9938<sup>Alter</sup> × 1,012 [wenn weiblich]
+          </div>
+          <div class="mt-4 text-sm text-stone-500 space-y-1">
+            <div>κ = 0,7 (weiblich) | 0,9 (männlich)</div>
+            <div>α = −0,241 (weiblich) | −0,302 (männlich)</div>
+            <div>Scr = Serum-Kreatinin in mg/dL</div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der Vorteil gegenüber der MDRD-Formel: CKD-EPI liefert präzisere Werte im normalen und leicht erhöhten Bereich — also genau dort, wo frühe Nierenschäden erkannt werden sollen.
+        </p>
+      </div>
+
+      <!-- CKD Stages table -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">CKD-Stadien nach KDIGO</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die KDIGO teilt die chronische Nierenerkrankung (CKD) in sechs Stadien ein:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Stadium</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">eGFR (mL/min/1,73m²)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bedeutung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 font-semibold text-green-700">G1</td>
+                <td class="px-6 py-3 text-stone-700">≥ 90</td>
+                <td class="px-6 py-3 text-stone-600">Normal oder erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-lime-700">G2</td>
+                <td class="px-6 py-3 text-stone-700">60 – 89</td>
+                <td class="px-6 py-3 text-stone-600">Leicht eingeschränkt</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-yellow-600">G3a</td>
+                <td class="px-6 py-3 text-stone-700">45 – 59</td>
+                <td class="px-6 py-3 text-stone-600">Leicht bis mäßig eingeschränkt</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-orange-600">G3b</td>
+                <td class="px-6 py-3 text-stone-700">30 – 44</td>
+                <td class="px-6 py-3 text-stone-600">Mäßig bis stark eingeschränkt</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-red-600">G4</td>
+                <td class="px-6 py-3 text-stone-700">15 – 29</td>
+                <td class="px-6 py-3 text-stone-600">Stark eingeschränkt</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-red-800">G5</td>
+                <td class="px-6 py-3 text-stone-700">&lt; 15</td>
+                <td class="px-6 py-3 text-stone-600">Nierenversagen</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500">
+          <strong>Wichtig:</strong> Ein einzelner eGFR-Wert ist kein Diagnosekriterium. CKD wird erst diagnostiziert, wenn Auffälligkeiten über mindestens 3 Monate anhalten.
+        </p>
+      </div>
+
+      <!-- Creatinine and unit conversion -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Serum-Kreatinin: mg/dL und µmol/L</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Kreatinin ist ein Stoffwechselprodukt des Muskelstoffwechsels. Es wird fast ausschließlich durch die Nieren ausgeschieden — ein erhöhter Kreatininwert weist daher auf eine eingeschränkte Filtration hin.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In Deutschland wird Kreatinin meist in <strong>mg/dL</strong> angegeben, in vielen anderen Ländern in <strong>µmol/L</strong>. Die Umrechnung:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <div class="font-mono text-sm text-stone-800 space-y-1">
+            <div>mg/dL = µmol/L ÷ 88,42</div>
+            <div>µmol/L = mg/dL × 88,42</div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Normalwerte: Männer 0,7–1,2 mg/dL (62–106 µmol/L), Frauen 0,5–1,0 mg/dL (44–88 µmol/L). Ältere Menschen und Personen mit wenig Muskelmasse haben tendenziell niedrigere Werte.
+        </p>
+      </div>
+
+      <!-- When to see a doctor -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann zum Arzt?</h2>
+        <div class="space-y-3">
+          <div class="flex gap-4 p-4 bg-white border border-stone-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-lime-700 text-sm pt-0.5">G2</div>
+            <p class="text-sm text-stone-600 leading-relaxed">Hausarzt informieren und Risikofaktoren (Blutdruck, Blutzucker) regelmäßig kontrollieren.</p>
+          </div>
+          <div class="flex gap-4 p-4 bg-white border border-stone-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-yellow-600 text-sm pt-0.5">G3a</div>
+            <p class="text-sm text-stone-600 leading-relaxed">Regelmäßige Verlaufskontrollen beim Hausarzt oder Nephrologen (mindestens einmal jährlich).</p>
+          </div>
+          <div class="flex gap-4 p-4 bg-white border border-stone-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-orange-600 text-sm pt-0.5">G3b</div>
+            <p class="text-sm text-stone-600 leading-relaxed">Nephrologen aufsuchen. Engmaschige Überwachung und Anpassung der Medikation notwendig.</p>
+          </div>
+          <div class="flex gap-4 p-4 bg-red-50 border border-red-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-red-700 text-sm pt-0.5">G4 / G5</div>
+            <p class="text-sm text-stone-600 leading-relaxed">Dringende nephrologische Behandlung. Vorbereitung auf Dialyse oder Nierentransplantation besprechen.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Related calculators -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Gesundheitsrechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Nierenfunktion ist eng mit anderen Gesundheitsparametern verknüpft. Diese Rechner helfen bei der Gesamtbewertung:
+        </p>
+        <ul class="space-y-2 text-sm text-stone-600">
+          <li>
+            <router-link :to="localePath('bloodPressure')" class="text-stone-800 font-medium hover:underline">
+              Blutdruck-Rechner
+            </router-link>
+            — Bluthochdruck ist eine der häufigsten Ursachen für Nierenerkrankungen.
+          </li>
+          <li>
+            <router-link :to="localePath('bloodSugar')" class="text-stone-800 font-medium hover:underline">
+              Blutzucker-Umrechner
+            </router-link>
+            — Diabetes ist die zweithäufigste Ursache für CKD.
+          </li>
+          <li>
+            <router-link :to="localePath('bmi')" class="text-stone-800 font-medium hover:underline">
+              BMI-Rechner
+            </router-link>
+            — Übergewicht erhöht das Risiko für Nieren- und Herz-Kreislauf-Erkrankungen.
+          </li>
+        </ul>
+      </div>
+
+      <RelatedArticles />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/GfrCalculatorKidneyFunction.vue
+++ b/src/pages/blog/en/GfrCalculatorKidneyFunction.vue
@@ -1,0 +1,215 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'GFR Calculator — Understanding eGFR & Kidney Function | Health Calculators',
+  description: 'Calculate eGFR using CKD-EPI 2021 and understand your kidney function. What do GFR values mean, CKD stages G1–G5, and when to see a doctor.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'GFR Calculator — Understanding eGFR & Kidney Function',
+    datePublished: '2026-04-13',
+    dateModified: '2026-04-13',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/gfr-calculator-kidney-function',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">
+        &larr; Blog
+      </router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">
+        GFR Calculator — Understanding eGFR &amp; Kidney Function
+      </h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 13, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>glomerular filtration rate (GFR)</strong> is the most important marker for assessing kidney function. It measures how much blood your kidneys filter per minute. A low value indicates impaired kidney function.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Because directly measuring GFR is complex, clinical practice uses the <strong>estimated GFR (eGFR)</strong>, calculated from serum creatinine, age, and sex. The <strong>CKD-EPI 2021 equation</strong> is the current gold standard.
+        </p>
+      </div>
+
+      <!-- What is GFR -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What Is Glomerular Filtration Rate?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The glomeruli are tiny filtering units in the kidneys — about one million per kidney. Together they filter roughly <strong>180 liters of blood per day</strong>, corresponding to an eGFR of 90–120 mL/min/1.73 m² in healthy adults.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          eGFR is normalized to a standard body surface area of <strong>1.73 m²</strong> to allow comparison between people of different sizes. Values above 60 are generally sufficient for everyday life; below that, chronic kidney disease (CKD) is indicated.
+        </p>
+      </div>
+
+      <!-- CKD-EPI 2021 -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The CKD-EPI 2021 Equation</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>CKD-EPI 2021</strong> (Chronic Kidney Disease Epidemiology Collaboration) is the equation recommended by <strong>KDIGO</strong> (Kidney Disease: Improving Global Outcomes). It replaced the older CKD-EPI 2009, which included a race-based correction factor that has since been removed for equity and accuracy reasons.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-6">
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">CKD-EPI 2021 Equation</div>
+          <div class="font-mono text-sm text-stone-800 leading-relaxed">
+            eGFR = 142 × min(Scr/κ, 1)<sup>α</sup> × max(Scr/κ, 1)<sup>−1.200</sup> × 0.9938<sup>Age</sup> × 1.012 [if female]
+          </div>
+          <div class="mt-4 text-sm text-stone-500 space-y-1">
+            <div>κ = 0.7 (female) | 0.9 (male)</div>
+            <div>α = −0.241 (female) | −0.302 (male)</div>
+            <div>Scr = serum creatinine in mg/dL</div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Compared to the older MDRD formula, CKD-EPI is more accurate in the normal and mildly elevated range — precisely where early kidney damage needs to be detected.
+        </p>
+      </div>
+
+      <!-- CKD Stages table -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">CKD Stages (KDIGO)</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          KDIGO classifies chronic kidney disease into six stages:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Stage</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">eGFR (mL/min/1.73m²)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Description</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 font-semibold text-green-700">G1</td>
+                <td class="px-6 py-3 text-stone-700">≥ 90</td>
+                <td class="px-6 py-3 text-stone-600">Normal or high</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-lime-700">G2</td>
+                <td class="px-6 py-3 text-stone-700">60 – 89</td>
+                <td class="px-6 py-3 text-stone-600">Mildly decreased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-yellow-600">G3a</td>
+                <td class="px-6 py-3 text-stone-700">45 – 59</td>
+                <td class="px-6 py-3 text-stone-600">Mildly to moderately decreased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-orange-600">G3b</td>
+                <td class="px-6 py-3 text-stone-700">30 – 44</td>
+                <td class="px-6 py-3 text-stone-600">Moderately to severely decreased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-red-600">G4</td>
+                <td class="px-6 py-3 text-stone-700">15 – 29</td>
+                <td class="px-6 py-3 text-stone-600">Severely decreased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 font-semibold text-red-800">G5</td>
+                <td class="px-6 py-3 text-stone-700">&lt; 15</td>
+                <td class="px-6 py-3 text-stone-600">Kidney failure</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500">
+          <strong>Important:</strong> A single eGFR value is not a diagnostic criterion. CKD is only diagnosed when abnormalities persist for at least 3 months.
+        </p>
+      </div>
+
+      <!-- Creatinine and unit conversion -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Serum Creatinine: mg/dL and µmol/L</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Creatinine is a metabolic byproduct of muscle activity. It is almost exclusively eliminated by the kidneys, making elevated creatinine a marker of reduced filtration.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Creatinine is reported in <strong>mg/dL</strong> in the US and some countries, and in <strong>µmol/L</strong> elsewhere. The conversion:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <div class="font-mono text-sm text-stone-800 space-y-1">
+            <div>mg/dL = µmol/L ÷ 88.42</div>
+            <div>µmol/L = mg/dL × 88.42</div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Normal values: men 0.7–1.2 mg/dL (62–106 µmol/L), women 0.5–1.0 mg/dL (44–88 µmol/L). Older adults and people with low muscle mass tend to have lower values.
+        </p>
+      </div>
+
+      <!-- When to see a doctor -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">When to See a Doctor</h2>
+        <div class="space-y-3">
+          <div class="flex gap-4 p-4 bg-white border border-stone-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-lime-700 text-sm pt-0.5">G2</div>
+            <p class="text-sm text-stone-600 leading-relaxed">Inform your primary care doctor and have risk factors (blood pressure, blood sugar) monitored regularly.</p>
+          </div>
+          <div class="flex gap-4 p-4 bg-white border border-stone-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-yellow-600 text-sm pt-0.5">G3a</div>
+            <p class="text-sm text-stone-600 leading-relaxed">Regular follow-up visits with your primary care doctor or nephrologist (at least once a year).</p>
+          </div>
+          <div class="flex gap-4 p-4 bg-white border border-stone-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-orange-600 text-sm pt-0.5">G3b</div>
+            <p class="text-sm text-stone-600 leading-relaxed">See a nephrologist. Close monitoring and medication adjustments are required.</p>
+          </div>
+          <div class="flex gap-4 p-4 bg-red-50 border border-red-200 rounded-xl">
+            <div class="w-14 shrink-0 font-semibold text-red-700 text-sm pt-0.5">G4 / G5</div>
+            <p class="text-sm text-stone-600 leading-relaxed">Urgent nephrology referral. Discuss preparation for dialysis or kidney transplantation.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Related calculators -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related Health Calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Kidney function is closely linked to other health parameters. These calculators help with a comprehensive assessment:
+        </p>
+        <ul class="space-y-2 text-sm text-stone-600">
+          <li>
+            <router-link :to="localePath('bloodPressure')" class="text-stone-800 font-medium hover:underline">
+              Blood Pressure Calculator
+            </router-link>
+            — Hypertension is one of the most common causes of kidney disease.
+          </li>
+          <li>
+            <router-link :to="localePath('bloodSugar')" class="text-stone-800 font-medium hover:underline">
+              Blood Sugar Converter
+            </router-link>
+            — Diabetes is the second most common cause of CKD.
+          </li>
+          <li>
+            <router-link :to="localePath('bmi')" class="text-stone-800 font-medium hover:underline">
+              BMI Calculator
+            </router-link>
+            — Obesity increases the risk of kidney and cardiovascular disease.
+          </li>
+        </ul>
+      </div>
+
+      <RelatedArticles />
+    </div>
+  </article>
+</template>

--- a/src/pages/gfr.meta.js
+++ b/src/pages/gfr.meta.js
@@ -1,0 +1,17 @@
+import Component from './GfrCalculator.vue'
+import BlogDe from './blog/NierenfunktionGFRRechner.vue'
+import BlogEn from './blog/en/GfrCalculatorKidneyFunction.vue'
+
+export default {
+  key: 'gfr',
+  component: Component,
+  slugs: { de: 'gfr-rechner', en: 'gfr-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 9,
+  oldRedirect: '/gfr-rechner',
+  blog: {
+    de: { slug: 'gfr-rechner', component: BlogDe },
+    en: { slug: 'gfr-calculator-kidney-function', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-106-gfr-calculator
**Agent:** claude
**Branch:** `agent/hc-106-gfr-calculator-20260413-030026`

Closes jenslaufer/health-calculators#106

### Prompt
> Implement the GFR Calculator (eGFR / Kidney Function) as described in issue #106.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: Serum creatinine (with unit toggle: mg/dL or µmol/L), Age (years), Sex (male/female)
- Use CKD-EPI 2021 equation (race-free, recommended by KDIGO)
- Output: eGFR value (mL/min/1.73m²), CKD stage (G1-G5) with description, risk assessment, when to see a doctor
- CKD stages: G1 ≥90, G2 60-89, G3a 45-59, G3b 30-44, G4 15-29, G5 <15
- Blog articles: DE `/de/blog/gfr-rechner` + EN `/en/blog/gfr-calculator-kidney-function`
- Internal links to Blood Pressure Calculator, Blood Sugar Converter, BMI Calculator
- Unit tests for CKD-EPI calculation (verify against published reference values), edge cases (very high/low creatinine, unit conversion)
- E2E test for the calculator page
- SSG pre-rendering must work

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks