### PR TITLE
Add Anion Gap Calculator (#123)

### DIFF
--- a/e2e/anion-gap.spec.js
+++ b/e2e/anion-gap.spec.js
@@ -1,0 +1,170 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Anion Gap Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/anionenluecke-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Anionenlücke/)
+  })
+
+  test('h1 contains Anionenlücke', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Anionenlücken-Rechner')
+  })
+
+  test('back link navigates to home page', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('results hidden before input', async ({ page }) => {
+    await expect(page.getByTestId('result-ag')).not.toBeVisible()
+  })
+
+  test('normal AG: Na 140, Cl 104, HCO3 26 → AG 10.0', async ({ page }) => {
+    await page.getByTestId('input-na').fill('140')
+    await page.getByTestId('input-cl').fill('104')
+    await page.getByTestId('input-hco3').fill('26')
+    await expect(page.getByTestId('result-ag')).toBeVisible()
+    const ag = await page.getByTestId('result-ag').textContent()
+    expect(parseFloat(ag)).toBeCloseTo(10, 0)
+    await expect(page.getByTestId('result-interpretation')).toContainText('Normal')
+  })
+
+  test('high AG: Na 135, Cl 95, HCO3 10 → AG 30.0, high interpretation', async ({ page }) => {
+    await page.getByTestId('input-na').fill('135')
+    await page.getByTestId('input-cl').fill('95')
+    await page.getByTestId('input-hco3').fill('10')
+    const ag = await page.getByTestId('result-ag').textContent()
+    expect(parseFloat(ag)).toBeCloseTo(30, 0)
+    await expect(page.getByTestId('result-interpretation')).toContainText('Hohe Anionenlücke')
+  })
+
+  test('low AG shows low interpretation', async ({ page }) => {
+    await page.getByTestId('input-na').fill('130')
+    await page.getByTestId('input-cl').fill('115')
+    await page.getByTestId('input-hco3').fill('22')
+    await expect(page.getByTestId('result-interpretation')).toContainText('Niedrige Anionenlücke')
+  })
+
+  test('mild AG shows mild interpretation', async ({ page }) => {
+    await page.getByTestId('input-na').fill('140')
+    await page.getByTestId('input-cl').fill('100')
+    await page.getByTestId('input-hco3').fill('24')
+    await expect(page.getByTestId('result-interpretation')).toContainText('Leicht erhöhte Anionenlücke')
+  })
+
+  test('albumin input shows corrected AG', async ({ page }) => {
+    await page.getByTestId('input-na').fill('140')
+    await page.getByTestId('input-cl').fill('104')
+    await page.getByTestId('input-hco3').fill('26')
+    await expect(page.getByTestId('result-corrected-ag')).not.toBeVisible()
+    await page.getByTestId('input-albumin').fill('2.0')
+    await expect(page.getByTestId('result-corrected-ag')).toBeVisible()
+    const corrected = await page.getByTestId('result-corrected-ag').textContent()
+    expect(parseFloat(corrected)).toBeCloseTo(15, 0)
+  })
+
+  test('no albumin → no corrected AG shown', async ({ page }) => {
+    await page.getByTestId('input-na').fill('140')
+    await page.getByTestId('input-cl').fill('104')
+    await page.getByTestId('input-hco3').fill('26')
+    await expect(page.getByTestId('result-corrected-ag')).not.toBeVisible()
+  })
+
+  test('plausibility warning shown for out-of-range Na', async ({ page }) => {
+    await page.getByTestId('input-na').fill('170')
+    await page.getByTestId('input-cl').fill('102')
+    await page.getByTestId('input-hco3').fill('24')
+    await expect(page.getByTestId('warning-plausibility')).toBeVisible()
+  })
+
+  test('no plausibility warning for normal values', async ({ page }) => {
+    await page.getByTestId('input-na').fill('140')
+    await page.getByTestId('input-cl').fill('102')
+    await page.getByTestId('input-hco3').fill('24')
+    await expect(page.getByTestId('warning-plausibility')).not.toBeVisible()
+  })
+
+  test('clinical hint is visible after result', async ({ page }) => {
+    await page.getByTestId('input-na').fill('140')
+    await page.getByTestId('input-cl').fill('104')
+    await page.getByTestId('input-hco3').fill('26')
+    await expect(page.getByTestId('result-hint')).toBeVisible()
+  })
+
+  test('reference ranges table is always visible', async ({ page }) => {
+    await expect(page.getByText('Referenzbereiche')).toBeVisible()
+  })
+})
+
+test.describe('Anion Gap Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/anion-gap-calculator')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Anion Gap/)
+  })
+
+  test('h1 contains Anion Gap', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Anion Gap Calculator')
+  })
+
+  test('normal AG: Na 140, Cl 104, HCO3 26 → Normal', async ({ page }) => {
+    await page.getByTestId('input-na').fill('140')
+    await page.getByTestId('input-cl').fill('104')
+    await page.getByTestId('input-hco3').fill('26')
+    await expect(page.getByTestId('result-interpretation')).toContainText('Normal Anion Gap')
+  })
+
+  test('high AG shows high AG metabolic acidosis', async ({ page }) => {
+    await page.getByTestId('input-na').fill('135')
+    await page.getByTestId('input-cl').fill('95')
+    await page.getByTestId('input-hco3').fill('10')
+    await expect(page.getByTestId('result-interpretation')).toContainText('High Anion Gap')
+  })
+
+  test('reference ranges table is always visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Reference Ranges' })).toBeVisible()
+  })
+})
+
+test.describe('Anion Gap DE blog article', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/blog/anionenluecke-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Anionenlücke/)
+  })
+
+  test('h1 contains Anionenlücke', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Anionenlücke')
+  })
+
+  test('CTA link navigates to calculator', async ({ page }) => {
+    await page.getByRole('link', { name: /Anionenlücken-Rechner/ }).click()
+    await expect(page).toHaveURL(/anionenluecke-rechner/)
+  })
+})
+
+test.describe('Anion Gap EN blog article', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/blog/anion-gap')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Anion Gap/)
+  })
+
+  test('h1 contains Anion Gap', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Anion Gap')
+  })
+
+  test('CTA link navigates to calculator', async ({ page }) => {
+    await page.getByRole('link', { name: /Anion Gap Calculator/ }).click()
+    await expect(page).toHaveURL(/anion-gap-calculator/)
+  })
+})

--- a/src/__tests__/anionGap.test.js
+++ b/src/__tests__/anionGap.test.js
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest'
+
+// Mirror the calculation logic from AnionGapCalculator.vue
+
+function calcAg(na, cl, hco3) {
+  return na - (cl + hco3)
+}
+
+function calcCorrectedAg(ag, albumin) {
+  return ag + 2.5 * (4.0 - albumin)
+}
+
+function getInterpretation(ag) {
+  if (ag < 8) return 'low'
+  if (ag <= 12) return 'normal'
+  if (ag <= 20) return 'mild'
+  return 'high'
+}
+
+function isPlausible(na, cl, hco3) {
+  if (na < 120 || na > 160) return false
+  if (cl < 80 || cl > 120) return false
+  if (hco3 < 5 || hco3 > 40) return false
+  return true
+}
+
+// ---- Basic AG calculation ----
+
+describe('calcAg', () => {
+  it('140 - (102 + 24) = 14', () => {
+    expect(calcAg(140, 102, 24)).toBe(14)
+  })
+
+  it('138 - (100 + 28) = 10 (normal)', () => {
+    expect(calcAg(138, 100, 28)).toBe(10)
+  })
+
+  it('145 - (105 + 15) = 25 (high)', () => {
+    expect(calcAg(145, 105, 15)).toBe(25)
+  })
+
+  it('130 - (115 + 20) = -5 (very low, edge case)', () => {
+    expect(calcAg(130, 115, 20)).toBe(-5)
+  })
+
+  it('Na 140, Cl 100, HCO3 32 → AG 8 (lower boundary of normal)', () => {
+    expect(calcAg(140, 100, 32)).toBe(8)
+  })
+
+  it('Na 140, Cl 100, HCO3 28 → AG 12 (upper boundary of normal)', () => {
+    expect(calcAg(140, 100, 28)).toBe(12)
+  })
+
+  it('Na 140, Cl 100, HCO3 27 → AG 13 (lower boundary of mild)', () => {
+    expect(calcAg(140, 100, 27)).toBe(13)
+  })
+
+  it('Na 140, Cl 100, HCO3 19 → AG 21 (lower boundary of high)', () => {
+    expect(calcAg(140, 100, 19)).toBe(21)
+  })
+})
+
+// ---- Albumin correction ----
+
+describe('calcCorrectedAg', () => {
+  it('AG 10, albumin 4.0 → corrected 10 (no change)', () => {
+    expect(calcCorrectedAg(10, 4.0)).toBeCloseTo(10, 5)
+  })
+
+  it('AG 10, albumin 2.0 → corrected 15', () => {
+    expect(calcCorrectedAg(10, 2.0)).toBeCloseTo(15, 5)
+  })
+
+  it('AG 8, albumin 2.0 → corrected 13', () => {
+    expect(calcCorrectedAg(8, 2.0)).toBeCloseTo(13, 5)
+  })
+
+  it('AG 12, albumin 3.0 → corrected 14.5', () => {
+    expect(calcCorrectedAg(12, 3.0)).toBeCloseTo(14.5, 5)
+  })
+
+  it('AG 20, albumin 1.0 → corrected 27.5 (high, severe hypoalbuminemia)', () => {
+    expect(calcCorrectedAg(20, 1.0)).toBeCloseTo(27.5, 5)
+  })
+
+  it('AG 10, albumin 5.0 → corrected 7.5 (albumin above normal)', () => {
+    expect(calcCorrectedAg(10, 5.0)).toBeCloseTo(7.5, 5)
+  })
+})
+
+// ---- Interpretation ----
+
+describe('getInterpretation', () => {
+  it('AG 5 → low', () => {
+    expect(getInterpretation(5)).toBe('low')
+  })
+
+  it('AG 7 → low (upper boundary)', () => {
+    expect(getInterpretation(7)).toBe('low')
+  })
+
+  it('AG 7.9 → low', () => {
+    expect(getInterpretation(7.9)).toBe('low')
+  })
+
+  it('AG 8 → normal (lower boundary)', () => {
+    expect(getInterpretation(8)).toBe('normal')
+  })
+
+  it('AG 10 → normal', () => {
+    expect(getInterpretation(10)).toBe('normal')
+  })
+
+  it('AG 12 → normal (upper boundary)', () => {
+    expect(getInterpretation(12)).toBe('normal')
+  })
+
+  it('AG 13 → mild (lower boundary)', () => {
+    expect(getInterpretation(13)).toBe('mild')
+  })
+
+  it('AG 16 → mild', () => {
+    expect(getInterpretation(16)).toBe('mild')
+  })
+
+  it('AG 20 → mild (upper boundary)', () => {
+    expect(getInterpretation(20)).toBe('mild')
+  })
+
+  it('AG 21 → high (lower boundary)', () => {
+    expect(getInterpretation(21)).toBe('high')
+  })
+
+  it('AG 30 → high', () => {
+    expect(getInterpretation(30)).toBe('high')
+  })
+})
+
+// ---- Plausibility checks ----
+
+describe('isPlausible', () => {
+  it('Na 140, Cl 102, HCO3 24 → plausible', () => {
+    expect(isPlausible(140, 102, 24)).toBe(true)
+  })
+
+  it('Na 119 → not plausible (Na too low)', () => {
+    expect(isPlausible(119, 102, 24)).toBe(false)
+  })
+
+  it('Na 161 → not plausible (Na too high)', () => {
+    expect(isPlausible(161, 102, 24)).toBe(false)
+  })
+
+  it('Na 120 → plausible (lower boundary)', () => {
+    expect(isPlausible(120, 102, 24)).toBe(true)
+  })
+
+  it('Na 160 → plausible (upper boundary)', () => {
+    expect(isPlausible(160, 102, 24)).toBe(true)
+  })
+
+  it('Cl 79 → not plausible (Cl too low)', () => {
+    expect(isPlausible(140, 79, 24)).toBe(false)
+  })
+
+  it('Cl 121 → not plausible (Cl too high)', () => {
+    expect(isPlausible(140, 121, 24)).toBe(false)
+  })
+
+  it('HCO3 4 → not plausible (HCO3 too low)', () => {
+    expect(isPlausible(140, 102, 4)).toBe(false)
+  })
+
+  it('HCO3 41 → not plausible (HCO3 too high)', () => {
+    expect(isPlausible(140, 102, 41)).toBe(false)
+  })
+
+  it('HCO3 5 → plausible (lower boundary)', () => {
+    expect(isPlausible(140, 102, 5)).toBe(true)
+  })
+
+  it('HCO3 40 → plausible (upper boundary)', () => {
+    expect(isPlausible(140, 102, 40)).toBe(true)
+  })
+})
+
+// ---- Combined: real clinical scenarios ----
+
+describe('Clinical scenarios', () => {
+  it('DKA: Na 135, Cl 95, HCO3 10 → AG 30, high, MUDPILES', () => {
+    const ag = calcAg(135, 95, 10)
+    expect(ag).toBe(30)
+    expect(getInterpretation(ag)).toBe('high')
+  })
+
+  it('Normal patient: Na 140, Cl 104, HCO3 26 → AG 10, normal', () => {
+    const ag = calcAg(140, 104, 26)
+    expect(ag).toBe(10)
+    expect(getInterpretation(ag)).toBe('normal')
+  })
+
+  it('Hypoalbuminemia masking high AG: AG 10, albumin 2.0 → corrected 15 (mild)', () => {
+    const ag = 10
+    const corrected = calcCorrectedAg(ag, 2.0)
+    expect(getInterpretation(ag)).toBe('normal')
+    expect(getInterpretation(corrected)).toBe('mild')
+  })
+
+  it('Lactic acidosis: Na 142, Cl 100, HCO3 12 → AG 30, high', () => {
+    const ag = calcAg(142, 100, 12)
+    expect(ag).toBe(30)
+    expect(getInterpretation(ag)).toBe('high')
+  })
+})

--- a/src/locales/calculators/de/anionGap.json
+++ b/src/locales/calculators/de/anionGap.json
@@ -1,0 +1,80 @@
+{
+  "home": {
+    "calculators": {
+      "anionGap": {
+        "name": "Anionenlücken-Rechner",
+        "description": "Anionenlücke berechnen und metabolische Azidose einordnen. Mit Albumin-Korrektur."
+      }
+    }
+  },
+  "anionGap": {
+    "meta": {
+      "title": "Anionenlücken-Rechner — Metabolische Azidose einordnen | Health Calculators",
+      "description": "Anionenlücke (Na − Cl − HCO₃) berechnen, albumin-korrigierte Anionenlücke berechnen und Ergebnis klinisch einordnen. Kostenloser Online-Rechner."
+    },
+    "title": "Anionenlücken-Rechner",
+    "description": "Anionenlücke aus Natrium, Chlorid und Bikarbonat berechnen, mit optionaler Albumin-Korrektur und klinischer Einordnung.",
+    "naLabel": "Natrium (Na⁺)",
+    "naPlaceholder": "z.B. 140",
+    "clLabel": "Chlorid (Cl⁻)",
+    "clPlaceholder": "z.B. 102",
+    "hco3Label": "Bikarbonat (HCO₃⁻)",
+    "hco3Placeholder": "z.B. 24",
+    "albuminLabel": "Albumin (optional)",
+    "albuminPlaceholder": "z.B. 4,0",
+    "albuminHint": "Nur angeben, wenn ein albumin-korrigierter Wert gewünscht wird (normal: 4,0 g/dL).",
+    "unitLabel": "mEq/L",
+    "unitAlbumin": "g/dL",
+    "calculate": "Berechnen",
+    "resultAg": "Anionenlücke",
+    "resultCorrectedAg": "Albumin-korrigierte Anionenlücke",
+    "resultInterpretation": "Einordnung",
+    "clinicalHint": "Klinischer Hinweis",
+    "warningPlausibility": "Achtung: Eingabewert außerhalb des physiologischen Bereichs. Bitte Eingabe prüfen.",
+    "formula": "Formel",
+    "formulaAg": "AG = Na⁺ − (Cl⁻ + HCO₃⁻)",
+    "formulaCorrected": "Korrigierte AG = AG + 2,5 × (4,0 − Albumin)",
+    "interpretation": {
+      "low": "Niedrige Anionenlücke",
+      "normal": "Normale Anionenlücke",
+      "mild": "Leicht erhöhte Anionenlücke",
+      "high": "Hohe Anionenlücke — metabolische Azidose"
+    },
+    "hint": {
+      "low": "Ursachen: Hypoalbuminämie, Bromid, Lithiumtoxizität, Hyperchlorämie.",
+      "normal": "Anionenlücke im Normbereich (8–12 mEq/L).",
+      "mild": "Leichte Erhöhung. Klinischen Kontext prüfen.",
+      "high": "Verdacht auf High-AG-Azidose. MUDPILES bedenken: Methanol, Urämie, Ketoazidose (DKA), Propylenglykol, Eisen/Isoniazid, Laktatazidose, Ethylenglykol, Salicylate."
+    },
+    "referenceTitle": "Referenzbereiche",
+    "referenceRanges": [
+      { "range": "< 8 mEq/L", "label": "Niedrig", "hint": "Hypoalbuminämie, Bromid, Lithium" },
+      { "range": "8 – 12 mEq/L", "label": "Normal", "hint": "Kein Hinweis auf AG-Azidose" },
+      { "range": "13 – 20 mEq/L", "label": "Leicht erhöht", "hint": "Klinischen Kontext prüfen" },
+      { "range": "> 20 mEq/L", "label": "Hoch", "hint": "High-AG metabolische Azidose (MUDPILES)" }
+    ],
+    "blogLink": "Mehr erfahren im Artikel zur Anionenlücke",
+    "faq": [
+      {
+        "q": "Was ist die Anionenlücke?",
+        "a": "Die Anionenlücke (AG) ist ein berechneter Parameter aus Serum-Elektrolyten: AG = Na⁺ − (Cl⁻ + HCO₃⁻). Sie hilft, die Ursache einer metabolischen Azidose einzugrenzen."
+      },
+      {
+        "q": "Warum ist die Albumin-Korrektur wichtig?",
+        "a": "Albumin trägt zur negativen Ladung im Serum bei. Bei Hypoalbuminämie ist die AG falsch niedrig. Die Formel AG + 2,5 × (4,0 − Albumin) korrigiert diesen Effekt."
+      },
+      {
+        "q": "Was sind die häufigsten Ursachen einer hohen Anionenlücke?",
+        "a": "MUDPILES: Methanol, Urämie, Diabetische Ketoazidose (DKA), Propylenglykol, Eisen/Isoniazid, Laktatazidose, Ethylenglykol, Salicylate."
+      },
+      {
+        "q": "Was bedeutet eine niedrige Anionenlücke?",
+        "a": "Eine AG < 8 mEq/L entsteht oft durch Hypoalbuminämie, Hyperchlorämie, Bromid-Intoxikation oder Lithiumtherapie. Selten ist ein Messfehler möglich."
+      },
+      {
+        "q": "Ersetzt der Rechner ärztliche Diagnose?",
+        "a": "Nein. Die Anionenlücke ist ein Hilfsmittel zur klinischen Differenzialdiagnostik und muss immer im Kontext von Anamnese, Symptomen und weiteren Laborwerten interpretiert werden."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/anionGap.json
+++ b/src/locales/calculators/en/anionGap.json
@@ -1,0 +1,80 @@
+{
+  "home": {
+    "calculators": {
+      "anionGap": {
+        "name": "Anion Gap Calculator",
+        "description": "Calculate anion gap and classify metabolic acidosis. Includes albumin correction."
+      }
+    }
+  },
+  "anionGap": {
+    "meta": {
+      "title": "Anion Gap Calculator — Classify Metabolic Acidosis | Health Calculators",
+      "description": "Calculate anion gap (Na − Cl − HCO₃), albumin-corrected anion gap, and get clinical interpretation. Free online calculator for metabolic acidosis."
+    },
+    "title": "Anion Gap Calculator",
+    "description": "Calculate anion gap from sodium, chloride, and bicarbonate with optional albumin correction and clinical interpretation.",
+    "naLabel": "Sodium (Na⁺)",
+    "naPlaceholder": "e.g. 140",
+    "clLabel": "Chloride (Cl⁻)",
+    "clPlaceholder": "e.g. 102",
+    "hco3Label": "Bicarbonate (HCO₃⁻)",
+    "hco3Placeholder": "e.g. 24",
+    "albuminLabel": "Albumin (optional)",
+    "albuminPlaceholder": "e.g. 4.0",
+    "albuminHint": "Enter only if you want the albumin-corrected value (normal: 4.0 g/dL).",
+    "unitLabel": "mEq/L",
+    "unitAlbumin": "g/dL",
+    "calculate": "Calculate",
+    "resultAg": "Anion Gap",
+    "resultCorrectedAg": "Albumin-corrected Anion Gap",
+    "resultInterpretation": "Interpretation",
+    "clinicalHint": "Clinical Hint",
+    "warningPlausibility": "Warning: Input value is outside the physiologic range. Please check your input.",
+    "formula": "Formula",
+    "formulaAg": "AG = Na⁺ − (Cl⁻ + HCO₃⁻)",
+    "formulaCorrected": "Corrected AG = AG + 2.5 × (4.0 − Albumin)",
+    "interpretation": {
+      "low": "Low Anion Gap",
+      "normal": "Normal Anion Gap",
+      "mild": "Mildly Elevated Anion Gap",
+      "high": "High Anion Gap — Metabolic Acidosis"
+    },
+    "hint": {
+      "low": "Causes: hypoalbuminemia, bromide, lithium toxicity, hyperchloremia.",
+      "normal": "Anion gap within normal range (8–12 mEq/L).",
+      "mild": "Mild elevation. Consider clinical context.",
+      "high": "Suspect high-AG metabolic acidosis. Consider MUDPILES: Methanol, Uremia, DKA, Propylene glycol, Iron/Isoniazid, Lactic acidosis, Ethylene glycol, Salicylates."
+    },
+    "referenceTitle": "Reference Ranges",
+    "referenceRanges": [
+      { "range": "< 8 mEq/L", "label": "Low", "hint": "Hypoalbuminemia, bromide, lithium" },
+      { "range": "8 – 12 mEq/L", "label": "Normal", "hint": "No evidence of AG acidosis" },
+      { "range": "13 – 20 mEq/L", "label": "Mildly elevated", "hint": "Consider clinical context" },
+      { "range": "> 20 mEq/L", "label": "High", "hint": "High-AG metabolic acidosis (MUDPILES)" }
+    ],
+    "blogLink": "Read more in the anion gap article",
+    "faq": [
+      {
+        "q": "What is the anion gap?",
+        "a": "The anion gap (AG) is a calculated parameter from serum electrolytes: AG = Na⁺ − (Cl⁻ + HCO₃⁻). It helps narrow the cause of metabolic acidosis."
+      },
+      {
+        "q": "Why is albumin correction important?",
+        "a": "Albumin contributes to negative charge in serum. In hypoalbuminemia the AG is falsely low. The formula AG + 2.5 × (4.0 − albumin) corrects for this effect."
+      },
+      {
+        "q": "What are the most common causes of a high anion gap?",
+        "a": "MUDPILES: Methanol, Uremia, Diabetic Ketoacidosis (DKA), Propylene glycol, Iron/Isoniazid, Lactic acidosis, Ethylene glycol, Salicylates."
+      },
+      {
+        "q": "What causes a low anion gap?",
+        "a": "An AG < 8 mEq/L is most often caused by hypoalbuminemia, hyperchloremia, bromide intoxication, or lithium therapy. Measurement error is also possible."
+      },
+      {
+        "q": "Does this calculator replace medical diagnosis?",
+        "a": "No. The anion gap is a tool for clinical differential diagnosis and must always be interpreted in the context of history, symptoms, and other laboratory values."
+      }
+    ]
+  }
+}

--- a/src/pages/AnionGapCalculator.vue
+++ b/src/pages/AnionGapCalculator.vue
@@ -1,0 +1,225 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogBanner from '../components/BlogBanner.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t, tm } = useI18n()
+
+const faqItems = computed(() => tm('anionGap.faq') || [])
+const { localePath } = useLocaleRouter()
+
+useHead(() => ({
+  title: t('anionGap.meta.title'),
+  description: t('anionGap.meta.description'),
+  routeKey: 'anionGap',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Anion Gap Calculator',
+    url: 'https://healthcalculator.app/anion-gap-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const na = ref(null)
+const cl = ref(null)
+const hco3 = ref(null)
+const albumin = ref(null)
+
+const hasAllRequired = computed(() => na.value !== null && cl.value !== null && hco3.value !== null)
+
+const ag = computed(() => {
+  if (!hasAllRequired.value) return null
+  return na.value - (cl.value + hco3.value)
+})
+
+const correctedAg = computed(() => {
+  if (ag.value === null || albumin.value === null) return null
+  return ag.value + 2.5 * (4.0 - albumin.value)
+})
+
+const interpretation = computed(() => {
+  const v = ag.value
+  if (v === null) return null
+  if (v < 8) return { key: 'low', color: 'text-blue-600', bg: 'bg-blue-600', border: 'border-blue-200' }
+  if (v <= 12) return { key: 'normal', color: 'text-green-600', bg: 'bg-green-600', border: 'border-green-200' }
+  if (v <= 20) return { key: 'mild', color: 'text-yellow-500', bg: 'bg-yellow-500', border: 'border-yellow-200' }
+  return { key: 'high', color: 'text-red-500', bg: 'bg-red-500', border: 'border-red-200' }
+})
+
+const plausibilityWarning = computed(() => {
+  if (!hasAllRequired.value) return false
+  if (na.value < 120 || na.value > 160) return true
+  if (cl.value < 80 || cl.value > 120) return true
+  if (hco3.value < 5 || hco3.value > 40) return true
+  return false
+})
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('anionGap.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('anionGap.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <!-- Inputs -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-5 mb-5">
+        <div>
+          <label for="input-na" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('anionGap.naLabel') }} (mEq/L)
+          </label>
+          <input
+            id="input-na"
+            v-model.number="na"
+            data-testid="input-na"
+            type="number"
+            step="1"
+            min="0"
+            :placeholder="t('anionGap.naPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="input-cl" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('anionGap.clLabel') }} (mEq/L)
+          </label>
+          <input
+            id="input-cl"
+            v-model.number="cl"
+            data-testid="input-cl"
+            type="number"
+            step="1"
+            min="0"
+            :placeholder="t('anionGap.clPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="input-hco3" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('anionGap.hco3Label') }} (mEq/L)
+          </label>
+          <input
+            id="input-hco3"
+            v-model.number="hco3"
+            data-testid="input-hco3"
+            type="number"
+            step="1"
+            min="0"
+            :placeholder="t('anionGap.hco3Placeholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="input-albumin" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('anionGap.albuminLabel') }} (g/dL)
+          </label>
+          <input
+            id="input-albumin"
+            v-model.number="albumin"
+            data-testid="input-albumin"
+            type="number"
+            step="0.1"
+            min="0"
+            :placeholder="t('anionGap.albuminPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+          <p class="text-xs text-stone-400 mt-1.5">{{ t('anionGap.albuminHint') }}</p>
+        </div>
+      </div>
+
+      <!-- Plausibility warning -->
+      <div v-if="plausibilityWarning" data-testid="warning-plausibility" class="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-2">
+        <span class="text-amber-500 text-lg leading-none mt-0.5">⚠</span>
+        <p class="text-sm text-amber-700">{{ t('anionGap.warningPlausibility') }}</p>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Results -->
+    <div v-if="ag !== null" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <!-- Interpretation badge -->
+      <div class="flex items-center gap-3 mb-6">
+        <span
+          data-testid="result-interpretation"
+          :class="[interpretation.bg, 'text-white text-sm font-semibold px-3 py-1 rounded-full']"
+        >{{ t('anionGap.interpretation.' + interpretation.key) }}</span>
+      </div>
+
+      <!-- AG value -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-6">
+        <div>
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('anionGap.resultAg') }}</div>
+          <div data-testid="result-ag" class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight">
+            {{ ag.toFixed(1) }}
+            <span class="text-base font-normal text-stone-500">mEq/L</span>
+          </div>
+        </div>
+
+        <!-- Corrected AG -->
+        <div v-if="correctedAg !== null">
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('anionGap.resultCorrectedAg') }}</div>
+          <div data-testid="result-corrected-ag" class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight">
+            {{ correctedAg.toFixed(1) }}
+            <span class="text-base font-normal text-stone-500">mEq/L</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Clinical hint -->
+      <div :class="[interpretation.border, 'border rounded-lg px-4 py-3 bg-stone-50 mb-4']">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('anionGap.clinicalHint') }}</div>
+        <p data-testid="result-hint" class="text-sm text-stone-700">{{ t('anionGap.hint.' + interpretation.key) }}</p>
+      </div>
+
+      <!-- Formula -->
+      <div class="border-t border-stone-100 pt-4">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('anionGap.formula') }}</div>
+        <div class="bg-stone-50 rounded-lg px-4 py-3 text-sm font-mono text-stone-700 space-y-1">
+          <div>{{ t('anionGap.formulaAg') }}</div>
+          <div v-if="correctedAg !== null">{{ t('anionGap.formulaCorrected') }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Reference ranges -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('anionGap.referenceTitle') }}</h2>
+      <div class="space-y-3">
+        <div
+          v-for="(row, i) in tm('anionGap.referenceRanges')"
+          :key="i"
+          class="flex items-start justify-between border-b border-stone-100 pb-3 last:border-0 last:pb-0"
+        >
+          <div class="flex items-center gap-3">
+            <div :class="[
+              i === 0 ? 'bg-blue-600' : i === 1 ? 'bg-green-600' : i === 2 ? 'bg-yellow-500' : 'bg-red-500',
+              'w-2.5 h-2.5 rounded-full shrink-0 mt-0.5'
+            ]"></div>
+            <div>
+              <span class="text-sm text-stone-900 font-medium">{{ row.label }}</span>
+              <p class="text-xs text-stone-500">{{ row.hint }}</p>
+            </div>
+          </div>
+          <div class="text-sm font-medium text-stone-900 tabular-nums shrink-0 ml-4">{{ row.range }}</div>
+        </div>
+      </div>
+
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <BlogBanner calculator-key="anionGap" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/anionGap.meta.js
+++ b/src/pages/anionGap.meta.js
@@ -1,0 +1,16 @@
+import Component from './AnionGapCalculator.vue'
+import BlogDe from './blog/AnionenlueckeRechner.vue'
+import BlogEn from './blog/en/AnionGapCalculatorBlog.vue'
+
+export default {
+  key: 'anionGap',
+  component: Component,
+  slugs: { de: 'anionenluecke-rechner', en: 'anion-gap-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 23,
+  blog: {
+    de: { slug: 'anionenluecke-rechner', component: BlogDe },
+    en: { slug: 'anion-gap', component: BlogEn },
+  },
+}

--- a/src/pages/blog/AnionenlueckeRechner.vue
+++ b/src/pages/blog/AnionenlueckeRechner.vue
@@ -1,0 +1,218 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Anionenlücke berechnen — Metabolische Azidose verstehen | Health Calculators',
+  description: 'Was ist die Anionenlücke? Formel, Normwerte, Albumin-Korrektur und MUDPILES einfach erklärt. Kostenloser Anionenlücken-Rechner online.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Anionenlücke berechnen — Metabolische Azidose verstehen',
+    description: 'Was ist die Anionenlücke? Formel, Normwerte, Albumin-Korrektur und MUDPILES einfach erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-21',
+    dateModified: '2026-04-21',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/anionenluecke-rechner',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Anionenlücke berechnen — Metabolische Azidose verstehen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">21. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>Anionenlücke (AG)</strong> ist ein einfach berechenbarer Parameter aus dem Blutbild, der hilft, die Ursache einer <strong>metabolischen Azidose</strong> systematisch einzugrenzen. Sie gehört zu den wichtigsten Werkzeugen in der klinischen Notfall- und Intensivmedizin.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Artikel erklärt du, wie die Anionenlücke berechnet wird, was die Normwerte bedeuten, wann eine Albumin-Korrektur notwendig ist und welche Erkrankungen hinter einer erhöhten Anionenlücke stecken können.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Anionenlücke ergibt sich aus der Differenz zwischen dem gemessenen Kation Natrium und den gemessenen Anionen Chlorid und Bikarbonat:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-6">
+          <p class="text-base font-mono text-stone-900 font-semibold">AG = Na⁺ − (Cl⁻ + HCO₃⁻)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Referenzbereich liegt bei <strong>8–12 mEq/L</strong> (ohne Kalium). Die „Lücke" entsteht, weil im Serum nicht alle Anionen standardmäßig gemessen werden — Albumin, Phosphat und andere tragen zur Ladungsneutralität bei.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Anionenlücke</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Einordnung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">&lt; 8 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Niedrig</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">8 – 12 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Normal</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">13 – 20 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Leicht erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">&gt; 20 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Hoch — High-AG-Azidose</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum Albumin-Korrektur?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Albumin ist das wichtigste „unmessbare Anion" im Serum. Bei Hypoalbuminämie (z.B. bei Lebererkrankung, Malnutrition, kritisch kranken Patienten) fällt die Anionenlücke falsch niedrig aus — eine High-AG-Azidose kann dadurch übersehen werden.
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base font-mono text-stone-900 font-semibold">Korrigierte AG = AG + 2,5 × (4,0 − Albumin [g/dL])</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ein Patient mit Albumin 2,0 g/dL und AG 10 mEq/L hat eine korrigierte AG von 10 + 2,5 × (4,0 − 2,0) = <strong>15 mEq/L</strong> — also eine leicht erhöhte Anionenlücke trotz scheinbar normalem Ausgangswert.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">High-AG-Azidose: MUDPILES</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eine Anionenlücke über 20 mEq/L weist auf eine High-AG-metabolische Azidose hin. Das Akronym <strong>MUDPILES</strong> hilft, die wichtigsten Ursachen zu erinnern:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Buchstabe</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Ursache</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">M</td><td class="px-6 py-3 text-stone-600">Methanol</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">U</td><td class="px-6 py-3 text-stone-600">Urämie</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">D</td><td class="px-6 py-3 text-stone-600">Diabetische Ketoazidose (DKA)</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">P</td><td class="px-6 py-3 text-stone-600">Propylenglykol</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">I</td><td class="px-6 py-3 text-stone-600">Eisen (Iron) / Isoniazid</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">L</td><td class="px-6 py-3 text-stone-600">Laktatazidose</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">E</td><td class="px-6 py-3 text-stone-600">Ethylenglykol</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">S</td><td class="px-6 py-3 text-stone-600">Salicylate (Acetylsalicylsäure)</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Niedrige Anionenlücke</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eine AG unter 8 mEq/L ist seltener, aber klinisch relevant. Häufige Ursachen:
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Hypoalbuminämie</strong> — häufigste Ursache einer niedrigen Anionenlücke</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Hyperchlorämie</strong> — z.B. durch Kochsalzinfusion oder Hyperchlorämische Azidose</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Bromid-Intoxikation</strong> — Bromid wird als Chlorid gemessen</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Lithiumtherapie</strong> — Lithium ist ein Kation, das die AG senkt</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Zusammenhang mit anderen Labortests</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Anionenlücke ist Teil einer umfassenderen Stoffwechselanalyse. Verwandte Laborparameter:
+        </p>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>GFR (Glomeruläre Filtrationsrate)</strong> — Nierenfunktion ist entscheidend für Urämie und renale Azidose. Berechne deinen <router-link :to="localePath('gfr')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">GFR-Wert</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>HbA1c</strong> — Langzeitblutzucker zur Beurteilung einer diabetischen Entgleisung. Zum <router-link :to="localePath('hba1c')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">HbA1c-Konverter</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Blutzucker</strong> — Glukose ist zentral für die Diagnose einer DKA. Zum <router-link :to="localePath('bloodSugar')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Blutzucker-Umrechner</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Anionenlücke jetzt berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Natrium, Chlorid und Bikarbonat eingeben — sofort Ergebnis und klinische Einordnung.</p>
+        <router-link
+          :to="localePath('anionGap')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum Anionenlücken-Rechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Warum wird Kalium bei der Anionenlücke oft weggelassen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Die klassische Formel AG = Na − (Cl + HCO₃) lässt Kalium weg, da dessen Konzentration im Vergleich zu Natrium sehr gering ist. Einige Formeln addieren Kalium zu Natrium, was den Normbereich leicht nach oben verschiebt (auf 10–14 mEq/L). Im klinischen Alltag wird meist die Formel ohne Kalium verwendet.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Kann ich die Anionenlücke ohne Blutgasanalyse berechnen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Ja. Natrium und Chlorid stammen aus der Serum-Elektrolytbestimmung, Bikarbonat (HCO₃⁻) aus der Blutgasanalyse oder als Serumbikarbonat aus dem Routinelabor. Werte aus verschiedenen Abnahmezeitpunkten sollten nicht kombiniert werden.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Gilt der Normbereich für alle Patienten?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Der Normbereich von 8–12 mEq/L gilt bei normalen Albuminwerten. Bei Hypoalbuminämie muss immer die korrigierte Anionenlücke berechnet werden, da sonst eine High-AG-Azidose übersehen werden kann.
+            </p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/pages/blog/en/AnionGapCalculatorBlog.vue
+++ b/src/pages/blog/en/AnionGapCalculatorBlog.vue
@@ -1,0 +1,218 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Anion Gap Calculator — Understanding Metabolic Acidosis | Health Calculators',
+  description: 'What is the anion gap? Formula, normal ranges, albumin correction, and MUDPILES explained. Free online anion gap calculator.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Anion Gap Calculator — Understanding Metabolic Acidosis',
+    description: 'What is the anion gap? Formula, normal ranges, albumin correction, and MUDPILES explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-04-21',
+    dateModified: '2026-04-21',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/anion-gap',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Anion Gap Calculator — Understanding Metabolic Acidosis</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 21, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>anion gap (AG)</strong> is a simple calculated parameter from serum electrolytes that helps systematically narrow the cause of <strong>metabolic acidosis</strong>. It is one of the most important tools in emergency and critical care medicine.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how to calculate the anion gap, what the normal values mean, when albumin correction is necessary, and which diseases can cause an elevated anion gap.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The Formula</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The anion gap is the difference between the measured cation sodium and the measured anions chloride and bicarbonate:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-6">
+          <p class="text-base font-mono text-stone-900 font-semibold">AG = Na⁺ − (Cl⁻ + HCO₃⁻)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The reference range is <strong>8–12 mEq/L</strong> (without potassium). The "gap" exists because not all anions in serum are routinely measured — albumin, phosphate, and others contribute to charge neutrality.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Anion Gap</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Interpretation</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">&lt; 8 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Low</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">8 – 12 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Normal</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">13 – 20 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Mildly elevated</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">&gt; 20 mEq/L</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">High — High-AG acidosis</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why Albumin Correction Matters</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Albumin is the most important "unmeasured anion" in serum. In hypoalbuminemia (e.g., liver disease, malnutrition, critically ill patients) the anion gap is falsely low — a high-AG acidosis can be missed.
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base font-mono text-stone-900 font-semibold">Corrected AG = AG + 2.5 × (4.0 − Albumin [g/dL])</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A patient with albumin 2.0 g/dL and AG 10 mEq/L has a corrected AG of 10 + 2.5 × (4.0 − 2.0) = <strong>15 mEq/L</strong> — a mildly elevated gap despite an apparently normal raw value.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">High-AG Acidosis: MUDPILES</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          An anion gap above 20 mEq/L suggests high-AG metabolic acidosis. The mnemonic <strong>MUDPILES</strong> helps recall the most important causes:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Letter</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Cause</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">M</td><td class="px-6 py-3 text-stone-600">Methanol</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">U</td><td class="px-6 py-3 text-stone-600">Uremia</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">D</td><td class="px-6 py-3 text-stone-600">Diabetic Ketoacidosis (DKA)</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">P</td><td class="px-6 py-3 text-stone-600">Propylene glycol</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">I</td><td class="px-6 py-3 text-stone-600">Iron / Isoniazid</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">L</td><td class="px-6 py-3 text-stone-600">Lactic acidosis</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">E</td><td class="px-6 py-3 text-stone-600">Ethylene glycol</td></tr>
+              <tr><td class="px-6 py-3 font-mono font-bold text-stone-900">S</td><td class="px-6 py-3 text-stone-600">Salicylates (aspirin)</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Low Anion Gap</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          An AG below 8 mEq/L is less common but clinically relevant. Common causes include:
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Hypoalbuminemia</strong> — most common cause of a low anion gap</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Hyperchloremia</strong> — e.g., from saline infusion or hyperchloremic acidosis</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Bromide intoxication</strong> — bromide is measured as chloride</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Lithium therapy</strong> — lithium is a cation that lowers the AG</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related Lab Parameters</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The anion gap is part of a broader metabolic workup. Related parameters:
+        </p>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>GFR (Glomerular Filtration Rate)</strong> — kidney function is key for uremia and renal acidosis. Calculate your <router-link :to="localePath('gfr')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">GFR value</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>HbA1c</strong> — long-term blood glucose for assessing diabetic decompensation. To the <router-link :to="localePath('hba1c')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">HbA1c Converter</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Blood Sugar</strong> — glucose is central to diagnosing DKA. To the <router-link :to="localePath('bloodSugar')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Blood Sugar Converter</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate Your Anion Gap Now</h3>
+        <p class="text-stone-300 text-sm mb-5">Enter sodium, chloride, and bicarbonate — get an instant result and clinical interpretation.</p>
+        <router-link
+          :to="localePath('anionGap')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Open Anion Gap Calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequently Asked Questions</h2>
+
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Why is potassium omitted from the anion gap formula?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              The classic formula AG = Na − (Cl + HCO₃) omits potassium because its concentration is much lower than sodium. Some formulas add potassium to sodium, which shifts the normal range slightly higher (to 10–14 mEq/L). Clinical practice typically uses the formula without potassium.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Can I calculate the anion gap without a blood gas?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Yes. Sodium and chloride come from the serum electrolyte panel; bicarbonate (HCO₃⁻) from a blood gas or as serum bicarbonate from a routine metabolic panel. Values from different draw times should not be mixed.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Does the normal range apply to all patients?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              The normal range of 8–12 mEq/L assumes normal albumin. In hypoalbuminemia the albumin-corrected anion gap must always be calculated, otherwise a high-AG acidosis can be missed.
+            </p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <RelatedArticlesEn />
+  </article>
+</template>


### PR DESCRIPTION
## Summary
- New Anion Gap Calculator with formula AG = Na⁺ − (Cl⁻ + HCO₃⁻)
- Albumin-corrected AG (AG + 2.5 × (4.0 − albumin)), shown only when albumin is entered
- Four interpretation buckets: low / normal / mild / high (MUDPILES hint)
- Plausibility warnings for out-of-range electrolyte values
- DE + EN blog articles with internal links to GFR, HbA1c, Blood Sugar calculators
- Auto-discovery pattern — zero shared files modified

## Files created
- `src/pages/AnionGapCalculator.vue`
- `src/pages/anionGap.meta.js`
- `src/locales/calculators/de/anionGap.json`
- `src/locales/calculators/en/anionGap.json`
- `src/pages/blog/AnionenlueckeRechner.vue`
- `src/pages/blog/en/AnionGapCalculatorBlog.vue`
- `src/__tests__/anionGap.test.js`
- `e2e/anion-gap.spec.js`

## Test plan
- [x] 40 unit tests — all passing (`vitest run`)
- [x] 25 E2E tests — all passing (`playwright test e2e/anion-gap.spec.js`)
- [x] SSG build — all 4 routes generated (DE/EN calculator + DE/EN blog)
- [x] No shared files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)