### PR TITLE
hc-111-seo-schemas: Add BreadcrumbList, Organization schema, and fix blog image 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,12 +2,25 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useHead } from '@unhead/vue'
 import { useLocaleRouter } from './composables/useLocaleRouter.js'
 
 const router = useRouter()
 const menuOpen = ref(false)
 const { t } = useI18n()
 const { localePath, switchLocale, locale } = useLocaleRouter()
+
+useHead({
+  script: [{
+    type: 'application/ld+json',
+    innerHTML: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: 'Health Calculator',
+      url: 'https://healthcalculator.app',
+    }),
+  }],
+})
 
 router.afterEach(() => { menuOpen.value = false })
 </script>

--- a/src/__tests__/useHead.test.js
+++ b/src/__tests__/useHead.test.js
@@ -3,22 +3,26 @@ import { ref } from 'vue'
 
 vi.mock('@unhead/vue', () => ({ useHead: vi.fn() }))
 
-const mockRoute = { path: '/de/bmi-rechner', meta: { slug: 'bmi' } }
+const mockRoute = { path: '/de/bmi-rechner', meta: { slug: 'bmi', routeKey: 'bmi' } }
 vi.mock('vue-router', () => ({ useRoute: () => mockRoute }))
 
 const mockLocale = ref('de')
-vi.mock('vue-i18n', () => ({ useI18n: () => ({ locale: mockLocale }) }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ locale: mockLocale, t: key => key }) }))
 vi.mock('../composables/useLocaleRouter.js', () => ({
   localePath: (key, locale) => `/${locale}/${key === 'bmi' ? (locale === 'de' ? 'bmi-rechner' : 'bmi-calculator') : key}`,
-  routeMap: { bmi: { de: 'bmi-rechner', en: 'bmi-calculator' } },
+  routeMap: { bmi: { de: 'bmi-rechner', en: 'bmi-calculator' }, home: { de: '', en: '' }, blog: { de: 'blog', en: 'blog' } },
+  keyToGroup: { bmi: 'bodyComposition' },
 }))
 
 import { useHead as useUnhead } from '@unhead/vue'
-import { useHead } from '../composables/useHead.js'
+import { useHead, buildBreadcrumb } from '../composables/useHead.js'
 
 describe('useHead', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLocale.value = 'de'
+    mockRoute.path = '/de/bmi-rechner'
+    mockRoute.meta = { slug: 'bmi', routeKey: 'bmi' }
   })
 
   it('calls @unhead/vue useHead with correct structure', () => {
@@ -69,16 +73,17 @@ describe('useHead', () => {
     }))
 
     const head = useUnhead.mock.calls[0][0].value
-    expect(head.script).toEqual([
-      { type: 'application/ld+json', innerHTML: JSON.stringify(jsonLd) },
-    ])
+    const jsonLdScript = head.script.find(s => JSON.parse(s.innerHTML)['@type'] === 'WebPage')
+    expect(jsonLdScript).toBeDefined()
+    expect(JSON.parse(jsonLdScript.innerHTML)).toEqual(jsonLd)
   })
 
-  it('omits script when jsonLd is not provided', () => {
+  it('omits script when jsonLd is not provided and routeKey is home', () => {
+    mockRoute.meta = { routeKey: 'home' }
     useHead(() => ({
-      title: 'BMI',
-      description: 'BMI',
-      routeKey: 'bmi',
+      title: 'Home',
+      description: 'Home',
+      routeKey: 'home',
     }))
 
     const head = useUnhead.mock.calls[0][0].value
@@ -135,5 +140,231 @@ describe('useHead', () => {
     for (const link of head.link.filter(l => l.rel === 'alternate')) {
       expect(link.href, `hreflang URL missing trailing slash: ${link.href}`).toMatch(/\/$/)
     }
+  })
+
+  describe('BreadcrumbList schema', () => {
+    it('adds BreadcrumbList for calculator pages', () => {
+      useHead(() => ({
+        title: 'BMI Rechner',
+        description: 'Berechne deinen BMI',
+        routeKey: 'bmi',
+      }))
+
+      const head = useUnhead.mock.calls[0][0].value
+      const breadcrumbScript = head.script.find(s => {
+        const data = JSON.parse(s.innerHTML)
+        return data['@type'] === 'BreadcrumbList'
+      })
+      expect(breadcrumbScript).toBeDefined()
+      const breadcrumb = JSON.parse(breadcrumbScript.innerHTML)
+      expect(breadcrumb.itemListElement).toHaveLength(3)
+      expect(breadcrumb.itemListElement[0]).toMatchObject({
+        position: 1, name: 'nav.brand', item: 'https://healthcalculator.app/de/',
+      })
+      expect(breadcrumb.itemListElement[1]).toMatchObject({
+        position: 2, name: 'home.groups.bodyComposition', item: 'https://healthcalculator.app/de/',
+      })
+      expect(breadcrumb.itemListElement[2]).toMatchObject({
+        position: 3, name: 'BMI Rechner',
+      })
+      expect(breadcrumb.itemListElement[2].item).toBeUndefined()
+    })
+
+    it('adds BreadcrumbList for blog home', () => {
+      mockRoute.meta = { routeKey: 'blog' }
+      useHead(() => ({
+        title: 'Blog',
+        description: 'Blog',
+        routeKey: 'blog',
+      }))
+
+      const head = useUnhead.mock.calls[0][0].value
+      const breadcrumbScript = head.script.find(s => {
+        const data = JSON.parse(s.innerHTML)
+        return data['@type'] === 'BreadcrumbList'
+      })
+      expect(breadcrumbScript).toBeDefined()
+      const breadcrumb = JSON.parse(breadcrumbScript.innerHTML)
+      expect(breadcrumb.itemListElement).toHaveLength(2)
+      expect(breadcrumb.itemListElement[0]).toMatchObject({ position: 1, name: 'nav.brand' })
+      expect(breadcrumb.itemListElement[1]).toMatchObject({ position: 2, name: 'nav.blog' })
+      expect(breadcrumb.itemListElement[1].item).toBeUndefined()
+    })
+
+    it('adds BreadcrumbList for blog articles', () => {
+      mockRoute.meta = { slug: 'bmi-berechnen', routeKey: 'blogArticle' }
+      useHead(() => ({
+        title: 'BMI berechnen',
+        description: 'BMI Artikel',
+        routeKey: 'blogArticle',
+      }))
+
+      const head = useUnhead.mock.calls[0][0].value
+      const breadcrumbScript = head.script.find(s => {
+        const data = JSON.parse(s.innerHTML)
+        return data['@type'] === 'BreadcrumbList'
+      })
+      expect(breadcrumbScript).toBeDefined()
+      const breadcrumb = JSON.parse(breadcrumbScript.innerHTML)
+      expect(breadcrumb.itemListElement).toHaveLength(3)
+      expect(breadcrumb.itemListElement[0]).toMatchObject({ position: 1, name: 'nav.brand' })
+      expect(breadcrumb.itemListElement[1]).toMatchObject({
+        position: 2, name: 'nav.blog', item: 'https://healthcalculator.app/de/blog/',
+      })
+      expect(breadcrumb.itemListElement[2]).toMatchObject({ position: 3, name: 'BMI berechnen' })
+    })
+
+    it('omits BreadcrumbList for home page', () => {
+      mockRoute.meta = { routeKey: 'home' }
+      useHead(() => ({
+        title: 'Home',
+        description: 'Home',
+        routeKey: 'home',
+        jsonLd: { '@context': 'https://schema.org', '@type': 'WebSite', name: 'Home' },
+      }))
+
+      const head = useUnhead.mock.calls[0][0].value
+      const breadcrumbScript = head.script.find(s => {
+        const data = JSON.parse(s.innerHTML)
+        return data['@type'] === 'BreadcrumbList'
+      })
+      expect(breadcrumbScript).toBeUndefined()
+    })
+
+    it('uses route.meta.routeKey as fallback for breadcrumb', () => {
+      mockRoute.meta = { routeKey: 'blogArticle', slug: 'calculate-bmi' }
+      mockRoute.path = '/en/blog/calculate-bmi'
+      mockLocale.value = 'en'
+      useHead({
+        title: 'Calculate BMI',
+        description: 'BMI article',
+      })
+
+      const head = useUnhead.mock.calls[0][0].value
+      const breadcrumbScript = head.script.find(s => {
+        const data = JSON.parse(s.innerHTML)
+        return data['@type'] === 'BreadcrumbList'
+      })
+      expect(breadcrumbScript).toBeDefined()
+      const breadcrumb = JSON.parse(breadcrumbScript.innerHTML)
+      expect(breadcrumb.itemListElement).toHaveLength(3)
+      expect(breadcrumb.itemListElement[1]).toMatchObject({ name: 'nav.blog' })
+    })
+  })
+
+  describe('Article image enrichment', () => {
+    it('adds default image to Article JSON-LD when not provided', () => {
+      mockRoute.meta = { slug: 'bmi-berechnen', routeKey: 'blogArticle' }
+      useHead(() => ({
+        title: 'BMI berechnen',
+        description: 'BMI Artikel',
+        routeKey: 'blogArticle',
+        jsonLd: {
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'BMI berechnen',
+        },
+      }))
+
+      const head = useUnhead.mock.calls[0][0].value
+      const articleScript = head.script.find(s => {
+        const data = JSON.parse(s.innerHTML)
+        return data['@type'] === 'Article'
+      })
+      const article = JSON.parse(articleScript.innerHTML)
+      expect(article.image).toBe('https://healthcalculator.app/og-image.png')
+    })
+
+    it('preserves custom image when provided in Article JSON-LD', () => {
+      mockRoute.meta = { slug: 'bmi-berechnen', routeKey: 'blogArticle' }
+      useHead(() => ({
+        title: 'BMI berechnen',
+        description: 'BMI Artikel',
+        routeKey: 'blogArticle',
+        jsonLd: {
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'BMI berechnen',
+          image: 'https://healthcalculator.app/custom-image.png',
+        },
+      }))
+
+      const head = useUnhead.mock.calls[0][0].value
+      const articleScript = head.script.find(s => {
+        const data = JSON.parse(s.innerHTML)
+        return data['@type'] === 'Article'
+      })
+      const article = JSON.parse(articleScript.innerHTML)
+      expect(article.image).toBe('https://healthcalculator.app/custom-image.png')
+    })
+  })
+})
+
+describe('buildBreadcrumb', () => {
+  const t = key => key
+
+  it('returns null for home page', () => {
+    const result = buildBreadcrumb({
+      routeKey: 'home',
+      title: 'Home',
+      locale: 'de',
+      t,
+      homeUrl: 'https://healthcalculator.app/de/',
+      blogUrl: 'https://healthcalculator.app/de/blog/',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('builds correct breadcrumb for blog home', () => {
+    const result = buildBreadcrumb({
+      routeKey: 'blog',
+      title: 'Blog',
+      locale: 'de',
+      t,
+      homeUrl: 'https://healthcalculator.app/de/',
+      blogUrl: 'https://healthcalculator.app/de/blog/',
+    })
+    expect(result['@type']).toBe('BreadcrumbList')
+    expect(result.itemListElement).toHaveLength(2)
+  })
+
+  it('builds correct breadcrumb for blog article', () => {
+    const result = buildBreadcrumb({
+      routeKey: 'blogArticle',
+      title: 'BMI berechnen',
+      locale: 'de',
+      t,
+      homeUrl: 'https://healthcalculator.app/de/',
+      blogUrl: 'https://healthcalculator.app/de/blog/',
+    })
+    expect(result['@type']).toBe('BreadcrumbList')
+    expect(result.itemListElement).toHaveLength(3)
+    expect(result.itemListElement[1].item).toBe('https://healthcalculator.app/de/blog/')
+  })
+
+  it('builds 3-level breadcrumb for calculator with known group', () => {
+    const result = buildBreadcrumb({
+      routeKey: 'bmi',
+      title: 'BMI Rechner',
+      locale: 'de',
+      t,
+      homeUrl: 'https://healthcalculator.app/de/',
+      blogUrl: 'https://healthcalculator.app/de/blog/',
+    })
+    expect(result.itemListElement).toHaveLength(3)
+    expect(result.itemListElement[1].name).toBe('home.groups.bodyComposition')
+  })
+
+  it('builds 2-level breadcrumb for unknown route', () => {
+    const result = buildBreadcrumb({
+      routeKey: 'unknownPage',
+      title: 'Unknown',
+      locale: 'de',
+      t,
+      homeUrl: 'https://healthcalculator.app/de/',
+      blogUrl: 'https://healthcalculator.app/de/blog/',
+    })
+    expect(result.itemListElement).toHaveLength(2)
+    expect(result.itemListElement[1].name).toBe('Unknown')
   })
 })

--- a/src/composables/useHead.js
+++ b/src/composables/useHead.js
@@ -2,36 +2,61 @@ import { computed } from 'vue'
 import { useHead as useUnhead } from '@unhead/vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { localePath as resolveLocalePath, routeMap } from './useLocaleRouter.js'
+import { localePath as resolveLocalePath, routeMap, keyToGroup } from './useLocaleRouter.js'
 
 const BASE_URL = 'https://healthcalculator.app'
 
 const ensureSlash = path => path.endsWith('/') ? path : `${path}/`
 
+export function buildBreadcrumb({ routeKey, title, locale, t, homeUrl, blogUrl }) {
+  if (routeKey === 'home') return null
+
+  const items = [
+    { '@type': 'ListItem', position: 1, name: t('nav.brand'), item: homeUrl },
+  ]
+
+  if (routeKey === 'blog') {
+    items.push({ '@type': 'ListItem', position: 2, name: t('nav.blog') })
+  } else if (routeKey === 'blogArticle') {
+    items.push({ '@type': 'ListItem', position: 2, name: t('nav.blog'), item: blogUrl })
+    items.push({ '@type': 'ListItem', position: 3, name: title })
+  } else {
+    const group = keyToGroup[routeKey]
+    if (group) {
+      items.push({ '@type': 'ListItem', position: 2, name: t(`home.groups.${group}`), item: homeUrl })
+    }
+    items.push({ '@type': 'ListItem', position: items.length + 1, name: title })
+  }
+
+  return { '@context': 'https://schema.org', '@type': 'BreadcrumbList', itemListElement: items }
+}
+
 export function useHead(getConfig) {
   const resolve = typeof getConfig === 'function' ? getConfig : () => getConfig
   const route = useRoute()
-  const { locale } = useI18n()
+  const { locale, t } = useI18n()
 
   const headData = computed(() => {
-    const { title, description, routeKey, jsonLd } = resolve()
+    const { title, description, routeKey: configRouteKey, jsonLd } = resolve()
     const currentLocale = locale.value
     const otherLocale = currentLocale === 'de' ? 'en' : 'de'
 
     let currentPath, otherPath
-    if (routeKey === 'blogArticle') {
+    if (configRouteKey === 'blogArticle') {
       const slug = route.meta.slug
       currentPath = `/${currentLocale}/blog/${slug}/`
       otherPath = `/${otherLocale}/blog/${slug}/`
-    } else if (routeKey && routeMap[routeKey]) {
-      currentPath = ensureSlash(resolveLocalePath(routeKey, currentLocale))
-      otherPath = ensureSlash(resolveLocalePath(routeKey, otherLocale))
+    } else if (configRouteKey && routeMap[configRouteKey]) {
+      currentPath = ensureSlash(resolveLocalePath(configRouteKey, currentLocale))
+      otherPath = ensureSlash(resolveLocalePath(configRouteKey, otherLocale))
     } else {
       currentPath = ensureSlash(route.path)
       otherPath = ensureSlash(route.path)
     }
 
     const url = `${BASE_URL}${currentPath}`
+    const homeUrl = `${BASE_URL}/${currentLocale}/`
+    const blogUrl = `${BASE_URL}/${currentLocale}/blog/`
 
     const head = {
       title,
@@ -54,6 +79,8 @@ export function useHead(getConfig) {
       ],
     }
 
+    const scripts = []
+
     if (jsonLd) {
       const enriched = { ...jsonLd }
       if (enriched['@type'] === 'WebApplication') {
@@ -62,10 +89,21 @@ export function useHead(getConfig) {
       }
       if (enriched['@type'] === 'Article') {
         enriched.mainEntityOfPage = { '@type': 'WebPage', '@id': url }
+        if (!enriched.image) {
+          enriched.image = `${BASE_URL}/og-image.png`
+        }
       }
-      head.script = [
-        { type: 'application/ld+json', innerHTML: JSON.stringify(enriched) },
-      ]
+      scripts.push({ type: 'application/ld+json', innerHTML: JSON.stringify(enriched) })
+    }
+
+    const effectiveRouteKey = configRouteKey || route.meta.routeKey
+    const breadcrumb = buildBreadcrumb({ routeKey: effectiveRouteKey, title, locale: currentLocale, t, homeUrl, blogUrl })
+    if (breadcrumb) {
+      scripts.push({ type: 'application/ld+json', innerHTML: JSON.stringify(breadcrumb) })
+    }
+
+    if (scripts.length) {
+      head.script = scripts
     }
 
     return head

--- a/src/composables/useLocaleRouter.js
+++ b/src/composables/useLocaleRouter.js
@@ -2,7 +2,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { articles } from '../data/articles.js'
 import { articlesEn } from '../data/articles-en.js'
-import { routeMap } from '../discovery.js'
+import { routeMap, keyToGroup } from '../discovery.js'
 
 // Build blog slug map from article data using calculatorKey
 const blogSlugMap = {}
@@ -14,7 +14,7 @@ for (const deArticle of articles) {
   }
 }
 
-export { routeMap }
+export { routeMap, keyToGroup }
 
 export function localePath(routeKey, locale) {
   const slug = routeMap[routeKey]?.[locale]

--- a/src/discovery.js
+++ b/src/discovery.js
@@ -50,3 +50,7 @@ export const calculatorGroups = [...groupMap.entries()].map(([key, calculators])
   key,
   calculators,
 }))
+
+export const keyToGroup = Object.fromEntries(
+  calculatorMetas.map(m => [m.key, m.group])
+)


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-111-seo-schemas
**Agent:** claude
**Model:** claude-haiku-4-5-20251001
**Branch:** `agent/hc-111-seo-schemas-20260415-030026`
**Cost:** $2.4217863499999996

Closes jenslaufer/health-calculators#111

### Prompt
> Add BreadcrumbList, Organization schema, and fix blog image in JSON-LD.

## Context
- Calculator pages lack BreadcrumbList schema
- No Organization schema in root template
- Blog Article JSON-LD is missing the `image` field (limits rich snippet previews)
- This is a template-level change affecting all 103 pages

## Instructions
1. Add BreadcrumbList schema to all calculator and blog pages
   - Home > Category > Page (use route metadata for breadcrumb labels)
2. Add Organization schema to App.vue or root layout
   - name: "Health Calculator", url: "https://healthcalculator.app"
3. Add `image` field to Article JSON-LD in blog templates
   - Use a default blog image or derive from blog metadata
4. Run `npm run test` to ensure all unit tests pass
5. Run `npm run build` to verify SSG build succeeds
6. DO NOT DELETE or modify any calculator components, blog articles, or unrelated files
7. DO NOT change routing, calculator logic, or visual appearance
8. Add tests for the new structured data generation