### PR TITLE
Add CalculatorFAQ + FAQPage JSON-LD on top 20 calculators

### DIFF
--- a/src/__tests__/calculatorFaq.test.js
+++ b/src/__tests__/calculatorFaq.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+
+const sampleQuestions = [
+  { q: 'Was bedeutet ein BMI von 23?', a: 'Ein BMI von 23 liegt im Normalbereich (18,5–24,9) laut WHO-Klassifikation.' },
+  { q: 'Wie wird der BMI berechnet?', a: 'BMI = Gewicht (kg) / Körpergröße (m)². Quelle: DGE.' },
+  { q: 'Ist der BMI für alle aussagekräftig?', a: 'Der BMI berücksichtigt weder Muskelmasse noch Körperbau. Athleten können einen erhöhten BMI haben.' },
+]
+
+async function renderFaq(props = { questions: sampleQuestions, title: 'Häufige Fragen' }) {
+  const app = createSSRApp({ render: () => h(CalculatorFAQ, props) })
+  return renderToString(app)
+}
+
+describe('CalculatorFAQ', () => {
+  it('renders a semantic <section> with an <h2> heading', async () => {
+    const html = await renderFaq()
+    expect(html).toMatch(/<section[^>]*data-testid="calculator-faq"/)
+    expect(html).toMatch(/<h2[^>]*>Häufige Fragen<\/h2>/)
+  })
+
+  it('renders each question inside a <details><summary> block', async () => {
+    const html = await renderFaq()
+    const detailsCount = (html.match(/<details/g) || []).length
+    expect(detailsCount).toBe(sampleQuestions.length)
+    for (const { q } of sampleQuestions) {
+      expect(html).toContain(`<summary`)
+      expect(html).toContain(q)
+    }
+  })
+
+  it('renders each answer text in the rendered HTML', async () => {
+    const html = await renderFaq()
+    for (const { a } of sampleQuestions) {
+      expect(html).toContain(a)
+    }
+  })
+
+  it('emits an inline <script type="application/ld+json"> with FAQPage schema', async () => {
+    const html = await renderFaq()
+    const scriptMatch = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)
+    expect(scriptMatch, 'no JSON-LD script tag found in SSR output').not.toBeNull()
+    const data = JSON.parse(scriptMatch[1])
+    expect(data['@context']).toBe('https://schema.org')
+    expect(data['@type']).toBe('FAQPage')
+    expect(Array.isArray(data.mainEntity)).toBe(true)
+    expect(data.mainEntity).toHaveLength(sampleQuestions.length)
+  })
+
+  it('builds mainEntity entries with Question + acceptedAnswer Answer', async () => {
+    const html = await renderFaq()
+    const scriptMatch = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)
+    const data = JSON.parse(scriptMatch[1])
+    for (let i = 0; i < sampleQuestions.length; i++) {
+      const entry = data.mainEntity[i]
+      expect(entry['@type']).toBe('Question')
+      expect(entry.name).toBe(sampleQuestions[i].q)
+      expect(entry.acceptedAnswer['@type']).toBe('Answer')
+      expect(entry.acceptedAnswer.text).toBe(sampleQuestions[i].a)
+    }
+  })
+
+  it('renders nothing when questions prop is empty', async () => {
+    const html = await renderFaq({ questions: [], title: '' })
+    expect(html).toBe('<!---->')
+  })
+
+  it('escapes HTML in question and answer to prevent XSS', async () => {
+    const html = await renderFaq({
+      questions: [{ q: '<script>alert(1)</script>', a: 'safe' }],
+      title: 't',
+    })
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})

--- a/src/__tests__/faq-ssr.test.js
+++ b/src/__tests__/faq-ssr.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const DIST = join(import.meta.dirname, '../../dist')
+
+const SAMPLE_PAGES = [
+  'de/bmi-rechner',
+  'en/bmi-calculator',
+  'de/bmr-rechner',
+  'de/tdee-rechner',
+  'de/wasser-rechner',
+  'de/schwangerschafts-rechner',
+  'de/eisprung-rechner',
+  'de/kaloriendefizit-rechner',
+  'de/taille-hueft-verhaeltnis',
+  'de/koerperfett-rechner',
+  'de/gfr-rechner',
+  'de/hba1c-konverter',
+  'de/promillerechner',
+  'de/lauftempo-rechner',
+  'de/vo2max-rechner',
+  'de/keto-rechner',
+  'de/makro-rechner',
+  'de/intervallfasten-rechner',
+  'de/zyklusrechner',
+  'de/blutzucker-umrechner',
+  'de/idealgewicht-rechner',
+]
+
+const distExists = existsSync(DIST)
+
+describe.skipIf(!distExists)('FAQPage JSON-LD in SSR build output', () => {
+  for (const page of SAMPLE_PAGES) {
+    it(`emits FAQPage JSON-LD inline in dist/${page}/index.html`, () => {
+      const file = join(DIST, page, 'index.html')
+      expect(existsSync(file), `missing built file: ${file}`).toBe(true)
+      const html = readFileSync(file, 'utf8')
+
+      const faqMatch = html.match(/<script type="application\/ld\+json">[\s\S]*?<\/script>/g) || []
+      const faqEntries = faqMatch.filter(s => s.includes('FAQPage'))
+      expect(faqEntries.length, `no FAQPage JSON-LD found in ${page}`).toBeGreaterThanOrEqual(1)
+
+      const inner = faqEntries[0].replace(/^<script[^>]*>/, '').replace(/<\/script>$/, '')
+      const json = inner.replace(/\\u003c/g, '<')
+      const data = JSON.parse(json)
+      expect(data['@context']).toBe('https://schema.org')
+      expect(data['@type']).toBe('FAQPage')
+      expect(Array.isArray(data.mainEntity)).toBe(true)
+      expect(data.mainEntity.length).toBeGreaterThanOrEqual(5)
+      expect(data.mainEntity.length).toBeLessThanOrEqual(7)
+      for (const entry of data.mainEntity) {
+        expect(entry['@type']).toBe('Question')
+        expect(entry.acceptedAnswer['@type']).toBe('Answer')
+        expect(entry.acceptedAnswer.text.length).toBeGreaterThan(20)
+      }
+    })
+  }
+
+  it('renders the FAQ section visibly (data-testid present)', () => {
+    const html = readFileSync(join(DIST, 'de/bmi-rechner/index.html'), 'utf8')
+    expect(html).toContain('data-testid="calculator-faq"')
+    expect(html).toMatch(/<details/)
+    expect(html).toMatch(/<summary/)
+  })
+})
+
+if (!distExists) {
+  describe('FAQPage JSON-LD in SSR build output', () => {
+    it.skip('skipped — run `npm run build` first to enable SSR verification', () => {})
+  })
+}

--- a/src/components/CalculatorFAQ.vue
+++ b/src/components/CalculatorFAQ.vue
@@ -1,0 +1,50 @@
+<script setup>
+import { computed, h } from 'vue'
+
+const props = defineProps({
+  questions: { type: Array, required: true },
+  title: { type: String, default: '' },
+})
+
+const jsonLd = computed(() => {
+  const data = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: props.questions.map(({ q, a }) => ({
+      '@type': 'Question',
+      name: q,
+      acceptedAnswer: { '@type': 'Answer', text: a },
+    })),
+  }
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+})
+
+// Render <script> via render function to bypass Vue's template parser,
+// keeping the JSON-LD inline in the SSR-emitted HTML.
+const FaqJsonLd = (p) => h('script', { type: 'application/ld+json', innerHTML: p.data })
+FaqJsonLd.props = ['data']
+</script>
+
+<template>
+  <section
+    v-if="questions.length"
+    class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mt-6"
+    data-testid="calculator-faq"
+  >
+    <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ title }}</h2>
+    <div class="space-y-3">
+      <details
+        v-for="(item, i) in questions"
+        :key="i"
+        class="group border-b border-stone-100 pb-3 last:border-0"
+      >
+        <summary class="font-medium text-stone-800 cursor-pointer text-sm py-1 list-none flex items-start justify-between gap-3">
+          <span>{{ item.q }}</span>
+          <span class="text-stone-400 text-xs mt-1 transition-transform group-open:rotate-45">+</span>
+        </summary>
+        <div class="mt-2 text-sm text-stone-600 leading-relaxed">{{ item.a }}</div>
+      </details>
+    </div>
+    <FaqJsonLd :data="jsonLd" />
+  </section>
+</template>

--- a/src/locales/calculators/de/bac.json
+++ b/src/locales/calculators/de/bac.json
@@ -47,6 +47,32 @@
     "effectSignificant": "Starke Gleichgewichtsstörungen, undeutliche Sprache",
     "effectDangerous": "Bewusstseinsstörungen, Lebensgefahr",
     "howItWorks": "So funktioniert's",
-    "howItWorksText": "Dieser Rechner verwendet die Widmark-Formel: Alkohol (g) = Volumen × (Vol.-% / 100) × 0,8. Der Blutalkoholspiegel ergibt sich aus Alkohol (g) / (Körpergewicht × r), wobei r = 0,68 (Männer) bzw. 0,55 (Frauen). Der Abbau beträgt ca. 0,15 ‰ pro Stunde. Dies ist eine Schätzung — individuelle Faktoren können abweichen."
+    "howItWorksText": "Dieser Rechner verwendet die Widmark-Formel: Alkohol (g) = Volumen × (Vol.-% / 100) × 0,8. Der Blutalkoholspiegel ergibt sich aus Alkohol (g) / (Körpergewicht × r), wobei r = 0,68 (Männer) bzw. 0,55 (Frauen). Der Abbau beträgt ca. 0,15 ‰ pro Stunde. Dies ist eine Schätzung — individuelle Faktoren können abweichen.",
+    "faq": [
+      {
+        "q": "Wie wird der Promillewert berechnet?",
+        "a": "Mit der Widmark-Formel: Alkohol (g) / (Körpergewicht × r). r = 0,68 für Männer, 0,55 für Frauen. Diese Schätzung ist medizinisch anerkannt, aber individuell variabel."
+      },
+      {
+        "q": "Wie schnell baut der Körper Alkohol ab?",
+        "a": "Etwa 0,1–0,2 ‰ pro Stunde, im Schnitt 0,15 ‰. Die Abbaurate kann nicht beschleunigt werden — weder durch Kaffee, Wasser noch durch Bewegung."
+      },
+      {
+        "q": "Welche Promille-Grenzwerte gelten in Deutschland?",
+        "a": "Auto: 0,5 ‰ Bußgeld, 0,3 ‰ mit Auffälligkeiten strafbar, 1,1 ‰ absolute Fahruntüchtigkeit. Fahranfänger und unter 21: 0,0 ‰. Fahrrad: 1,6 ‰. Quelle: StVG."
+      },
+      {
+        "q": "Warum ist die Schätzung ungenau?",
+        "a": "Individuelle Faktoren wie Magenfüllung, Leberfunktion, Geschlecht, Medikamente und Körperzusammensetzung beeinflussen den realen Wert um ±20–30 %."
+      },
+      {
+        "q": "Sind Frauen alkoholempfindlicher?",
+        "a": "Ja. Frauen haben durchschnittlich weniger Wasseranteil und das Magenenzym Alkoholdehydrogenase ist weniger aktiv. Bei gleichem Konsum sind die Promillewerte höher."
+      },
+      {
+        "q": "Wann ist man wieder fahrtüchtig?",
+        "a": "Erst bei 0,0 ‰. Bei 1,0 ‰ Promille dauert der Abbau ca. 6–7 Stunden. Restalkohol am Morgen ist häufig — auch nach 8 Stunden Schlaf."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/bloodSugar.json
+++ b/src/locales/calculators/de/bloodSugar.json
@@ -50,6 +50,32 @@
     "normalDesc": "Kein erhöhtes Risiko.",
     "prediabetesDesc": "Erhöhtes Risiko. Lebensstiländerungen empfohlen.",
     "diabetesDesc": "Diabetes-Bereich. Arzt aufsuchen.",
-    "contextNote": "Werte können je nach Messzeitpunkt, Tageszeit und Ernährung variieren. Kein Ersatz für ärztliche Beratung."
+    "contextNote": "Werte können je nach Messzeitpunkt, Tageszeit und Ernährung variieren. Kein Ersatz für ärztliche Beratung.",
+    "faq": [
+      {
+        "q": "Welche Blutzucker-Einheiten gibt es?",
+        "a": "mg/dl (USA, Deutschland) und mmol/l (UK, Kanada, internationale Studien). Umrechnung: 1 mmol/l = 18,016 mg/dl."
+      },
+      {
+        "q": "Welche Werte sind normal (nüchtern)?",
+        "a": "Normal: < 100 mg/dl (5,6 mmol/l). Prädiabetes: 100–125 mg/dl (5,6–6,9 mmol/l). Diabetes: ≥ 126 mg/dl (7,0 mmol/l). Quelle: ADA."
+      },
+      {
+        "q": "Welche Werte sind normal (postprandial)?",
+        "a": "2 Stunden nach dem Essen: < 140 mg/dl (7,8 mmol/l) normal. 140–199 mg/dl (7,8–11,0 mmol/l) prädiabetisch. ≥ 200 mg/dl (11,1 mmol/l) Diabetes."
+      },
+      {
+        "q": "Was ist Hypoglykämie?",
+        "a": "Blutzucker < 70 mg/dl (3,9 mmol/l). Symptome: Zittern, Schwitzen, Heißhunger, Verwirrung. Bei Werten < 54 mg/dl (3,0 mmol/l) klinisch relevante Hypoglykämie."
+      },
+      {
+        "q": "Wie oft sollte ich messen?",
+        "a": "Bei Diabetes Typ 1 mehrfach täglich. Bei Diabetes Typ 2 unter Insulin 1–4× täglich, bei oraler Therapie nach Arztempfehlung. Bei Gesunden ist Selbstmessung nicht nötig."
+      },
+      {
+        "q": "Welche Faktoren beeinflussen den Blutzucker?",
+        "a": "Ernährung (Kohlenhydrate), Bewegung, Stress, Schlaf, Krankheit, Medikamente, Hormone. Auch Tageszeit (Dawn-Phänomen) und Alkohol spielen eine Rolle."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/bmi.json
+++ b/src/locales/calculators/de/bmi.json
@@ -18,6 +18,14 @@
     "underweight": "Untergewicht",
     "normal": "Normalgewicht",
     "overweight": "Übergewicht",
-    "obese": "Adipositas"
+    "obese": "Adipositas",
+    "faq": [
+      { "q": "Wie wird der BMI berechnet?", "a": "Der Body-Mass-Index berechnet sich nach der Formel BMI = Gewicht (kg) / Körpergröße (m)². Diese Formel wurde im 19. Jahrhundert von Adolphe Quetelet entwickelt und ist heute der international anerkannte Standard (WHO)." },
+      { "q": "Was bedeutet ein BMI im Normalbereich?", "a": "Laut WHO liegt der Normalbereich zwischen 18,5 und 24,9 kg/m². In diesem Bereich ist das statistische Risiko für gewichtsbedingte Erkrankungen am niedrigsten." },
+      { "q": "Ab welchem BMI spricht man von Übergewicht?", "a": "Übergewicht beginnt nach WHO-Kriterien ab einem BMI von 25,0. Ab 30,0 wird von Adipositas (Fettleibigkeit) gesprochen, unterteilt in drei Schweregrade." },
+      { "q": "Ist der BMI auch für Sportler aussagekräftig?", "a": "Nur eingeschränkt. Der BMI unterscheidet nicht zwischen Muskel- und Fettmasse. Athleten mit hoher Muskelmasse können einen BMI im Übergewichtsbereich haben, ohne tatsächlich überfettet zu sein." },
+      { "q": "Gilt der BMI auch für Kinder und Senioren?", "a": "Für Kinder gelten alters- und geschlechtsspezifische Perzentilen statt fester BMI-Grenzen. Bei Senioren über 65 verschiebt sich der gesunde Bereich laut DGE leicht nach oben (24–29 kg/m²)." },
+      { "q": "Was sagt der BMI nicht aus?", "a": "Der BMI berücksichtigt weder Körperfettverteilung noch Muskelanteil, Geschlecht oder Ethnizität. Für ein vollständiges Bild sind ergänzende Werte wie Taillenumfang oder Körperfettanteil sinnvoll." }
+    ]
   }
 }

--- a/src/locales/calculators/de/bmr.json
+++ b/src/locales/calculators/de/bmr.json
@@ -23,6 +23,14 @@
     "lightlyActive": "Leicht aktiv (1–3 Tage/Woche)",
     "moderatelyActive": "Moderat aktiv (3–5 Tage/Woche)",
     "veryActive": "Sehr aktiv (6–7 Tage/Woche)",
-    "extremelyActive": "Extrem aktiv (Athlet/körperliche Arbeit)"
+    "extremelyActive": "Extrem aktiv (Athlet/körperliche Arbeit)",
+    "faq": [
+      { "q": "Was ist der Grundumsatz (BMR)?", "a": "Der Grundumsatz beschreibt die Energie, die der Körper in völliger Ruhe für lebenswichtige Funktionen wie Atmung, Herzschlag und Zellstoffwechsel benötigt. Quelle: Deutsche Gesellschaft für Ernährung (DGE)." },
+      { "q": "Welche Formel ist genauer: Mifflin-St Jeor oder Harris-Benedict?", "a": "Die Mifflin-St Jeor-Formel (1990) gilt heute als präziser für die Allgemeinbevölkerung als die ältere Harris-Benedict-Formel (1919). Beide Schätzungen liegen typischerweise innerhalb von ±10 % des tatsächlichen Werts." },
+      { "q": "Wie unterscheidet sich BMR vom Tagesumsatz (TDEE)?", "a": "Der BMR ist nur der Ruhebedarf. Der TDEE (Total Daily Energy Expenditure) addiert zusätzlich Bewegung, Verdauung und Alltagsaktivität durch Multiplikation mit einem Aktivitätsfaktor (1,2–1,9)." },
+      { "q": "Welche Faktoren beeinflussen den Grundumsatz?", "a": "Geschlecht, Alter, Körpergröße, Gewicht und vor allem Muskelmasse. Männer haben durchschnittlich einen um 5–10 % höheren BMR als Frauen aufgrund höherer Muskelmasse." },
+      { "q": "Sinkt der BMR mit dem Alter?", "a": "Ja, ab dem 30. Lebensjahr sinkt der Grundumsatz um etwa 1–2 % pro Jahrzehnt, hauptsächlich durch Verlust an Muskelmasse (Sarkopenie). Krafttraining kann diesen Effekt deutlich verlangsamen." },
+      { "q": "Sollte ich weniger Kalorien als meinen BMR essen?", "a": "Ein dauerhaftes Unterschreiten des Grundumsatzes wird von der DGE nicht empfohlen, da es Stoffwechselanpassungen, Muskelabbau und Nährstoffmangel begünstigen kann. Defizite sollten sich am TDEE orientieren." }
+    ]
   }
 }

--- a/src/locales/calculators/de/bodyFat.json
+++ b/src/locales/calculators/de/bodyFat.json
@@ -24,6 +24,32 @@
     "obese": "Adipositas",
     "fatMass": "Fettmasse",
     "leanMass": "Magermasse",
-    "categoriesTitle": "Körperfett-Kategorien ({gender})"
+    "categoriesTitle": "Körperfett-Kategorien ({gender})",
+    "faq": [
+      {
+        "q": "Was ist ein gesunder Körperfettanteil?",
+        "a": "Männer: 10–20 % gesund, Frauen: 18–28 % gesund (American Council on Exercise). Athleten liegen oft niedriger, sehr niedrige Werte können hormonelle Probleme verursachen."
+      },
+      {
+        "q": "Wie wird der Körperfettanteil hier berechnet?",
+        "a": "Dieser Rechner nutzt die US-Navy-Methode anhand von Umfangmessungen (Hals, Taille, Hüfte) und Körpergröße. Diese hat eine Genauigkeit von ±3–4 % gegenüber DEXA."
+      },
+      {
+        "q": "Welche Methode ist am genauesten?",
+        "a": "DEXA (Doppelröntgen) gilt als Referenzstandard. BIA-Waagen sind weniger genau (±5–8 %), Hautfaltenmessungen liegen dazwischen, abhängig vom Untersucher."
+      },
+      {
+        "q": "Warum ist Körperfett wichtiger als BMI?",
+        "a": "Der BMI unterscheidet nicht zwischen Muskel- und Fettmasse. Zwei Personen mit gleichem BMI können sehr unterschiedliche Stoffwechselrisiken haben — der Körperfettanteil zeigt das deutlich."
+      },
+      {
+        "q": "Wie schnell kann man Körperfett reduzieren?",
+        "a": "Realistisch sind 0,5–1 % Körperfettanteil pro Monat bei moderatem Defizit. Sehr schnelle Reduktion erhöht das Risiko für Muskelverlust."
+      },
+      {
+        "q": "Was ist essentielles Fett?",
+        "a": "Essentielles Fett (Männer ~3 %, Frauen ~12 %) wird für Hormonsynthese, Organschutz und Zellfunktion benötigt. Werte darunter sind gesundheitlich riskant."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/calorieDeficit.json
+++ b/src/locales/calculators/de/calorieDeficit.json
@@ -29,6 +29,32 @@
     "weeklyLoss": "Abnahme / Woche",
     "perWeek": "pro Woche",
     "warningUnsafe": "Dein Kalorienziel liegt unter 1.200 kcal/Tag. Das ist gesundheitlich bedenklich — bitte sprich mit einem Arzt.",
-    "warningAggressive": "Du planst mehr als 1 kg pro Woche abzunehmen. Ein langsameres Tempo ist nachhaltiger und gesünder."
+    "warningAggressive": "Du planst mehr als 1 kg pro Woche abzunehmen. Ein langsameres Tempo ist nachhaltiger und gesünder.",
+    "faq": [
+      {
+        "q": "Was ist ein gesundes Kaloriendefizit?",
+        "a": "300–500 kcal pro Tag unter dem TDEE führen zu etwa 0,3–0,5 kg Fettverlust pro Woche. Diese Größenordnung gilt als nachhaltig (DGE)."
+      },
+      {
+        "q": "Wie viel Kalorien sollte ich mindestens essen?",
+        "a": "Frauen sollten 1.200 kcal/Tag, Männer 1.500 kcal/Tag nicht dauerhaft unterschreiten. Zu niedrige Aufnahme begünstigt Nährstoffmangel und Stoffwechselanpassung."
+      },
+      {
+        "q": "Warum sind 7.000 kcal Defizit ≠ 1 kg Fett?",
+        "a": "Die Faustregel '7.000 kcal = 1 kg Fett' ist eine Vereinfachung. Wasserverlust, Glykogenabbau und Muskelmasse beeinflussen die Bilanz. Realer Fettverlust ist meist 0,3–0,5 kg pro 3.500 kcal Defizit."
+      },
+      {
+        "q": "Wie verhindere ich Muskelabbau in der Diät?",
+        "a": "Mindestens 1,6–2,2 g Protein pro kg Körpergewicht und Krafttraining 2–4× pro Woche reduzieren den Muskelverlust deutlich (ISSN-Empfehlung)."
+      },
+      {
+        "q": "Wann sollte ich eine Diätpause einlegen?",
+        "a": "Nach 8–12 Wochen Defizit kann eine Diätpause (Refeed) von 7–14 Tagen bei Erhaltungskalorien Hormone (Leptin) und Stoffwechsel regenerieren."
+      },
+      {
+        "q": "Was tun bei Plateaus?",
+        "a": "Plateaus sind normal. Genauere Tracking-Periode, Erhöhung der Aktivität, leichte Defizit-Anpassung (-100 kcal) oder Diätpause können helfen."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/gfr.json
+++ b/src/locales/calculators/de/gfr.json
@@ -62,6 +62,32 @@
       "G3b": "Nephrologen aufsuchen. Engmaschige Überwachung und Anpassung der Medikation erforderlich.",
       "G4": "Dringend zum Nephrologen. Vorbereitung auf Nierenersatztherapie (Dialyse/Transplantation) besprechen.",
       "G5": "Sofortige nephrologische Behandlung erforderlich. Nierenersatztherapie ist in der Regel notwendig."
-    }
+    },
+    "faq": [
+      {
+        "q": "Was ist die glomeruläre Filtrationsrate (GFR)?",
+        "a": "Die GFR misst, wie viel Blut die Nieren pro Minute filtern (ml/min/1,73 m²). Sie ist der wichtigste Marker für die Nierenfunktion. Quelle: KDIGO."
+      },
+      {
+        "q": "Welche GFR ist normal?",
+        "a": "Erwachsene: > 90 ml/min/1,73 m² gilt als normal. Werte zwischen 60–89 sind grenzwertig (G2), unter 60 deuten auf chronische Nierenerkrankung (CKD) hin."
+      },
+      {
+        "q": "Welche Formel wird verwendet?",
+        "a": "Dieser Rechner verwendet die CKD-EPI-Formel (2021), den aktuellen Standard zur Schätzung der GFR aus Serumkreatinin. Sie ist genauer als die ältere MDRD-Formel."
+      },
+      {
+        "q": "Warum sinkt die GFR mit dem Alter?",
+        "a": "Ab dem 40. Lebensjahr nimmt die GFR um etwa 1 ml/min/Jahr ab. Bluthochdruck, Diabetes und Übergewicht beschleunigen diesen Prozess."
+      },
+      {
+        "q": "Was sind die CKD-Stadien?",
+        "a": "G1 (>90), G2 (60–89), G3a (45–59), G3b (30–44), G4 (15–29), G5 (<15, terminales Nierenversagen). Quelle: KDIGO 2012."
+      },
+      {
+        "q": "Was kann ich tun, um meine Nieren zu schützen?",
+        "a": "Blutdruck unter 130/80, gute Blutzuckereinstellung, ausreichend Wasser, salzarme Ernährung, NSAR meiden, Rauchen einstellen. Bei eGFR < 60 nephrologische Abklärung."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/hba1c.json
+++ b/src/locales/calculators/de/hba1c.json
@@ -37,6 +37,32 @@
     "categoriesTitle": "Risikokategorien (ADA)",
     "normalDesc": "Kein erhöhtes Risiko für Diabetes.",
     "prediabetesDesc": "Erhöhtes Risiko. Lebensstiländerungen empfohlen.",
-    "diabetesDesc": "Diabetes-Bereich. Arzt aufsuchen."
+    "diabetesDesc": "Diabetes-Bereich. Arzt aufsuchen.",
+    "faq": [
+      {
+        "q": "Was ist HbA1c?",
+        "a": "HbA1c ist der glykierte Anteil des roten Blutfarbstoffs Hämoglobin. Er spiegelt den durchschnittlichen Blutzuckerspiegel der letzten 8–12 Wochen wider. Quelle: Deutsche Diabetes Gesellschaft."
+      },
+      {
+        "q": "Welche Werte sind normal?",
+        "a": "Normal: < 5,7 % (39 mmol/mol). Prädiabetes: 5,7–6,4 % (39–47 mmol/mol). Diabetes: ≥ 6,5 % (48 mmol/mol). Quelle: ADA-Klassifikation."
+      },
+      {
+        "q": "Wie wird HbA1c in mmol/mol umgerechnet?",
+        "a": "HbA1c (mmol/mol) = (HbA1c % - 2,15) × 10,929. NGSP (%) ist der ältere US-Standard, IFCC (mmol/mol) der internationale Standard."
+      },
+      {
+        "q": "Welche Faktoren beeinflussen HbA1c falsch?",
+        "a": "Anämie, Hämoglobinopathien (z. B. Sichelzelle), Schwangerschaft, Niereninsuffizienz und kürzliche Bluttransfusionen können den Wert verfälschen."
+      },
+      {
+        "q": "Wie oft sollte HbA1c gemessen werden?",
+        "a": "Bei stabilem Diabetes alle 6 Monate. Bei Therapieänderung oder schlechter Einstellung alle 3 Monate. Empfehlung: Nationale Versorgungsleitlinie Diabetes."
+      },
+      {
+        "q": "Welcher HbA1c-Zielwert wird empfohlen?",
+        "a": "Individuell: meist < 7 % (53 mmol/mol). Bei jungen Menschen ohne Komorbiditäten kann < 6,5 % sinnvoll sein. Bei älteren Patienten oft 7,5–8 % zur Hypoglykämie-Vermeidung."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/idealWeight.json
+++ b/src/locales/calculators/de/idealWeight.json
@@ -16,6 +16,32 @@
     "description": "Finde deinen gesunden Gewichtsbereich basierend auf vier wissenschaftlich fundierten Formeln.",
     "formulaComparison": "Formelvergleich",
     "healthyBmiRange": "Gesunder BMI-Bereich",
-    "bmiRangeText": "Basierend auf einem BMI von 18,5 – 24,9 liegt dein gesunder Gewichtsbereich bei"
+    "bmiRangeText": "Basierend auf einem BMI von 18,5 – 24,9 liegt dein gesunder Gewichtsbereich bei",
+    "faq": [
+      {
+        "q": "Was ist das Idealgewicht?",
+        "a": "Das statistisch optimale Gewicht für eine bestimmte Körpergröße — assoziiert mit niedrigster Sterblichkeit und Krankheitsrisiko. Es ist eine Schätzung, kein Pflichtwert. Quelle: WHO."
+      },
+      {
+        "q": "Welche Formeln werden verwendet?",
+        "a": "Bekannte Formeln: Devine (1974), Robinson, Miller, Hamwi. Sie wurden ursprünglich zur Medikamentendosierung entwickelt und liefern leicht unterschiedliche Werte."
+      },
+      {
+        "q": "Wie unterscheidet sich Idealgewicht vom Normalgewicht?",
+        "a": "Normalgewicht ist der gesamte BMI-Bereich 18,5–24,9. Das Idealgewicht ist ein Punktwert innerhalb dieses Bereichs, oft nahe BMI 22, dem statistischen Risikominimum."
+      },
+      {
+        "q": "Wie aussagekräftig ist das Idealgewicht?",
+        "a": "Es ist eine grobe Orientierung, da es Muskelmasse, Geschlecht (in einigen Formeln) oder Alter nicht berücksichtigt. Körperfettanteil und Taillenumfang sind aussagekräftiger."
+      },
+      {
+        "q": "Sollte ich genau das Idealgewicht anstreben?",
+        "a": "Nein. Studien zeigen, dass leichtes Übergewicht bei älteren Menschen mit niedrigerer Mortalität einhergeht ('Obesity Paradox'). Wohlbefinden und Gesundheitsmarker sind wichtiger als ein Punktwert."
+      },
+      {
+        "q": "Welcher BMI gilt als ideal?",
+        "a": "Studien (Lancet 2016) zeigen das niedrigste Mortalitätsrisiko bei BMI 20–25 für Erwachsene unter 65. Bei Senioren liegt das Optimum eher bei BMI 24–29."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/intermittentFasting.json
+++ b/src/locales/calculators/de/intermittentFasting.json
@@ -31,6 +31,32 @@
     "tip204": "Nur 4 Stunden Essen, z. B. 15:00–19:00 Uhr. Erfordert Erfahrung und sättigende Mahlzeiten.",
     "tipOmad": "Eine Mahlzeit am Tag. Maximale Fastenzeit, erfordert eine nährstoffreiche, kalorienreiche Mahlzeit.",
     "howItWorks": "So funktioniert's",
-    "howItWorksText": "Beim Intervallfasten wechselst du zwischen Essens- und Fastenphasen. Dieser Rechner berechnet dein persönliches Zeitfenster basierend auf dem gewählten Protokoll und deiner letzten oder ersten Mahlzeit. Während der Fastenphase sind nur Wasser, Tee und schwarzer Kaffee erlaubt."
+    "howItWorksText": "Beim Intervallfasten wechselst du zwischen Essens- und Fastenphasen. Dieser Rechner berechnet dein persönliches Zeitfenster basierend auf dem gewählten Protokoll und deiner letzten oder ersten Mahlzeit. Während der Fastenphase sind nur Wasser, Tee und schwarzer Kaffee erlaubt.",
+    "faq": [
+      {
+        "q": "Was ist Intervallfasten?",
+        "a": "Eine Ernährungsform, bei der Essens- und Fastenphasen abwechseln. Beliebt: 16:8, 14:10, 18:6 oder OMAD. Quelle: Cell Metabolism Reviews."
+      },
+      {
+        "q": "Welches Protokoll ist am beliebtesten?",
+        "a": "16:8 — 16 Stunden fasten, 8 Stunden Essensfenster. Es ist alltagstauglich und gut erforscht."
+      },
+      {
+        "q": "Was darf ich während des Fastens trinken?",
+        "a": "Wasser, ungesüßter Tee, schwarzer Kaffee — alles ohne Kalorien. Brühen mit < 50 kcal werden meist toleriert, brechen das Fasten aber streng genommen."
+      },
+      {
+        "q": "Hilft Intervallfasten beim Abnehmen?",
+        "a": "Ja, primär weil das verkürzte Essensfenster die Kalorienaufnahme oft reduziert. Studien zeigen ähnliche Resultate wie konventionelle Diäten bei gleichem Defizit (JAMA 2020)."
+      },
+      {
+        "q": "Welche gesundheitlichen Effekte hat Intervallfasten?",
+        "a": "Studien zeigen verbesserte Insulinsensitivität, niedrigere Entzündungsmarker und mögliche Autophagie-Aktivierung. Langzeitnutzen ist wissenschaftlich noch offen."
+      },
+      {
+        "q": "Für wen ist Intervallfasten nicht geeignet?",
+        "a": "Schwangere, Stillende, Kinder, Untergewichtige, Menschen mit Essstörungen oder Diabetes Typ 1 sollten kein Intervallfasten ohne ärztliche Begleitung machen."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/keto.json
+++ b/src/locales/calculators/de/keto.json
@@ -29,6 +29,32 @@
     "fat": "Fett (g)",
     "protein": "Protein (g)",
     "netCarbs": "Netto-KH (g)",
-    "fiberRecommendation": "Ballaststoff-Empfehlung"
+    "fiberRecommendation": "Ballaststoff-Empfehlung",
+    "faq": [
+      {
+        "q": "Was ist die ketogene Ernährung?",
+        "a": "Eine sehr kohlenhydratarme (≤ 50 g/Tag), fettreiche Ernährung. Der Körper schaltet auf Ketonkörper als primäre Energiequelle um. Quelle: AHA Statement 2021."
+      },
+      {
+        "q": "Wie viele Kohlenhydrate erlaubt Keto?",
+        "a": "Standard-Keto: 20–50 g Netto-Kohlenhydrate pro Tag. Strenge Keto: < 20 g. Netto-KH = Gesamt-KH minus Ballaststoffe."
+      },
+      {
+        "q": "Wie ist die Makroverteilung?",
+        "a": "Klassisch: 70–75 % Fett, 20–25 % Protein, 5–10 % Kohlenhydrate. Zu hoher Proteinanteil kann die Ketose stören (Glukoneogenese)."
+      },
+      {
+        "q": "Wie lange dauert es bis zur Ketose?",
+        "a": "2–7 Tage bei strikter KH-Reduktion. Ketonkörper im Blut > 0,5 mmol/l = leichte Ketose. Symptome wie 'Keto-Grippe' (Müdigkeit, Kopfweh) treten in der Anfangsphase oft auf."
+      },
+      {
+        "q": "Welche Risiken hat Keto?",
+        "a": "Erhöhtes LDL-Cholesterin, Nierensteine, Nährstoffmangel (B-Vitamine, Magnesium), Verstopfung. Bei Schwangerschaft, Diabetes Typ 1, Lebererkrankungen kontraindiziert."
+      },
+      {
+        "q": "Ist Keto zum Abnehmen besser als andere Diäten?",
+        "a": "Studien zeigen: kurzfristig oft schnelle Gewichtsabnahme, langfristig (>12 Monate) keine signifikanten Vorteile gegenüber kalorienreduzierten Mischkost-Diäten (NEJM 2018)."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/macro.json
+++ b/src/locales/calculators/de/macro.json
@@ -26,6 +26,32 @@
     "targetCalories": "Zielkalorien",
     "protein": "Protein (g)",
     "carbs": "Kohlenhydrate (g)",
-    "fat": "Fett (g)"
+    "fat": "Fett (g)",
+    "faq": [
+      {
+        "q": "Was sind Makronährstoffe?",
+        "a": "Die drei Hauptenergieträger: Kohlenhydrate (4 kcal/g), Proteine (4 kcal/g), Fette (9 kcal/g). Sie liefern Energie und Bausteine für Stoffwechsel und Gewebe. Quelle: DGE."
+      },
+      {
+        "q": "Welche Makroverteilung empfiehlt die DGE?",
+        "a": "Kohlenhydrate > 50 % der Energie, Fett ~30 %, Protein ~15 %. Diese Werte gelten für gesunde Erwachsene mit normaler Aktivität."
+      },
+      {
+        "q": "Wie viel Protein für Muskelaufbau?",
+        "a": "1,6–2,2 g Protein pro kg Körpergewicht/Tag laut ISSN-Empfehlung. Mehr bringt keinen zusätzlichen Effekt für Muskelaufbau."
+      },
+      {
+        "q": "Welche Makros zum Abnehmen?",
+        "a": "Höherer Proteinanteil (1,8–2,4 g/kg) erhält Muskelmasse im Defizit. KH und Fett werden je nach Vorliebe reduziert. Wichtig: Gesamtkaloriendefizit."
+      },
+      {
+        "q": "Sind Low-Carb oder Low-Fat besser?",
+        "a": "Studien (DIETFITS 2018) zeigen: kein signifikanter Unterschied im Gewichtsverlust zwischen Low-Carb und Low-Fat bei gleichem Defizit. Persönliche Vorlieben entscheiden."
+      },
+      {
+        "q": "Wie genau muss ich Makros tracken?",
+        "a": "Wettkampfsportler tracken auf 5 g genau. Für allgemeine Gesundheit reicht eine Annäherung. Tracken über 4–6 Wochen schult das Mengenverständnis."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/ovulation.json
+++ b/src/locales/calculators/de/ovulation.json
@@ -35,6 +35,32 @@
     "periodLabel": "Periode",
     "ovulationLabel": "Eisprung",
     "howItWorks": "So funktioniert's",
-    "howItWorksText": "Dieser Rechner nutzt die Kalendermethode: Der Eisprung findet etwa 14 Tage vor der nächsten Periode statt. Bei einem 28-Tage-Zyklus ist das Tag 14, bei einem 32-Tage-Zyklus Tag 18. Das fruchtbare Fenster umfasst 5 Tage vor dem Eisprung, den Eisprungtag und 1 Tag danach."
+    "howItWorksText": "Dieser Rechner nutzt die Kalendermethode: Der Eisprung findet etwa 14 Tage vor der nächsten Periode statt. Bei einem 28-Tage-Zyklus ist das Tag 14, bei einem 32-Tage-Zyklus Tag 18. Das fruchtbare Fenster umfasst 5 Tage vor dem Eisprung, den Eisprungtag und 1 Tag danach.",
+    "faq": [
+      {
+        "q": "Wann findet der Eisprung statt?",
+        "a": "Etwa 14 Tage vor der nächsten Periode. Bei einem 28-Tage-Zyklus an Tag 14, bei einem 32-Tage-Zyklus an Tag 18. Quelle: Bundeszentrale für gesundheitliche Aufklärung (BZgA)."
+      },
+      {
+        "q": "Was ist das fruchtbare Fenster?",
+        "a": "Die 5 Tage vor dem Eisprung plus der Eisprungtag selbst. Spermien überleben bis zu 5 Tage in der Gebärmutter, die Eizelle 12–24 Stunden."
+      },
+      {
+        "q": "Wie genau ist die Kalendermethode?",
+        "a": "Bei regelmäßigen Zyklen relativ zuverlässig (±2 Tage). Bei unregelmäßigen Zyklen sind Ovulationstests (LH-Strips) oder Basaltemperaturmessungen genauer."
+      },
+      {
+        "q": "Welche Anzeichen deuten auf den Eisprung hin?",
+        "a": "Klarer, dehnbarer Zervixschleim (eiweißartig), leichter Anstieg der Basaltemperatur (0,2–0,5 °C), Mittelschmerz und gesteigertes Lustempfinden."
+      },
+      {
+        "q": "Funktioniert der Rechner zur Verhütung?",
+        "a": "Nein. Die Kalendermethode hat einen Pearl-Index von 9–40 und ist als alleinige Verhütung ungeeignet. Symptothermale Methoden (NFP) sind sicherer."
+      },
+      {
+        "q": "Wann ist die Empfängniswahrscheinlichkeit am höchsten?",
+        "a": "Am höchsten 1–2 Tage vor dem Eisprung (~33 % pro Zyklus laut Studie Wilcox 1995). Geschlechtsverkehr alle 1–2 Tage im fruchtbaren Fenster maximiert die Chance."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/period.json
+++ b/src/locales/calculators/de/period.json
@@ -40,6 +40,32 @@
     "fertileLabel": "Fruchtbar",
     "to": "bis",
     "howItWorks": "So funktioniert's",
-    "howItWorksText": "Dieser Rechner nutzt die Kalendermethode: Die nächste Periode beginnt nach deiner Zykluslänge. Der Eisprung findet etwa 14 Tage vor der nächsten Periode statt. Das fruchtbare Fenster umfasst die 5 Tage vor dem Eisprung und den Eisprungtag selbst."
+    "howItWorksText": "Dieser Rechner nutzt die Kalendermethode: Die nächste Periode beginnt nach deiner Zykluslänge. Der Eisprung findet etwa 14 Tage vor der nächsten Periode statt. Das fruchtbare Fenster umfasst die 5 Tage vor dem Eisprung und den Eisprungtag selbst.",
+    "faq": [
+      {
+        "q": "Wie lange ist ein normaler Zyklus?",
+        "a": "21–35 Tage gelten als normal, der Mittelwert liegt bei 28 Tagen. Schwankungen von ±7 Tagen zwischen den Zyklen sind unbedenklich. Quelle: ACOG."
+      },
+      {
+        "q": "Wie wird die Zykluslänge gezählt?",
+        "a": "Vom ersten Tag der Periode bis zum Tag vor der nächsten Periode. Der erste Blutungstag ist Tag 1."
+      },
+      {
+        "q": "Wann ist ein Zyklus unregelmäßig?",
+        "a": "Wenn die Länge zwischen den Zyklen um mehr als 7–9 Tage schwankt oder weniger als 21 oder mehr als 35 Tage beträgt. Häufige Ursachen: PCOS, Stress, Hormonstörungen."
+      },
+      {
+        "q": "Wie genau ist der Periodenrechner?",
+        "a": "Bei regelmäßigen Zyklen sehr genau (±2 Tage). Bei stark schwankenden Zyklen weniger zuverlässig — eine App mit Symptom-Tracking liefert genauere Vorhersagen."
+      },
+      {
+        "q": "Welche vier Zyklusphasen gibt es?",
+        "a": "1. Menstruation (Tag 1–5), 2. Follikelphase (Tag 1–13), 3. Ovulation (Tag 14), 4. Lutealphase (Tag 15–28). Hormonprofile und Symptome unterscheiden sich pro Phase."
+      },
+      {
+        "q": "Wann sollte ich zum Arzt?",
+        "a": "Bei Ausbleiben der Periode > 90 Tage, sehr starken Blutungen (> 80 ml), Blutungen zwischen den Perioden oder starken Schmerzen ist ärztliche Abklärung empfehlenswert."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/pregnancy.json
+++ b/src/locales/calculators/de/pregnancy.json
@@ -34,6 +34,32 @@
     "milestone37": "Frühes Termin",
     "milestone40": "Geburtstermin",
     "howItWorks": "So funktioniert's",
-    "howItWorksText": "Dieser Rechner verwendet die Naegele-Regel: 280 Tage zum ersten Tag deiner letzten Monatsblutung addieren. Wenn dein Zyklus länger oder kürzer als 28 Tage ist, wird der Termin entsprechend angepasst. Das Schwangerschaftsalter zählt ab der letzten Monatsblutung, nicht ab der Empfängnis."
+    "howItWorksText": "Dieser Rechner verwendet die Naegele-Regel: 280 Tage zum ersten Tag deiner letzten Monatsblutung addieren. Wenn dein Zyklus länger oder kürzer als 28 Tage ist, wird der Termin entsprechend angepasst. Das Schwangerschaftsalter zählt ab der letzten Monatsblutung, nicht ab der Empfängnis.",
+    "faq": [
+      {
+        "q": "Wie wird der Geburtstermin berechnet?",
+        "a": "Mit der Naegele-Regel werden 280 Tage zum ersten Tag der letzten Periode addiert. Bei abweichender Zykluslänge wird angepasst. Quelle: Deutsche Gesellschaft für Gynäkologie."
+      },
+      {
+        "q": "Ab wann zählt die Schwangerschaftswoche (SSW)?",
+        "a": "Die SSW wird ab dem ersten Tag der letzten Periode gezählt — nicht ab der Empfängnis. Eine durchschnittliche Schwangerschaft dauert 40 SSW (280 Tage)."
+      },
+      {
+        "q": "Wie genau ist die Berechnung?",
+        "a": "Nur etwa 4 % der Babys werden am errechneten Termin geboren. 90 % kommen innerhalb eines Zeitfensters von ±2 Wochen zur Welt. Eine Ultraschall-Datierung im 1. Trimester ist präziser."
+      },
+      {
+        "q": "Was ist der Unterschied zwischen Schwangerschaftswoche und -monat?",
+        "a": "Schwangerschaftsmonate sind keine Kalendermonate, sondern 4 SSW à 7 Tagen — also insgesamt 10 'Monate' à 28 Tagen für 280 Tage."
+      },
+      {
+        "q": "Welche Untersuchungen stehen wann an?",
+        "a": "Erstvorstellung 6.–8. SSW, Ersttrimester-Screening 11.–14. SSW, Feindiagnostik 19.–22. SSW, Glukosetoleranztest 24.–28. SSW. Quelle: Mutterschaftsrichtlinien G-BA."
+      },
+      {
+        "q": "Was passiert nach dem errechneten Termin?",
+        "a": "Bei Übertragung erfolgt ab SSW 40+0 engmaschige CTG-Überwachung. Eine Geburtseinleitung wird meist zwischen SSW 41+0 und 42+0 empfohlen."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/runningPace.json
+++ b/src/locales/calculators/de/runningPace.json
@@ -39,6 +39,32 @@
     "secondHalf": "Zweite Hälfte",
     "splits": "Splits",
     "splitTime": "Split-Zeit",
-    "cumTime": "Gesamtzeit"
+    "cumTime": "Gesamtzeit",
+    "faq": [
+      {
+        "q": "Was ist Lauftempo (Pace)?",
+        "a": "Das Lauftempo gibt an, wie viele Minuten pro Kilometer (oder Meile) man läuft. Es ist die gängigste Maßeinheit für Lauftraining. Quelle: Deutscher Leichtathletik-Verband."
+      },
+      {
+        "q": "Wie berechne ich meine Pace?",
+        "a": "Pace (min/km) = Zeit (min) / Distanz (km). Beispiel: 30 min für 5 km = 6:00 min/km. Dieser Rechner berechnet Pace, Distanz oder Zeit aus zwei der drei Werte."
+      },
+      {
+        "q": "Was ist eine gute Pace für Anfänger?",
+        "a": "Für Anfänger sind 6:30–8:00 min/km typisch. Wichtiger ist, dass du dich noch unterhalten kannst (Sprechtempo). Geschwindigkeit kommt mit der Zeit."
+      },
+      {
+        "q": "Wie kann ich meine Pace verbessern?",
+        "a": "Eine Mischung aus 80 % langsamen Dauerläufen, Intervalltraining und Tempoläufen verbessert die Pace nachhaltig. Quelle: Polarisiertes Training nach Stephen Seiler."
+      },
+      {
+        "q": "Was ist der Unterschied zwischen Pace und Geschwindigkeit?",
+        "a": "Pace ist Zeit pro Strecke (min/km), Geschwindigkeit ist Strecke pro Zeit (km/h). Umrechnung: Geschwindigkeit (km/h) = 60 / Pace (min/km)."
+      },
+      {
+        "q": "Welche Pace für Marathon, Halbmarathon, 10 km?",
+        "a": "Hobbyläufer-Mittelwerte: Marathon ~5:30–6:30 min/km, Halbmarathon ~5:15–6:15 min/km, 10 km ~5:00–6:00 min/km. Profis liegen deutlich darunter."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/tdee.json
+++ b/src/locales/calculators/de/tdee.json
@@ -22,6 +22,32 @@
     "bmr": "BMR: {value} kcal",
     "weightLoss": "Abnehmen",
     "maintenance": "Halten",
-    "weightGain": "Zunehmen"
+    "weightGain": "Zunehmen",
+    "faq": [
+      {
+        "q": "Was ist der TDEE?",
+        "a": "Der Total Daily Energy Expenditure (TDEE) ist dein gesamter Tagesenergiebedarf — Grundumsatz plus Bewegung, Nahrungsverdauung (TEF) und Alltagsaktivität. Quelle: DGE."
+      },
+      {
+        "q": "Wie wird der TDEE berechnet?",
+        "a": "Der TDEE entsteht durch Multiplikation des Grundumsatzes (BMR) mit einem Aktivitätsfaktor zwischen 1,2 (sitzend) und 1,9 (sehr aktiv). Diese Schätzung weicht typischerweise um ±10–15 % vom realen Verbrauch ab."
+      },
+      {
+        "q": "Welcher Aktivitätsfaktor passt zu mir?",
+        "a": "1,2 sitzend; 1,375 leicht aktiv (1–3 Trainings/Woche); 1,55 moderat (3–5×); 1,725 sehr aktiv (6–7×); 1,9 extrem aktiv (zweimal täglich oder körperliche Arbeit)."
+      },
+      {
+        "q": "Wie viele Kalorien soll ich für eine Diät einsparen?",
+        "a": "Ein moderates Defizit von 300–500 kcal/Tag entspricht etwa 0,3–0,5 kg Fettverlust pro Woche. Größere Defizite riskieren Muskelabbau und Stoffwechselanpassung."
+      },
+      {
+        "q": "Wie genau ist die Schätzung?",
+        "a": "TDEE-Rechner liefern Ausgangswerte, keine Messungen. Passe nach 2–3 Wochen anhand der tatsächlichen Gewichtsentwicklung an."
+      },
+      {
+        "q": "Ändert sich mein TDEE im Diätverlauf?",
+        "a": "Ja. Mit sinkendem Körpergewicht sinkt auch der Energieverbrauch. Eine Neuberechnung alle 3–4 kg Gewichtsänderung wird empfohlen."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/vo2Max.json
+++ b/src/locales/calculators/de/vo2Max.json
@@ -37,6 +37,32 @@
     "cooperInfo": "Laufe 12 Minuten so weit wie möglich und gib die Distanz in Metern ein.",
     "rockportInfo": "Gehe 1 Meile (1.609 m) so schnell wie möglich und miss deine Herzfrequenz am Ende.",
     "directInfo": "Gib deinen bekannten VO2 Max Wert direkt ein.",
-    "weightUnit": "Einheit"
+    "weightUnit": "Einheit",
+    "faq": [
+      {
+        "q": "Was ist VO2max?",
+        "a": "VO2max ist die maximale Sauerstoffaufnahme pro Minute, gemessen in ml/kg/min. Sie gilt als wichtigster Marker der kardiorespiratorischen Fitness. Quelle: American Heart Association."
+      },
+      {
+        "q": "Welche VO2max-Werte sind normal?",
+        "a": "Männer 30–39 J.: 31–40 ml/kg/min Durchschnitt. Frauen 30–39 J.: 27–35 ml/kg/min. Spitzenausdauersportler erreichen 70–90 ml/kg/min. Quelle: ACSM."
+      },
+      {
+        "q": "Wie wird VO2max hier geschätzt?",
+        "a": "Mit dem 1-Meilen-Gehtest (Rockport-Methode), der aus Gewicht, Zeit, Endpuls und Geschlecht VO2max schätzt. Genauigkeit: ±10–15 % gegenüber Spiroergometrie."
+      },
+      {
+        "q": "Wie kann ich meine VO2max steigern?",
+        "a": "Hochintensives Intervalltraining (HIIT) und langes Grundlagentraining sind am effektivsten. Erwartbar: +10–25 % in 8–12 Wochen bei untrainierten Personen."
+      },
+      {
+        "q": "Sinkt VO2max mit dem Alter?",
+        "a": "Ja, etwa 1 % pro Jahr ab dem 30. Lebensjahr. Regelmäßiges Ausdauertraining kann diesen Rückgang halbieren oder umkehren."
+      },
+      {
+        "q": "Welcher Zusammenhang besteht zwischen VO2max und Lebenserwartung?",
+        "a": "Eine niedrige VO2max ist ein stärkerer Risikofaktor für Frühsterblichkeit als Rauchen oder Diabetes (JAMA 2018). Eine VO2max-Steigerung ist mit niedrigerer Mortalität assoziiert."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/waistHipRatio.json
+++ b/src/locales/calculators/de/waistHipRatio.json
@@ -22,6 +22,32 @@
     "recLow": "Dein THV zeigt ein {start}niedriges Gesundheitsrisiko{end}. Behalte deinen gesunden Lebensstil mit regelmäßiger Bewegung und ausgewogener Ernährung bei.",
     "recModerate": "Dein THV zeigt ein {start}mittleres Gesundheitsrisiko{end}. Erwäge, deine körperliche Aktivität zu erhöhen und deinen Taillenumfang zu überwachen.",
     "recHigh": "Dein THV zeigt ein {start}hohes Gesundheitsrisiko{end} gemäß WHO-Richtlinien. Bauchfettleibigkeit ist mit erhöhtem kardiovaskulärem und metabolischem Risiko verbunden. Konsultiere einen Arzt.",
-    "thresholdsTitle": "WHO-Risikoschwellen ({gender})"
+    "thresholdsTitle": "WHO-Risikoschwellen ({gender})",
+    "faq": [
+      {
+        "q": "Was ist das Taille-Hüft-Verhältnis (THV)?",
+        "a": "Das THV ist der Quotient aus Taillen- und Hüftumfang. Es zeigt die Fettverteilung und ist ein Indikator für kardiovaskuläre und metabolische Risiken. Quelle: WHO."
+      },
+      {
+        "q": "Welche WHO-Grenzwerte gelten?",
+        "a": "Bei Männern erhöhtes Risiko ab THV ≥ 0,90; bei Frauen ab ≥ 0,85. Werte darüber gehen mit höherem Risiko für Diabetes Typ 2 und Herzerkrankungen einher."
+      },
+      {
+        "q": "Wie messe ich Taille und Hüfte korrekt?",
+        "a": "Taille: schmalste Stelle zwischen Rippenbogen und Beckenkamm, im Stehen, am Ende einer normalen Ausatmung. Hüfte: an der breitesten Stelle des Gesäßes."
+      },
+      {
+        "q": "Ist THV besser als BMI?",
+        "a": "Studien (Lancet 2011) zeigen, dass das THV das kardiovaskuläre Risiko zuverlässiger vorhersagt als der BMI, insbesondere bei normalgewichtigen Personen mit Bauchfett."
+      },
+      {
+        "q": "Was tun bei erhöhtem THV?",
+        "a": "Reduktion des viszeralen Bauchfetts durch Kaloriendefizit, Ausdauertraining und ballaststoffreiche Ernährung. Krafttraining unterstützt zusätzlich die Insulinsensitivität."
+      },
+      {
+        "q": "Eignet sich das THV auch für Schwangere?",
+        "a": "Nein. Während Schwangerschaft und Stillzeit ist das THV nicht aussagekräftig — der Bauchumfang ist physiologisch verändert."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/water.json
+++ b/src/locales/calculators/de/water.json
@@ -26,6 +26,32 @@
     "litersPerDay": "Liter / Tag",
     "glasses": "Gläser",
     "oz": "oz",
-    "tip": "Verteile die Flüssigkeitsaufnahme über den ganzen Tag für optimale Hydration."
+    "tip": "Verteile die Flüssigkeitsaufnahme über den ganzen Tag für optimale Hydration.",
+    "faq": [
+      {
+        "q": "Wie viel Wasser sollte ich täglich trinken?",
+        "a": "Die DGE empfiehlt etwa 1,5 Liter Trinkwasser pro Tag für Erwachsene, plus rund 0,7 Liter aus fester Nahrung. Bei körperlicher Aktivität, Hitze oder Stillzeit steigt der Bedarf."
+      },
+      {
+        "q": "Wie wird der individuelle Wasserbedarf berechnet?",
+        "a": "Eine gängige Faustformel ist 30–35 ml pro kg Körpergewicht. Sport- oder Hitzephasen erhöhen den Bedarf um 0,5–1 Liter pro Stunde Aktivität."
+      },
+      {
+        "q": "Zählen Kaffee und Tee zur Flüssigkeitszufuhr?",
+        "a": "Ja. Aktuelle Studien (EFSA) zeigen, dass moderater Koffeinkonsum nicht entwässert. Wasser, ungesüßte Tees und verdünnte Säfte tragen alle zur Bilanz bei."
+      },
+      {
+        "q": "Was sind Anzeichen von Dehydration?",
+        "a": "Dunkler Urin, Durstgefühl, Kopfschmerzen, Müdigkeit und Konzentrationsschwäche. Heller Urin (strohgelb) ist ein gutes Hydrationsmerkmal."
+      },
+      {
+        "q": "Kann man zu viel Wasser trinken?",
+        "a": "Ja, in seltenen Fällen führt extrem hohe Wasseraufnahme (mehrere Liter in kurzer Zeit) zu Hyponatriämie. Über den Tag verteiltes Trinken ist sicher."
+      },
+      {
+        "q": "Brauchen Sportler mehr Wasser?",
+        "a": "Ja. Pro Stunde intensiver Belastung verliert man 0,5–1 L Schweiß. Bei längerer Aktivität sind Elektrolyte (Natrium, Kalium) zusätzlich sinnvoll."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/bac.json
+++ b/src/locales/calculators/en/bac.json
@@ -47,6 +47,32 @@
     "effectSignificant": "Severe balance issues, slurred speech",
     "effectDangerous": "Impaired consciousness, life-threatening",
     "howItWorks": "How it works",
-    "howItWorksText": "This calculator uses the Widmark formula: Alcohol (g) = Volume × (ABV / 100) × 0.8. BAC = Alcohol (g) / (Body weight × r), where r = 0.68 (men) or 0.55 (women). Elimination rate is approximately 0.15‰ per hour. This is an estimate — individual factors may vary."
+    "howItWorksText": "This calculator uses the Widmark formula: Alcohol (g) = Volume × (ABV / 100) × 0.8. BAC = Alcohol (g) / (Body weight × r), where r = 0.68 (men) or 0.55 (women). Elimination rate is approximately 0.15‰ per hour. This is an estimate — individual factors may vary.",
+    "faq": [
+      {
+        "q": "How is BAC calculated?",
+        "a": "Using the Widmark formula: alcohol (g) / (body weight × r). r = 0.68 for men, 0.55 for women. This estimate is medically established but varies individually."
+      },
+      {
+        "q": "How fast does the body metabolize alcohol?",
+        "a": "About 0.015–0.02 % per hour, on average 0.015 % BAC. Metabolism cannot be sped up by coffee, water, or exercise."
+      },
+      {
+        "q": "What are the legal BAC limits?",
+        "a": "Most U.S. states: 0.08 % BAC. Many European countries: 0.05 %. Germany: 0.05 %. New drivers and under 21: typically 0.00 %. Always check local law."
+      },
+      {
+        "q": "Why is the estimate imprecise?",
+        "a": "Individual factors like stomach contents, liver function, sex, medications, and body composition can shift the real value by ±20–30 %."
+      },
+      {
+        "q": "Are women more sensitive to alcohol?",
+        "a": "Yes. Women on average have lower body water and reduced alcohol dehydrogenase activity. For the same intake, BAC is higher."
+      },
+      {
+        "q": "When is it safe to drive again?",
+        "a": "Only at 0.00 % BAC. After reaching 0.10 %, full clearance takes about 6–7 hours. Residual alcohol the next morning is common — even after 8 hours of sleep."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/bloodSugar.json
+++ b/src/locales/calculators/en/bloodSugar.json
@@ -50,6 +50,32 @@
     "normalDesc": "No elevated risk.",
     "prediabetesDesc": "Elevated risk. Lifestyle changes recommended.",
     "diabetesDesc": "Diabetes range. Consult a doctor.",
-    "contextNote": "Values can vary depending on measurement time, time of day, and diet. Not a substitute for medical advice."
+    "contextNote": "Values can vary depending on measurement time, time of day, and diet. Not a substitute for medical advice.",
+    "faq": [
+      {
+        "q": "Which blood-sugar units exist?",
+        "a": "mg/dL (US, Germany) and mmol/L (UK, Canada, international studies). Conversion: 1 mmol/L = 18.016 mg/dL."
+      },
+      {
+        "q": "What are normal fasting values?",
+        "a": "Normal: < 100 mg/dL (5.6 mmol/L). Prediabetes: 100–125 mg/dL (5.6–6.9 mmol/L). Diabetes: ≥ 126 mg/dL (7.0 mmol/L). Source: ADA."
+      },
+      {
+        "q": "What are normal post-meal values?",
+        "a": "2 hours after eating: < 140 mg/dL (7.8 mmol/L) normal. 140–199 mg/dL (7.8–11.0 mmol/L) prediabetic. ≥ 200 mg/dL (11.1 mmol/L) diabetic."
+      },
+      {
+        "q": "What is hypoglycemia?",
+        "a": "Blood sugar < 70 mg/dL (3.9 mmol/L). Symptoms: shakiness, sweating, hunger, confusion. Values < 54 mg/dL (3.0 mmol/L) signify clinically significant hypoglycemia."
+      },
+      {
+        "q": "How often should I check?",
+        "a": "Type-1 diabetes: multiple times daily. Type-2 on insulin: 1–4×/day, on oral therapy as advised. Healthy people generally do not need self-monitoring."
+      },
+      {
+        "q": "Which factors influence blood sugar?",
+        "a": "Diet (carbs), exercise, stress, sleep, illness, medication, hormones. Time of day (dawn phenomenon) and alcohol also matter."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/bmi.json
+++ b/src/locales/calculators/en/bmi.json
@@ -18,6 +18,14 @@
     "underweight": "Underweight",
     "normal": "Normal weight",
     "overweight": "Overweight",
-    "obese": "Obese"
+    "obese": "Obese",
+    "faq": [
+      { "q": "How is BMI calculated?", "a": "Body Mass Index is calculated using the formula BMI = weight (kg) / height (m)². This formula, developed by Adolphe Quetelet in the 19th century, is the internationally recognized standard (WHO)." },
+      { "q": "What does a BMI in the normal range mean?", "a": "According to the WHO, the normal range is 18.5 to 24.9 kg/m². In this range, the statistical risk for weight-related diseases is the lowest." },
+      { "q": "At what BMI is someone considered overweight?", "a": "By WHO criteria, overweight starts at a BMI of 25.0. From 30.0 onward, the classification becomes obesity, divided into three severity classes." },
+      { "q": "Is BMI accurate for athletes?", "a": "Only to a limited degree. BMI does not distinguish between muscle and fat mass. Athletes with high muscle mass may show a BMI in the overweight range without being overfat." },
+      { "q": "Does BMI apply to children and seniors?", "a": "Children are assessed using age- and sex-specific percentiles rather than fixed BMI cutoffs. For seniors over 65, the healthy range shifts slightly upward (24–29 kg/m²) per recent guidelines." },
+      { "q": "What does BMI not tell you?", "a": "BMI ignores body fat distribution, muscle ratio, sex, and ethnicity. Complementary measures like waist circumference or body-fat percentage give a fuller picture." }
+    ]
   }
 }

--- a/src/locales/calculators/en/bmr.json
+++ b/src/locales/calculators/en/bmr.json
@@ -23,6 +23,14 @@
     "lightlyActive": "Lightly active (1–3 days/week)",
     "moderatelyActive": "Moderately active (3–5 days/week)",
     "veryActive": "Very active (6–7 days/week)",
-    "extremelyActive": "Extremely active (athlete/physical job)"
+    "extremelyActive": "Extremely active (athlete/physical job)",
+    "faq": [
+      { "q": "What is Basal Metabolic Rate (BMR)?", "a": "BMR is the energy your body uses at complete rest for vital functions such as breathing, circulation, and cell metabolism. Source: Academy of Nutrition and Dietetics." },
+      { "q": "Which formula is more accurate: Mifflin-St Jeor or Harris-Benedict?", "a": "The Mifflin-St Jeor equation (1990) is generally considered more accurate for the modern population than the older Harris-Benedict equation (1919). Both estimates typically fall within ±10 % of measured values." },
+      { "q": "What is the difference between BMR and TDEE?", "a": "BMR is your at-rest baseline. TDEE (Total Daily Energy Expenditure) adds physical activity, digestion (TEF), and non-exercise movement by multiplying BMR by an activity factor of 1.2–1.9." },
+      { "q": "Which factors influence BMR?", "a": "Sex, age, height, weight, and especially lean muscle mass. Men typically have a 5–10 % higher BMR than women due to greater muscle mass." },
+      { "q": "Does BMR decrease with age?", "a": "Yes — from around age 30, BMR drops about 1–2 % per decade, mostly due to muscle loss (sarcopenia). Resistance training can substantially slow this decline." },
+      { "q": "Should I eat below my BMR to lose weight?", "a": "Sustained intake below BMR is not recommended by major nutrition bodies because it risks metabolic adaptation, muscle loss, and nutrient deficiencies. Calorie deficits should be set against TDEE, not BMR." }
+    ]
   }
 }

--- a/src/locales/calculators/en/bodyFat.json
+++ b/src/locales/calculators/en/bodyFat.json
@@ -24,6 +24,32 @@
     "obese": "Obese",
     "fatMass": "Fat Mass",
     "leanMass": "Lean Mass",
-    "categoriesTitle": "Body Fat Categories ({gender})"
+    "categoriesTitle": "Body Fat Categories ({gender})",
+    "faq": [
+      {
+        "q": "What is a healthy body fat percentage?",
+        "a": "Men: 10–20 % healthy, women: 18–28 % healthy (American Council on Exercise). Athletes often run lower; very low values can cause hormonal disturbances."
+      },
+      {
+        "q": "How does this calculator estimate body fat?",
+        "a": "It uses the U.S. Navy circumference method (neck, waist, hip, and height). This method is accurate to within ±3–4 % of DEXA."
+      },
+      {
+        "q": "Which body-fat method is most accurate?",
+        "a": "DEXA (dual-energy X-ray) is the reference standard. Bioimpedance scales are less accurate (±5–8 %); skinfold calipers fall between, depending on the operator."
+      },
+      {
+        "q": "Why is body fat more telling than BMI?",
+        "a": "BMI does not separate muscle from fat. Two people with the same BMI can have very different metabolic risks; body-fat percentage reveals that."
+      },
+      {
+        "q": "How fast can body fat be reduced?",
+        "a": "Realistic: 0.5–1 % body-fat reduction per month with a moderate deficit. Very fast reductions raise the risk of muscle loss."
+      },
+      {
+        "q": "What is essential body fat?",
+        "a": "Essential fat (men ~3 %, women ~12 %) is required for hormone production, organ protection, and cell function. Lower values pose health risks."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/calorieDeficit.json
+++ b/src/locales/calculators/en/calorieDeficit.json
@@ -29,6 +29,32 @@
     "weeklyLoss": "Loss / Week",
     "perWeek": "per week",
     "warningUnsafe": "Your calorie goal is below 1,200 kcal/day. This is a health concern — please consult a doctor.",
-    "warningAggressive": "You are planning to lose more than 1 kg per week. A slower pace is more sustainable and healthier."
+    "warningAggressive": "You are planning to lose more than 1 kg per week. A slower pace is more sustainable and healthier.",
+    "faq": [
+      {
+        "q": "What is a healthy calorie deficit?",
+        "a": "300–500 kcal/day below TDEE produces roughly 0.3–0.5 kg of fat loss per week. This pace is considered sustainable by major nutrition bodies."
+      },
+      {
+        "q": "What is the minimum I should eat?",
+        "a": "Women should not chronically eat below 1,200 kcal/day, men below 1,500 kcal/day. Lower intakes risk nutrient deficiencies and metabolic adaptation."
+      },
+      {
+        "q": "Why is 7,000 kcal deficit ≠ 1 kg of fat?",
+        "a": "The '3,500 kcal = 1 lb fat' rule is a simplification. Water shifts, glycogen depletion, and muscle changes affect the scale. Actual fat loss is usually 0.3–0.5 kg per 3,500 kcal deficit."
+      },
+      {
+        "q": "How do I avoid muscle loss while dieting?",
+        "a": "Eating 1.6–2.2 g of protein per kg of body weight and resistance training 2–4×/week sharply reduces muscle loss (ISSN guidance)."
+      },
+      {
+        "q": "When should I take a diet break?",
+        "a": "After 8–12 weeks in a deficit, a 7–14-day diet break at maintenance calories can help restore hormones (leptin) and metabolic rate."
+      },
+      {
+        "q": "What do I do if I plateau?",
+        "a": "Plateaus are normal. Re-check tracking accuracy, raise activity, lower calories by ~100 kcal, or take a brief diet break."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/gfr.json
+++ b/src/locales/calculators/en/gfr.json
@@ -62,6 +62,32 @@
       "G3b": "See a nephrologist. Close monitoring and medication adjustments are needed.",
       "G4": "Urgent nephrology referral. Discuss preparation for kidney replacement therapy (dialysis/transplant).",
       "G5": "Immediate nephrology care required. Kidney replacement therapy is typically necessary."
-    }
+    },
+    "faq": [
+      {
+        "q": "What is the glomerular filtration rate (GFR)?",
+        "a": "GFR measures how much blood the kidneys filter per minute (mL/min/1.73 m²). It is the most important marker of kidney function. Source: KDIGO."
+      },
+      {
+        "q": "What is a normal GFR?",
+        "a": "Adults: > 90 mL/min/1.73 m² is normal. 60–89 is borderline (G2). Values below 60 sustained for 3+ months indicate chronic kidney disease (CKD)."
+      },
+      {
+        "q": "Which formula does this calculator use?",
+        "a": "It uses the CKD-EPI 2021 equation, the current standard for estimating GFR from serum creatinine. It is more accurate than the older MDRD formula."
+      },
+      {
+        "q": "Why does GFR decline with age?",
+        "a": "From around age 40, GFR drops about 1 mL/min/year. Hypertension, diabetes, and obesity accelerate the decline."
+      },
+      {
+        "q": "What are the CKD stages?",
+        "a": "G1 (>90), G2 (60–89), G3a (45–59), G3b (30–44), G4 (15–29), G5 (<15, kidney failure). Source: KDIGO 2012 guidelines."
+      },
+      {
+        "q": "How can I protect my kidneys?",
+        "a": "Keep blood pressure under 130/80, manage blood sugar, stay hydrated, eat low-sodium, avoid NSAIDs, stop smoking. Refer to nephrology if eGFR < 60."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/hba1c.json
+++ b/src/locales/calculators/en/hba1c.json
@@ -37,6 +37,32 @@
     "categoriesTitle": "Risk Categories (ADA)",
     "normalDesc": "No elevated diabetes risk.",
     "prediabetesDesc": "Elevated risk. Lifestyle changes recommended.",
-    "diabetesDesc": "Diabetes range. Consult a doctor."
+    "diabetesDesc": "Diabetes range. Consult a doctor.",
+    "faq": [
+      {
+        "q": "What is HbA1c?",
+        "a": "HbA1c is the glycated portion of hemoglobin in red blood cells. It reflects the average blood-sugar level over the past 8–12 weeks. Source: American Diabetes Association (ADA)."
+      },
+      {
+        "q": "What are the reference ranges?",
+        "a": "Normal: < 5.7 % (39 mmol/mol). Prediabetes: 5.7–6.4 % (39–47 mmol/mol). Diabetes: ≥ 6.5 % (48 mmol/mol). Source: ADA."
+      },
+      {
+        "q": "How are NGSP % and IFCC mmol/mol converted?",
+        "a": "HbA1c (mmol/mol) = (HbA1c % − 2.15) × 10.929. NGSP (%) is the older US standard; IFCC (mmol/mol) is the international standard."
+      },
+      {
+        "q": "What can falsely alter HbA1c?",
+        "a": "Anemia, hemoglobinopathies (e.g. sickle cell), pregnancy, kidney failure, and recent blood transfusions can distort the value."
+      },
+      {
+        "q": "How often should HbA1c be measured?",
+        "a": "Every 6 months if diabetes is stable; every 3 months if treatment is changing or control is poor. Source: ADA Standards of Care."
+      },
+      {
+        "q": "What HbA1c target is recommended?",
+        "a": "Individualized — typically < 7 % (53 mmol/mol). Young patients without comorbidities may target < 6.5 %; older patients often 7.5–8 % to avoid hypoglycemia."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/idealWeight.json
+++ b/src/locales/calculators/en/idealWeight.json
@@ -16,6 +16,32 @@
     "description": "Find your healthy weight range based on four science-backed formulas.",
     "formulaComparison": "Formula Comparison",
     "healthyBmiRange": "Healthy BMI Range",
-    "bmiRangeText": "Based on a BMI of 18.5 – 24.9, your healthy weight range is"
+    "bmiRangeText": "Based on a BMI of 18.5 – 24.9, your healthy weight range is",
+    "faq": [
+      {
+        "q": "What is ideal body weight?",
+        "a": "The statistically optimal weight for a given height — associated with lowest mortality and disease risk. It is an estimate, not a target everyone must hit. Source: WHO."
+      },
+      {
+        "q": "Which formulas are used?",
+        "a": "Common formulas: Devine (1974), Robinson, Miller, Hamwi. They were originally developed for medication dosing and produce slightly different values."
+      },
+      {
+        "q": "How does ideal differ from normal weight?",
+        "a": "Normal weight is the entire BMI range 18.5–24.9. Ideal weight is a point value within that range, often near BMI 22 — the statistical low-risk point."
+      },
+      {
+        "q": "How meaningful is ideal weight?",
+        "a": "It is rough guidance, since it ignores muscle mass, sex (in some formulas), and age. Body-fat percentage and waist circumference are more informative."
+      },
+      {
+        "q": "Should I aim exactly for the ideal weight?",
+        "a": "No. Studies show slight overweight in older adults is associated with lower mortality ('obesity paradox'). Wellbeing and health markers matter more than a point value."
+      },
+      {
+        "q": "What BMI is considered ideal?",
+        "a": "Studies (Lancet 2016) show lowest mortality at BMI 20–25 for adults under 65. For seniors, the optimum is closer to BMI 24–29."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/intermittentFasting.json
+++ b/src/locales/calculators/en/intermittentFasting.json
@@ -31,6 +31,32 @@
     "tip204": "Only 4 hours of eating, e.g. 3:00 PM–7:00 PM. Requires experience and filling meals.",
     "tipOmad": "One meal per day. Maximum fasting time, requires a nutrient-dense, high-calorie meal.",
     "howItWorks": "How it works",
-    "howItWorksText": "With intermittent fasting, you alternate between eating and fasting windows. This calculator computes your personal time window based on the chosen protocol and your last or first meal time. During the fasting phase, only water, tea, and black coffee are allowed."
+    "howItWorksText": "With intermittent fasting, you alternate between eating and fasting windows. This calculator computes your personal time window based on the chosen protocol and your last or first meal time. During the fasting phase, only water, tea, and black coffee are allowed.",
+    "faq": [
+      {
+        "q": "What is intermittent fasting?",
+        "a": "An eating pattern that alternates fasting and eating windows. Popular protocols: 16:8, 14:10, 18:6, or OMAD. Source: Cell Metabolism reviews."
+      },
+      {
+        "q": "Which protocol is most popular?",
+        "a": "16:8 — 16 hours fasting, 8 hours eating window. It is practical for daily life and the most studied protocol."
+      },
+      {
+        "q": "What can I drink during the fasting window?",
+        "a": "Water, unsweetened tea, black coffee — anything without calories. Broths < 50 kcal are usually tolerated but technically break a strict fast."
+      },
+      {
+        "q": "Does intermittent fasting help with weight loss?",
+        "a": "Yes, mainly because the compressed eating window often lowers total intake. Trials show similar results to conventional diets at matched deficits (JAMA 2020)."
+      },
+      {
+        "q": "What health effects does intermittent fasting have?",
+        "a": "Studies report improved insulin sensitivity, lower inflammation markers, and possible autophagy activation. Long-term outcomes are not yet conclusive."
+      },
+      {
+        "q": "Who should avoid intermittent fasting?",
+        "a": "Pregnant or breastfeeding women, children, underweight individuals, people with eating disorders or type-1 diabetes should not fast without medical supervision."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/keto.json
+++ b/src/locales/calculators/en/keto.json
@@ -29,6 +29,32 @@
     "fat": "Fat (g)",
     "protein": "Protein (g)",
     "netCarbs": "Net Carbs (g)",
-    "fiberRecommendation": "Fiber Recommendation"
+    "fiberRecommendation": "Fiber Recommendation",
+    "faq": [
+      {
+        "q": "What is the ketogenic diet?",
+        "a": "A very low-carb (≤50 g/day), high-fat diet. The body shifts to ketone bodies as its main energy source. Source: AHA scientific statement 2021."
+      },
+      {
+        "q": "How many carbs are allowed on keto?",
+        "a": "Standard keto: 20–50 g net carbs/day. Strict keto: < 20 g. Net carbs = total carbs minus fiber."
+      },
+      {
+        "q": "What is the macro split?",
+        "a": "Classic: 70–75 % fat, 20–25 % protein, 5–10 % carbs. Excess protein can disrupt ketosis via gluconeogenesis."
+      },
+      {
+        "q": "How long does it take to enter ketosis?",
+        "a": "2–7 days with strict carb restriction. Blood ketones > 0.5 mmol/L = nutritional ketosis. 'Keto flu' (fatigue, headache) is common in the first week."
+      },
+      {
+        "q": "What are the risks of keto?",
+        "a": "Elevated LDL cholesterol, kidney stones, nutrient deficiencies (B vitamins, magnesium), constipation. Contraindicated in pregnancy, type-1 diabetes, and liver disease."
+      },
+      {
+        "q": "Is keto better for weight loss than other diets?",
+        "a": "Studies show fast initial loss but no significant long-term (>12 months) advantage over calorie-matched mixed diets (NEJM 2018)."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/macro.json
+++ b/src/locales/calculators/en/macro.json
@@ -26,6 +26,32 @@
     "targetCalories": "Target Calories",
     "protein": "Protein (g)",
     "carbs": "Carbs (g)",
-    "fat": "Fat (g)"
+    "fat": "Fat (g)",
+    "faq": [
+      {
+        "q": "What are macronutrients?",
+        "a": "The three main energy-providing nutrients: carbohydrates (4 kcal/g), protein (4 kcal/g), fat (9 kcal/g). They supply energy and building blocks for metabolism and tissues."
+      },
+      {
+        "q": "What macro split do nutrition bodies recommend?",
+        "a": "Roughly carbs > 50 % of energy, fat ~30 %, protein ~15 %, per most national dietary guidelines. These values apply to healthy adults with normal activity."
+      },
+      {
+        "q": "How much protein for muscle building?",
+        "a": "1.6–2.2 g protein per kg body weight/day per ISSN recommendation. More than that provides no additional muscle-building effect."
+      },
+      {
+        "q": "Which macros for fat loss?",
+        "a": "A higher protein intake (1.8–2.4 g/kg) preserves muscle mass during a deficit. Carbs and fat are reduced per preference. The overall calorie deficit matters most."
+      },
+      {
+        "q": "Is low-carb or low-fat better?",
+        "a": "Studies (DIETFITS 2018) show no significant difference in weight loss between low-carb and low-fat diets at matched calorie deficits. Personal preference decides."
+      },
+      {
+        "q": "How precisely do I need to track macros?",
+        "a": "Competitive athletes track within 5 g. For general health, approximation is enough. Tracking 4–6 weeks builds long-term portion sense."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/ovulation.json
+++ b/src/locales/calculators/en/ovulation.json
@@ -35,6 +35,32 @@
     "periodLabel": "Period",
     "ovulationLabel": "Ovulation",
     "howItWorks": "How it works",
-    "howItWorksText": "This calculator uses the calendar method: ovulation occurs approximately 14 days before your next period. For a 28-day cycle, that is day 14; for a 32-day cycle, day 18. The fertile window spans 5 days before ovulation, ovulation day, and 1 day after."
+    "howItWorksText": "This calculator uses the calendar method: ovulation occurs approximately 14 days before your next period. For a 28-day cycle, that is day 14; for a 32-day cycle, day 18. The fertile window spans 5 days before ovulation, ovulation day, and 1 day after.",
+    "faq": [
+      {
+        "q": "When does ovulation occur?",
+        "a": "About 14 days before the next period. In a 28-day cycle, day 14; in a 32-day cycle, day 18. Source: ACOG."
+      },
+      {
+        "q": "What is the fertile window?",
+        "a": "The 5 days before ovulation plus the day of ovulation itself. Sperm survive up to 5 days in the uterus; the egg lives 12–24 hours after release."
+      },
+      {
+        "q": "How accurate is the calendar method?",
+        "a": "Reasonably reliable for regular cycles (±2 days). For irregular cycles, LH ovulation tests or basal body temperature tracking are more accurate."
+      },
+      {
+        "q": "What are signs of ovulation?",
+        "a": "Clear, stretchy cervical mucus (egg-white texture), slight rise in basal body temperature (0.2–0.5 °C), mid-cycle pelvic pain, and increased libido."
+      },
+      {
+        "q": "Can this calculator be used for contraception?",
+        "a": "No. The calendar method has a Pearl index of 9–40 and is not adequate as a sole contraceptive. Symptothermal (FAM) methods are safer."
+      },
+      {
+        "q": "When is conception most likely?",
+        "a": "Highest 1–2 days before ovulation (~33 % per cycle per Wilcox 1995). Intercourse every 1–2 days during the fertile window maximizes the chance."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/period.json
+++ b/src/locales/calculators/en/period.json
@@ -40,6 +40,32 @@
     "fertileLabel": "Fertile",
     "to": "to",
     "howItWorks": "How it works",
-    "howItWorksText": "This calculator uses the calendar method: your next period starts after your cycle length. Ovulation occurs approximately 14 days before your next period. The fertile window spans the 5 days before ovulation and ovulation day itself."
+    "howItWorksText": "This calculator uses the calendar method: your next period starts after your cycle length. Ovulation occurs approximately 14 days before your next period. The fertile window spans the 5 days before ovulation and ovulation day itself.",
+    "faq": [
+      {
+        "q": "How long is a normal menstrual cycle?",
+        "a": "21–35 days is considered normal, with an average of 28. Variations of ±7 days between cycles are unconcerning. Source: ACOG."
+      },
+      {
+        "q": "How is cycle length counted?",
+        "a": "From the first day of one period to the day before the next period starts. Day 1 is the first day of bleeding."
+      },
+      {
+        "q": "When is a cycle considered irregular?",
+        "a": "If length varies by more than 7–9 days between cycles, or is shorter than 21 or longer than 35 days. Common causes: PCOS, stress, hormone disorders."
+      },
+      {
+        "q": "How accurate is the period calculator?",
+        "a": "For regular cycles, very accurate (±2 days). For variable cycles, less reliable — an app with symptom tracking gives more precise forecasts."
+      },
+      {
+        "q": "What are the four cycle phases?",
+        "a": "1. Menstruation (days 1–5), 2. Follicular (days 1–13), 3. Ovulation (day ~14), 4. Luteal (days 15–28). Hormone profiles and symptoms differ across phases."
+      },
+      {
+        "q": "When should I see a doctor?",
+        "a": "If your period is absent for > 90 days, bleeding is very heavy (> 80 mL), there is bleeding between periods, or severe pain — consult a clinician."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/pregnancy.json
+++ b/src/locales/calculators/en/pregnancy.json
@@ -34,6 +34,32 @@
     "milestone37": "Early term",
     "milestone40": "Due date",
     "howItWorks": "How it works",
-    "howItWorksText": "This calculator uses Naegele's rule: add 280 days to the first day of your last menstrual period (LMP). If your cycle is longer or shorter than 28 days, the due date is adjusted accordingly. Gestational age counts from LMP, not from conception."
+    "howItWorksText": "This calculator uses Naegele's rule: add 280 days to the first day of your last menstrual period (LMP). If your cycle is longer or shorter than 28 days, the due date is adjusted accordingly. Gestational age counts from LMP, not from conception.",
+    "faq": [
+      {
+        "q": "How is the due date calculated?",
+        "a": "Naegele's rule adds 280 days to the first day of the last menstrual period (LMP), adjusted for non-28-day cycles. Source: ACOG (American College of Obstetricians and Gynecologists)."
+      },
+      {
+        "q": "From when is the pregnancy week counted?",
+        "a": "Pregnancy weeks are counted from the first day of the last period — not from conception. An average pregnancy lasts 40 weeks (280 days)."
+      },
+      {
+        "q": "How accurate is the calculation?",
+        "a": "Only about 4 % of babies are born on the predicted date. 90 % arrive within ±2 weeks. A first-trimester ultrasound provides a more precise estimate."
+      },
+      {
+        "q": "What's the difference between pregnancy weeks and months?",
+        "a": "Pregnancy 'months' are not calendar months but 4-week (28-day) blocks. So 280 days = 10 four-week 'months', not 9 calendar months."
+      },
+      {
+        "q": "Which prenatal visits happen when?",
+        "a": "First visit weeks 6–8, first-trimester screen weeks 11–14, anatomy scan weeks 19–22, glucose tolerance test weeks 24–28. Source: ACOG guidelines."
+      },
+      {
+        "q": "What happens after the due date?",
+        "a": "Past 40+0 weeks, monitoring intensifies (e.g. CTG/NST). Labor induction is usually recommended between 41+0 and 42+0 weeks."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/runningPace.json
+++ b/src/locales/calculators/en/runningPace.json
@@ -39,6 +39,32 @@
     "secondHalf": "Second Half",
     "splits": "Splits",
     "splitTime": "Split Time",
-    "cumTime": "Cumulative Time"
+    "cumTime": "Cumulative Time",
+    "faq": [
+      {
+        "q": "What is running pace?",
+        "a": "Running pace is the time it takes to cover one kilometer (or one mile). It is the standard measure for endurance training. Source: USATF."
+      },
+      {
+        "q": "How do I calculate my pace?",
+        "a": "Pace (min/km) = time (min) / distance (km). Example: 30 min for 5 km = 6:00 min/km. This calculator derives pace, distance, or time from any two values."
+      },
+      {
+        "q": "What's a good pace for beginners?",
+        "a": "For beginners, 6:30–8:00 min/km (or 10:30–13:00 min/mile) is typical. The conversational test (you can still talk) matters more than speed."
+      },
+      {
+        "q": "How can I improve my pace?",
+        "a": "A mix of 80 % easy aerobic runs plus interval and tempo work yields lasting improvement. Source: polarized training (Stephen Seiler)."
+      },
+      {
+        "q": "What's the difference between pace and speed?",
+        "a": "Pace is time per distance (min/km); speed is distance per time (km/h). Convert: speed (km/h) = 60 / pace (min/km)."
+      },
+      {
+        "q": "What pace for marathon, half-marathon, 10K?",
+        "a": "Recreational averages: marathon ~5:30–6:30 min/km, half marathon ~5:15–6:15 min/km, 10K ~5:00–6:00 min/km. Elite athletes run significantly faster."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/tdee.json
+++ b/src/locales/calculators/en/tdee.json
@@ -22,6 +22,32 @@
     "bmr": "BMR: {value} kcal",
     "weightLoss": "Weight Loss",
     "maintenance": "Maintenance",
-    "weightGain": "Weight Gain"
+    "weightGain": "Weight Gain",
+    "faq": [
+      {
+        "q": "What is TDEE?",
+        "a": "Total Daily Energy Expenditure (TDEE) is the total calories you burn per day — BMR plus activity, digestion (TEF), and non-exercise movement. Source: Academy of Nutrition and Dietetics."
+      },
+      {
+        "q": "How is TDEE calculated?",
+        "a": "TDEE multiplies your Basal Metabolic Rate (BMR) by an activity factor between 1.2 (sedentary) and 1.9 (extremely active). This estimate typically falls within ±10–15 % of measured values."
+      },
+      {
+        "q": "Which activity factor fits me?",
+        "a": "1.2 sedentary; 1.375 lightly active (1–3 workouts/week); 1.55 moderate (3–5×); 1.725 very active (6–7×); 1.9 extremely active (twice-daily training or physical job)."
+      },
+      {
+        "q": "How big a deficit should I use to lose weight?",
+        "a": "A moderate 300–500 kcal/day deficit yields roughly 0.3–0.5 kg of fat loss per week. Larger deficits risk muscle loss and metabolic adaptation."
+      },
+      {
+        "q": "How accurate is the estimate?",
+        "a": "TDEE calculators provide a starting point, not a measurement. Adjust after 2–3 weeks based on actual weight trend."
+      },
+      {
+        "q": "Does my TDEE change while dieting?",
+        "a": "Yes. As body weight drops, energy expenditure declines too. Recalculate every 3–4 kg of weight change for accuracy."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/vo2Max.json
+++ b/src/locales/calculators/en/vo2Max.json
@@ -37,6 +37,32 @@
     "cooperInfo": "Run for 12 minutes as far as you can and enter the distance in meters.",
     "rockportInfo": "Walk 1 mile (1,609 m) as fast as you can and measure your heart rate at the end.",
     "directInfo": "Enter your known VO2 Max value directly.",
-    "weightUnit": "Unit"
+    "weightUnit": "Unit",
+    "faq": [
+      {
+        "q": "What is VO2max?",
+        "a": "VO2max is the maximum amount of oxygen the body can utilize per minute (mL/kg/min). It is regarded as the gold-standard marker of cardiorespiratory fitness. Source: American Heart Association."
+      },
+      {
+        "q": "What are normal VO2max values?",
+        "a": "Men 30–39: average 31–40 mL/kg/min. Women 30–39: average 27–35. Elite endurance athletes reach 70–90 mL/kg/min. Source: ACSM."
+      },
+      {
+        "q": "How is VO2max estimated here?",
+        "a": "Using the 1-mile Rockport walking test, which estimates VO2max from weight, time, end-of-test heart rate, and sex. Accuracy: ±10–15 % vs. lab spirometry."
+      },
+      {
+        "q": "How can I improve my VO2max?",
+        "a": "High-intensity interval training (HIIT) combined with long aerobic base work is most effective. Expect +10–25 % in 8–12 weeks if untrained."
+      },
+      {
+        "q": "Does VO2max decline with age?",
+        "a": "Yes — roughly 1 % per year from age 30 onward. Regular endurance training can halve or reverse this decline."
+      },
+      {
+        "q": "How is VO2max linked to lifespan?",
+        "a": "Low VO2max is a stronger predictor of early mortality than smoking or diabetes (JAMA 2018). Improving VO2max is associated with lower mortality."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/waistHipRatio.json
+++ b/src/locales/calculators/en/waistHipRatio.json
@@ -22,6 +22,32 @@
     "recLow": "Your WHR indicates a {start}low health risk{end}. Keep up your healthy lifestyle with regular exercise and a balanced diet.",
     "recModerate": "Your WHR indicates a {start}moderate health risk{end}. Consider increasing physical activity and monitoring your waist circumference.",
     "recHigh": "Your WHR indicates a {start}high health risk{end} according to WHO guidelines. Central obesity is associated with increased cardiovascular and metabolic risk. Consult a healthcare professional.",
-    "thresholdsTitle": "WHO Risk Thresholds ({gender})"
+    "thresholdsTitle": "WHO Risk Thresholds ({gender})",
+    "faq": [
+      {
+        "q": "What is the waist-to-hip ratio (WHR)?",
+        "a": "WHR is waist circumference divided by hip circumference. It indicates fat distribution and is a marker for cardiovascular and metabolic risk. Source: WHO."
+      },
+      {
+        "q": "What are the WHO cutoffs?",
+        "a": "Men: increased risk at WHR ≥ 0.90. Women: increased risk at WHR ≥ 0.85. Higher values are associated with greater type-2 diabetes and heart disease risk."
+      },
+      {
+        "q": "How do I measure waist and hip correctly?",
+        "a": "Waist: narrowest point between the rib cage and iliac crest, standing, at the end of a normal exhalation. Hip: widest part of the buttocks."
+      },
+      {
+        "q": "Is WHR better than BMI?",
+        "a": "Studies (Lancet 2011) suggest WHR predicts cardiovascular risk more reliably than BMI, especially in normal-weight individuals with central adiposity."
+      },
+      {
+        "q": "How can I lower an elevated WHR?",
+        "a": "Reduce visceral fat via calorie deficit, aerobic training, and a fiber-rich diet. Resistance training also improves insulin sensitivity."
+      },
+      {
+        "q": "Is WHR useful during pregnancy?",
+        "a": "No. During pregnancy and breastfeeding, WHR is not meaningful — abdominal circumference is physiologically altered."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/water.json
+++ b/src/locales/calculators/en/water.json
@@ -26,6 +26,32 @@
     "litersPerDay": "liters / day",
     "glasses": "glasses",
     "oz": "oz",
-    "tip": "Spread your intake throughout the day for best hydration."
+    "tip": "Spread your intake throughout the day for best hydration.",
+    "faq": [
+      {
+        "q": "How much water should I drink daily?",
+        "a": "EFSA recommends about 2.0 L/day for women and 2.5 L/day for men from beverages, with additional water from food. Needs rise with exercise, heat, and breastfeeding."
+      },
+      {
+        "q": "How is personal water need calculated?",
+        "a": "A common rule of thumb is 30–35 ml per kg of body weight. Add 0.5–1 L per hour of intense exercise or hot-weather exposure."
+      },
+      {
+        "q": "Do coffee and tea count toward fluid intake?",
+        "a": "Yes. Recent EFSA reviews show moderate caffeine intake does not cause net dehydration. Water, unsweetened teas, and diluted juices all contribute."
+      },
+      {
+        "q": "What are the signs of dehydration?",
+        "a": "Dark urine, thirst, headaches, fatigue, and reduced concentration. Light straw-colored urine is a good hydration indicator."
+      },
+      {
+        "q": "Can you drink too much water?",
+        "a": "Yes, in rare cases excessive intake (several liters in a short time) can cause hyponatremia. Spreading intake throughout the day is safe."
+      },
+      {
+        "q": "Do athletes need more water?",
+        "a": "Yes. Intense exercise costs roughly 0.5–1 L of sweat per hour. For prolonged activity, electrolytes (sodium, potassium) should be added."
+      }
+    ]
   }
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -17,7 +17,8 @@
     "kcal": "kcal",
     "kcalPerDay": "kcal / Tag",
     "activityLevel": "Aktivitätslevel",
-    "method": "Methode"
+    "method": "Methode",
+    "faqTitle": "Häufige Fragen"
   },
   "nav": {
     "brand": "Gesundheitsrechner",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,8 @@
     "kcal": "kcal",
     "kcalPerDay": "kcal / day",
     "activityLevel": "Activity Level",
-    "method": "Method"
+    "method": "Method",
+    "faqTitle": "Frequently Asked Questions"
   },
   "nav": {
     "brand": "Health Calculators",

--- a/src/pages/BacCalculator.vue
+++ b/src/pages/BacCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('bac.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -290,5 +293,6 @@ const bacCategory = computed(() => {
   </div>
 
   <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="bac" />
 </template>

--- a/src/pages/BloodSugarConverter.vue
+++ b/src/pages/BloodSugarConverter.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('bloodSugar.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -270,6 +273,8 @@ const outputUnit = computed(() => (unit.value === 'mg' ? 'mmol/L' : 'mg/dL'))
 
       <p class="text-xs text-stone-400 mt-6 italic">{{ t('bloodSugar.contextNote') }}</p>
     </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <BlogBanner calculator-key="bloodSugar" />
     <AdSlot class="mt-8" />

--- a/src/pages/BmiCalculator.vue
+++ b/src/pages/BmiCalculator.vue
@@ -5,10 +5,13 @@ import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('bmi.faq') || [])
 
 useHead(() => ({
   title: t('bmi.meta.title'),
@@ -164,6 +167,8 @@ const barPosition = computed(() => {
         </div>
       </div>
     </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <BlogBanner calculator-key="bmi" />
 

--- a/src/pages/BmrCalculator.vue
+++ b/src/pages/BmrCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('bmr.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -153,5 +156,6 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="bmr" />
 </template>

--- a/src/pages/BodyFatCalculator.vue
+++ b/src/pages/BodyFatCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('bodyFat.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -231,5 +234,6 @@ const unitLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'cm' :
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="bodyFat" />
 </template>

--- a/src/pages/CalorieDeficitCalculator.vue
+++ b/src/pages/CalorieDeficitCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('calorieDeficit.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -190,5 +193,6 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="calorieDeficit" />
 </template>

--- a/src/pages/GfrCalculator.vue
+++ b/src/pages/GfrCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('gfr.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -254,6 +257,8 @@ const ckdStage = computed(() => {
         </div>
       </div>
     </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <BlogBanner calculator-key="gfr" />
     <AdSlot class="mt-8" />

--- a/src/pages/HbA1cConverter.vue
+++ b/src/pages/HbA1cConverter.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('hba1c.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -273,6 +276,8 @@ const hasResult = computed(() =>
         </div>
       </div>
     </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <BlogBanner calculator-key="hba1c" />
     <AdSlot class="mt-8" />

--- a/src/pages/IdealWeightCalculator.vue
+++ b/src/pages/IdealWeightCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('idealWeight.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -161,5 +164,6 @@ const fmt = (v) => v?.toFixed(1)
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="idealWeight" />
 </template>

--- a/src/pages/IntermittentFastingCalculator.vue
+++ b/src/pages/IntermittentFastingCalculator.vue
@@ -4,9 +4,12 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('intermittentFasting.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -210,6 +213,8 @@ const timelineSegments = computed(() => {
       {{ t('intermittentFasting.howItWorksText') }}
     </p>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <BlogBanner calculator-key="intermittentFasting" />
   <AffiliateBanner />

--- a/src/pages/KetoCalculator.vue
+++ b/src/pages/KetoCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('keto.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -257,5 +260,6 @@ const macros = computed(() => {
   </div>
 
   <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="keto" />
 </template>

--- a/src/pages/MacroCalculator.vue
+++ b/src/pages/MacroCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('macro.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -218,5 +221,6 @@ const macros = computed(() => {
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="macro" />
 </template>

--- a/src/pages/OvulationCalculator.vue
+++ b/src/pages/OvulationCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t, locale } = useI18n()
+const { t, locale, tm } = useI18n()
+
+const faqItems = computed(() => tm('ovulation.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -169,5 +172,6 @@ const hasResults = computed(() => !!lmpDate.value)
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="ovulation" />
 </template>

--- a/src/pages/PeriodCalculator.vue
+++ b/src/pages/PeriodCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t, locale } = useI18n()
+const { t, locale, tm } = useI18n()
+
+const faqItems = computed(() => tm('period.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -191,5 +194,6 @@ const hasResults = computed(() => !!lmpDate.value)
   </div>
 
   <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="period" />
 </template>

--- a/src/pages/PregnancyCalculator.vue
+++ b/src/pages/PregnancyCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t, locale } = useI18n()
+const { t, locale, tm } = useI18n()
+
+const faqItems = computed(() => tm('pregnancy.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -171,5 +174,6 @@ const hasResults = computed(() => !!lmpDate.value)
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="pregnancy" />
 </template>

--- a/src/pages/RunningPaceCalculator.vue
+++ b/src/pages/RunningPaceCalculator.vue
@@ -4,9 +4,12 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('runningPace.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -328,6 +331,8 @@ function formatPace(secPerKm) {
       </table>
     </div>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <BlogBanner calculator-key="runningPace" />
   <AffiliateBanner />

--- a/src/pages/TdeeCalculator.vue
+++ b/src/pages/TdeeCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('tdee.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -161,5 +164,6 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="tdee" />
 </template>

--- a/src/pages/Vo2MaxCalculator.vue
+++ b/src/pages/Vo2MaxCalculator.vue
@@ -4,9 +4,12 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('vo2Max.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -276,6 +279,8 @@ const testTypes = [
       </div>
     </div>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <BlogBanner calculator-key="vo2Max" />
   <AffiliateBanner />

--- a/src/pages/WaistHipRatioCalculator.vue
+++ b/src/pages/WaistHipRatioCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('waistHipRatio.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -161,5 +164,6 @@ const recColors = { low: 'text-green-600', moderate: 'text-yellow-600', high: 't
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="waistHipRatio" />
 </template>

--- a/src/pages/WaterIntakeCalculator.vue
+++ b/src/pages/WaterIntakeCalculator.vue
@@ -4,10 +4,13 @@ import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogBanner from '../components/BlogBanner.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('water.faq') || [])
 const { localePath } = useLocaleRouter()
 
 useHead(() => ({
@@ -147,5 +150,6 @@ const glassRatio = computed(() => {
 
 
     <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
   <BlogBanner calculator-key="water" />
 </template>


### PR DESCRIPTION
## Summary

- New shared `<CalculatorFAQ>` component renders a semantic `<details>`/`<summary>` block and emits an inline `<script type="application/ld+json">` with `FAQPage` schema that lives in the SSR-rendered HTML (verified in `dist/`).
- Wired into the top 20 calculator pages with 5–7 educational, sourced Q&A each: BMI (DE+EN), BMR, TDEE, Wasserbedarf, Schwangerschaft, Eisprung, Kaloriendefizit, WHR, Körperfett, GFR, HbA1c, Promille, Lauftempo, VO2max, Keto, Makro, Intervallfasten, Zyklus, Blutzucker, Idealgewicht.
- Sources cited where appropriate (DGE, WHO, RKI, AHA, ADA, KDIGO, ACOG, ISSN, EFSA …). Educational framing only — never diagnostic.

## Tests

- `src/__tests__/calculatorFaq.test.js` — unit tests via `renderToString`: semantic HTML, JSON-LD shape, XSS-safe encoding (`</script>` → `\u003c`).
- `src/__tests__/faq-ssr.test.js` — SSR verification: greps each of the 21 built `dist/<page>/index.html` files for FAQPage JSON-LD with valid `mainEntity`.
- `npm test` → **911 pass / 0 fail** (was 889).
- `npm run build` succeeds; FAQPage present in every targeted `dist/` page.
- E2E: 12 pre-existing failures unchanged on this branch (verified by stashing and re-running on main); no FAQ-related regressions.

## Sample JSON-LD (de/bmi-rechner)

```json
{
  "@context": "https://schema.org",
  "@type": "FAQPage",
  "mainEntity": [
    {
      "@type": "Question",
      "name": "Wie wird der BMI berechnet?",
      "acceptedAnswer": {
        "@type": "Answer",
        "text": "Der Body-Mass-Index berechnet sich nach der Formel BMI = Gewicht (kg) / Körpergröße (m)². Diese Formel wurde im 19. Jahrhundert von Adolphe Quetelet entwickelt und ist heute der international anerkannte Standard (WHO)."
      }
    }
  ]
}
```

## Follow-up

Created #198 to roll FAQ out to the remaining 20 calculator pages.

## Test plan

- [ ] Spot-check `dist/de/bmi-rechner/index.html` for `FAQPage` JSON-LD.
- [ ] Validate the JSON-LD above in Google Rich Results Test.
- [ ] Verify a sample page renders the `<details>` accordion in browser.

Closes jenslaufer/health-calculators#194

🤖 Generated with [Claude Code](https://claude.com/claude-code)