### PR TITLE
hc-115-diabetes-risk: Implement the Diabetes Risk Score (FINDRISC) Calculator as d

### DIFF
--- a/e2e/diabetes-risk.spec.js
+++ b/e2e/diabetes-risk.spec.js
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/diabetes-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Diabetes/)
+})
+
+test('metric unit is selected by default', async ({ page }) => {
+  const metricBtn = page.getByRole('button', { name: 'Metrisch', exact: true })
+  await expect(metricBtn).toHaveClass(/bg-stone-900/)
+})
+
+test('result not shown without complete input', async ({ page }) => {
+  await expect(page.getByTestId('result-section')).not.toBeVisible()
+})
+
+async function fillForm(page, overrides = {}) {
+  const opts = {
+    ageGroup: 'lt45',
+    weight: '70',
+    height: '175',
+    waist: '80',
+    activity: 'yes',
+    vegfruit: 'yes',
+    bpMed: 'no',
+    glucose: 'no',
+    family: 'none',
+    ...overrides,
+  }
+
+  await page.getByTestId('age-group-select').selectOption(opts.ageGroup)
+  await page.getByTestId('weight-input').fill(opts.weight)
+  await page.getByTestId('height-input').fill(opts.height)
+  await page.getByTestId('waist-input').fill(opts.waist)
+  await page.getByTestId(`activity-${opts.activity}`).click()
+  await page.getByTestId(`vegfruit-${opts.vegfruit}`).click()
+  await page.getByTestId(`bp-med-${opts.bpMed}`).click()
+  await page.getByTestId(`glucose-${opts.glucose}`).click()
+  await page.getByTestId('family-history-select').selectOption(opts.family)
+}
+
+test('BMI is displayed when weight and height are entered', async ({ page }) => {
+  await page.getByTestId('weight-input').fill('75')
+  await page.getByTestId('height-input').fill('175')
+  const bmiDisplay = page.getByTestId('bmi-display')
+  await expect(bmiDisplay).toBeVisible()
+  const bmi = parseFloat(await bmiDisplay.textContent())
+  expect(bmi).toBeGreaterThanOrEqual(24)
+  expect(bmi).toBeLessThanOrEqual(25)
+})
+
+test('low-risk profile shows score 0 and low risk category', async ({ page }) => {
+  await fillForm(page)
+  await expect(page.getByTestId('result-section')).toBeVisible()
+  const score = page.getByTestId('findrisc-score')
+  await expect(score).toHaveText('0')
+  await expect(page.getByTestId('risk-category')).toBeVisible()
+})
+
+test('probability is shown as percentage', async ({ page }) => {
+  await fillForm(page)
+  const prob = page.getByTestId('probability')
+  await expect(prob).toBeVisible()
+  const text = await prob.textContent()
+  expect(text).toMatch(/\d+%/)
+})
+
+test('factor breakdown is visible after completing form', async ({ page }) => {
+  await fillForm(page)
+  await expect(page.getByTestId('factor-breakdown')).toBeVisible()
+})
+
+test('recommendations section is shown', async ({ page }) => {
+  await fillForm(page)
+  await expect(page.getByTestId('recommendations')).toBeVisible()
+})
+
+test('disclaimer is visible in results', async ({ page }) => {
+  await fillForm(page)
+  await expect(page.getByTestId('disclaimer')).toBeVisible()
+})
+
+test('high-risk profile scores higher than low-risk profile', async ({ page }) => {
+  await fillForm(page)
+  const lowScore = parseInt(await page.getByTestId('findrisc-score').textContent())
+
+  // Re-fill with high-risk profile
+  await page.getByTestId('age-group-select').selectOption('gt64')
+  await page.getByTestId('weight-input').fill('100')
+  await page.getByTestId('height-input').fill('170')
+  await page.getByTestId('waist-input').fill('110')
+  await page.getByTestId('activity-no').click()
+  await page.getByTestId('vegfruit-no').click()
+  await page.getByTestId('bp-med-yes').click()
+  await page.getByTestId('glucose-yes').click()
+  await page.getByTestId('family-history-select').selectOption('close')
+
+  const highScore = parseInt(await page.getByTestId('findrisc-score').textContent())
+  expect(highScore).toBeGreaterThan(lowScore)
+})
+
+test('adding blood pressure medication increases score by 2', async ({ page }) => {
+  await fillForm(page, { bpMed: 'no' })
+  const scoreBefore = parseInt(await page.getByTestId('findrisc-score').textContent())
+
+  await page.getByTestId('bp-med-yes').click()
+  const scoreAfter = parseInt(await page.getByTestId('findrisc-score').textContent())
+  expect(scoreAfter - scoreBefore).toBe(2)
+})
+
+test('prior high glucose history increases score by 5', async ({ page }) => {
+  await fillForm(page, { glucose: 'no' })
+  const scoreBefore = parseInt(await page.getByTestId('findrisc-score').textContent())
+
+  await page.getByTestId('glucose-yes').click()
+  const scoreAfter = parseInt(await page.getByTestId('findrisc-score').textContent())
+  expect(scoreAfter - scoreBefore).toBe(5)
+})
+
+test('imperial unit toggle shows inch/lbs inputs', async ({ page }) => {
+  await page.getByRole('button', { name: 'Imperial' }).click()
+  await expect(page.getByTestId('waist-in-input')).toBeVisible()
+  await expect(page.getByTestId('weight-lbs-input')).toBeVisible()
+})
+
+test('imperial inputs produce a valid score', async ({ page }) => {
+  await page.getByRole('button', { name: 'Imperial' }).click()
+  await page.getByTestId('age-group-select').selectOption('lt45')
+  await page.getByTestId('weight-lbs-input').fill('154')
+  await page.getByTestId('height-ft-input').fill('5')
+  await page.getByTestId('height-in-input').fill('9')
+  await page.getByTestId('waist-in-input').fill('31')
+  await page.getByTestId('activity-yes').click()
+  await page.getByTestId('vegfruit-yes').click()
+  await page.getByTestId('bp-med-no').click()
+  await page.getByTestId('glucose-no').click()
+  await page.getByTestId('family-history-select').selectOption('none')
+
+  await expect(page.getByTestId('result-section')).toBeVisible()
+  const score = parseInt(await page.getByTestId('findrisc-score').textContent())
+  expect(score).toBeGreaterThanOrEqual(0)
+  expect(score).toBeLessThanOrEqual(26)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})
+
+test('English version loads correctly', async ({ page }) => {
+  await page.goto('en/diabetes-risk-calculator')
+  await expect(page).toHaveTitle(/Diabetes/)
+  await page.getByTestId('age-group-select').selectOption('lt45')
+  await page.getByTestId('weight-input').fill('70')
+  await page.getByTestId('height-input').fill('175')
+  await page.getByTestId('waist-input').fill('80')
+  await page.getByTestId('activity-yes').click()
+  await page.getByTestId('vegfruit-yes').click()
+  await page.getByTestId('bp-med-no').click()
+  await page.getByTestId('glucose-no').click()
+  await page.getByTestId('family-history-select').selectOption('none')
+  await expect(page.getByTestId('result-section')).toBeVisible()
+})
+
+test('DE blog article loads', async ({ page }) => {
+  await page.goto('de/blog/diabetes-risiko-berechnen')
+  await expect(page).toHaveTitle(/Diabetes/)
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+})
+
+test('EN blog article loads', async ({ page }) => {
+  await page.goto('en/blog/diabetes-risk-score')
+  await expect(page).toHaveTitle(/Diabetes/)
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -17,7 +17,7 @@ const EXPECTED_KEYS = [
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
   'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
-  'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy',
+  'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -56,6 +56,7 @@ const EXPECTED_ROUTE_MAP = {
   smokingCost: { de: 'rauchen-kosten-rechner', en: 'smoking-cost-calculator' },
   childGrowth: { de: 'wachstumsperzentile-kind', en: 'child-growth-percentile' },
   lifeExpectancy: { de: 'lebenserwartung-rechner', en: 'life-expectancy-calculator' },
+  diabetesRisk: { de: 'diabetes-risiko-rechner', en: 'diabetes-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -82,6 +83,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'rauchen-kosten-rechner',
   'wachstumsperzentile-kinder',
   'lebenserwartung-berechnen',
+  'diabetes-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -108,19 +110,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'smoking-cost-calculator',
   'child-growth-percentile-chart',
   'life-expectancy-calculator',
+  'diabetes-risk-score',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 35 calculators', () => {
-    expect(calculatorMetas).toHaveLength(35)
+  it('discovers all 36 calculators', () => {
+    expect(calculatorMetas).toHaveLength(36)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 35 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(35)
+  it('builds calculatorComponents map for all 36 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(36)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -143,15 +146,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 35 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(35)
+  it('discovers all 36 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(36)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 35 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(35)
+  it('discovers all 36 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(36)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -167,10 +170,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 35 calculators with no duplicates', () => {
+  it('groups contain all 36 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(35)
-    expect(new Set(allKeys).size).toBe(35)
+    expect(allKeys).toHaveLength(36)
+    expect(new Set(allKeys).size).toBe(36)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -191,7 +194,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
     ])
   })
 
@@ -239,8 +242,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 217 routes', () => {
-    expect(routes).toHaveLength(217)
+  it('generates exactly 223 routes', () => {
+    expect(routes).toHaveLength(223)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/diabetes-risk.test.js
+++ b/src/__tests__/diabetes-risk.test.js
@@ -1,0 +1,460 @@
+import { describe, it, expect } from 'vitest'
+
+// FINDRISC scoring — Finnish Diabetes Risk Score
+// Source: Lindström J, Tuomilehto J. Diabetes Care. 2003;26(3):725-731.
+
+// Age scoring
+function ageScore(group) {
+  const map = { lt45: 0, '45_54': 2, '55_64': 3, gt64: 4 }
+  return map[group]
+}
+
+// BMI scoring
+function bmiScore(bmi) {
+  if (bmi < 25) return 0
+  if (bmi <= 30) return 1
+  return 3
+}
+
+// BMI from weight (kg) and height (cm)
+function calcBmi(weightKg, heightCm) {
+  return weightKg / ((heightCm / 100) ** 2)
+}
+
+// Waist circumference scoring
+function waistScore(waistCm, isFemale) {
+  if (isFemale) {
+    if (waistCm < 80) return 0
+    if (waistCm <= 88) return 3
+    return 4
+  } else {
+    if (waistCm < 94) return 0
+    if (waistCm <= 102) return 3
+    return 4
+  }
+}
+
+// Physical activity scoring (at least 30 min/day)
+function activityScore(active) {
+  return active ? 0 : 2
+}
+
+// Vegetable/fruit daily scoring
+function vegFruitScore(daily) {
+  return daily ? 0 : 1
+}
+
+// Blood pressure medication scoring
+function bpMedScore(onMed) {
+  return onMed ? 2 : 0
+}
+
+// High blood glucose history scoring
+function highGlucoseScore(history) {
+  return history ? 5 : 0
+}
+
+// Family history scoring
+function familyScore(type) {
+  const map = { none: 0, distant: 3, close: 5 }
+  return map[type]
+}
+
+// Total FINDRISC score
+function findrisc({ age, bmi, waist, isFemale, active, vegFruit, bpMed, highGlucose, family }) {
+  return (
+    ageScore(age) +
+    bmiScore(bmi) +
+    waistScore(waist, isFemale) +
+    activityScore(active) +
+    vegFruitScore(vegFruit) +
+    bpMedScore(bpMed) +
+    highGlucoseScore(highGlucose) +
+    familyScore(family)
+  )
+}
+
+// Risk category
+function riskCategory(score) {
+  if (score <= 7) return 'low'
+  if (score <= 11) return 'slightly_elevated'
+  if (score <= 14) return 'moderate'
+  if (score <= 20) return 'high'
+  return 'very_high'
+}
+
+// 10-year probability (%)
+function probability(score) {
+  const cat = riskCategory(score)
+  return { low: 1, slightly_elevated: 4, moderate: 17, high: 33, very_high: 50 }[cat]
+}
+
+// -------------------------------------------------------------------
+// Age scoring
+// -------------------------------------------------------------------
+
+describe('FINDRISC — age scoring', () => {
+  it('under 45 → 0 points', () => {
+    expect(ageScore('lt45')).toBe(0)
+  })
+
+  it('45–54 → 2 points', () => {
+    expect(ageScore('45_54')).toBe(2)
+  })
+
+  it('55–64 → 3 points', () => {
+    expect(ageScore('55_64')).toBe(3)
+  })
+
+  it('over 64 → 4 points', () => {
+    expect(ageScore('gt64')).toBe(4)
+  })
+})
+
+// -------------------------------------------------------------------
+// BMI scoring
+// -------------------------------------------------------------------
+
+describe('FINDRISC — BMI scoring', () => {
+  it('BMI < 25 → 0 points', () => {
+    expect(bmiScore(22.5)).toBe(0)
+    expect(bmiScore(24.9)).toBe(0)
+  })
+
+  it('BMI = 25 → 1 point', () => {
+    expect(bmiScore(25)).toBe(1)
+  })
+
+  it('BMI 25–30 → 1 point', () => {
+    expect(bmiScore(27.5)).toBe(1)
+    expect(bmiScore(30)).toBe(1)
+  })
+
+  it('BMI > 30 → 3 points', () => {
+    expect(bmiScore(30.1)).toBe(3)
+    expect(bmiScore(35)).toBe(3)
+    expect(bmiScore(45)).toBe(3)
+  })
+
+  it('BMI boundary: 30.0 → 1, 30.1 → 3', () => {
+    expect(bmiScore(30.0)).toBe(1)
+    expect(bmiScore(30.1)).toBe(3)
+  })
+})
+
+// -------------------------------------------------------------------
+// BMI calculation
+// -------------------------------------------------------------------
+
+describe('BMI calculation', () => {
+  it('75 kg, 175 cm → ~24.5', () => {
+    const b = calcBmi(75, 175)
+    expect(b).toBeGreaterThanOrEqual(24.4)
+    expect(b).toBeLessThanOrEqual(24.6)
+  })
+
+  it('90 kg, 170 cm → ~31.1', () => {
+    const b = calcBmi(90, 170)
+    expect(b).toBeGreaterThanOrEqual(31.0)
+    expect(b).toBeLessThanOrEqual(31.2)
+  })
+
+  it('BMI scores correctly when derived from weight/height', () => {
+    expect(bmiScore(calcBmi(70, 175))).toBe(0)   // ~22.9
+    expect(bmiScore(calcBmi(82, 175))).toBe(1)   // ~26.8
+    expect(bmiScore(calcBmi(100, 175))).toBe(3)  // ~32.7
+  })
+})
+
+// -------------------------------------------------------------------
+// Waist circumference scoring
+// -------------------------------------------------------------------
+
+describe('FINDRISC — waist scoring (male)', () => {
+  it('< 94 cm → 0 points', () => {
+    expect(waistScore(85, false)).toBe(0)
+    expect(waistScore(93, false)).toBe(0)
+  })
+
+  it('94–102 cm → 3 points', () => {
+    expect(waistScore(94, false)).toBe(3)
+    expect(waistScore(98, false)).toBe(3)
+    expect(waistScore(102, false)).toBe(3)
+  })
+
+  it('> 102 cm → 4 points', () => {
+    expect(waistScore(103, false)).toBe(4)
+    expect(waistScore(120, false)).toBe(4)
+  })
+
+  it('boundary: 93.9 → 0, 94.0 → 3', () => {
+    expect(waistScore(93.9, false)).toBe(0)
+    expect(waistScore(94.0, false)).toBe(3)
+  })
+
+  it('boundary: 102.0 → 3, 102.1 → 4', () => {
+    expect(waistScore(102.0, false)).toBe(3)
+    expect(waistScore(102.1, false)).toBe(4)
+  })
+})
+
+describe('FINDRISC — waist scoring (female)', () => {
+  it('< 80 cm → 0 points', () => {
+    expect(waistScore(70, true)).toBe(0)
+    expect(waistScore(79, true)).toBe(0)
+  })
+
+  it('80–88 cm → 3 points', () => {
+    expect(waistScore(80, true)).toBe(3)
+    expect(waistScore(84, true)).toBe(3)
+    expect(waistScore(88, true)).toBe(3)
+  })
+
+  it('> 88 cm → 4 points', () => {
+    expect(waistScore(89, true)).toBe(4)
+    expect(waistScore(100, true)).toBe(4)
+  })
+
+  it('boundary: 79.9 → 0, 80.0 → 3', () => {
+    expect(waistScore(79.9, true)).toBe(0)
+    expect(waistScore(80.0, true)).toBe(3)
+  })
+
+  it('boundary: 88.0 → 3, 88.1 → 4', () => {
+    expect(waistScore(88.0, true)).toBe(3)
+    expect(waistScore(88.1, true)).toBe(4)
+  })
+})
+
+// -------------------------------------------------------------------
+// Binary question scoring
+// -------------------------------------------------------------------
+
+describe('FINDRISC — activity scoring', () => {
+  it('active ≥ 30 min/day → 0 points', () => {
+    expect(activityScore(true)).toBe(0)
+  })
+
+  it('not active → 2 points', () => {
+    expect(activityScore(false)).toBe(2)
+  })
+})
+
+describe('FINDRISC — vegetable/fruit scoring', () => {
+  it('daily consumption → 0 points', () => {
+    expect(vegFruitScore(true)).toBe(0)
+  })
+
+  it('not daily → 1 point', () => {
+    expect(vegFruitScore(false)).toBe(1)
+  })
+})
+
+describe('FINDRISC — blood pressure medication scoring', () => {
+  it('no medication → 0 points', () => {
+    expect(bpMedScore(false)).toBe(0)
+  })
+
+  it('on medication → 2 points', () => {
+    expect(bpMedScore(true)).toBe(2)
+  })
+})
+
+describe('FINDRISC — high blood glucose scoring', () => {
+  it('no history → 0 points', () => {
+    expect(highGlucoseScore(false)).toBe(0)
+  })
+
+  it('history of high blood glucose → 5 points', () => {
+    expect(highGlucoseScore(true)).toBe(5)
+  })
+})
+
+// -------------------------------------------------------------------
+// Family history scoring
+// -------------------------------------------------------------------
+
+describe('FINDRISC — family history scoring', () => {
+  it('no family history → 0 points', () => {
+    expect(familyScore('none')).toBe(0)
+  })
+
+  it('distant relative (grandparent, aunt/uncle, cousin) → 3 points', () => {
+    expect(familyScore('distant')).toBe(3)
+  })
+
+  it('close relative (parent, sibling, child) → 5 points', () => {
+    expect(familyScore('close')).toBe(5)
+  })
+})
+
+// -------------------------------------------------------------------
+// Total FINDRISC score — published reference cases
+// -------------------------------------------------------------------
+
+describe('FINDRISC — total score reference cases', () => {
+  // Lowest possible score: young, normal BMI, normal waist, active, eats well, no meds, no glucose history, no family
+  it('best-case profile → score 0', () => {
+    const s = findrisc({
+      age: 'lt45', bmi: 22, waist: 80, isFemale: false,
+      active: true, vegFruit: true, bpMed: false, highGlucose: false, family: 'none',
+    })
+    expect(s).toBe(0)
+  })
+
+  // Maximum score: all worst-case answers
+  it('worst-case profile → score 26', () => {
+    const s = findrisc({
+      age: 'gt64', bmi: 35, waist: 110, isFemale: false,
+      active: false, vegFruit: false, bpMed: true, highGlucose: true, family: 'close',
+    })
+    // 4 + 3 + 4 + 2 + 1 + 2 + 5 + 5 = 26
+    expect(s).toBe(26)
+  })
+
+  // Typical moderate-risk middle-aged person
+  it('typical moderate-risk profile → 12–14', () => {
+    const s = findrisc({
+      age: '45_54', bmi: 27, waist: 96, isFemale: false,
+      active: false, vegFruit: true, bpMed: false, highGlucose: false, family: 'none',
+    })
+    // 2 + 1 + 3 + 2 + 0 + 0 + 0 + 0 = 8
+    expect(s).toBeGreaterThanOrEqual(6)
+    expect(s).toBeLessThanOrEqual(10)
+  })
+
+  // High-risk elderly female with multiple factors
+  it('high-risk elderly female → score ≥ 15', () => {
+    const s = findrisc({
+      age: 'gt64', bmi: 31, waist: 90, isFemale: true,
+      active: false, vegFruit: false, bpMed: true, highGlucose: false, family: 'distant',
+    })
+    // 4 + 3 + 4 + 2 + 1 + 2 + 0 + 3 = 19
+    expect(s).toBeGreaterThanOrEqual(15)
+  })
+
+  // Score with prior high glucose (5 points) pushes into high risk
+  it('prior high glucose adds 5 points', () => {
+    const without = findrisc({
+      age: '45_54', bmi: 22, waist: 80, isFemale: false,
+      active: true, vegFruit: true, bpMed: false, highGlucose: false, family: 'none',
+    })
+    const with_ = findrisc({
+      age: '45_54', bmi: 22, waist: 80, isFemale: false,
+      active: true, vegFruit: true, bpMed: false, highGlucose: true, family: 'none',
+    })
+    expect(with_ - without).toBe(5)
+  })
+})
+
+// -------------------------------------------------------------------
+// Risk category classification
+// -------------------------------------------------------------------
+
+describe('FINDRISC — risk category', () => {
+  it('score 0–7 → low', () => {
+    expect(riskCategory(0)).toBe('low')
+    expect(riskCategory(7)).toBe('low')
+  })
+
+  it('score 8–11 → slightly_elevated', () => {
+    expect(riskCategory(8)).toBe('slightly_elevated')
+    expect(riskCategory(11)).toBe('slightly_elevated')
+  })
+
+  it('score 12–14 → moderate', () => {
+    expect(riskCategory(12)).toBe('moderate')
+    expect(riskCategory(14)).toBe('moderate')
+  })
+
+  it('score 15–20 → high', () => {
+    expect(riskCategory(15)).toBe('high')
+    expect(riskCategory(20)).toBe('high')
+  })
+
+  it('score 21–26 → very_high', () => {
+    expect(riskCategory(21)).toBe('very_high')
+    expect(riskCategory(26)).toBe('very_high')
+  })
+
+  it('boundary: score 7 → low, score 8 → slightly_elevated', () => {
+    expect(riskCategory(7)).toBe('low')
+    expect(riskCategory(8)).toBe('slightly_elevated')
+  })
+
+  it('boundary: score 11 → slightly_elevated, score 12 → moderate', () => {
+    expect(riskCategory(11)).toBe('slightly_elevated')
+    expect(riskCategory(12)).toBe('moderate')
+  })
+
+  it('boundary: score 14 → moderate, score 15 → high', () => {
+    expect(riskCategory(14)).toBe('moderate')
+    expect(riskCategory(15)).toBe('high')
+  })
+
+  it('boundary: score 20 → high, score 21 → very_high', () => {
+    expect(riskCategory(20)).toBe('high')
+    expect(riskCategory(21)).toBe('very_high')
+  })
+})
+
+// -------------------------------------------------------------------
+// 10-year probability
+// -------------------------------------------------------------------
+
+describe('FINDRISC — 10-year probability', () => {
+  it('low risk → 1%', () => {
+    expect(probability(5)).toBe(1)
+  })
+
+  it('slightly elevated → 4%', () => {
+    expect(probability(9)).toBe(4)
+  })
+
+  it('moderate → 17%', () => {
+    expect(probability(13)).toBe(17)
+  })
+
+  it('high → 33%', () => {
+    expect(probability(17)).toBe(33)
+  })
+
+  it('very high → 50%', () => {
+    expect(probability(24)).toBe(50)
+  })
+})
+
+// -------------------------------------------------------------------
+// Imperial unit conversion (for the UI)
+// -------------------------------------------------------------------
+
+describe('imperial unit conversion', () => {
+  it('150 lbs → ~68 kg', () => {
+    const kg = 150 * 0.453592
+    expect(kg).toBeGreaterThanOrEqual(67.5)
+    expect(kg).toBeLessThanOrEqual(68.5)
+  })
+
+  it('5 ft 9 in → ~175 cm', () => {
+    const cm = (5 * 12 + 9) * 2.54
+    expect(cm).toBeGreaterThanOrEqual(174)
+    expect(cm).toBeLessThanOrEqual(176)
+  })
+
+  it('35 in waist → ~88.9 cm', () => {
+    const cm = 35 * 2.54
+    expect(cm).toBeGreaterThanOrEqual(88.8)
+    expect(cm).toBeLessThanOrEqual(89.0)
+  })
+
+  it('BMI from imperial inputs matches metric', () => {
+    const weightLbs = 165
+    const heightFt = 5
+    const heightIn = 10
+    const weightKg = weightLbs * 0.453592
+    const heightCm = (heightFt * 12 + heightIn) * 2.54
+    const b = calcBmi(weightKg, heightCm)
+    expect(b).toBeGreaterThanOrEqual(23.5)
+    expect(b).toBeLessThanOrEqual(24.0)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 140 links (35 calcs × 2 locales + 35 blogs × 2 locales)', () => {
+  it('generates 144 links (36 calcs × 2 locales + 36 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(140)
+    expect(links).toHaveLength(144)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -13,7 +13,7 @@ const EXPECTED_KEYS = [
   'intermittentFasting', 'vo2Max', 'oneRepMax', 'runningPace', 'keto',
   'period', 'bac', 'proteinNeed', 'caffeine',
   'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
-  'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy',
+  'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -40,6 +40,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'rauchen-kosten-rechner',
   'wachstumsperzentile-kinder',
   'lebenserwartung-berechnen',
+  'diabetes-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -66,12 +67,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'smoking-cost-calculator',
   'child-growth-percentile-chart',
   'life-expectancy-calculator',
+  'diabetes-risk-score',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 35 calculator meta files', () => {
+  it('discovers all 36 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(35)
+    expect(metas).toHaveLength(36)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -109,19 +111,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 35 DE blog slugs', () => {
+  it('returns all 36 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(35)
+    expect(de).toHaveLength(36)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 35 EN blog slugs', () => {
+  it('returns all 36 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(35)
+    expect(en).toHaveLength(36)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -189,9 +191,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 70 calcs + 2 blog index + 70 blog articles = 144)', () => {
+  it('generates correct total URL count (2 home + 72 calcs + 2 blog index + 72 blog articles = 148)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(144)
+    expect(urlCount).toBe(148)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -281,6 +281,15 @@ slug: 'period-calculator-guide',
     calculatorKey: 'lifeExpectancy',
     related: ['calculate-bmi', 'smoking-cost-calculator'],
   },
+  {
+    slug: 'diabetes-risk-score',
+    title: 'Diabetes Risk Score: FINDRISC Explained',
+    description: 'Calculate your type 2 diabetes risk with the FINDRISC score. How the test works, what the points mean, and which measures reduce your risk.',
+    date: '2026-04-15',
+    readTime: '8 min',
+    calculatorKey: 'diabetesRisk',
+    related: ['hba1c-converter-guide', 'blood-sugar-converter-guide'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -281,6 +281,15 @@ slug: 'zyklusrechner-guide',
     calculatorKey: 'lifeExpectancy',
     related: ['bmi-berechnen', 'rauchen-kosten-rechner'],
   },
+  {
+    slug: 'diabetes-risiko-berechnen',
+    title: 'Diabetes-Risiko berechnen: FINDRISC-Score erklärt',
+    description: 'Typ-2-Diabetes-Risiko mit dem FINDRISC-Score berechnen. Wie der Test funktioniert, was die Punkte bedeuten und welche Maßnahmen das Risiko senken.',
+    date: '2026-04-15',
+    readTime: '8 min',
+    calculatorKey: 'diabetesRisk',
+    related: ['hba1c-umrechnen', 'blutzucker-umrechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/diabetesRisk.json
+++ b/src/locales/calculators/de/diabetesRisk.json
@@ -1,0 +1,74 @@
+{
+  "common": {
+    "yes": "Ja",
+    "no": "Nein"
+  },
+  "home": {
+    "calculators": {
+      "diabetesRisk": {
+        "name": "Diabetes-Risiko-Rechner",
+        "description": "Berechne dein Typ-2-Diabetes-Risiko mit dem validierten FINDRISC-Score."
+      }
+    }
+  },
+  "diabetesRisk": {
+    "meta": {
+      "title": "Diabetes-Risiko berechnen — FINDRISC-Score Rechner",
+      "description": "Typ-2-Diabetes-Risiko mit dem FINDRISC-Score berechnen. 8 Fragen, wissenschaftlich validiert. 10-Jahres-Wahrscheinlichkeit, Risikokategorien und Präventionsempfehlungen."
+    },
+    "title": "Diabetes-Risiko-Rechner (FINDRISC)",
+    "description": "Berechne dein 10-Jahres-Risiko für Typ-2-Diabetes mit dem validierten FINDRISC-Fragebogen.",
+    "gender": "Geschlecht",
+    "ageGroup": "Altersgruppe",
+    "selectAge": "Altersgruppe wählen",
+    "ageLt45": "Unter 45 Jahre",
+    "age45_54": "45–54 Jahre",
+    "age55_64": "55–64 Jahre",
+    "ageGt64": "Über 64 Jahre",
+    "weightHeight": "Gewicht & Größe (für BMI)",
+    "placeholderWeight": "z. B. 75",
+    "placeholderHeight": "z. B. 175",
+    "bmiLabel": "BMI",
+    "waist": "Taillenumfang",
+    "waistHint": "Gemessen auf Höhe der untersten Rippe, im Stehen.",
+    "placeholderWaistMale": "Männer: < 94 / 94–102 / > 102 cm",
+    "placeholderWaistFemale": "Frauen: < 80 / 80–88 / > 88 cm",
+    "physicalActivity": "Körperliche Aktivität",
+    "physicalActivityHint": "Mindestens 30 Minuten täglich — auch Alltagsaktivität wie Gehen zählt.",
+    "vegFruitDaily": "Täglich Gemüse oder Obst?",
+    "vegFruitHint": "Konsumierst du jeden Tag Gemüse und/oder Obst?",
+    "bpMedication": "Blutdruckmedikamente",
+    "highBloodGlucose": "Erhöhter Blutzucker in der Vergangenheit?",
+    "highBloodGlucoseHint": "Wurde je ein erhöhter Blutzucker festgestellt — z. B. bei einer Untersuchung, Schwangerschaft oder Erkrankung?",
+    "familyHistory": "Familiengeschichte Diabetes",
+    "selectFamily": "Familiengeschichte wählen",
+    "familyNone": "Kein Diabetes in der Familie",
+    "familyDistant": "Ja — Großelternteil, Tante/Onkel oder Cousin",
+    "familyClose": "Ja — Elternteil, Geschwister oder eigenes Kind",
+    "scoreRange": "Skala 0–26 Punkte",
+    "riskCategory": "Risikokategorie",
+    "probability10y": "10-Jahres-Wahrscheinlichkeit",
+    "risk_low": "Gering",
+    "risk_slightly_elevated": "Leicht erhöht",
+    "risk_moderate": "Mäßig",
+    "risk_high": "Hoch",
+    "risk_very_high": "Sehr hoch",
+    "factorBreakdown": "Punkteverteilung nach Faktor",
+    "factorAge": "Alter",
+    "factorBmi": "BMI",
+    "factorWaist": "Taillenumfang",
+    "factorActivity": "Körperliche Aktivität",
+    "factorVegFruit": "Gemüse/Obst täglich",
+    "factorBpMed": "Blutdruckmedikamente",
+    "factorHighGlucose": "Erhöhter Blutzucker",
+    "factorFamily": "Familiengeschichte",
+    "recommendations": "Präventionsempfehlungen",
+    "recWeight": "Normalgewicht anstreben: Ein BMI unter 25 senkt das Risiko deutlich.",
+    "recActivity": "Mehr Bewegung: 30 Minuten moderate Aktivität täglich reduzieren das Diabetesrisiko um bis zu 58 %.",
+    "recDiet": "Ernährung verbessern: Täglich Gemüse und Obst, weniger Zucker und verarbeitete Lebensmittel.",
+    "recScreening": "Regelmäßiges Screening: Blutzucker und HbA1c beim Arzt kontrollieren lassen.",
+    "recDoctor": "Ärztliche Abklärung: Bei diesem Risiko ist eine Beratung durch einen Arzt empfehlenswert.",
+    "recMaintain": "Weiter so: Dein Lebensstil unterstützt ein geringes Diabetesrisiko.",
+    "disclaimer": "Dieser Rechner verwendet den validierten FINDRISC-Fragebogen (Lindström & Tuomilehto, 2003) als Screeninginstrument. Er ersetzt keine ärztliche Diagnose. Ein erhöhtes Ergebnis bedeutet nicht, dass du Diabetes hast oder bekommst. Konsultiere bei Fragen oder Bedenken einen Arzt."
+  }
+}

--- a/src/locales/calculators/en/diabetesRisk.json
+++ b/src/locales/calculators/en/diabetesRisk.json
@@ -1,0 +1,74 @@
+{
+  "common": {
+    "yes": "Yes",
+    "no": "No"
+  },
+  "home": {
+    "calculators": {
+      "diabetesRisk": {
+        "name": "Diabetes Risk Calculator",
+        "description": "Calculate your type 2 diabetes risk using the validated FINDRISC score."
+      }
+    }
+  },
+  "diabetesRisk": {
+    "meta": {
+      "title": "Diabetes Risk Calculator — FINDRISC Score",
+      "description": "Calculate your type 2 diabetes risk with the FINDRISC score. 8 questions, scientifically validated. 10-year probability, risk categories and prevention recommendations."
+    },
+    "title": "Diabetes Risk Calculator (FINDRISC)",
+    "description": "Calculate your 10-year risk of developing type 2 diabetes using the validated FINDRISC questionnaire.",
+    "gender": "Sex",
+    "ageGroup": "Age group",
+    "selectAge": "Select age group",
+    "ageLt45": "Under 45 years",
+    "age45_54": "45–54 years",
+    "age55_64": "55–64 years",
+    "ageGt64": "Over 64 years",
+    "weightHeight": "Weight & Height (for BMI)",
+    "placeholderWeight": "e.g. 75",
+    "placeholderHeight": "e.g. 175",
+    "bmiLabel": "BMI",
+    "waist": "Waist circumference",
+    "waistHint": "Measured at the level of the lowest rib, while standing.",
+    "placeholderWaistMale": "Men: < 94 / 94–102 / > 102 cm",
+    "placeholderWaistFemale": "Women: < 80 / 80–88 / > 88 cm",
+    "physicalActivity": "Physical activity",
+    "physicalActivityHint": "At least 30 minutes daily — everyday activities like walking count too.",
+    "vegFruitDaily": "Daily vegetables or fruit?",
+    "vegFruitHint": "Do you eat vegetables and/or fruit every day?",
+    "bpMedication": "Blood pressure medication",
+    "highBloodGlucose": "History of high blood glucose?",
+    "highBloodGlucoseHint": "Has high blood glucose ever been found — e.g. during a check-up, pregnancy or illness?",
+    "familyHistory": "Family history of diabetes",
+    "selectFamily": "Select family history",
+    "familyNone": "No diabetes in the family",
+    "familyDistant": "Yes — grandparent, aunt/uncle or first cousin",
+    "familyClose": "Yes — parent, sibling or own child",
+    "scoreRange": "Scale 0–26 points",
+    "riskCategory": "Risk category",
+    "probability10y": "10-year probability",
+    "risk_low": "Low",
+    "risk_slightly_elevated": "Slightly elevated",
+    "risk_moderate": "Moderate",
+    "risk_high": "High",
+    "risk_very_high": "Very high",
+    "factorBreakdown": "Score breakdown by factor",
+    "factorAge": "Age",
+    "factorBmi": "BMI",
+    "factorWaist": "Waist circumference",
+    "factorActivity": "Physical activity",
+    "factorVegFruit": "Daily vegetables/fruit",
+    "factorBpMed": "Blood pressure medication",
+    "factorHighGlucose": "High blood glucose history",
+    "factorFamily": "Family history",
+    "recommendations": "Prevention recommendations",
+    "recWeight": "Reach a healthy weight: A BMI below 25 significantly reduces your risk.",
+    "recActivity": "Move more: 30 minutes of moderate activity daily reduces diabetes risk by up to 58%.",
+    "recDiet": "Improve your diet: Daily vegetables and fruit, less sugar and processed foods.",
+    "recScreening": "Regular screening: Have blood glucose and HbA1c checked by your doctor.",
+    "recDoctor": "See a doctor: At this risk level, medical consultation is recommended.",
+    "recMaintain": "Keep it up: Your lifestyle supports a low diabetes risk.",
+    "disclaimer": "This calculator uses the validated FINDRISC questionnaire (Lindström & Tuomilehto, 2003) as a screening tool. It does not replace medical diagnosis. An elevated result does not mean you have or will develop diabetes. Consult a doctor if you have questions or concerns."
+  }
+}

--- a/src/pages/DiabetesRiskCalculator.vue
+++ b/src/pages/DiabetesRiskCalculator.vue
@@ -1,0 +1,534 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t } = useI18n()
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('diabetesRisk.meta.title'),
+  description: t('diabetesRisk.meta.description'),
+  routeKey: 'diabetesRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Diabetes Risk Calculator (FINDRISC)',
+    url: 'https://healthcalculator.app/diabetes-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+// FINDRISC scoring constants
+// Source: Lindström J, Tuomilehto J. Diabetes Care. 2003;26(3):725-731.
+const AGE_SCORES = { lt45: 0, '45_54': 2, '55_64': 3, gt64: 4 }
+const BMI_SCORES = { lt25: 0, '25_30': 1, gt30: 3 }
+// Waist circumference thresholds: men <94/94-102/>102, women <80/80-88/>88
+const WAIST_SCORES = { low: 0, mid: 3, high: 4 }
+const ACTIVITY_SCORES = { yes: 0, no: 2 }
+const VEGFRUIT_SCORES = { yes: 0, no: 1 }
+const BP_MED_SCORES = { no: 0, yes: 2 }
+const HIGH_GLUCOSE_SCORES = { no: 0, yes: 5 }
+const FAMILY_SCORES = { none: 0, distant: 3, close: 5 }
+
+// Inputs
+const unit = ref('metric')
+const gender = ref('male')
+const ageGroup = ref(null)
+const weightKg = ref(null)
+const weightLbs = ref(null)
+const heightCmVal = ref(null)
+const heightFt = ref(null)
+const heightIn = ref(null)
+const waistCm = ref(null)
+const waistIn = ref(null)
+const physicalActivity = ref(null)
+const vegFruitDaily = ref(null)
+const bpMedication = ref(null)
+const highBloodGlucose = ref(null)
+const familyHistory = ref(null)
+
+// Unit conversion helpers
+const weightInKg = computed(() => {
+  if (unit.value === 'imperial') return weightLbs.value ? weightLbs.value * 0.453592 : null
+  return weightKg.value
+})
+
+const heightInCm = computed(() => {
+  if (unit.value === 'imperial') {
+    const ft = heightFt.value || 0
+    const inches = heightIn.value || 0
+    return ft || inches ? (ft * 12 + inches) * 2.54 : null
+  }
+  return heightCmVal.value
+})
+
+const waistInCm = computed(() => {
+  if (unit.value === 'imperial') return waistIn.value ? waistIn.value * 2.54 : null
+  return waistCm.value
+})
+
+// BMI calculation
+const bmi = computed(() => {
+  const w = weightInKg.value
+  const h = heightInCm.value
+  if (!w || !h || h <= 0) return null
+  return w / ((h / 100) ** 2)
+})
+
+// BMI category for scoring
+const bmiScore = computed(() => {
+  const b = bmi.value
+  if (b === null) return null
+  if (b < 25) return BMI_SCORES.lt25
+  if (b <= 30) return BMI_SCORES['25_30']
+  return BMI_SCORES.gt30
+})
+
+// Waist circumference score
+const waistScore = computed(() => {
+  const w = waistInCm.value
+  if (w === null) return null
+  if (gender.value === 'male') {
+    if (w < 94) return WAIST_SCORES.low
+    if (w <= 102) return WAIST_SCORES.mid
+    return WAIST_SCORES.high
+  } else {
+    if (w < 80) return WAIST_SCORES.low
+    if (w <= 88) return WAIST_SCORES.mid
+    return WAIST_SCORES.high
+  }
+})
+
+// Total FINDRISC score
+const score = computed(() => {
+  const ageScore = ageGroup.value !== null ? AGE_SCORES[ageGroup.value] : null
+  const bScore = bmiScore.value
+  const wScore = waistScore.value
+  const actScore = physicalActivity.value !== null ? ACTIVITY_SCORES[physicalActivity.value] : null
+  const vegScore = vegFruitDaily.value !== null ? VEGFRUIT_SCORES[vegFruitDaily.value] : null
+  const bpScore = bpMedication.value !== null ? BP_MED_SCORES[bpMedication.value] : null
+  const glScore = highBloodGlucose.value !== null ? HIGH_GLUCOSE_SCORES[highBloodGlucose.value] : null
+  const famScore = familyHistory.value !== null ? FAMILY_SCORES[familyHistory.value] : null
+
+  if ([ageScore, bScore, wScore, actScore, vegScore, bpScore, glScore, famScore].some(v => v === null)) return null
+
+  return ageScore + bScore + wScore + actScore + vegScore + bpScore + glScore + famScore
+})
+
+// Risk category
+const riskCategory = computed(() => {
+  const s = score.value
+  if (s === null) return null
+  if (s <= 7) return 'low'
+  if (s <= 11) return 'slightly_elevated'
+  if (s <= 14) return 'moderate'
+  if (s <= 20) return 'high'
+  return 'very_high'
+})
+
+// 10-year probability of developing type 2 diabetes
+const probability = computed(() => {
+  const cat = riskCategory.value
+  if (!cat) return null
+  const map = { low: 1, slightly_elevated: 4, moderate: 17, high: 33, very_high: 50 }
+  return map[cat]
+})
+
+const riskColor = computed(() => {
+  const cat = riskCategory.value
+  if (!cat) return ''
+  return {
+    low: 'text-green-700',
+    slightly_elevated: 'text-lime-700',
+    moderate: 'text-yellow-700',
+    high: 'text-orange-700',
+    very_high: 'text-red-700',
+  }[cat]
+})
+
+const riskBg = computed(() => {
+  const cat = riskCategory.value
+  if (!cat) return ''
+  return {
+    low: 'bg-green-50 border-green-200',
+    slightly_elevated: 'bg-lime-50 border-lime-200',
+    moderate: 'bg-yellow-50 border-yellow-200',
+    high: 'bg-orange-50 border-orange-200',
+    very_high: 'bg-red-50 border-red-200',
+  }[cat]
+})
+
+// Factor breakdown for display
+const factorRows = computed(() => {
+  if (score.value === null) return []
+  return [
+    { label: t('diabetesRisk.factorAge'), score: AGE_SCORES[ageGroup.value] },
+    { label: t('diabetesRisk.factorBmi'), score: bmiScore.value },
+    { label: t('diabetesRisk.factorWaist'), score: waistScore.value },
+    { label: t('diabetesRisk.factorActivity'), score: ACTIVITY_SCORES[physicalActivity.value] },
+    { label: t('diabetesRisk.factorVegFruit'), score: VEGFRUIT_SCORES[vegFruitDaily.value] },
+    { label: t('diabetesRisk.factorBpMed'), score: BP_MED_SCORES[bpMedication.value] },
+    { label: t('diabetesRisk.factorHighGlucose'), score: HIGH_GLUCOSE_SCORES[highBloodGlucose.value] },
+    { label: t('diabetesRisk.factorFamily'), score: FAMILY_SCORES[familyHistory.value] },
+  ]
+})
+
+// Prevention recommendations
+const recommendations = computed(() => {
+  const cat = riskCategory.value
+  if (!cat) return []
+  const recs = []
+
+  if (bmiScore.value > 0) recs.push(t('diabetesRisk.recWeight'))
+  if (ACTIVITY_SCORES[physicalActivity.value] > 0) recs.push(t('diabetesRisk.recActivity'))
+  if (VEGFRUIT_SCORES[vegFruitDaily.value] > 0) recs.push(t('diabetesRisk.recDiet'))
+  if (cat === 'moderate' || cat === 'high' || cat === 'very_high') recs.push(t('diabetesRisk.recScreening'))
+  if (cat === 'high' || cat === 'very_high') recs.push(t('diabetesRisk.recDoctor'))
+
+  if (recs.length === 0) recs.push(t('diabetesRisk.recMaintain'))
+  return recs
+})
+
+function switchUnit(u) {
+  unit.value = u
+  weightKg.value = null
+  weightLbs.value = null
+  heightCmVal.value = null
+  heightFt.value = null
+  heightIn.value = null
+  waistCm.value = null
+  waistIn.value = null
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-8">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-3xl font-bold tracking-tight text-stone-900 mb-2">{{ t('diabetesRisk.title') }}</h1>
+      <p class="text-stone-500 text-base">{{ t('diabetesRisk.description') }}</p>
+    </div>
+
+    <BlogBanner calculatorKey="diabetesRisk" />
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-6">
+
+      <!-- Unit toggle -->
+      <div class="flex gap-2 mb-6">
+        <button
+          @click="switchUnit('metric')"
+          :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+        >{{ t('common.metric') }}</button>
+        <button
+          @click="switchUnit('imperial')"
+          :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+        >{{ t('common.imperial') }}</button>
+      </div>
+
+      <!-- Gender -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-2">{{ t('diabetesRisk.gender') }}</label>
+        <div class="flex gap-2">
+          <button
+            @click="gender = 'male'"
+            :class="gender === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.male') }}</button>
+          <button
+            @click="gender = 'female'"
+            :class="gender === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.female') }}</button>
+        </div>
+      </div>
+
+      <!-- Age group -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-2">{{ t('diabetesRisk.ageGroup') }}</label>
+        <select
+          v-model="ageGroup"
+          data-testid="age-group-select"
+          class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-stone-400"
+        >
+          <option :value="null" disabled>{{ t('diabetesRisk.selectAge') }}</option>
+          <option value="lt45">{{ t('diabetesRisk.ageLt45') }}</option>
+          <option value="45_54">{{ t('diabetesRisk.age45_54') }}</option>
+          <option value="55_64">{{ t('diabetesRisk.age55_64') }}</option>
+          <option value="gt64">{{ t('diabetesRisk.ageGt64') }}</option>
+        </select>
+      </div>
+
+      <!-- Weight & Height for BMI -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-2">{{ t('diabetesRisk.weightHeight') }}</label>
+        <div v-if="unit === 'metric'" class="flex gap-3">
+          <div class="flex-1">
+            <label class="block text-xs text-stone-500 mb-1">{{ t('common.weight') }} (kg)</label>
+            <input
+              v-model.number="weightKg"
+              type="number"
+              min="30"
+              max="300"
+              data-testid="weight-input"
+              class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-400"
+              :placeholder="t('diabetesRisk.placeholderWeight')"
+            />
+          </div>
+          <div class="flex-1">
+            <label class="block text-xs text-stone-500 mb-1">{{ t('common.height') }} (cm)</label>
+            <input
+              v-model.number="heightCmVal"
+              type="number"
+              min="100"
+              max="250"
+              data-testid="height-input"
+              class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-400"
+              :placeholder="t('diabetesRisk.placeholderHeight')"
+            />
+          </div>
+        </div>
+        <div v-else class="flex gap-3 flex-wrap">
+          <div class="w-28">
+            <label class="block text-xs text-stone-500 mb-1">{{ t('common.weight') }} (lbs)</label>
+            <input
+              v-model.number="weightLbs"
+              type="number"
+              min="60"
+              max="660"
+              data-testid="weight-lbs-input"
+              class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-400"
+            />
+          </div>
+          <div class="w-24">
+            <label for="height-ft" class="block text-xs text-stone-500 mb-1">ft</label>
+            <input
+              id="height-ft"
+              v-model.number="heightFt"
+              type="number"
+              min="3"
+              max="8"
+              data-testid="height-ft-input"
+              class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-400"
+            />
+          </div>
+          <div class="w-24">
+            <label for="height-in" class="block text-xs text-stone-500 mb-1">in</label>
+            <input
+              id="height-in"
+              v-model.number="heightIn"
+              type="number"
+              min="0"
+              max="11"
+              data-testid="height-in-input"
+              class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-400"
+            />
+          </div>
+        </div>
+        <div v-if="bmi !== null" class="mt-2 text-xs text-stone-500">
+          {{ t('diabetesRisk.bmiLabel') }}: <span data-testid="bmi-display" class="font-semibold text-stone-700">{{ bmi.toFixed(1) }}</span>
+        </div>
+      </div>
+
+      <!-- Waist circumference -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-1">{{ t('diabetesRisk.waist') }}</label>
+        <p class="text-xs text-stone-400 mb-2">{{ t('diabetesRisk.waistHint') }}</p>
+        <div v-if="unit === 'metric'" class="flex items-center gap-2">
+          <input
+            v-model.number="waistCm"
+            type="number"
+            min="40"
+            max="200"
+            data-testid="waist-input"
+            class="w-40 border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-400"
+            :placeholder="gender === 'male' ? t('diabetesRisk.placeholderWaistMale') : t('diabetesRisk.placeholderWaistFemale')"
+          />
+          <span class="text-sm text-stone-500">cm</span>
+        </div>
+        <div v-else class="flex items-center gap-2">
+          <input
+            v-model.number="waistIn"
+            type="number"
+            min="15"
+            max="80"
+            data-testid="waist-in-input"
+            class="w-40 border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-400"
+          />
+          <span class="text-sm text-stone-500">in</span>
+        </div>
+      </div>
+
+      <!-- Physical activity -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-1">{{ t('diabetesRisk.physicalActivity') }}</label>
+        <p class="text-xs text-stone-400 mb-2">{{ t('diabetesRisk.physicalActivityHint') }}</p>
+        <div class="flex gap-2">
+          <button
+            @click="physicalActivity = 'yes'"
+            :class="physicalActivity === 'yes' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="activity-yes"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.yes') }}</button>
+          <button
+            @click="physicalActivity = 'no'"
+            :class="physicalActivity === 'no' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="activity-no"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.no') }}</button>
+        </div>
+      </div>
+
+      <!-- Vegetable/fruit consumption -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-1">{{ t('diabetesRisk.vegFruitDaily') }}</label>
+        <p class="text-xs text-stone-400 mb-2">{{ t('diabetesRisk.vegFruitHint') }}</p>
+        <div class="flex gap-2">
+          <button
+            @click="vegFruitDaily = 'yes'"
+            :class="vegFruitDaily === 'yes' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="vegfruit-yes"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.yes') }}</button>
+          <button
+            @click="vegFruitDaily = 'no'"
+            :class="vegFruitDaily === 'no' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="vegfruit-no"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.no') }}</button>
+        </div>
+      </div>
+
+      <!-- Blood pressure medication -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-2">{{ t('diabetesRisk.bpMedication') }}</label>
+        <div class="flex gap-2">
+          <button
+            @click="bpMedication = 'no'"
+            :class="bpMedication === 'no' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="bp-med-no"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.no') }}</button>
+          <button
+            @click="bpMedication = 'yes'"
+            :class="bpMedication === 'yes' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="bp-med-yes"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.yes') }}</button>
+        </div>
+      </div>
+
+      <!-- High blood glucose history -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-1">{{ t('diabetesRisk.highBloodGlucose') }}</label>
+        <p class="text-xs text-stone-400 mb-2">{{ t('diabetesRisk.highBloodGlucoseHint') }}</p>
+        <div class="flex gap-2">
+          <button
+            @click="highBloodGlucose = 'no'"
+            :class="highBloodGlucose === 'no' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="glucose-no"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.no') }}</button>
+          <button
+            @click="highBloodGlucose = 'yes'"
+            :class="highBloodGlucose === 'yes' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            data-testid="glucose-yes"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >{{ t('common.yes') }}</button>
+        </div>
+      </div>
+
+      <!-- Family history -->
+      <div class="mb-5">
+        <label class="block text-sm font-medium text-stone-700 mb-2">{{ t('diabetesRisk.familyHistory') }}</label>
+        <select
+          v-model="familyHistory"
+          data-testid="family-history-select"
+          class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-stone-400"
+        >
+          <option :value="null" disabled>{{ t('diabetesRisk.selectFamily') }}</option>
+          <option value="none">{{ t('diabetesRisk.familyNone') }}</option>
+          <option value="distant">{{ t('diabetesRisk.familyDistant') }}</option>
+          <option value="close">{{ t('diabetesRisk.familyClose') }}</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div v-if="score !== null" data-testid="result-section">
+      <!-- Score + risk category -->
+      <div :class="['border rounded-xl p-6 mb-6', riskBg]">
+        <div class="flex items-start justify-between mb-4">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-1">FINDRISC Score</p>
+            <p data-testid="findrisc-score" class="text-5xl font-bold text-stone-900 tabular-nums">{{ score }}</p>
+            <p class="text-sm text-stone-500 mt-1">{{ t('diabetesRisk.scoreRange') }}</p>
+          </div>
+          <div class="text-right">
+            <p class="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-1">{{ t('diabetesRisk.riskCategory') }}</p>
+            <p data-testid="risk-category" :class="['text-2xl font-bold', riskColor]">{{ t(`diabetesRisk.risk_${riskCategory}`) }}</p>
+            <p data-testid="probability" class="text-sm text-stone-500 mt-1">{{ probability }}% {{ t('diabetesRisk.probability10y') }}</p>
+          </div>
+        </div>
+
+        <!-- Score bar -->
+        <div class="w-full bg-white bg-opacity-60 rounded-full h-3 overflow-hidden">
+          <div
+            :class="[riskColor.replace('text-', 'bg-')]"
+            class="h-3 rounded-full transition-all duration-500"
+            :style="{ width: `${(score / 26) * 100}%` }"
+          ></div>
+        </div>
+        <div class="flex justify-between text-xs text-stone-400 mt-1">
+          <span>0</span>
+          <span>26</span>
+        </div>
+      </div>
+
+      <AdSlot slot-id="diabetes-risk-result" />
+
+      <!-- Factor breakdown -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-6" data-testid="factor-breakdown">
+        <h2 class="text-base font-semibold text-stone-800 mb-4">{{ t('diabetesRisk.factorBreakdown') }}</h2>
+        <div class="space-y-2">
+          <div
+            v-for="row in factorRows"
+            :key="row.label"
+            class="flex items-center justify-between py-2 border-b border-stone-100 last:border-0"
+          >
+            <span class="text-sm text-stone-600">{{ row.label }}</span>
+            <span
+              :class="row.score > 0 ? 'text-orange-700 font-semibold' : 'text-green-700'"
+              class="text-sm tabular-nums"
+            >+{{ row.score }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Recommendations -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-6" data-testid="recommendations">
+        <h2 class="text-base font-semibold text-stone-800 mb-4">{{ t('diabetesRisk.recommendations') }}</h2>
+        <ul class="space-y-2">
+          <li v-for="rec in recommendations" :key="rec" class="flex items-start gap-2 text-sm text-stone-600">
+            <span class="text-stone-400 mt-0.5">›</span>
+            <span>{{ rec }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Medical disclaimer -->
+      <div class="bg-stone-50 border border-stone-200 rounded-xl p-5 mb-6" data-testid="disclaimer">
+        <p class="text-xs text-stone-500 leading-relaxed">{{ t('diabetesRisk.disclaimer') }}</p>
+      </div>
+    </div>
+
+    <AdSlot slot-id="diabetes-risk-bottom" />
+  </div>
+</template>

--- a/src/pages/blog/DiabetesRisikoBerechnen.vue
+++ b/src/pages/blog/DiabetesRisikoBerechnen.vue
@@ -1,0 +1,257 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Diabetes-Risiko berechnen: FINDRISC-Score erklärt | Health Calculators',
+  description: 'Typ-2-Diabetes-Risiko mit dem FINDRISC-Score berechnen. Wie der Test funktioniert, was die Punkte bedeuten und welche Maßnahmen das Risiko senken.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Diabetes-Risiko berechnen: FINDRISC-Score erklärt',
+    description: 'Typ-2-Diabetes-Risiko mit dem FINDRISC-Score berechnen. Wie der Test funktioniert, was die Punkte bedeuten und welche Maßnahmen das Risiko senken.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-15',
+    dateModified: '2026-04-15',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/diabetes-risiko-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Diabetes-Risiko berechnen: FINDRISC-Score erklärt</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">15. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Typ-2-Diabetes entwickelt sich schleichend — oft über Jahre, ohne Beschwerden. Der <strong>FINDRISC-Score</strong> (Finnish Diabetes Risk Score) ist ein validiertes Screeninginstrument, das mit 8 einfachen Fragen dein 10-Jahres-Risiko einschätzt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Unser <router-link :to="localePath('diabetesRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko-Rechner</router-link> berechnet deinen persönlichen FINDRISC-Score und gibt Empfehlungen, wie du dein Risiko senken kannst.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist der FINDRISC-Score?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der FINDRISC wurde 2003 von Lindström und Tuomilehto in Finnland entwickelt und in der Zeitschrift <em>Diabetes Care</em> veröffentlicht. Er basiert auf einer Langzeitstudie mit über 4.700 Teilnehmern und ist heute das meistgenutzte Diabetes-Screeningwerkzeug in Europa.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Fragebogen umfasst 8 Fragen ohne Blutabnahme oder ärztliche Untersuchung. Er identifiziert Personen mit erhöhtem Risiko, die von weiterführenden Tests und Präventionsmaßnahmen profitieren.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die 8 Risikofaktoren im Detail</h2>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Faktor</th>
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Punkte</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Alter unter 45 Jahren</td>
+                <td class="px-5 py-3 font-medium tabular-nums">0</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Alter 45–54 Jahre</td>
+                <td class="px-5 py-3 font-medium tabular-nums">2</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Alter 55–64 Jahre</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Alter über 64 Jahre</td>
+                <td class="px-5 py-3 font-medium tabular-nums">4</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">BMI 25–30 kg/m²</td>
+                <td class="px-5 py-3 font-medium tabular-nums">1</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">BMI über 30 kg/m²</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Taillenumfang erhöht (Männer 94–102 cm / Frauen 80–88 cm)</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Taillenumfang stark erhöht (Männer &gt;102 cm / Frauen &gt;88 cm)</td>
+                <td class="px-5 py-3 font-medium tabular-nums">4</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Keine tägliche körperliche Aktivität ≥ 30 min</td>
+                <td class="px-5 py-3 font-medium tabular-nums">2</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Kein tägliches Gemüse/Obst</td>
+                <td class="px-5 py-3 font-medium tabular-nums">1</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Blutdruckmedikamente</td>
+                <td class="px-5 py-3 font-medium tabular-nums">2</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Erhöhter Blutzucker in der Vergangenheit</td>
+                <td class="px-5 py-3 font-medium tabular-nums">5</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Diabetes bei Großelternteil, Tante/Onkel oder Cousin</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Diabetes bei Elternteil, Geschwister oder eigenem Kind</td>
+                <td class="px-5 py-3 font-medium tabular-nums">5</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500">Quelle: Lindström J, Tuomilehto J. Diabetes Care. 2003;26(3):725-731.</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was bedeuten die Punkte?</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Punkte</th>
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Risiko</th>
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">10-Jahres-Wahrscheinlichkeit</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">0–7</td>
+                <td class="px-5 py-3 text-green-700 font-medium">Gering</td>
+                <td class="px-5 py-3 text-stone-600">ca. 1 %</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">8–11</td>
+                <td class="px-5 py-3 text-lime-700 font-medium">Leicht erhöht</td>
+                <td class="px-5 py-3 text-stone-600">ca. 4 %</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">12–14</td>
+                <td class="px-5 py-3 text-yellow-700 font-medium">Mäßig</td>
+                <td class="px-5 py-3 text-stone-600">ca. 17 %</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">15–20</td>
+                <td class="px-5 py-3 text-orange-700 font-medium">Hoch</td>
+                <td class="px-5 py-3 text-stone-600">ca. 33 %</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">21–26</td>
+                <td class="px-5 py-3 text-red-700 font-medium">Sehr hoch</td>
+                <td class="px-5 py-3 text-stone-600">ca. 50 %</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum Taillenumfang so wichtig ist</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bauchfett — auch viszerales Fett genannt — ist stoffwechselaktiv und fördert Insulinresistenz. Der Taillenumfang ist daher ein stärkerer Prädiktor für Typ-2-Diabetes als der BMI allein.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Grenzwerte:</strong> Für Männer gelten 94 cm als erhöht, 102 cm als stark erhöht. Für Frauen liegen die Grenzwerte bei 80 cm und 88 cm. Der Taillenumfang wird im Stehen auf Höhe der untersten Rippe gemessen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was tun bei erhöhtem Risiko?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei einem FINDRISC-Score ab 12 empfehlen die Leitlinien eine weiterführende Abklärung. Das bedeutet nicht, dass du Diabetes hast — aber es lohnt sich, aktiv zu werden.
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Bewegung steigern:</strong>
+              <span class="text-stone-600"> Mindestens 150 Minuten moderate Aktivität pro Woche. Studien zeigen eine Risikoreduktion um bis zu 58 % allein durch mehr Bewegung.</span>
+            </div>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Gewicht reduzieren:</strong>
+              <span class="text-stone-600"> Schon 5–7 % weniger Körpergewicht verbessern die Insulinsensitivität spürbar.</span>
+            </div>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Ernährung anpassen:</strong>
+              <span class="text-stone-600"> Täglich Gemüse und Obst, ballaststoffreiche Vollkornprodukte, weniger Zucker und gesättigte Fettsäuren.</span>
+            </div>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Blutzucker kontrollieren:</strong>
+              <span class="text-stone-600"> Beim Arzt Nüchternblutzucker und HbA1c messen lassen. Prädiabetes ist reversibel — wenn man rechtzeitig handelt.</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Grenzen des FINDRISC</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der FINDRISC ist ein Screeninginstrument, kein Diagnosewerkzeug. Er wurde für Typ-2-Diabetes entwickelt — Typ-1-Diabetes oder MODY (monogene Diabetesformen) werden damit nicht erfasst. Personen mit bereits diagnostiziertem Diabetes sollten den Score nicht zur Selbsteinschätzung verwenden.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ein niedriger Score schließt Diabetes nicht aus. Ein hoher Score bedeutet nicht, dass du Diabetes hast. Beide Fälle erfordern ärztliche Einschätzung bei Unsicherheit.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 border border-stone-200 rounded-xl p-6 mb-8">
+        <p class="text-sm font-semibold text-stone-700 mb-2">Verwandte Rechner</p>
+        <ul class="space-y-1">
+          <li>
+            <router-link :to="localePath('hba1c')" class="text-sm text-stone-600 hover:text-stone-900 underline underline-offset-2">HbA1c-Konverter</router-link>
+            — Langzeit-Blutzucker in mmol/mol und % umrechnen
+          </li>
+          <li>
+            <router-link :to="localePath('bloodSugar')" class="text-sm text-stone-600 hover:text-stone-900 underline underline-offset-2">Blutzucker-Umrechner</router-link>
+            — mg/dL und mmol/L verstehen und vergleichen
+          </li>
+          <li>
+            <router-link :to="localePath('bmi')" class="text-sm text-stone-600 hover:text-stone-900 underline underline-offset-2">BMI-Rechner</router-link>
+            — Body Mass Index berechnen und einordnen
+          </li>
+        </ul>
+      </div>
+
+    </div>
+
+    <RelatedArticles slug="diabetes-risiko-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/DiabetesRiskScore.vue
+++ b/src/pages/blog/en/DiabetesRiskScore.vue
@@ -1,0 +1,257 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Diabetes Risk Score: FINDRISC Explained | Health Calculators',
+  description: 'Calculate your type 2 diabetes risk with the FINDRISC score. How the test works, what the points mean, and which measures reduce your risk.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Diabetes Risk Score: FINDRISC Explained',
+    description: 'Calculate your type 2 diabetes risk with the FINDRISC score. How the test works, what the points mean, and which measures reduce your risk.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-15',
+    dateModified: '2026-04-15',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/diabetes-risk-score',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Diabetes Risk Score: FINDRISC Explained</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 15, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Type 2 diabetes develops gradually — often over years without any symptoms. The <strong>FINDRISC score</strong> (Finnish Diabetes Risk Score) is a validated screening tool that estimates your 10-year risk with just 8 simple questions.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Our <router-link :to="localePath('diabetesRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes Risk Calculator</router-link> computes your personal FINDRISC score and provides recommendations to reduce your risk.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is the FINDRISC score?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          FINDRISC was developed in 2003 by Lindström and Tuomilehto in Finland and published in the journal <em>Diabetes Care</em>. It is based on a long-term study of over 4,700 participants and is now the most widely used diabetes screening tool in Europe.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The questionnaire covers 8 questions and requires no blood draw or medical examination. It identifies people at elevated risk who could benefit from further testing and preventive measures.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The 8 risk factors in detail</h2>
+
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Factor</th>
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Points</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Age under 45</td>
+                <td class="px-5 py-3 font-medium tabular-nums">0</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Age 45–54</td>
+                <td class="px-5 py-3 font-medium tabular-nums">2</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Age 55–64</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Age over 64</td>
+                <td class="px-5 py-3 font-medium tabular-nums">4</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">BMI 25–30 kg/m²</td>
+                <td class="px-5 py-3 font-medium tabular-nums">1</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">BMI over 30 kg/m²</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Waist elevated (men 94–102 cm / women 80–88 cm)</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Waist markedly elevated (men &gt;102 cm / women &gt;88 cm)</td>
+                <td class="px-5 py-3 font-medium tabular-nums">4</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">No daily physical activity ≥ 30 min</td>
+                <td class="px-5 py-3 font-medium tabular-nums">2</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">No daily vegetables or fruit</td>
+                <td class="px-5 py-3 font-medium tabular-nums">1</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Blood pressure medication</td>
+                <td class="px-5 py-3 font-medium tabular-nums">2</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">History of high blood glucose</td>
+                <td class="px-5 py-3 font-medium tabular-nums">5</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Diabetes in grandparent, aunt/uncle or first cousin</td>
+                <td class="px-5 py-3 font-medium tabular-nums">3</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 text-stone-600">Diabetes in parent, sibling or own child</td>
+                <td class="px-5 py-3 font-medium tabular-nums">5</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500">Source: Lindström J, Tuomilehto J. Diabetes Care. 2003;26(3):725-731.</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What do the points mean?</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">Risk</th>
+                <th class="text-left px-5 py-3 font-semibold text-stone-700">10-year probability</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">0–7</td>
+                <td class="px-5 py-3 text-green-700 font-medium">Low</td>
+                <td class="px-5 py-3 text-stone-600">approx. 1%</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">8–11</td>
+                <td class="px-5 py-3 text-lime-700 font-medium">Slightly elevated</td>
+                <td class="px-5 py-3 text-stone-600">approx. 4%</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">12–14</td>
+                <td class="px-5 py-3 text-yellow-700 font-medium">Moderate</td>
+                <td class="px-5 py-3 text-stone-600">approx. 17%</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">15–20</td>
+                <td class="px-5 py-3 text-orange-700 font-medium">High</td>
+                <td class="px-5 py-3 text-stone-600">approx. 33%</td>
+              </tr>
+              <tr>
+                <td class="px-5 py-3 font-medium tabular-nums">21–26</td>
+                <td class="px-5 py-3 text-red-700 font-medium">Very high</td>
+                <td class="px-5 py-3 text-stone-600">approx. 50%</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why waist circumference matters so much</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Abdominal fat — also called visceral fat — is metabolically active and promotes insulin resistance. Waist circumference is therefore a stronger predictor of type 2 diabetes than BMI alone.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Thresholds:</strong> For men, 94 cm is considered elevated and 102 cm markedly elevated. For women, the thresholds are 80 cm and 88 cm. Waist circumference is measured standing at the level of the lowest rib.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What to do with an elevated score</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A FINDRISC score of 12 or above calls for further evaluation. This does not mean you have diabetes — but it is worth taking action.
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Increase activity:</strong>
+              <span class="text-stone-600"> At least 150 minutes of moderate activity per week. Studies show up to a 58% risk reduction from exercise alone.</span>
+            </div>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Lose weight:</strong>
+              <span class="text-stone-600"> Even a 5–7% reduction in body weight noticeably improves insulin sensitivity.</span>
+            </div>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Improve your diet:</strong>
+              <span class="text-stone-600"> Daily vegetables and fruit, fibre-rich whole grains, less sugar and saturated fat.</span>
+            </div>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-stone-400 mt-0.5 font-bold">›</span>
+            <div>
+              <strong class="text-stone-800">Monitor blood glucose:</strong>
+              <span class="text-stone-600"> Have fasting blood glucose and HbA1c checked by your doctor. Prediabetes is reversible — if caught in time.</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Limitations of FINDRISC</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          FINDRISC is a screening tool, not a diagnostic instrument. It was developed for type 2 diabetes — type 1 diabetes or MODY (monogenic diabetes) are not captured. People already diagnosed with diabetes should not use it for self-assessment.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A low score does not rule out diabetes. A high score does not mean you have diabetes. When in doubt, always seek medical advice.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 border border-stone-200 rounded-xl p-6 mb-8">
+        <p class="text-sm font-semibold text-stone-700 mb-2">Related calculators</p>
+        <ul class="space-y-1">
+          <li>
+            <router-link :to="localePath('hba1c')" class="text-sm text-stone-600 hover:text-stone-900 underline underline-offset-2">HbA1c Converter</router-link>
+            — Convert long-term blood glucose between mmol/mol and %
+          </li>
+          <li>
+            <router-link :to="localePath('bloodSugar')" class="text-sm text-stone-600 hover:text-stone-900 underline underline-offset-2">Blood Sugar Converter</router-link>
+            — Understand and compare mg/dL and mmol/L
+          </li>
+          <li>
+            <router-link :to="localePath('bmi')" class="text-sm text-stone-600 hover:text-stone-900 underline underline-offset-2">BMI Calculator</router-link>
+            — Calculate and interpret your Body Mass Index
+          </li>
+        </ul>
+      </div>
+
+    </div>
+
+    <RelatedArticles slug="diabetes-risk-score" />
+  </article>
+</template>

--- a/src/pages/diabetesRisk.meta.js
+++ b/src/pages/diabetesRisk.meta.js
@@ -1,0 +1,17 @@
+import Component from './DiabetesRiskCalculator.vue'
+import BlogDe from './blog/DiabetesRisikoBerechnen.vue'
+import BlogEn from './blog/en/DiabetesRiskScore.vue'
+
+export default {
+  key: 'diabetesRisk',
+  component: Component,
+  slugs: { de: 'diabetes-risiko-rechner', en: 'diabetes-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 17,
+  oldRedirect: '/diabetes-risiko',
+  blog: {
+    de: { slug: 'diabetes-risiko-berechnen', component: BlogDe },
+    en: { slug: 'diabetes-risk-score', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-115-diabetes-risk
**Agent:** claude
**Model:** claude-haiku-4-5-20251001
**Branch:** `agent/hc-115-diabetes-risk-20260415-210026`
**Cost:** $3.8311633

Closes jenslaufer/health-calculators#115

### Prompt
> Implement the Diabetes Risk Score (FINDRISC) Calculator as described in issue #115.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: Age, BMI (auto-calc), Waist circumference, Physical activity, Vegetable consumption, BP medication history, High blood glucose history, Family history
- Output: FINDRISC score (0-26), Risk category, 10-year probability, Factor breakdown, Prevention recommendations
- FINDRISC is a validated public-domain screening tool — implement exact scoring
- Clear medical disclaimer (screening only, not diagnosis)
- Metric + imperial unit toggle
- Blog articles: DE (/blog/diabetes-risiko-berechnen) + EN (/blog/diabetes-risk-score)
- Unit tests for FINDRISC scoring with known reference values
- E2E test for the calculator page
- SSG pre-rendering must work

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks