### PR TITLE
hc-169-html-lang-attribute: Fix the HTML lang attribute. Currently hardcoded as "en" in 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/__tests__/useHead.test.js
+++ b/src/__tests__/useHead.test.js
@@ -5,7 +5,9 @@ vi.mock('@unhead/vue', () => ({ useHead: vi.fn() }))
 
 const mockRoute = { path: '/de/bmi-rechner', meta: { slug: 'bmi' } }
 vi.mock('vue-router', () => ({ useRoute: () => mockRoute }))
-vi.mock('vue-i18n', () => ({ useI18n: () => ({ locale: ref('de') }) }))
+
+const mockLocale = ref('de')
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ locale: mockLocale }) }))
 vi.mock('../composables/useLocaleRouter.js', () => ({
   localePath: (key, locale) => `/${locale}/${key === 'bmi' ? (locale === 'de' ? 'bmi-rechner' : 'bmi-calculator') : key}`,
   routeMap: { bmi: { de: 'bmi-rechner', en: 'bmi-calculator' } },
@@ -93,5 +95,29 @@ describe('useHead', () => {
     const head = useUnhead.mock.calls[0][0].value
     const ogUrl = head.meta.find(m => m.property === 'og:url')
     expect(ogUrl.content).toBe('https://healthcalculator.app/de/bmi-rechner')
+  })
+
+  it('sets htmlAttrs.lang to "de" when locale is "de"', () => {
+    mockLocale.value = 'de'
+    useHead(() => ({
+      title: 'BMI Rechner',
+      description: 'Berechne deinen BMI',
+      routeKey: 'bmi',
+    }))
+
+    const head = useUnhead.mock.calls[0][0].value
+    expect(head.htmlAttrs).toEqual({ lang: 'de' })
+  })
+
+  it('sets htmlAttrs.lang to "en" when locale is "en"', () => {
+    mockLocale.value = 'en'
+    useHead(() => ({
+      title: 'BMI Calculator',
+      description: 'Calculate your BMI',
+      routeKey: 'bmi',
+    }))
+
+    const head = useUnhead.mock.calls[0][0].value
+    expect(head.htmlAttrs).toEqual({ lang: 'en' })
   })
 })

--- a/src/composables/useHead.js
+++ b/src/composables/useHead.js
@@ -33,6 +33,7 @@ export function useHead(getConfig) {
 
     const head = {
       title,
+      htmlAttrs: { lang: currentLocale },
       meta: [
         { name: 'description', content: description },
         { property: 'og:title', content: title },


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-169-html-lang-attribute
**Agent:** claude
**Model:** claude-sonnet-4-6
**Branch:** `agent/hc-169-html-lang-attribute-20260413-151026`
**Cost:** $0.24350085000000002

Closes jenslaufer/health-calculators#169

### Prompt
> Fix the HTML lang attribute. Currently hardcoded as "en" in index.html, so ALL pages
(including German /de/* pages) claim to be English. This hurts SEO.

The fix is in src/composables/useHead.js — add `htmlAttrs: { lang: currentLocale }` to
the head object returned in the computed. This sets <html lang="de"> on German pages and
<html lang="en"> on English pages during SSG rendering.

Reference: finanzkalkulatoren repo's src/composables/usePageMeta.js line 42 does exactly this.

Also update index.html to use lang="de" as default (majority of pages are German).

Write tests first:
- Test that useHead sets htmlAttrs.lang to "de" when locale is "de"
- Test that useHead sets htmlAttrs.lang to "en" when locale is "en"

DO NOT DELETE or modify unrelated files.
DO NOT change any calculator logic, routing, or styling.