### PR TITLE
hc-185-root-path-fix: Fix the root path `/` SSR content on healthcalculator.app.

### DIFF
--- a/e2e/i18n-routing.spec.js
+++ b/e2e/i18n-routing.spec.js
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Locale-prefixed route resolution', () => {
-  test('/ redirects to /de/', async ({ page }) => {
+  test('/ redirects to /en/', async ({ page }) => {
     await page.goto('')
-    await expect(page).toHaveURL(/\/de\/?$/)
+    await expect(page).toHaveURL(/\/en\/?$/)
   })
 
   test('/de/ loads home page in German', async ({ page }) => {

--- a/e2e/root-path.spec.js
+++ b/e2e/root-path.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Root path / behavior', () => {
+  test('/ redirects to /en/', async ({ page }) => {
+    const response = await page.goto('/')
+    await expect(page).toHaveURL(/\/en\/?$/)
+    expect(response?.status()).toBeLessThan(400)
+  })
+
+  test('/ does not serve wrong calculator content', async ({ page }) => {
+    await page.goto('/')
+    const h1 = await page.locator('h1').textContent()
+    expect(h1).not.toMatch(/Eiwei/)
+    expect(h1).not.toMatch(/Protein/)
+  })
+
+  test('/en/ has 40+ internal calculator links', async ({ page }) => {
+    await page.goto('en/')
+    const links = page.locator('a[href*="/en/"]')
+    const count = await links.count()
+    expect(count).toBeGreaterThanOrEqual(40)
+  })
+
+  test('/de/ has 40+ internal calculator links', async ({ page }) => {
+    await page.goto('de/')
+    const links = page.locator('a[href*="/de/"]')
+    const count = await links.count()
+    expect(count).toBeGreaterThanOrEqual(40)
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -269,7 +269,7 @@ describe('SSG routes', () => {
   })
 
   it('has redirect routes for old paths', () => {
-    expect(routes.find(r => r.path === '/')?.redirect).toBe('/de/')
+    expect(routes.find(r => r.path === '/')?.redirect).toBe('/en/')
     expect(routes.find(r => r.path === '/bmi')?.redirect).toBe('/de/bmi-rechner')
     expect(routes.find(r => r.path === '/blog')?.redirect).toBe('/de/blog')
   })

--- a/src/__tests__/ssg-routes.test.js
+++ b/src/__tests__/ssg-routes.test.js
@@ -34,7 +34,7 @@ describe('routes.js exports', () => {
     const redirectRoutes = routes.filter(r => r.redirect)
     expect(redirectRoutes.length).toBeGreaterThan(0)
     const rootRedirect = routes.find(r => r.path === '/')
-    expect(rootRedirect?.redirect).toBe('/de/')
+    expect(rootRedirect?.redirect).toBe('/en/')
   })
 
   it('has no routes with undefined or empty path', () => {
@@ -45,10 +45,10 @@ describe('routes.js exports', () => {
     }
   })
 
-  it('root redirect goes to /de/ with no competing undefined-path routes', () => {
+  it('root redirect goes to /en/ with no competing undefined-path routes', () => {
     const undefinedPathRoutes = routes.filter(r => r.path === undefined || r.path === '')
     expect(undefinedPathRoutes).toHaveLength(0)
     const rootRoute = routes.find(r => r.path === '/')
-    expect(rootRoute?.redirect).toBe('/de/')
+    expect(rootRoute?.redirect).toBe('/en/')
   })
 })

--- a/src/routes.js
+++ b/src/routes.js
@@ -62,7 +62,7 @@ const oldBlogRedirects = blogSlugs.map(slug => ({
 }))
 
 const routes = [
-  { path: '/', redirect: '/de/' },
+  { path: '/', redirect: '/en/' },
   ...createLocaleRoutes('de'),
   ...createLocaleRoutes('en'),
   ...oldRedirects,


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-185-root-path-fix
**Agent:** claude
**Model:** claude-haiku-4-5-20251001
**Branch:** `agent/hc-185-root-path-fix-20260417-113024`
**Cost:** $1.3571204999999997

Closes jenslaufer/health-calculators#185

### Prompt
> Fix the root path `/` SSR content on healthcalculator.app.

## Problem
`GET /` currently serves the German protein calculator (Eiweißbedarfs-Rechner) instead of the homepage.
This creates a Googlebot dead-end: 0 internal links, wrong canonical, wrong title.
Both `/de/` and `/en/` work correctly with 40+ internal links each.

## Expected behavior
`GET /` should either:
1. 301 redirect to `/en/` (preferred — simple, SEO-safe), OR
2. Serve the homepage content with full internal linking

## Investigation hints
- Check the vite-ssg route configuration — the root route likely maps to the wrong component
- Check `src/router/index.ts` for the `/` route definition
- Check `vite.config.ts` for SSG route generation
- FK (finanzkalkulatoren) handles this correctly — `/` redirects to `/de/` homepage with 47 links

## Tests
- Write tests FIRST, then implement the fix
- Test that `GET /` returns 301 to `/en/` or `/de/` (or serves homepage content)
- Test that `/de/` and `/en/` still work correctly (regression)
- Run the full test suite and ensure no regressions

## Constraints
- DO NOT delete or modify unrelated calculator components
- DO NOT change the URL structure of existing calculator pages
- DO NOT modify blog articles or content files
- Keep the fix minimal — this is a routing/SSG configuration issue