### PR TITLE
hc-209-decouple-parsemeta-llms-txt: Decouple parseMeta() in scripts/generate-llms-txt.js so that

### DIFF
--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -25,7 +25,7 @@ function parseMeta(source) {
     en: { slug: blogEnSlug, file: blogEnFile },
   } : null
 
-  return key && slugs && blog ? { key, slugs, blog } : null
+  return key && slugs ? { key, slugs, blog } : null
 }
 
 export function discoverMetas(metaDir = META_DIR) {
@@ -83,7 +83,7 @@ export function generateLlmsTxt(metas, baseUrl = BASE_URL, metaDir = META_DIR) {
   }
 
   txt += '\n## Blog\n\n'
-  for (const meta of metas) {
+  for (const meta of metas.filter(m => m.blog)) {
     const enBlog = meta.blog.en.file ? parseBlogComponent(meta.blog.en.file, metaDir) : { title: '', description: '' }
     const deBlog = meta.blog.de.file ? parseBlogComponent(meta.blog.de.file, metaDir) : { title: '', description: '' }
     if (enBlog.title) txt += `- [${enBlog.title}](${baseUrl}/en/blog/${meta.blog.en.slug}): ${enBlog.description}\n`

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -30,26 +30,26 @@ describe('generateLlmsTxt', () => {
     expect(txt).toContain('## Blog')
   })
 
-  it('includes EN calculator URLs for all 30 calculators', () => {
+  it('includes EN calculator URLs for all calculators', () => {
     for (const meta of metas) {
       expect(txt, `missing EN URL for ${meta.key}`).toContain(`${BASE_URL}/en/${meta.slugs.en}`)
     }
   })
 
-  it('includes DE calculator URLs for all 30 calculators', () => {
+  it('includes DE calculator URLs for all calculators', () => {
     for (const meta of metas) {
       expect(txt, `missing DE URL for ${meta.key}`).toContain(`${BASE_URL}/de/${meta.slugs.de}`)
     }
   })
 
-  it('includes EN blog URLs for all 30 articles', () => {
-    for (const meta of metas) {
+  it('includes EN blog URLs for all articles', () => {
+    for (const meta of metas.filter(m => m.blog)) {
       expect(txt, `missing EN blog URL for ${meta.key}`).toContain(`${BASE_URL}/en/blog/${meta.blog.en.slug}`)
     }
   })
 
-  it('includes DE blog URLs for all 30 articles', () => {
-    for (const meta of metas) {
+  it('includes DE blog URLs for all articles', () => {
+    for (const meta of metas.filter(m => m.blog)) {
       expect(txt, `missing DE blog URL for ${meta.key}`).toContain(`${BASE_URL}/de/blog/${meta.blog.de.slug}`)
     }
   })
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 172 links (43 calcs × 2 locales + 43 blogs × 2 locales)', () => {
+  it('generates 176 links (45 calcs × 2 locales + 43 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(172)
+    expect(links).toHaveLength(176)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-209-decouple-parsemeta-llms-txt
**Agent:** claude
**Model:** claude-sonnet-4-6
**Branch:** `agent/hc-209-decouple-parsemeta-llms-txt-20260427-073532`
**Cost:** $0.37592119999999996

Closes jenslaufer/health-calculators#209

### Prompt
> Decouple parseMeta() in scripts/generate-llms-txt.js so that calculators without a blog: block are still listed in dist/llms.txt. See issue #209 for full context.

## Problem

Currently parseMeta() in scripts/generate-llms-txt.js returns null when no blog block is found. Result: bmi-frauen.meta.js and bmi-maenner.meta.js (which intentionally have no blog:) are filtered out completely → 4 URLs missing in dist/llms.txt:
  /de/bmi-rechner-frauen, /en/bmi-calculator-women
  /de/bmi-rechner-maenner, /en/bmi-calculator-men

scripts/generate-sitemap.js already does the right thing: parseMeta returns { key, slugs, blog: null } when blog absent, and discoverBlogSlugs filters down to metas with blog. Mirror that pattern in generate-llms-txt.js.

## TDD-RED-FIRST (mandatory ordering)

STEP 1 — Write/update tests FIRST (must FAIL on current main):
  - Update src/__tests__/llms-txt.test.js:
    - Bump literal count assertion from 172 to 176.
    - Calculator-URL loops MUST iterate ALL metas (for meta of metas).
    - Blog-URL loops MUST iterate only metas with blog: for meta of metas.filter(m => m.blog).
    - Update describe-strings: "30 calculators" / "30 articles" → use metas.length and metas.filter(m => m.blog).length so they don't drift.
  - Run: npx vitest run src/__tests__/llms-txt.test.js → expect FAIL on the count assertion (172 actual, 176 expected) and 4 missing-URL assertions for the BMI variants.

STEP 2 — Implement the fix in scripts/generate-llms-txt.js:
  - parseMeta(source): change last line from
      return key && slugs && blog ? { key, slugs, blog } : null
    to
      return key && slugs ? { key, slugs, blog } : null
  - generateLlmsTxt(metas, baseUrl, metaDir):
    - Calculators loop: unchanged structure, but now meta.blog may be null (it is not used in the calc-section anyway).
    - Blog loop: change `for (const meta of metas)` to `for (const meta of metas.filter(m => m.blog))` so blog-less metas are skipped.

STEP 3 — Re-run npx vitest run → all green (including the bumped 176-count assertion).

STEP 4 — Run npm run build → expect dist/llms.txt to contain 176 "- [" link lines and the 4 BMI variant URLs.

## Hard rules

- DO NOT modify any *.meta.js file. bmi-frauen.meta.js and bmi-maenner.meta.js MUST stay blog-less by design.
- DO NOT modify scripts/generate-sitemap.js (already correct, count assertions there stay 180).
- DO NOT modify any other test file. Only src/__tests__/llms-txt.test.js changes.
- DO NOT touch src/data/articles*.js (no new blog being registered).
- DO NOT bump unrelated counts (180 sitemap stays, 45 calc count stays).
- The only count that changes is llms.txt link count: 172 → 176.

## Verify (before committing)

- npx vitest run → 1216 passed (was 1212 + 4 new effective assertions covered by the loops)
- node scripts/generate-llms-txt.js (or via npm run build) → look for "176 links" in stdout
- grep -c '^- \[' dist/llms.txt → 176
- grep -E 'bmi-rechner-(frauen|maenner)|bmi-calculator-(women|men)' dist/llms.txt → 4 matches

## Files touched (max scope)

- scripts/generate-llms-txt.js (parseMeta return + blog-loop filter)
- src/__tests__/llms-txt.test.js (count + filtered loops)

No other files. Single PR. No merge by the agent.