### PR TITLE
hc-119-alcohol-units: Implement the Alcohol Unit Calculator as described in issue 

### DIFF
--- a/e2e/alcoholUnits.spec.js
+++ b/e2e/alcoholUnits.spec.js
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/alkohol-einheiten-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Alkohol/)
+})
+
+test('default state shows 0 units and 0 grams', async ({ page }) => {
+  await expect(page.getByTestId('total-units')).toHaveText('0.0')
+  await expect(page.getByTestId('total-grams')).toHaveText('0')
+})
+
+test('default risk category shows none', async ({ page }) => {
+  await expect(page.getByTestId('risk-badge')).toBeVisible()
+})
+
+test('entering beer count updates total units', async ({ page }) => {
+  await page.getByTestId('count-beer').fill('4')
+  await page.getByTestId('count-beer').dispatchEvent('input')
+
+  const unitsEl = page.getByTestId('total-units')
+  const text = await unitsEl.textContent()
+  const units = parseFloat(text)
+  // 4 × (500ml × 5%) / 1000 = 4 × 2.5 = 10.0 units
+  expect(units).toBeCloseTo(10.0, 0)
+})
+
+test('entering beer and wine updates total units correctly', async ({ page }) => {
+  await page.getByTestId('count-beer').fill('2')
+  await page.getByTestId('count-beer').dispatchEvent('input')
+  await page.getByTestId('count-wine').fill('3')
+  await page.getByTestId('count-wine').dispatchEvent('input')
+
+  const unitsEl = page.getByTestId('total-units')
+  await expect(unitsEl).toBeVisible()
+  const text = await unitsEl.textContent()
+  const units = parseFloat(text)
+  // beer: 2 × 2.5 = 5; wine: 3 × 2.1 = 6.3; total ≈ 11.3
+  expect(units).toBeGreaterThan(10)
+  expect(units).toBeLessThan(13)
+})
+
+test('calories increase with consumption', async ({ page }) => {
+  const calsBefore = await page.getByTestId('total-calories').textContent()
+
+  await page.getByTestId('count-spirits').fill('5')
+  await page.getByTestId('count-spirits').dispatchEvent('input')
+
+  const calsAfter = await page.getByTestId('total-calories').textContent()
+  expect(parseFloat(calsAfter)).toBeGreaterThan(parseFloat(calsBefore))
+})
+
+test('guidelines comparison is visible', async ({ page }) => {
+  await expect(page.getByTestId('guidelines-comparison')).toBeVisible()
+  await expect(page.getByTestId('guideline-uk_nhs')).toBeVisible()
+  await expect(page.getByTestId('guideline-de_dhs')).toBeVisible()
+  await expect(page.getByTestId('guideline-us_niaaa')).toBeVisible()
+})
+
+test('switching sex changes DE DHS guideline display', async ({ page }) => {
+  await page.getByTestId('count-beer').fill('10')
+  await page.getByTestId('count-beer').dispatchEvent('input')
+
+  const maleText = await page.getByTestId('guideline-de_dhs').textContent()
+  await page.getByTestId('sex-female').click()
+  const femaleText = await page.getByTestId('guideline-de_dhs').textContent()
+
+  // DHS limit is different for male and female
+  expect(maleText).not.toBe(femaleText)
+})
+
+test('cost section is hidden by default and shows after toggle', async ({ page }) => {
+  await expect(page.getByTestId('cost-beer')).not.toBeVisible()
+  await page.getByTestId('cost-toggle').click()
+  await expect(page.getByTestId('cost-beer')).toBeVisible()
+})
+
+test('risk category shows low when consuming 10 units/week', async ({ page }) => {
+  // 4 beers × 2.5 units = 10 units (within 14 unit limit)
+  await page.getByTestId('count-beer').fill('4')
+  await page.getByTestId('count-beer').dispatchEvent('input')
+
+  await expect(page.getByTestId('risk-badge')).toBeVisible()
+  const badgeText = await page.getByTestId('risk-badge').textContent()
+  expect(badgeText).toMatch(/Gering|Low/i)
+})
+
+test('risk category shows increasing when consuming 20 units/week', async ({ page }) => {
+  // 8 beers × 2.5 units = 20 units (above 14 unit limit)
+  await page.getByTestId('count-beer').fill('8')
+  await page.getByTestId('count-beer').dispatchEvent('input')
+
+  await expect(page.getByTestId('risk-badge')).toBeVisible()
+  const badgeText = await page.getByTestId('risk-badge').textContent()
+  expect(badgeText).toMatch(/Erhöht|Increasing/i)
+})
+
+test('EN route loads correctly', async ({ page }) => {
+  await page.goto('en/alcohol-units-calculator')
+  await expect(page).toHaveTitle(/Alcohol/)
+  await expect(page.getByTestId('total-units')).toBeVisible()
+})
+
+test('DE blog article loads', async ({ page }) => {
+  await page.goto('de/blog/alkohol-einheiten-berechnen')
+  await expect(page).toHaveTitle(/Alkohol/)
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+})
+
+test('EN blog article loads', async ({ page }) => {
+  await page.goto('en/blog/alcohol-unit-calculator')
+  await expect(page).toHaveTitle(/Alcohol/)
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+})
+
+test('blog article links to calculator', async ({ page }) => {
+  await page.goto('de/blog/alkohol-einheiten-berechnen')
+  const link = page.getByRole('link', { name: /berechnen/i }).first()
+  await expect(link).toBeVisible()
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: /Alle Rechner/i }).first().click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/alcoholUnits.test.js
+++ b/src/__tests__/alcoholUnits.test.js
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+
+// Pure alcohol unit calculation functions — mirrors AlcoholUnitsCalculator.vue
+
+const GRAMS_PER_UK_UNIT = 8
+const KCAL_PER_GRAM_ALCOHOL = 7
+
+function calcUnitsPerDrink(volumeMl, abvPct) {
+  return (volumeMl * abvPct) / 1000
+}
+
+function calcGramsFromUnits(units) {
+  return units * GRAMS_PER_UK_UNIT
+}
+
+function calcCaloriesFromGrams(grams) {
+  return Math.round(grams * KCAL_PER_GRAM_ALCOHOL)
+}
+
+function getRiskLevel(units) {
+  if (units === 0) return 'none'
+  if (units <= 14) return 'low'
+  if (units <= 28) return 'increasing'
+  if (units <= 50) return 'high'
+  return 'very_high'
+}
+
+const GUIDELINE_LIMITS = {
+  uk_nhs: { male: 14, female: 14 },
+  de_dhs: { male: 21, female: 10.5 },
+  us_niaaa: { male: 24.5, female: 12.25 },
+}
+
+function getGuidelineStatus(totalUnits, guideline, sex) {
+  const limit = GUIDELINE_LIMITS[guideline][sex]
+  const pct = totalUnits / limit
+  return { limit, pct, exceeds: pct > 1 }
+}
+
+describe('calcUnitsPerDrink', () => {
+  it('500 ml at 5% → 2.5 units (pint of beer)', () => {
+    expect(calcUnitsPerDrink(500, 5)).toBeCloseTo(2.5)
+  })
+
+  it('175 ml at 12% → 2.1 units (small glass of wine)', () => {
+    expect(calcUnitsPerDrink(175, 12)).toBeCloseTo(2.1)
+  })
+
+  it('40 ml at 40% → 1.6 units (single spirit)', () => {
+    expect(calcUnitsPerDrink(40, 40)).toBeCloseTo(1.6)
+  })
+
+  it('200 ml at 15% → 3.0 units (cocktail)', () => {
+    expect(calcUnitsPerDrink(200, 15)).toBeCloseTo(3.0)
+  })
+
+  it('250 ml at 0% → 0 units (non-alcoholic)', () => {
+    expect(calcUnitsPerDrink(250, 0)).toBe(0)
+  })
+
+  it('larger volume and higher ABV gives more units', () => {
+    const small = calcUnitsPerDrink(100, 5)
+    const large = calcUnitsPerDrink(500, 10)
+    expect(large).toBeGreaterThan(small)
+  })
+})
+
+describe('calcGramsFromUnits', () => {
+  it('1 unit → 8 g', () => {
+    expect(calcGramsFromUnits(1)).toBe(8)
+  })
+
+  it('2.5 units → 20 g', () => {
+    expect(calcGramsFromUnits(2.5)).toBe(20)
+  })
+
+  it('14 units → 112 g (UK NHS weekly limit)', () => {
+    expect(calcGramsFromUnits(14)).toBe(112)
+  })
+
+  it('0 units → 0 g', () => {
+    expect(calcGramsFromUnits(0)).toBe(0)
+  })
+})
+
+describe('calcCaloriesFromGrams', () => {
+  it('8 g (1 unit) → 56 kcal', () => {
+    expect(calcCaloriesFromGrams(8)).toBe(56)
+  })
+
+  it('80 g → 560 kcal (4 pints of 5% beer)', () => {
+    expect(calcCaloriesFromGrams(80)).toBe(560)
+  })
+
+  it('0 g → 0 kcal', () => {
+    expect(calcCaloriesFromGrams(0)).toBe(0)
+  })
+})
+
+describe('getRiskLevel', () => {
+  it('0 units → none', () => {
+    expect(getRiskLevel(0)).toBe('none')
+  })
+
+  it('1 unit → low', () => {
+    expect(getRiskLevel(1)).toBe('low')
+  })
+
+  it('14 units → low (at UK NHS limit)', () => {
+    expect(getRiskLevel(14)).toBe('low')
+  })
+
+  it('15 units → increasing', () => {
+    expect(getRiskLevel(15)).toBe('increasing')
+  })
+
+  it('28 units → increasing', () => {
+    expect(getRiskLevel(28)).toBe('increasing')
+  })
+
+  it('29 units → high', () => {
+    expect(getRiskLevel(29)).toBe('high')
+  })
+
+  it('50 units → high', () => {
+    expect(getRiskLevel(50)).toBe('high')
+  })
+
+  it('51 units → very_high', () => {
+    expect(getRiskLevel(51)).toBe('very_high')
+  })
+})
+
+describe('getGuidelineStatus — UK NHS', () => {
+  it('14 units for male → within limit (pct = 1)', () => {
+    const status = getGuidelineStatus(14, 'uk_nhs', 'male')
+    expect(status.exceeds).toBe(false)
+    expect(status.pct).toBeCloseTo(1)
+  })
+
+  it('15 units for male → exceeds limit', () => {
+    const status = getGuidelineStatus(15, 'uk_nhs', 'male')
+    expect(status.exceeds).toBe(true)
+  })
+
+  it('14 units for female → within limit', () => {
+    const status = getGuidelineStatus(14, 'uk_nhs', 'female')
+    expect(status.exceeds).toBe(false)
+  })
+
+  it('limit is 14 for both sexes', () => {
+    expect(GUIDELINE_LIMITS.uk_nhs.male).toBe(14)
+    expect(GUIDELINE_LIMITS.uk_nhs.female).toBe(14)
+  })
+})
+
+describe('getGuidelineStatus — DE DHS', () => {
+  it('10.5 units for female → within limit (pct = 1)', () => {
+    const status = getGuidelineStatus(10.5, 'de_dhs', 'female')
+    expect(status.exceeds).toBe(false)
+    expect(status.pct).toBeCloseTo(1)
+  })
+
+  it('11 units for female → exceeds DE DHS limit', () => {
+    const status = getGuidelineStatus(11, 'de_dhs', 'female')
+    expect(status.exceeds).toBe(true)
+  })
+
+  it('21 units for male → within limit', () => {
+    const status = getGuidelineStatus(21, 'de_dhs', 'male')
+    expect(status.exceeds).toBe(false)
+  })
+
+  it('male limit is twice the female limit', () => {
+    expect(GUIDELINE_LIMITS.de_dhs.male / GUIDELINE_LIMITS.de_dhs.female).toBe(2)
+  })
+})
+
+describe('getGuidelineStatus — US NIAAA', () => {
+  it('12.25 units for female → within limit (pct = 1)', () => {
+    const status = getGuidelineStatus(12.25, 'us_niaaa', 'female')
+    expect(status.exceeds).toBe(false)
+    expect(status.pct).toBeCloseTo(1)
+  })
+
+  it('24.5 units for male → within limit', () => {
+    const status = getGuidelineStatus(24.5, 'us_niaaa', 'male')
+    expect(status.exceeds).toBe(false)
+  })
+
+  it('25 units for male → exceeds NIAAA limit', () => {
+    const status = getGuidelineStatus(25, 'us_niaaa', 'male')
+    expect(status.exceeds).toBe(true)
+  })
+})
+
+describe('weekly totals', () => {
+  it('5 beers (500ml, 5%) → 12.5 units, 100 g, 700 kcal', () => {
+    const units = 5 * calcUnitsPerDrink(500, 5)
+    const grams = calcGramsFromUnits(units)
+    const kcal = calcCaloriesFromGrams(grams)
+    expect(units).toBeCloseTo(12.5)
+    expect(grams).toBeCloseTo(100)
+    expect(kcal).toBe(700)
+  })
+
+  it('7 glasses wine (175ml, 12%) → 14.7 units — exceeds UK NHS for women', () => {
+    const units = 7 * calcUnitsPerDrink(175, 12)
+    expect(units).toBeCloseTo(14.7)
+    const status = getGuidelineStatus(units, 'uk_nhs', 'female')
+    expect(status.exceeds).toBe(true)
+  })
+
+  it('0 drinks of all types → 0 units, risk level none', () => {
+    const units = 0
+    expect(getRiskLevel(units)).toBe('none')
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -18,7 +18,7 @@ const EXPECTED_KEYS = [
   'period', 'bac', 'proteinNeed', 'caffeine',
   'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
-  'bodyType', 'biologicalAge', 'vitaminD',
+  'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -61,6 +61,7 @@ const EXPECTED_ROUTE_MAP = {
   bodyType: { de: 'koerpertyp-rechner', en: 'body-type-calculator' },
   biologicalAge: { de: 'biologisches-alter-rechner', en: 'biological-age-calculator' },
   vitaminD: { de: 'vitamin-d-rechner', en: 'vitamin-d-calculator' },
+  alcoholUnits: { de: 'alkohol-einheiten-rechner', en: 'alcohol-units-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -91,6 +92,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'koerpertyp-bestimmen',
   'biologisches-alter-berechnen',
   'vitamin-d-berechnen',
+  'alkohol-einheiten-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -121,19 +123,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'body-type-calculator',
   'biological-age-calculator',
   'vitamin-d-calculator',
+  'alcohol-unit-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 39 calculators', () => {
-    expect(calculatorMetas).toHaveLength(39)
+  it('discovers all 40 calculators', () => {
+    expect(calculatorMetas).toHaveLength(40)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 39 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(39)
+  it('builds calculatorComponents map for all 40 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(40)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -156,15 +159,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 39 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(39)
+  it('discovers all 40 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(40)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 39 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(39)
+  it('discovers all 40 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(40)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -180,10 +183,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 39 calculators with no duplicates', () => {
+  it('groups contain all 40 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(39)
-    expect(new Set(allKeys).size).toBe(39)
+    expect(allKeys).toHaveLength(40)
+    expect(new Set(allKeys).size).toBe(40)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -204,7 +207,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits',
     ])
   })
 
@@ -252,8 +255,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 237 routes', () => {
-    expect(routes).toHaveLength(237)
+  it('generates exactly 242 routes', () => {
+    expect(routes).toHaveLength(242)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 156 links (39 calcs × 2 locales + 39 blogs × 2 locales)', () => {
+  it('generates 160 links (40 calcs × 2 locales + 40 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(156)
+    expect(links).toHaveLength(160)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -14,7 +14,7 @@ const EXPECTED_KEYS = [
   'period', 'bac', 'proteinNeed', 'caffeine',
   'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
-  'bodyType', 'biologicalAge', 'vitaminD',
+  'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -45,6 +45,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'koerpertyp-bestimmen',
   'biologisches-alter-berechnen',
   'vitamin-d-berechnen',
+  'alkohol-einheiten-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -75,12 +76,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'body-type-calculator',
   'biological-age-calculator',
   'vitamin-d-calculator',
+  'alcohol-unit-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 39 calculator meta files', () => {
+  it('discovers all 40 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(39)
+    expect(metas).toHaveLength(40)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -118,19 +120,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 39 DE blog slugs', () => {
+  it('returns all 40 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(39)
+    expect(de).toHaveLength(40)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 39 EN blog slugs', () => {
+  it('returns all 40 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(39)
+    expect(en).toHaveLength(40)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -198,9 +200,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 78 calcs + 2 blog index + 78 blog articles = 160)', () => {
+  it('generates correct total URL count (2 home + 80 calcs + 2 blog index + 80 blog articles = 164)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(160)
+    expect(urlCount).toBe(164)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -299,6 +299,15 @@ slug: 'period-calculator-guide',
     calculatorKey: 'vitaminD',
     related: ['life-expectancy-calculator', 'calculate-water-intake', 'blood-sugar-converter-guide'],
   },
+  {
+    slug: 'alcohol-unit-calculator',
+    title: 'Alcohol Unit Calculator — Weekly Consumption & Health Risk',
+    description: 'What is an alcohol unit? UK units, grams of pure alcohol, WHO risk categories and comparison with DHS, NHS and NIAAA guidelines explained.',
+    date: '2026-04-18',
+    readTime: '9 min',
+    calculatorKey: 'alcoholUnits',
+    related: ['blood-alcohol-calculator', 'life-expectancy-calculator', 'smoking-cost-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -299,6 +299,15 @@ slug: 'zyklusrechner-guide',
     calculatorKey: 'vitaminD',
     related: ['lebenserwartung-berechnen', 'wasserbedarf-berechnen', 'blutzucker-umrechnen'],
   },
+  {
+    slug: 'alkohol-einheiten-berechnen',
+    title: 'Alkoholeinheiten berechnen: Wöchentlicher Konsum & Gesundheitsrisiko',
+    description: 'Was ist eine Alkoholeinheit? UK-Einheiten, Gramm reiner Alkohol, WHO-Risikoklassen und Vergleich mit DHS-, NHS- und NIAAA-Leitlinien erklärt.',
+    date: '2026-04-18',
+    readTime: '9 min',
+    calculatorKey: 'alcoholUnits',
+    related: ['promille-berechnen', 'lebenserwartung-berechnen', 'rauchen-kosten-rechner'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/alcoholUnits.json
+++ b/src/locales/calculators/de/alcoholUnits.json
@@ -1,0 +1,90 @@
+{
+  "home": {
+    "calculators": {
+      "alcoholUnits": {
+        "name": "Alkoholeinheiten Rechner",
+        "description": "Berechne deinen wöchentlichen Alkoholkonsum in UK-Einheiten, Gramm reinen Alkohol und dein Gesundheitsrisiko."
+      }
+    }
+  },
+  "alcoholUnits": {
+    "meta": {
+      "title": "Alkoholeinheiten berechnen — Wöchentlicher Konsum & Gesundheitsrisiko",
+      "description": "Berechne deine wöchentlichen Alkoholeinheiten (UK/WHO) und Gramm reinen Alkohol. Vergleich mit DE DHS, UK NHS und US NIAAA — mit Kalorien- und Kostenschätzung."
+    },
+    "title": "Alkoholeinheiten Rechner",
+    "description": "Berechne deinen wöchentlichen Alkoholkonsum in UK-Einheiten und Gramm reinen Alkohol — mit Risikokategorie nach WHO, DHS und NHS sowie Kalorien- und Kostenschätzung.",
+    "sex": "Geschlecht",
+    "male": "Mann",
+    "female": "Frau",
+    "drinkTypes": "Getränke pro Woche",
+    "countLabel": "Anzahl / Woche",
+    "volumeLabel": "Volumen (ml)",
+    "abvLabel": "Alkohol (%)",
+    "costLabel": "Kosten (€/Stück)",
+    "costToggle": "Kosten schätzen (optional)",
+    "unitsPerDrink": "Einh. pro Stück",
+    "drinkType": {
+      "beer": "Bier",
+      "wine": "Wein",
+      "spirits": "Spirituosen",
+      "cocktails": "Cocktails"
+    },
+    "drinkDesc": {
+      "beer": "z. B. 500 ml Pils, 5 %",
+      "wine": "z. B. 175 ml Rotwein, 12 %",
+      "spirits": "z. B. 4 cl Whisky, 40 %",
+      "cocktails": "z. B. 200 ml, 15 %"
+    },
+    "results": "Ergebnis",
+    "totalUnits": "UK-Einheiten / Woche",
+    "totalGrams": "Gramm reiner Alkohol / Woche",
+    "caloriesLabel": "Kalorien / Woche",
+    "fromAlcohol": "aus Alkohol",
+    "weeklyCost": "Kosten / Woche",
+    "riskCategory": "Risikostufe",
+    "risk": {
+      "none": "Kein Konsum",
+      "low": "Geringes Risiko",
+      "increasing": "Erhöhtes Risiko",
+      "high": "Hohes Risiko",
+      "very_high": "Sehr hohes Risiko"
+    },
+    "riskDesc": {
+      "none": "Kein Alkohol ist die gesündeste Wahl.",
+      "low": "Dein Konsum liegt im Bereich geringen Risikos. Regelmäßige alkoholfreie Tage empfohlen.",
+      "increasing": "Dein Konsum übersteigt die Empfehlungen der meisten Leitlinien. Reduktion empfohlen.",
+      "high": "Erhebliches Gesundheitsrisiko. Körperliche und psychische Schäden wahrscheinlich.",
+      "very_high": "Sehr hohes Risiko. Professionelle Beratung dringend empfohlen."
+    },
+    "guidelinesTitle": "Vergleich mit nationalen Leitlinien",
+    "guidelineWithin": "innerhalb",
+    "guidelineExceeds": "überschritten um",
+    "of": "von",
+    "limit": "Grenze",
+    "units": "Einheiten",
+    "guidelines": {
+      "uk_nhs": "UK NHS",
+      "de_dhs": "DE DHS",
+      "us_niaaa": "US NIAAA"
+    },
+    "guidelineDesc": {
+      "uk_nhs": "14 Einheiten / Woche (beide Geschlechter)",
+      "de_dhs": "10,5 Einh./Wo. Frauen · 21 Einh./Wo. Männer",
+      "us_niaaa": "12,25 Einh./Wo. Frauen · 24,5 Einh./Wo. Männer"
+    },
+    "healthEffectsTitle": "Gesundheitliche Auswirkungen",
+    "healthEffects": {
+      "liver": "Leber",
+      "liverDesc": "Regelmäßiger Alkoholkonsum belastet die Leber. Ab ca. 30g/Tag (Frauen) bzw. 60g/Tag (Männer) steigt das Risiko für Fettleber und Zirrhose.",
+      "cancer": "Krebsrisiko",
+      "cancerDesc": "Alkohol ist ein Klasse-1-Karzinogen (IARC). Kein Konsum ist vollständig risikolos. Das Risiko steigt linear mit der konsumierten Menge.",
+      "cardiovascular": "Herz-Kreislauf",
+      "cardiovascularDesc": "Erhöhter Blutdruck, Herzrhythmusstörungen und erhöhtes Schlaganfallrisiko bei regelmäßigem Konsum über den Leitliniengrenzen.",
+      "sleep": "Schlaf & Erholung",
+      "sleepDesc": "Alkohol verschlechtert die Schlafqualität, unterdrückt den REM-Schlaf und erhöht Müdigkeit am Folgetag."
+    },
+    "disclaimerTitle": "Hinweis",
+    "disclaimer": "Dieser Rechner dient zur Information und ersetzt keine ärztliche Beratung. Kein Alkohol ist sicherer als jeder Konsum. Bei Fragen zu deinem Trinkverhalten wende dich an einen Arzt oder die Suchtberatung (z. B. BZgA: 0800 111 0 111)."
+  }
+}

--- a/src/locales/calculators/en/alcoholUnits.json
+++ b/src/locales/calculators/en/alcoholUnits.json
@@ -1,0 +1,90 @@
+{
+  "home": {
+    "calculators": {
+      "alcoholUnits": {
+        "name": "Alcohol Unit Calculator",
+        "description": "Calculate your weekly alcohol consumption in UK units, grams of pure alcohol, and health risk."
+      }
+    }
+  },
+  "alcoholUnits": {
+    "meta": {
+      "title": "Alcohol Unit Calculator — Weekly Consumption & Health Risk",
+      "description": "Calculate your weekly alcohol units (UK/WHO) and grams of pure alcohol. Compare to DE DHS, UK NHS and US NIAAA guidelines — with calorie and cost estimates."
+    },
+    "title": "Alcohol Unit Calculator",
+    "description": "Calculate your weekly alcohol consumption in UK units and grams of pure alcohol — with risk category per WHO, NHS and DHS guidelines, plus calorie and cost estimates.",
+    "sex": "Sex",
+    "male": "Male",
+    "female": "Female",
+    "drinkTypes": "Drinks per week",
+    "countLabel": "Count / week",
+    "volumeLabel": "Volume (ml)",
+    "abvLabel": "Alcohol (%)",
+    "costLabel": "Cost (€/drink)",
+    "costToggle": "Estimate weekly cost (optional)",
+    "unitsPerDrink": "units each",
+    "drinkType": {
+      "beer": "Beer",
+      "wine": "Wine",
+      "spirits": "Spirits",
+      "cocktails": "Cocktails"
+    },
+    "drinkDesc": {
+      "beer": "e.g. 500 ml lager, 5%",
+      "wine": "e.g. 175 ml red wine, 12%",
+      "spirits": "e.g. 40 ml whisky, 40%",
+      "cocktails": "e.g. 200 ml, 15%"
+    },
+    "results": "Results",
+    "totalUnits": "UK units / week",
+    "totalGrams": "Grams pure alcohol / week",
+    "caloriesLabel": "Calories / week",
+    "fromAlcohol": "from alcohol",
+    "weeklyCost": "Weekly cost",
+    "riskCategory": "Risk level",
+    "risk": {
+      "none": "No consumption",
+      "low": "Low risk",
+      "increasing": "Increasing risk",
+      "high": "High risk",
+      "very_high": "Very high risk"
+    },
+    "riskDesc": {
+      "none": "Not drinking is the healthiest choice.",
+      "low": "Your consumption is within the low-risk range. Regular alcohol-free days are recommended.",
+      "increasing": "Your consumption exceeds the recommendations of most guidelines. Reducing is advised.",
+      "high": "Significant health risk. Physical and mental harm is likely.",
+      "very_high": "Very high risk. Professional advice strongly recommended."
+    },
+    "guidelinesTitle": "Comparison with national guidelines",
+    "guidelineWithin": "within",
+    "guidelineExceeds": "exceeds by",
+    "of": "of",
+    "limit": "limit",
+    "units": "units",
+    "guidelines": {
+      "uk_nhs": "UK NHS",
+      "de_dhs": "DE DHS",
+      "us_niaaa": "US NIAAA"
+    },
+    "guidelineDesc": {
+      "uk_nhs": "14 units / week (both sexes)",
+      "de_dhs": "10.5 units/wk women · 21 units/wk men",
+      "us_niaaa": "12.25 units/wk women · 24.5 units/wk men"
+    },
+    "healthEffectsTitle": "Health effects",
+    "healthEffects": {
+      "liver": "Liver",
+      "liverDesc": "Regular alcohol consumption stresses the liver. From ~30g/day (women) or ~60g/day (men) the risk of fatty liver and cirrhosis rises significantly.",
+      "cancer": "Cancer risk",
+      "cancerDesc": "Alcohol is a class 1 carcinogen (IARC). No level of consumption is entirely risk-free. Risk increases linearly with the amount consumed.",
+      "cardiovascular": "Cardiovascular",
+      "cardiovascularDesc": "Regular consumption above guideline limits raises blood pressure, increases arrhythmia risk, and raises stroke risk.",
+      "sleep": "Sleep & recovery",
+      "sleepDesc": "Alcohol impairs sleep quality, suppresses REM sleep, and increases daytime fatigue even after moderate consumption."
+    },
+    "disclaimerTitle": "Disclaimer",
+    "disclaimer": "This calculator is for informational purposes only and does not replace medical advice. No alcohol is safer than any consumption. If you have concerns about your drinking, speak to a doctor or a support service (e.g. UK Drinkline: 0300 123 1110)."
+  }
+}

--- a/src/pages/AlcoholUnitsCalculator.vue
+++ b/src/pages/AlcoholUnitsCalculator.vue
@@ -1,0 +1,382 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t } = useI18n()
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('alcoholUnits.meta.title'),
+  description: t('alcoholUnits.meta.description'),
+  routeKey: 'alcoholUnits',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Alcohol Unit Calculator',
+    url: 'https://healthcalculator.app/alcohol-units',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+// Pure calculation functions
+
+const GRAMS_PER_UK_UNIT = 8
+const KCAL_PER_GRAM_ALCOHOL = 7
+
+function calcUnitsPerDrink(volumeMl, abvPct) {
+  return (volumeMl * abvPct) / 1000
+}
+
+function calcGramsFromUnits(units) {
+  return units * GRAMS_PER_UK_UNIT
+}
+
+function calcCaloriesFromGrams(grams) {
+  return Math.round(grams * KCAL_PER_GRAM_ALCOHOL)
+}
+
+function getRiskLevel(units) {
+  if (units === 0) return 'none'
+  if (units <= 14) return 'low'
+  if (units <= 28) return 'increasing'
+  if (units <= 50) return 'high'
+  return 'very_high'
+}
+
+const GUIDELINE_LIMITS = {
+  uk_nhs: { male: 14, female: 14 },
+  de_dhs: { male: 21, female: 10.5 },
+  us_niaaa: { male: 24.5, female: 12.25 },
+}
+
+// State
+
+const sex = ref('male')
+const showCost = ref(false)
+
+const DRINK_DEFAULTS = {
+  beer:      { volume: 500, abv: 5.0 },
+  wine:      { volume: 175, abv: 12.0 },
+  spirits:   { volume: 40,  abv: 40.0 },
+  cocktails: { volume: 200, abv: 15.0 },
+}
+
+const drinks = ref([
+  { key: 'beer',      count: 0, volume: 500, abv: 5.0,  cost: 0 },
+  { key: 'wine',      count: 0, volume: 175, abv: 12.0, cost: 0 },
+  { key: 'spirits',   count: 0, volume: 40,  abv: 40.0, cost: 0 },
+  { key: 'cocktails', count: 0, volume: 200, abv: 15.0, cost: 0 },
+])
+
+// Computed
+
+const drinkDetails = computed(() =>
+  drinks.value.map(d => ({
+    ...d,
+    units: calcUnitsPerDrink(d.volume, d.abv),
+    totalUnits: d.count * calcUnitsPerDrink(d.volume, d.abv),
+  }))
+)
+
+const totalUnits = computed(() =>
+  drinkDetails.value.reduce((sum, d) => sum + d.totalUnits, 0)
+)
+
+const totalGrams = computed(() => calcGramsFromUnits(totalUnits.value))
+
+const totalCalories = computed(() => calcCaloriesFromGrams(totalGrams.value))
+
+const totalCost = computed(() => {
+  if (!showCost.value) return null
+  return drinks.value.reduce((sum, d) => sum + d.count * (d.cost || 0), 0)
+})
+
+const riskLevel = computed(() => getRiskLevel(totalUnits.value))
+
+const guidelineStatus = computed(() =>
+  ['uk_nhs', 'de_dhs', 'us_niaaa'].map(key => {
+    const limit = GUIDELINE_LIMITS[key][sex.value]
+    const pct = limit > 0 ? totalUnits.value / limit : 0
+    return { key, limit, pct, exceeds: pct > 1 }
+  })
+)
+
+const riskColors = {
+  none:      { bg: 'bg-stone-50',  border: 'border-stone-200', text: 'text-stone-600',  badge: 'bg-stone-100 text-stone-700' },
+  low:       { bg: 'bg-green-50',  border: 'border-green-200', text: 'text-green-700',  badge: 'bg-green-100 text-green-800' },
+  increasing:{ bg: 'bg-yellow-50', border: 'border-yellow-200',text: 'text-yellow-700', badge: 'bg-yellow-100 text-yellow-800' },
+  high:      { bg: 'bg-orange-50', border: 'border-orange-200',text: 'text-orange-700', badge: 'bg-orange-100 text-orange-800' },
+  very_high: { bg: 'bg-red-50',    border: 'border-red-200',   text: 'text-red-700',    badge: 'bg-red-100 text-red-800' },
+}
+
+function barWidth(pct) {
+  return Math.min(pct * 100, 100)
+}
+
+function barColor(exceeds) {
+  return exceeds ? 'bg-red-500' : 'bg-green-500'
+}
+
+function resetDrink(drink) {
+  const defaults = DRINK_DEFAULTS[drink.key]
+  drink.volume = defaults.volume
+  drink.abv = defaults.abv
+}
+</script>
+
+<template>
+  <div>
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-6 inline-block">
+      ← {{ t('common.backToAll') }}
+    </router-link>
+
+    <h1 class="text-3xl font-bold tracking-tight text-stone-900 mb-2">{{ t('alcoholUnits.title') }}</h1>
+    <p class="text-base text-stone-500 leading-relaxed mb-8">{{ t('alcoholUnits.description') }}</p>
+
+    <!-- Sex selector -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">
+        {{ t('alcoholUnits.sex') }}
+      </label>
+      <div class="flex gap-2 w-fit" data-testid="sex-selector">
+        <button
+          v-for="s in ['male', 'female']"
+          :key="s"
+          @click="sex = s"
+          :class="sex === s ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-5 py-2.5 rounded-lg text-sm font-semibold transition-colors duration-150"
+          :data-testid="`sex-${s}`"
+        >{{ t(`alcoholUnits.${s}`) }}</button>
+      </div>
+    </div>
+
+    <!-- Drink inputs -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-sm font-semibold text-stone-500 uppercase tracking-widest mb-5">
+        {{ t('alcoholUnits.drinkTypes') }}
+      </h2>
+
+      <div class="space-y-6">
+        <div
+          v-for="drink in drinks"
+          :key="drink.key"
+          class="border border-stone-100 rounded-xl p-5"
+          :data-testid="`drink-${drink.key}`"
+        >
+          <div class="flex items-start justify-between mb-4">
+            <div>
+              <p class="text-sm font-semibold text-stone-900">{{ t(`alcoholUnits.drinkType.${drink.key}`) }}</p>
+              <p class="text-xs text-stone-400 mt-0.5">{{ t(`alcoholUnits.drinkDesc.${drink.key}`) }}</p>
+            </div>
+            <span class="text-xs text-stone-400 tabular-nums mt-0.5" :data-testid="`units-per-drink-${drink.key}`">
+              {{ calcUnitsPerDrink(drink.volume, drink.abv).toFixed(1) }} {{ t('alcoholUnits.unitsPerDrink') }}
+            </span>
+          </div>
+
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <!-- Count -->
+            <div>
+              <label class="block text-xs text-stone-500 mb-1.5">{{ t('alcoholUnits.countLabel') }}</label>
+              <input
+                v-model.number="drink.count"
+                type="number"
+                min="0"
+                max="100"
+                step="1"
+                class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400 tabular-nums"
+                :data-testid="`count-${drink.key}`"
+              />
+            </div>
+            <!-- Volume -->
+            <div>
+              <label class="block text-xs text-stone-500 mb-1.5">{{ t('alcoholUnits.volumeLabel') }}</label>
+              <input
+                v-model.number="drink.volume"
+                type="number"
+                min="1"
+                max="2000"
+                step="1"
+                class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400 tabular-nums"
+                :data-testid="`volume-${drink.key}`"
+              />
+            </div>
+            <!-- ABV -->
+            <div>
+              <label class="block text-xs text-stone-500 mb-1.5">{{ t('alcoholUnits.abvLabel') }}</label>
+              <input
+                v-model.number="drink.abv"
+                type="number"
+                min="0.1"
+                max="100"
+                step="0.1"
+                class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400 tabular-nums"
+                :data-testid="`abv-${drink.key}`"
+              />
+            </div>
+            <!-- Cost (optional) -->
+            <div v-if="showCost">
+              <label class="block text-xs text-stone-500 mb-1.5">{{ t('alcoholUnits.costLabel') }}</label>
+              <input
+                v-model.number="drink.cost"
+                type="number"
+                min="0"
+                step="0.1"
+                class="w-full border border-stone-200 rounded-lg px-3 py-2 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400 tabular-nums"
+                :data-testid="`cost-${drink.key}`"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Cost toggle -->
+      <div class="mt-5 pt-5 border-t border-stone-100">
+        <button
+          @click="showCost = !showCost"
+          class="text-sm text-stone-500 hover:text-stone-800 transition-colors"
+          data-testid="cost-toggle"
+        >
+          <span v-if="showCost">− {{ t('alcoholUnits.costToggle') }}</span>
+          <span v-else>+ {{ t('alcoholUnits.costToggle') }}</span>
+        </button>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Results -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-5">{{ t('alcoholUnits.results') }}</h2>
+
+      <!-- Primary metrics -->
+      <div class="grid grid-cols-2 gap-4 mb-5" :class="totalCost !== null ? 'sm:grid-cols-4' : 'sm:grid-cols-3'">
+        <div class="bg-stone-50 rounded-xl p-5">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2 leading-tight">
+            {{ t('alcoholUnits.totalUnits') }}
+          </p>
+          <span
+            class="text-4xl font-bold tabular-nums tracking-tight leading-none text-stone-900"
+            data-testid="total-units"
+          >{{ totalUnits.toFixed(1) }}</span>
+        </div>
+        <div class="bg-stone-50 rounded-xl p-5">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2 leading-tight">
+            {{ t('alcoholUnits.totalGrams') }}
+          </p>
+          <span
+            class="text-4xl font-bold tabular-nums tracking-tight leading-none text-stone-900"
+            data-testid="total-grams"
+          >{{ Math.round(totalGrams) }}</span>
+          <span class="text-sm text-stone-400 ml-1">g</span>
+        </div>
+        <div class="bg-stone-50 rounded-xl p-5">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2 leading-tight">
+            {{ t('alcoholUnits.caloriesLabel') }}
+          </p>
+          <span
+            class="text-4xl font-bold tabular-nums tracking-tight leading-none text-stone-900"
+            data-testid="total-calories"
+          >{{ totalCalories }}</span>
+          <span class="text-sm text-stone-400 ml-1">kcal</span>
+        </div>
+        <div v-if="totalCost !== null" class="bg-stone-50 rounded-xl p-5">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2 leading-tight">
+            {{ t('alcoholUnits.weeklyCost') }}
+          </p>
+          <span
+            class="text-4xl font-bold tabular-nums tracking-tight leading-none text-stone-900"
+            data-testid="total-cost"
+          >{{ totalCost.toFixed(2) }}</span>
+          <span class="text-sm text-stone-400 ml-1">€</span>
+        </div>
+      </div>
+
+      <!-- Risk category -->
+      <div
+        :class="[riskColors[riskLevel].bg, riskColors[riskLevel].border]"
+        class="border rounded-xl p-5 mb-5"
+        data-testid="risk-category"
+      >
+        <div class="flex items-center justify-between mb-2">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest">
+            {{ t('alcoholUnits.riskCategory') }}
+          </p>
+          <span
+            :class="riskColors[riskLevel].badge"
+            class="text-xs font-semibold px-2.5 py-1 rounded-full"
+            data-testid="risk-badge"
+          >{{ t(`alcoholUnits.risk.${riskLevel}`) }}</span>
+        </div>
+        <p :class="riskColors[riskLevel].text" class="text-sm leading-relaxed">
+          {{ t(`alcoholUnits.riskDesc.${riskLevel}`) }}
+        </p>
+      </div>
+
+      <!-- Guidelines comparison -->
+      <div class="mb-1">
+        <h3 class="text-sm font-semibold text-stone-900 mb-4">{{ t('alcoholUnits.guidelinesTitle') }}</h3>
+        <div class="space-y-4" data-testid="guidelines-comparison">
+          <div v-for="g in guidelineStatus" :key="g.key" :data-testid="`guideline-${g.key}`">
+            <div class="flex items-center justify-between mb-1.5">
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-semibold text-stone-900">{{ t(`alcoholUnits.guidelines.${g.key}`) }}</span>
+                <span class="text-xs text-stone-400">{{ t(`alcoholUnits.guidelineDesc.${g.key}`) }}</span>
+              </div>
+              <span
+                :class="g.exceeds ? 'text-red-600' : 'text-green-600'"
+                class="text-xs font-semibold whitespace-nowrap ml-2"
+              >
+                <template v-if="!g.exceeds">
+                  {{ totalUnits.toFixed(1) }} {{ t('alcoholUnits.of') }} {{ g.limit }} {{ t('alcoholUnits.units') }} ({{ t('alcoholUnits.guidelineWithin') }})
+                </template>
+                <template v-else>
+                  {{ t('alcoholUnits.guidelineExceeds') }} {{ (totalUnits - g.limit).toFixed(1) }} {{ t('alcoholUnits.units') }}
+                </template>
+              </span>
+            </div>
+            <div class="h-2 bg-stone-100 rounded-full overflow-hidden">
+              <div
+                :class="barColor(g.exceeds)"
+                class="h-full rounded-full transition-all duration-300"
+                :style="{ width: barWidth(g.pct) + '%' }"
+              ></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Health effects -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-5">{{ t('alcoholUnits.healthEffectsTitle') }}</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div
+          v-for="effect in ['liver', 'cancer', 'cardiovascular', 'sleep']"
+          :key="effect"
+          class="bg-stone-50 rounded-xl p-5"
+        >
+          <p class="text-sm font-semibold text-stone-900 mb-2">{{ t(`alcoholUnits.healthEffects.${effect}`) }}</p>
+          <p class="text-xs text-stone-500 leading-relaxed">{{ t(`alcoholUnits.healthEffects.${effect}Desc`) }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Disclaimer -->
+    <div class="bg-stone-50 border border-stone-200 rounded-xl p-6 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">
+        <strong class="text-stone-700">{{ t('alcoholUnits.disclaimerTitle') }}:</strong>
+        {{ t('alcoholUnits.disclaimer') }}
+      </p>
+    </div>
+
+    <BlogBanner calculator-key="alcoholUnits" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/alcoholUnits.meta.js
+++ b/src/pages/alcoholUnits.meta.js
@@ -1,0 +1,16 @@
+import Component from './AlcoholUnitsCalculator.vue'
+import BlogDe from './blog/AlkoholEinheitenBerechnen.vue'
+import BlogEn from './blog/en/AlcoholUnitsCalculatorBlog.vue'
+
+export default {
+  key: 'alcoholUnits',
+  component: Component,
+  slugs: { de: 'alkohol-einheiten-rechner', en: 'alcohol-units-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 21,
+  blog: {
+    de: { slug: 'alkohol-einheiten-berechnen', component: BlogDe },
+    en: { slug: 'alcohol-unit-calculator', component: BlogEn },
+  },
+}

--- a/src/pages/blog/AlkoholEinheitenBerechnen.vue
+++ b/src/pages/blog/AlkoholEinheitenBerechnen.vue
@@ -1,0 +1,239 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Alkoholeinheiten berechnen — Wöchentlicher Konsum & Gesundheitsrisiko | Health Calculators',
+  description: 'Was ist eine Alkoholeinheit? UK-Einheiten, Gramm reiner Alkohol, WHO-Risikoklassen und Vergleich mit DHS-, NHS- und NIAAA-Leitlinien erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Alkoholeinheiten berechnen — Wöchentlicher Konsum & Gesundheitsrisiko',
+    description: 'Was ist eine Alkoholeinheit? UK-Einheiten, Gramm reiner Alkohol, WHO-Risikoklassen und Vergleich mit DHS-, NHS- und NIAAA-Leitlinien erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-18',
+    dateModified: '2026-04-18',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/alkohol-einheiten-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Alkoholeinheiten berechnen — Wöchentlicher Konsum & Gesundheitsrisiko</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">18. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wie viel Alkohol ist zu viel? Die Antwort hängt davon ab, in welchen Einheiten du denkst. Eine <strong>UK-Alkoholeinheit</strong> entspricht 10 ml (8 g) reinen Alkohols — eine Messgröße, die es ermöglicht, Bier, Wein und Spirituosen auf einen gemeinsamen Nenner zu bringen und mit internationalen Leitlinien zu vergleichen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Artikel lernst du, wie Alkoholeinheiten berechnet werden, was die Leitlinien von DHS, NHS und NIAAA bedeuten, und warum die gesündeste Option immer noch <strong>kein Alkohol</strong> ist.
+        </p>
+      </div>
+
+      <!-- Was ist eine Alkoholeinheit? -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist eine Alkoholeinheit?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eine <strong>UK-Alkoholeinheit</strong> ist definiert als 10 ml (8 g) reiner Alkohol (Ethanol). Diese Einheit wurde in Großbritannien eingeführt, um den Konsum verschiedener Getränke vergleichbar zu machen. Die Formel ist einfach:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4 text-center">
+          <p class="text-base font-semibold text-stone-900">Einheiten = Volumen (ml) × Alkoholgehalt (%) ÷ 1 000</p>
+          <p class="text-sm text-stone-500 mt-2">Gramm reiner Alkohol = Einheiten × 8</p>
+        </div>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Getränk</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Volumen</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Alkohol</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Einheiten</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Gramm</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Bier (Pils)</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">500 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">5 %</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">2,5</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">20 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Wein (Rotwein)</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">175 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">12 %</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">2,1</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">16,8 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Whisky (Einfach)</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">40 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">40 %</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">1,6</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">12,8 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Cocktail</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">200 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">15 %</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">3,0</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">24 g</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Leitlinien -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Nationale Leitlinien im Vergleich</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Verschiedene Länder und Organisationen haben unterschiedliche Richtwerte für risikoarmen Alkoholkonsum definiert. Wichtig: Alle Leitlinien betonen, dass <em>weniger immer besser ist</em>.
+        </p>
+        <div class="space-y-4 mb-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">UK NHS — 14 Einheiten / Woche</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Das britische Gesundheitssystem empfiehlt, nicht mehr als 14 UK-Einheiten (112 g) pro Woche zu konsumieren — für Männer und Frauen gleichermaßen. Das entspricht etwa 6 mittelgroßen Gläsern Wein oder 6 Pint Bier. Außerdem wird empfohlen, den Konsum auf mehrere Tage zu verteilen und mindestens 2 alkoholfreie Tage pro Woche einzulegen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">DE DHS — 84 g / Woche Frauen · 168 g / Woche Männer</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Die Deutsche Hauptstelle für Suchtfragen (DHS) unterscheidet nach Geschlecht: Frauen gelten bei max. 12 g/Tag (84 g/Woche, ≈ 10,5 UK-Einheiten) als risikoarm, Männer bei max. 24 g/Tag (168 g/Woche, ≈ 21 UK-Einheiten). Der niedrigere Grenzwert für Frauen erklärt sich durch physiologische Unterschiede beim Alkoholabbau.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">US NIAAA — 7 Drinks / Woche Frauen · 14 Drinks / Woche Männer</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Das National Institute on Alcohol Abuse and Alcoholism (NIAAA) definiert einen US-Standard-Drink als 14 g Alkohol (≈ 1,75 UK-Einheiten). Risikoarmer Konsum liegt bei max. 7 Drinks/Woche für Frauen und 14 Drinks/Woche für Männer — entsprechend etwa 98 g bzw. 196 g pro Woche.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">WHO 2023 — Kein sicheres Niveau</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Die Weltgesundheitsorganisation betonte 2023, dass es <strong>kein sicheres Konsumniveau</strong> gibt. Alkohol ist ein Klasse-1-Karzinogen (IARC) und verursacht mindestens 7 Krebsarten. Selbst geringer Konsum erhöht das Krebsrisiko leicht. Die bestehenden Leitlinien beschreiben lediglich ein <em>geringes</em>, nicht ein <em>null</em> Risiko.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Deinen Alkoholkonsum berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">UK-Einheiten, Gramm, Risikostufe und Vergleich mit allen Leitlinien — in einem Rechner.</p>
+        <router-link
+          :to="localePath('alcoholUnits')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <!-- Gesundheitsrisiken -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Gesundheitsrisiken durch Alkohol</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Regelmäßiger Alkoholkonsum wirkt sich auf nahezu alle Organsysteme aus. Das Risiko steigt nicht erst ab einem bestimmten Schwellenwert — es beginnt mit dem ersten Glas.
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Leber</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Die Leber ist das Hauptorgan für den Alkoholabbau. Bei chronisch erhöhtem Konsum (ab ~30 g/Tag bei Frauen, ~60 g/Tag bei Männern) entwickelt sich zunächst eine Fettleber, dann Alkoholhepatitis und schließlich Zirrhose. Eine Leberzirrhose ist irreversibel.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Krebs</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Alkohol erhöht das Risiko für mindestens 7 Krebsarten: Mund-, Rachen-, Kehlkopf-, Speiseröhren-, Leber-, Darm- und Brustkrebs. Der Mechanismus: Acetaldehyd (ein Abbauprodukt) schädigt die DNA direkt. Selbst 1–2 Drinks pro Tag erhöhen das Brustkrebsrisiko um etwa 7–10 %.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Herz-Kreislauf</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Auch wenn frühere Studien einen "Herzschutz" durch moderaten Alkohol behaupteten, zeigen neuere Analysen: Der vermeintliche Vorteil war methodischer Fehler. Bei erhöhtem Konsum steigen Blutdruck, Schlaganfall- und Vorhofflimmern-Risiko deutlich an.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Schlaf & psychische Gesundheit</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Alkohol unterdrückt den REM-Schlaf und führt zu fragmentiertem Schlaf in der zweiten Nachthälfte. Langfristig erhöht regelmäßiger Konsum das Risiko für Depression und Angststörungen — teils als Ursache, teils als Selbstmedikation in einem Teufelskreis.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Kalorien -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Alkohol und Kalorien</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Alkohol liefert 7 kcal pro Gramm — nur Fett (9 kcal/g) enthält mehr Energie. Diese Kalorien sind <em>leere Kalorien</em>: kein Protein, keine Mikronährstoffe, kein Sättigungsgefühl. Ein typischer Abend mit 4 Bier (je 500 ml, 5 %) liefert:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base font-semibold text-stone-900 mb-2">4 × 500 ml Bier, 5 %</p>
+          <ul class="space-y-1 text-sm text-stone-600">
+            <li>• 10 UK-Einheiten → 80 g reiner Alkohol</li>
+            <li>• 80 g × 7 kcal = <strong>560 kcal</strong> aus Alkohol</li>
+            <li>• Plus Kohlenhydrate im Bier: weitere ~200–300 kcal</li>
+            <li>• Gesamt: ~750–850 kcal — entspricht einer vollständigen Hauptmahlzeit</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Verwandte Rechner -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <div class="space-y-4">
+          <router-link :to="localePath('bac')" class="block bg-white border border-stone-200 rounded-xl shadow-sm p-6 hover:border-stone-300 hover:shadow transition-all duration-150">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Promillerechner</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Berechne deinen Blutalkoholspiegel nach dem Trinken — wie schnell baut dein Körper Alkohol ab?</p>
+            <span class="text-sm font-medium text-stone-900 mt-2 inline-block">Zum Promillerechner &rarr;</span>
+          </router-link>
+          <router-link :to="localePath('smokingCost')" class="block bg-white border border-stone-200 rounded-xl shadow-sm p-6 hover:border-stone-300 hover:shadow transition-all duration-150">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Rauchen-Kosten-Rechner</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Wie viel kostet Rauchen wirklich? Tages-, Jahres- und Lebenskosten im Vergleich — ähnlich wie bei Alkohol unterschätzt.</p>
+            <span class="text-sm font-medium text-stone-900 mt-2 inline-block">Zum Rauchen-Kosten-Rechner &rarr;</span>
+          </router-link>
+          <router-link :to="localePath('lifeExpectancy')" class="block bg-white border border-stone-200 rounded-xl shadow-sm p-6 hover:border-stone-300 hover:shadow transition-all duration-150">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lebenserwartung-Rechner</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Alkohol ist einer der stärksten Einflussfaktoren auf die Lebenserwartung — berechne, wie sich dein Lebensstil auswirkt.</p>
+            <span class="text-sm font-medium text-stone-900 mt-2 inline-block">Zum Lebenserwartung-Rechner &rarr;</span>
+          </router-link>
+        </div>
+      </div>
+
+      <!-- Fazit -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Alkoholeinheiten ermöglichen einen präzisen Vergleich des Konsums mit nationalen und internationalen Leitlinien. Die Kernbotschaft ist klar: Weniger ist immer besser. Kein Konsum ist am gesündesten — das ist der wissenschaftliche Konsens von WHO, IARC und allen führenden Gesundheitsbehörden.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Berechne deinen wöchentlichen Konsum mit unserem <router-link :to="localePath('alcoholUnits')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Alkoholeinheiten-Rechner</router-link> — mit Vergleich zu DHS-, NHS- und NIAAA-Leitlinien sowie Kalorien- und Kostenschätzung.
+        </p>
+      </div>
+
+      <RelatedArticles slug="alkohol-einheiten-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/AlcoholUnitsCalculatorBlog.vue
+++ b/src/pages/blog/en/AlcoholUnitsCalculatorBlog.vue
@@ -1,0 +1,239 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Alcohol Unit Calculator — Weekly Consumption & Health Risk | Health Calculators',
+  description: 'What is an alcohol unit? UK units, grams of pure alcohol, WHO risk categories and comparison with DHS, NHS and NIAAA guidelines explained.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Alcohol Unit Calculator — Weekly Consumption & Health Risk',
+    description: 'What is an alcohol unit? UK units, grams of pure alcohol, WHO risk categories and comparison with DHS, NHS and NIAAA guidelines explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-18',
+    dateModified: '2026-04-18',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/alcohol-unit-calculator',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Alcohol Unit Calculator — Weekly Consumption & Health Risk</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 18, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          How much alcohol is too much? The answer depends on how you measure it. A <strong>UK alcohol unit</strong> equals 10 ml (8 g) of pure alcohol — a standard that lets you compare beer, wine and spirits on a level playing field and benchmark against international health guidelines.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In this article you'll learn how to calculate alcohol units, what the guidelines from the DHS, NHS and NIAAA actually mean, and why the science is clear: the healthiest option is <strong>no alcohol at all</strong>.
+        </p>
+      </div>
+
+      <!-- What is an alcohol unit? -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is an alcohol unit?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          One <strong>UK alcohol unit</strong> is defined as 10 ml (8 g) of pure ethanol. The formula is straightforward:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4 text-center">
+          <p class="text-base font-semibold text-stone-900">Units = Volume (ml) × ABV (%) ÷ 1,000</p>
+          <p class="text-sm text-stone-500 mt-2">Grams of pure alcohol = Units × 8</p>
+        </div>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Drink</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Volume</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">ABV</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Units</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Grams</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Lager / Beer</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">500 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">5%</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">2.5</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">20 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Red wine</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">175 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">12%</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">2.1</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">16.8 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Whisky (single)</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">40 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">40%</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">1.6</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">12.8 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Cocktail</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">200 ml</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">15%</td>
+                <td class="px-6 py-3 text-stone-900 font-semibold tabular-nums">3.0</td>
+                <td class="px-6 py-3 text-stone-900 tabular-nums">24 g</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- National guidelines -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">National guidelines compared</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Different countries have set different thresholds for low-risk drinking. All guidelines agree on one principle: <em>less is always better</em>.
+        </p>
+        <div class="space-y-4 mb-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">UK NHS — 14 units / week</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              The NHS recommends no more than 14 UK units (112 g) per week for both men and women — roughly 6 medium glasses of wine or 6 pints of beer. Spreading consumption across several days and having at least two alcohol-free days per week is also advised.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">DE DHS — 84 g / week women · 168 g / week men</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Germany's Deutsche Hauptstelle für Suchtfragen (DHS) differentiates by sex: low-risk consumption is up to 12 g/day for women (84 g/week ≈ 10.5 UK units) and 24 g/day for men (168 g/week ≈ 21 UK units). The lower threshold for women reflects physiological differences in alcohol metabolism.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">US NIAAA — 7 drinks / week women · 14 drinks / week men</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              The National Institute on Alcohol Abuse and Alcoholism defines one US standard drink as 14 g of alcohol (≈ 1.75 UK units). Low-risk limits are 7 drinks/week for women and 14 drinks/week for men — equivalent to about 98 g and 196 g per week respectively.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">WHO 2023 — No safe level</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              In 2023, the World Health Organization stated that there is <strong>no safe level of alcohol consumption</strong>. Alcohol is a Group 1 carcinogen (IARC) linked to at least 7 cancers. Even low consumption carries a small but real increase in cancer risk. Existing guidelines describe a <em>lower</em> risk, not <em>zero</em> risk.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your weekly alcohol units</h3>
+        <p class="text-stone-300 text-sm mb-5">UK units, grams, risk level and comparison with all major guidelines — in one calculator.</p>
+        <router-link
+          :to="localePath('alcoholUnits')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free &rarr;</router-link>
+      </div>
+
+      <!-- Health risks -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Health risks from alcohol</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Regular alcohol consumption affects almost every organ system. Risk does not start at some threshold — it begins with the first drink.
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Liver</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              The liver is the primary organ for alcohol metabolism. Chronic consumption above ~30 g/day (women) or ~60 g/day (men) leads to fatty liver, then alcoholic hepatitis, and eventually cirrhosis. Liver cirrhosis is irreversible.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Cancer</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Alcohol raises the risk of at least 7 cancers: mouth, throat, larynx, oesophagus, liver, bowel and breast. The mechanism: acetaldehyde (a metabolite) directly damages DNA. Even 1–2 drinks per day increases breast cancer risk by approximately 7–10%.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Cardiovascular</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              While older studies suggested a "cardioprotective" effect from moderate drinking, newer Mendelian randomisation analyses show this was a methodological artefact. Higher consumption raises blood pressure, atrial fibrillation risk, and stroke risk significantly.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Sleep & mental health</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Alcohol suppresses REM sleep and causes fragmented sleep in the second half of the night. Long-term regular use increases the risk of depression and anxiety disorders — often creating a self-medication cycle that worsens both.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Calories -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Alcohol and calories</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Alcohol delivers 7 kcal per gram — only fat (9 kcal/g) is more calorie-dense. These are <em>empty calories</em>: no protein, no micronutrients, no satiety. A typical night with 4 pints of beer (500 ml, 5%):
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base font-semibold text-stone-900 mb-2">4 × 500 ml beer, 5%</p>
+          <ul class="space-y-1 text-sm text-stone-600">
+            <li>• 10 UK units → 80 g pure alcohol</li>
+            <li>• 80 g × 7 kcal = <strong>560 kcal</strong> from alcohol alone</li>
+            <li>• Plus carbohydrates in beer: another ~200–300 kcal</li>
+            <li>• Total: ~750–850 kcal — equivalent to a full main meal</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Related calculators -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <div class="space-y-4">
+          <router-link :to="localePath('bac')" class="block bg-white border border-stone-200 rounded-xl shadow-sm p-6 hover:border-stone-300 hover:shadow transition-all duration-150">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Blood Alcohol Calculator</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Calculate your blood alcohol level after drinking — how quickly does your body break down alcohol?</p>
+            <span class="text-sm font-medium text-stone-900 mt-2 inline-block">To the BAC Calculator &rarr;</span>
+          </router-link>
+          <router-link :to="localePath('smokingCost')" class="block bg-white border border-stone-200 rounded-xl shadow-sm p-6 hover:border-stone-300 hover:shadow transition-all duration-150">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Smoking Cost Calculator</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">How much does smoking really cost? Daily, annual and lifetime costs — similar hidden costs as with alcohol.</p>
+            <span class="text-sm font-medium text-stone-900 mt-2 inline-block">To the Smoking Cost Calculator &rarr;</span>
+          </router-link>
+          <router-link :to="localePath('lifeExpectancy')" class="block bg-white border border-stone-200 rounded-xl shadow-sm p-6 hover:border-stone-300 hover:shadow transition-all duration-150">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Life Expectancy Calculator</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Alcohol is one of the strongest lifestyle factors affecting life expectancy — calculate the impact of your habits.</p>
+            <span class="text-sm font-medium text-stone-900 mt-2 inline-block">To the Life Expectancy Calculator &rarr;</span>
+          </router-link>
+        </div>
+      </div>
+
+      <!-- Conclusion -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conclusion</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Alcohol units provide a precise way to compare your consumption against national and international guidelines. The central message is consistent across all health authorities: less is always better. Not drinking at all is the healthiest choice.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Calculate your weekly consumption with our <router-link :to="localePath('alcoholUnits')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Alcohol Unit Calculator</router-link> — with comparison against DHS, NHS and NIAAA guidelines, plus calorie and cost estimates.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="alcohol-unit-calculator" />
+    </div>
+  </article>
+</template>


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-119-alcohol-units
**Agent:** claude
**Model:** claude-haiku-4-5-20251001
**Branch:** `agent/hc-119-alcohol-units-20260418-120023`
**Cost:** $3.4576846000000017

Closes jenslaufer/health-calculators#119

### Prompt
> Implement the Alcohol Unit Calculator as described in issue #119.

This is DIFFERENT from the existing Promillerechner (BAC calculator).
This calculates weekly alcohol consumption units and long-term health risk.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: Drinks per week by type (beer, wine, spirits, cocktails), Volume per drink, Alcohol percentage
- Output: Total alcohol units/week (UK/WHO), Total grams pure alcohol/week, Risk category (WHO guidelines), Comparison to national guidelines (DE DHS, UK NHS, US NIAAA), Calorie count, Cost estimate, Health risk breakdown
- Blog articles: DE (/blog/alkohol-einheiten-berechnen) + EN (/blog/alcohol-unit-calculator)
- Unit tests for unit calculations and risk categorization
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks