### PR TITLE
hc-185-root-path-fix: Fix the root path `/` SSR content on healthcalculator.app.

### DIFF
--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -246,8 +246,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 229 routes', () => {
-    expect(routes).toHaveLength(229)
+  it('generates exactly 227 routes', () => {
+    expect(routes).toHaveLength(227)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/ssg-routes.test.js
+++ b/src/__tests__/ssg-routes.test.js
@@ -36,4 +36,19 @@ describe('routes.js exports', () => {
     const rootRedirect = routes.find(r => r.path === '/')
     expect(rootRedirect?.redirect).toBe('/de/')
   })
+
+  it('has no routes with undefined or empty path', () => {
+    for (const route of routes) {
+      expect(route.path).toBeDefined()
+      expect(typeof route.path).toBe('string')
+      expect(route.path.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('root redirect goes to /de/ with no competing undefined-path routes', () => {
+    const undefinedPathRoutes = routes.filter(r => r.path === undefined || r.path === '')
+    expect(undefinedPathRoutes).toHaveLength(0)
+    const rootRoute = routes.find(r => r.path === '/')
+    expect(rootRoute?.redirect).toBe('/de/')
+  })
 })

--- a/src/discovery.js
+++ b/src/discovery.js
@@ -31,11 +31,13 @@ export const blogComponentsEn = Object.fromEntries(
   calculatorMetas.map(m => [m.blog.en.slug, m.blog.en.component])
 )
 
-// Old redirect paths for backwards compatibility
-export const oldRedirects = calculatorMetas.map(m => ({
-  path: m.oldRedirect,
-  redirect: `/de/${m.slugs.de}`,
-}))
+// Old redirect paths for backwards compatibility (only for calculators that define one)
+export const oldRedirects = calculatorMetas
+  .filter(m => m.oldRedirect)
+  .map(m => ({
+    path: m.oldRedirect,
+    redirect: `/de/${m.slugs.de}`,
+  }))
 
 // Calculator groups for Home page, derived from meta ordering
 const groupMap = new Map()


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-185-root-path-fix
**Agent:** claude
**Model:** claude-haiku-4-5-20251001
**Branch:** `agent/hc-185-root-path-fix-20260417-100024`
**Cost:** $1.0958025499999997

Closes jenslaufer/health-calculators#185

### Prompt
> Fix the root path `/` SSR content on healthcalculator.app.

## Problem
`GET /` currently serves the German protein calculator (Eiweißbedarfs-Rechner) instead of the homepage.
This creates a Googlebot dead-end: 0 internal links, wrong canonical, wrong title.
Both `/de/` and `/en/` work correctly with 40+ internal links each.

## Expected behavior
`GET /` should either:
1. 301 redirect to `/en/` (preferred — simple, SEO-safe), OR
2. Serve the homepage content with full internal linking

## Investigation hints
- Check the vite-ssg route configuration — the root route likely maps to the wrong component
- Check `src/router/index.ts` for the `/` route definition
- Check `vite.config.ts` for SSG route generation
- FK (finanzkalkulatoren) handles this correctly — `/` redirects to `/de/` homepage with 47 links

## Tests
- Write tests FIRST, then implement the fix
- Test that `GET /` returns 301 to `/en/` or `/de/` (or serves homepage content)
- Test that `/de/` and `/en/` still work correctly (regression)
- Run the full test suite and ensure no regressions

## Constraints
- DO NOT delete or modify unrelated calculator components
- DO NOT change the URL structure of existing calculator pages
- DO NOT modify blog articles or content files
- Keep the fix minimal — this is a routing/SSG configuration issue