### PR TITLE
hc-121-cholesterol-ratio: RETRY: the previous run produced NO DIFF (silent failure —

### DIFF
--- a/e2e/cholesterolRatio.spec.js
+++ b/e2e/cholesterolRatio.spec.js
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/cholesterol-verhaeltnis-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Cholesterin-Verh/)
+})
+
+test('Test 1: Total=150 HDL=50 LDL=80 Trig=100 → optimal (3.0)', async ({ page }) => {
+  await page.getByTestId('total').fill('150')
+  await page.getByTestId('hdl').fill('50')
+  await page.getByTestId('ldl').fill('80')
+  await page.getByTestId('trig').fill('100')
+
+  const totalHdl = page.getByTestId('result-total-hdl')
+  await expect(totalHdl).toBeVisible()
+  await expect(totalHdl).toHaveText('3.00')
+
+  const cls = page.getByTestId('result-classification')
+  await expect(cls).toHaveText('optimal')
+})
+
+test('Test 2: Total=220 HDL=40 LDL=150 Trig=150 → high', async ({ page }) => {
+  await page.getByTestId('total').fill('220')
+  await page.getByTestId('hdl').fill('40')
+  await page.getByTestId('ldl').fill('150')
+  await page.getByTestId('trig').fill('150')
+
+  const cls = page.getByTestId('result-classification')
+  await expect(cls).toHaveText('high')
+
+  const totalHdl = page.getByTestId('result-total-hdl')
+  await expect(totalHdl).toHaveText('5.50')
+})
+
+test('Test 3: Friedewald fallback — LDL omitted', async ({ page }) => {
+  await page.getByTestId('total').fill('160')
+  await page.getByTestId('hdl').fill('50')
+  await page.getByTestId('trig').fill('150')
+
+  const cls = page.getByTestId('result-classification')
+  await expect(cls).toHaveText('optimal')
+
+  await expect(page.getByTestId('friedewald-used')).toBeVisible()
+})
+
+test('back link navigates to home', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -19,7 +19,7 @@ const EXPECTED_KEYS = [
   'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
-  'bmiFrauen', 'bmiMaenner', 'childDosage',
+  'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -67,6 +67,7 @@ const EXPECTED_ROUTE_MAP = {
   bmiFrauen: { de: 'bmi-rechner-frauen', en: 'bmi-calculator-women' },
   bmiMaenner: { de: 'bmi-rechner-maenner', en: 'bmi-calculator-men' },
   childDosage: { de: 'kinder-dosierung-rechner', en: 'child-dosage-calculator' },
+  cholesterolRatio: { de: 'cholesterol-verhaeltnis-rechner', en: 'cholesterol-ratio' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -102,6 +103,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'anionenluecke-rechner',
   'natrium-korrektur-berechnen',
   'kinder-dosierung-rechner',
+  'cholesterol-verhaeltnis-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -137,19 +139,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'anion-gap',
   'sodium-correction-calculator',
   'child-dosage-calculator',
+  'cholesterol-ratio',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 46 calculators', () => {
-    expect(calculatorMetas).toHaveLength(46)
+  it('discovers all 47 calculators', () => {
+    expect(calculatorMetas).toHaveLength(47)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 46 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(46)
+  it('builds calculatorComponents map for all 47 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(47)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -172,15 +175,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 44 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(44)
+  it('discovers all 45 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(45)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 44 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(44)
+  it('discovers all 45 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(45)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -198,8 +201,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 46 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(46)
-    expect(new Set(allKeys).size).toBe(46)
+    expect(allKeys).toHaveLength(47)
+    expect(new Set(allKeys).size).toBe(47)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -220,7 +223,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio',
     ])
   })
 
@@ -268,8 +271,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 266 routes', () => {
-    expect(routes).toHaveLength(266)
+  it('generates exactly 271 routes', () => {
+    expect(routes).toHaveLength(271)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/cholesterolRatio.test.js
+++ b/src/__tests__/cholesterolRatio.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+
+const MGDL_PER_MMOL_CHOL = 38.67
+const MGDL_PER_MMOL_TRIG = 88.57
+
+function toMgDl(value, unit, kind = 'cholesterol') {
+  if (value === null || value === undefined || value === '') return null
+  const num = Number(value)
+  if (!Number.isFinite(num)) return null
+  if (unit === 'mmol') {
+    const factor = kind === 'triglycerides' ? MGDL_PER_MMOL_TRIG : MGDL_PER_MMOL_CHOL
+    return num * factor
+  }
+  return num
+}
+
+function friedewaldLdl(total, hdl, trig) {
+  if (total == null || hdl == null || trig == null) return null
+  if (trig >= 400) return null
+  return total - hdl - trig / 5
+}
+
+function plausibilityWarnings(total, hdl, ldl, trig) {
+  const w = []
+  if (total != null && (total < 100 || total > 400)) w.push('totalOutOfRange')
+  if (hdl != null && (hdl < 20 || hdl > 120)) w.push('hdlOutOfRange')
+  if (ldl != null && (ldl < 30 || ldl > 300)) w.push('ldlOutOfRange')
+  if (trig != null && (trig < 30 || trig > 1000)) w.push('trigOutOfRange')
+  return w
+}
+
+function calcRatios({ total, hdl, ldl, trig, unit = 'mg' }) {
+  const t = toMgDl(total, unit, 'cholesterol')
+  const h = toMgDl(hdl, unit, 'cholesterol')
+  let l = toMgDl(ldl, unit, 'cholesterol')
+  const tr = toMgDl(trig, unit, 'triglycerides')
+
+  const warnings = []
+  if (h === 0) {
+    return {
+      totalHdl: null, ldlHdl: null, trigHdl: null,
+      ldl: null, classification: 'invalid',
+      warnings: ['hdlZero'],
+    }
+  }
+
+  let friedewaldUsed = false
+  let friedewaldSkipped = false
+  if (l == null && t != null && h != null && tr != null) {
+    if (tr < 400) {
+      l = friedewaldLdl(t, h, tr)
+      friedewaldUsed = true
+    } else {
+      friedewaldSkipped = true
+      warnings.push('friedewaldSkipped')
+    }
+  }
+
+  const totalHdl = (t != null && h) ? t / h : null
+  const ldlHdl = (l != null && h) ? l / h : null
+  const trigHdl = (tr != null && h) ? tr / h : null
+
+  let classification = null
+  if (totalHdl != null) {
+    if (totalHdl < 3.5) classification = 'optimal'
+    else if (totalHdl <= 5.0) classification = 'moderate'
+    else classification = 'high'
+  }
+
+  warnings.push(...plausibilityWarnings(t, h, l, tr))
+
+  return {
+    totalHdl, ldlHdl, trigHdl, ldl: l,
+    classification,
+    friedewaldUsed,
+    friedewaldSkipped,
+    warnings,
+  }
+}
+
+describe('Unit conversion mmol/L → mg/dL', () => {
+  it('converts cholesterol mmol → mg/dL', () => {
+    expect(toMgDl(5.17, 'mmol', 'cholesterol')).toBeCloseTo(199.92, 1)
+  })
+
+  it('converts triglycerides mmol → mg/dL', () => {
+    expect(toMgDl(1.1, 'mmol', 'triglycerides')).toBeCloseTo(97.43, 1)
+  })
+
+  it('passes through mg/dL unchanged', () => {
+    expect(toMgDl(150, 'mg', 'cholesterol')).toBe(150)
+  })
+})
+
+describe('Friedewald LDL fallback', () => {
+  it('190 - 50 - 150/5 = 110', () => {
+    expect(friedewaldLdl(190, 50, 150)).toBe(110)
+  })
+
+  it('returns null when triglycerides ≥ 400', () => {
+    expect(friedewaldLdl(250, 40, 450)).toBe(null)
+  })
+})
+
+describe('Cholesterol ratio classification', () => {
+  it('Test 1: Total=150, HDL=50, LDL=80, Trig=100 → optimal (3.0)', () => {
+    const r = calcRatios({ total: 150, hdl: 50, ldl: 80, trig: 100 })
+    expect(r.totalHdl).toBeCloseTo(3.0, 2)
+    expect(r.ldlHdl).toBeCloseTo(1.6, 2)
+    expect(r.classification).toBe('optimal')
+  })
+
+  it('Test 2: Total=220, HDL=40, LDL=150, Trig=150 → high (5.5)', () => {
+    const r = calcRatios({ total: 220, hdl: 40, ldl: 150, trig: 150 })
+    expect(r.totalHdl).toBeCloseTo(5.5, 2)
+    expect(r.classification).toBe('high')
+  })
+
+  it('Test 3: Friedewald fallback — Total=160, HDL=50, LDL null, Trig=150 → LDL=80, optimal', () => {
+    const r = calcRatios({ total: 160, hdl: 50, ldl: null, trig: 150 })
+    expect(r.friedewaldUsed).toBe(true)
+    expect(r.ldl).toBe(80)
+    expect(r.ldlHdl).toBeCloseTo(1.6, 2)
+    expect(r.classification).toBe('optimal')
+  })
+
+  it('Test 4: Friedewald skipped when Trig ≥ 400 — warning present', () => {
+    const r = calcRatios({ total: 250, hdl: 40, ldl: null, trig: 450 })
+    expect(r.friedewaldSkipped).toBe(true)
+    expect(r.ldlHdl).toBe(null)
+    expect(r.warnings).toContain('friedewaldSkipped')
+  })
+
+  it('Test 5: mmol/L input — 3.88 / 1.30 ≈ 3.0 → optimal', () => {
+    const r = calcRatios({ total: 3.88, hdl: 1.30, ldl: 2.07, trig: 1.13, unit: 'mmol' })
+    expect(r.classification).toBe('optimal')
+    expect(r.totalHdl).toBeCloseTo(3.0, 1)
+  })
+
+  it('Test 6: HDL=0 → invalid with hdlZero warning', () => {
+    const r = calcRatios({ total: 200, hdl: 0, ldl: 120, trig: 150 })
+    expect(r.classification).toBe('invalid')
+    expect(r.warnings).toContain('hdlZero')
+  })
+
+  it('moderate band: ratio between 3.5 and 5.0', () => {
+    const r = calcRatios({ total: 200, hdl: 50, ldl: 130, trig: 150 })
+    expect(r.totalHdl).toBeCloseTo(4.0, 1)
+    expect(r.classification).toBe('moderate')
+  })
+})
+
+describe('Plausibility warnings', () => {
+  it('flags out-of-range total cholesterol', () => {
+    const w = plausibilityWarnings(80, 50, 100, 100)
+    expect(w).toContain('totalOutOfRange')
+  })
+
+  it('flags out-of-range HDL', () => {
+    const w = plausibilityWarnings(200, 15, 100, 100)
+    expect(w).toContain('hdlOutOfRange')
+  })
+
+  it('no warnings for plausible values', () => {
+    expect(plausibilityWarnings(200, 50, 130, 150)).toEqual([])
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 180 links (46 calcs × 2 locales + 44 blogs × 2 locales)', () => {
+  it('generates 184 links (47 calcs × 2 locales + 45 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(180)
+    expect(links).toHaveLength(184)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -50,6 +50,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'koerpertemperatur-berechnen',
   'anionenluecke-rechner',
   'kinder-dosierung-rechner',
+  'cholesterol-verhaeltnis-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -84,12 +85,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'body-temperature-calculator',
   'anion-gap',
   'child-dosage-calculator',
+  'cholesterol-ratio',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 46 calculator meta files', () => {
+  it('discovers all 47 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(46)
+    expect(metas).toHaveLength(47)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -127,19 +129,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 44 DE blog slugs', () => {
+  it('returns all 45 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(44)
+    expect(de).toHaveLength(45)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 44 EN blog slugs', () => {
+  it('returns all 45 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(44)
+    expect(en).toHaveLength(45)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -207,9 +209,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 92 calcs + 2 blog index + 88 blog articles = 184)', () => {
+  it('generates correct total URL count (2 home + 94 calcs + 2 blog index + 90 blog articles = 188)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(184)
+    expect(urlCount).toBe(188)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -395,6 +395,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'childDosage',
     related: ['child-growth-percentile-chart', 'body-surface-area-calculator', 'calculate-bmi'],
   },
+  {
+    slug: 'cholesterol-ratio',
+    title: 'Cholesterol Ratio Explained: What Your Blood Work Really Tells You',
+    description: 'Calculate your cholesterol ratios — Total/HDL, LDL/HDL and the atherogenic index. AHA/ESC risk classification, Friedewald formula and tips to improve.',
+    date: '2026-04-30',
+    readTime: '8 min',
+    calculatorKey: 'cholesterolRatio',
+    related: ['calculate-bmi', 'measure-blood-pressure', 'diabetes-risk-score'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -395,6 +395,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'childDosage',
     related: ['wachstumsperzentile-kinder', 'koerperoberflaeche-berechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'cholesterol-verhaeltnis-rechner',
+    title: 'Cholesterin-Verhältnis berechnen: Was deine Blutwerte wirklich aussagen',
+    description: 'Cholesterin-Verhältnis berechnen — Total/HDL, LDL/HDL und atherogener Index. Risikoeinordnung nach AHA/ESC, Friedewald-Formel und Tipps zur Verbesserung.',
+    date: '2026-04-30',
+    readTime: '8 min',
+    calculatorKey: 'cholesterolRatio',
+    related: ['bmi-berechnen', 'blutdruck-richtig-messen', 'diabetes-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/cholesterolRatio.json
+++ b/src/locales/calculators/de/cholesterolRatio.json
@@ -1,0 +1,74 @@
+{
+  "home": {
+    "calculators": {
+      "cholesterolRatio": {
+        "name": "Cholesterin-Verhältnis-Rechner",
+        "description": "Berechne Total-, LDL- und Triglycerid-zu-HDL-Verhältnisse mit Risikoeinordnung."
+      }
+    }
+  },
+  "cholesterolRatio": {
+    "meta": {
+      "title": "Cholesterin-Verhältnis-Rechner — Total/HDL, LDL/HDL & Triglyceride/HDL",
+      "description": "Berechne dein Cholesterin-Verhältnis (Total/HDL, LDL/HDL, Triglyceride/HDL) für eine bessere Einschätzung des kardiovaskulären Risikos. Mit Friedewald-Fallback. Kostenlos, sofort, ohne Anmeldung."
+    },
+    "title": "Cholesterin-Verhältnis-Rechner",
+    "description": "Berechne dein Cholesterin-Verhältnis und das atherogene Risiko nach AHA/ESC-Leitlinien.",
+    "totalLabel": "Gesamtcholesterin",
+    "hdlLabel": "HDL",
+    "ldlLabel": "LDL",
+    "trigLabel": "Triglyceride",
+    "optional": "optional",
+    "friedewaldHint": "Wenn LDL leer ist, wird es per Friedewald-Formel geschätzt (nur bei Triglyceriden < 400 mg/dL).",
+    "totalHdlSuffix": "Total/HDL",
+    "totalHdlLabel": "Total/HDL",
+    "ldlHdlLabel": "LDL/HDL",
+    "trigHdlLabel": "Triglyceride/HDL",
+    "targetTotalHdl": "Ziel < 3.5 (AHA/ESC)",
+    "ldlBand_optimal": "Optimal",
+    "ldlBand_borderline": "Grenzwertig",
+    "ldlBand_high": "Erhöht",
+    "trigBand_optimal": "Optimal",
+    "trigBand_borderline": "Grenzwertig",
+    "trigBand_high": "Erhöht (Marker für metabolisches Syndrom)",
+    "refRatio": "Verhältnis",
+    "refOptimal": "Optimal",
+    "refModerate": "Moderat",
+    "refHigh": "Erhöhtes Risiko",
+    "friedewaldUsed": "LDL geschätzt per Friedewald-Formel: {ldl} mg/dL.",
+    "warning_friedewaldSkipped": "LDL konnte nicht per Friedewald geschätzt werden (Triglyceride ≥ 400 mg/dL). Bitte LDL direkt eingeben.",
+    "warning_totalOutOfRange": "Gesamtcholesterin außerhalb des klinisch plausiblen Bereichs (100–400 mg/dL).",
+    "warning_hdlOutOfRange": "HDL außerhalb des klinisch plausiblen Bereichs (20–120 mg/dL).",
+    "warning_ldlOutOfRange": "LDL außerhalb des klinisch plausiblen Bereichs (30–300 mg/dL).",
+    "warning_trigOutOfRange": "Triglyceride außerhalb des klinisch plausiblen Bereichs (30–1000 mg/dL).",
+    "warning_hdlZero": "HDL kann nicht 0 sein — Verhältnis nicht berechenbar.",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Das Total/HDL-Verhältnis ist ein etablierter Marker für das kardiovaskuläre Risiko. Werte unter 3.5 gelten nach AHA/ESC als optimal, 3.5–5.0 als moderat, über 5.0 als erhöht. Das LDL/HDL-Verhältnis und der atherogene Index (Triglyceride/HDL) liefern zusätzliche Risikoinformationen. Bei fehlendem LDL und Triglyceriden < 400 mg/dL wird die Friedewald-Formel verwendet: LDL = Gesamt − HDL − Triglyceride/5.",
+    "faq": [
+      {
+        "q": "Was ist das Cholesterin-Verhältnis und warum ist es wichtig?",
+        "a": "Das Total/HDL-Verhältnis ist nach Studien (Framingham, INTERHEART) ein präziserer Prädiktor für Herzinfarkte als das absolute Cholesterin. Es berücksichtigt das schützende HDL und ist daher als Single-Marker robuster."
+      },
+      {
+        "q": "Welcher Wert ist optimal?",
+        "a": "Total/HDL unter 3.5 ist nach AHA/ESC 2023 optimal. 3.5–5.0 gilt als moderat, über 5.0 als erhöhtes Risiko. Das LDL/HDL-Verhältnis sollte unter 2.5 liegen."
+      },
+      {
+        "q": "Was ist die Friedewald-Formel?",
+        "a": "Die Friedewald-Formel schätzt das LDL aus Gesamt-, HDL-Cholesterin und Triglyceriden: LDL = Gesamt − HDL − Triglyceride/5. Sie ist nur valide bei Triglyceriden unter 400 mg/dL."
+      },
+      {
+        "q": "Was bedeutet ein hohes Triglyceride/HDL-Verhältnis?",
+        "a": "Werte über 4 deuten auf Insulinresistenz und ein erhöhtes metabolisches Risiko hin. Dieses Verhältnis korreliert stark mit kleinen, dichten LDL-Partikeln, die besonders atherogen sind."
+      },
+      {
+        "q": "Wie kann ich mein Cholesterin-Verhältnis verbessern?",
+        "a": "HDL erhöhen durch Ausdauersport, Olivenöl, fettem Fisch und Verzicht auf Transfette. LDL und Triglyceride senken durch Gewichtsabnahme, weniger Zucker und Alkohol sowie ballaststoffreiche Ernährung."
+      },
+      {
+        "q": "Müssen die Blutwerte nüchtern abgenommen werden?",
+        "a": "Für Triglyceride und damit auch die Friedewald-LDL-Schätzung ja — mindestens 9–12 Stunden nüchtern. Für Total und HDL ist Nüchternheit nicht zwingend erforderlich."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/cholesterolRatio.json
+++ b/src/locales/calculators/en/cholesterolRatio.json
@@ -1,0 +1,74 @@
+{
+  "home": {
+    "calculators": {
+      "cholesterolRatio": {
+        "name": "Cholesterol Ratio Calculator",
+        "description": "Calculate Total, LDL and Triglyceride to HDL ratios with risk classification."
+      }
+    }
+  },
+  "cholesterolRatio": {
+    "meta": {
+      "title": "Cholesterol Ratio Calculator — Total/HDL, LDL/HDL & Triglyceride/HDL",
+      "description": "Calculate your cholesterol ratios (Total/HDL, LDL/HDL, Triglyceride/HDL) for a more accurate cardiovascular risk assessment. Friedewald fallback included. Free, instant, no sign-up."
+    },
+    "title": "Cholesterol Ratio Calculator",
+    "description": "Calculate your cholesterol ratios and atherogenic risk per AHA/ESC guidelines.",
+    "totalLabel": "Total Cholesterol",
+    "hdlLabel": "HDL",
+    "ldlLabel": "LDL",
+    "trigLabel": "Triglycerides",
+    "optional": "optional",
+    "friedewaldHint": "If LDL is empty, it will be estimated via the Friedewald formula (only when triglycerides < 400 mg/dL).",
+    "totalHdlSuffix": "Total/HDL",
+    "totalHdlLabel": "Total/HDL",
+    "ldlHdlLabel": "LDL/HDL",
+    "trigHdlLabel": "Triglyceride/HDL",
+    "targetTotalHdl": "Target < 3.5 (AHA/ESC)",
+    "ldlBand_optimal": "Optimal",
+    "ldlBand_borderline": "Borderline",
+    "ldlBand_high": "Elevated",
+    "trigBand_optimal": "Optimal",
+    "trigBand_borderline": "Borderline",
+    "trigBand_high": "Elevated (metabolic syndrome marker)",
+    "refRatio": "Ratio",
+    "refOptimal": "Optimal",
+    "refModerate": "Moderate",
+    "refHigh": "Elevated risk",
+    "friedewaldUsed": "LDL estimated via Friedewald formula: {ldl} mg/dL.",
+    "warning_friedewaldSkipped": "LDL could not be estimated via Friedewald (triglycerides ≥ 400 mg/dL). Please enter LDL directly.",
+    "warning_totalOutOfRange": "Total cholesterol outside the clinically plausible range (100–400 mg/dL).",
+    "warning_hdlOutOfRange": "HDL outside the clinically plausible range (20–120 mg/dL).",
+    "warning_ldlOutOfRange": "LDL outside the clinically plausible range (30–300 mg/dL).",
+    "warning_trigOutOfRange": "Triglycerides outside the clinically plausible range (30–1000 mg/dL).",
+    "warning_hdlZero": "HDL cannot be 0 — ratio is undefined.",
+    "howItWorks": "How it works",
+    "howItWorksText": "The Total/HDL ratio is an established marker of cardiovascular risk. Per AHA/ESC, values below 3.5 are optimal, 3.5–5.0 moderate, above 5.0 elevated. The LDL/HDL ratio and atherogenic index (Triglyceride/HDL) provide additional risk insight. When LDL is missing and triglycerides < 400 mg/dL, the Friedewald formula is used: LDL = Total − HDL − Triglycerides/5.",
+    "faq": [
+      {
+        "q": "What is the cholesterol ratio and why does it matter?",
+        "a": "Studies (Framingham, INTERHEART) show that the Total/HDL ratio predicts heart attacks more accurately than total cholesterol alone. By accounting for protective HDL, it is a more robust single marker."
+      },
+      {
+        "q": "What value is optimal?",
+        "a": "AHA/ESC 2023: Total/HDL below 3.5 is optimal, 3.5–5.0 moderate, above 5.0 elevated risk. The LDL/HDL ratio should be below 2.5."
+      },
+      {
+        "q": "What is the Friedewald formula?",
+        "a": "The Friedewald formula estimates LDL from total cholesterol, HDL and triglycerides: LDL = Total − HDL − Triglycerides/5. It is only valid when triglycerides are below 400 mg/dL."
+      },
+      {
+        "q": "What does a high Triglyceride/HDL ratio mean?",
+        "a": "Values above 4 indicate insulin resistance and elevated metabolic risk. This ratio correlates strongly with small dense LDL particles, which are particularly atherogenic."
+      },
+      {
+        "q": "How can I improve my cholesterol ratio?",
+        "a": "Raise HDL with endurance exercise, olive oil, fatty fish, and avoiding trans fats. Lower LDL and triglycerides through weight loss, less sugar and alcohol, and a fibre-rich diet."
+      },
+      {
+        "q": "Do I need to fast before the blood test?",
+        "a": "Yes for triglycerides — and therefore for the Friedewald LDL estimate — at least 9–12 hours fasting. Total cholesterol and HDL do not strictly require fasting."
+      }
+    ]
+  }
+}

--- a/src/pages/CholesterolRatioCalculator.vue
+++ b/src/pages/CholesterolRatioCalculator.vue
@@ -1,0 +1,259 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('cholesterolRatio.faq') || [])
+
+useHead(() => ({
+  title: t('cholesterolRatio.meta.title'),
+  description: t('cholesterolRatio.meta.description'),
+  routeKey: 'cholesterolRatio',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Cholesterol Ratio Calculator',
+    url: 'https://healthcalculator.app/cholesterol-ratio',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const unit = ref('mg')
+const total = ref(null)
+const hdl = ref(null)
+const ldl = ref(null)
+const trig = ref(null)
+
+const MGDL_PER_MMOL_CHOL = 38.67
+const MGDL_PER_MMOL_TRIG = 88.57
+
+function toMgDl(value, kind) {
+  if (value === null || value === undefined || value === '') return null
+  const num = Number(value)
+  if (!Number.isFinite(num)) return null
+  if (unit.value === 'mmol') {
+    const factor = kind === 'triglycerides' ? MGDL_PER_MMOL_TRIG : MGDL_PER_MMOL_CHOL
+    return num * factor
+  }
+  return num
+}
+
+const result = computed(() => {
+  const t = toMgDl(total.value, 'cholesterol')
+  const h = toMgDl(hdl.value, 'cholesterol')
+  let l = toMgDl(ldl.value, 'cholesterol')
+  const tr = toMgDl(trig.value, 'triglycerides')
+
+  if (t == null || h == null) return null
+
+  if (h === 0) {
+    return {
+      classification: 'invalid',
+      totalHdl: null, ldlHdl: null, trigHdl: null, ldl: null,
+      friedewaldUsed: false,
+      friedewaldSkipped: false,
+      warnings: ['hdlZero'],
+    }
+  }
+
+  let friedewaldUsed = false
+  let friedewaldSkipped = false
+  if (l == null && tr != null) {
+    if (tr < 400) {
+      l = t - h - tr / 5
+      friedewaldUsed = true
+    } else {
+      friedewaldSkipped = true
+    }
+  }
+
+  const totalHdl = t / h
+  const ldlHdl = l != null ? l / h : null
+  const trigHdl = tr != null ? tr / h : null
+
+  let classification
+  if (totalHdl < 3.5) classification = 'optimal'
+  else if (totalHdl <= 5.0) classification = 'moderate'
+  else classification = 'high'
+
+  const warnings = []
+  if (friedewaldSkipped) warnings.push('friedewaldSkipped')
+  if (t < 100 || t > 400) warnings.push('totalOutOfRange')
+  if (h < 20 || h > 120) warnings.push('hdlOutOfRange')
+  if (l != null && (l < 30 || l > 300)) warnings.push('ldlOutOfRange')
+  if (tr != null && (tr < 30 || tr > 1000)) warnings.push('trigOutOfRange')
+
+  return {
+    classification,
+    totalHdl, ldlHdl, trigHdl,
+    ldl: l,
+    friedewaldUsed,
+    friedewaldSkipped,
+    warnings,
+  }
+})
+
+const classificationColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.classification) {
+    case 'optimal': return 'text-green-600'
+    case 'moderate': return 'text-yellow-600'
+    case 'high': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+
+function fmt(v, digits = 2) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return v.toFixed(digits)
+}
+
+function ldlBand(ratio) {
+  if (ratio < 2.5) return 'optimal'
+  if (ratio <= 3.5) return 'borderline'
+  return 'high'
+}
+
+function trigBand(ratio) {
+  if (ratio < 2) return 'optimal'
+  if (ratio <= 4) return 'borderline'
+  return 'high'
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('cholesterolRatio.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('cholesterolRatio.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button @click="unit = 'mg'" data-testid="unit-mg"
+        :class="unit === 'mg' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >mg/dL</button>
+      <button @click="unit = 'mmol'" data-testid="unit-mmol"
+        :class="unit === 'mmol' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >mmol/L</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('cholesterolRatio.totalLabel') }}</label>
+        <input v-model.number="total" type="number" step="0.01" :placeholder="unit === 'mg' ? '200' : '5.17'" data-testid="total"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('cholesterolRatio.hdlLabel') }}</label>
+        <input v-model.number="hdl" type="number" step="0.01" :placeholder="unit === 'mg' ? '50' : '1.3'" data-testid="hdl"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('cholesterolRatio.ldlLabel') }} <span class="text-stone-400 normal-case font-normal">({{ t('cholesterolRatio.optional') }})</span>
+        </label>
+        <input v-model.number="ldl" type="number" step="0.01" :placeholder="unit === 'mg' ? '120' : '3.1'" data-testid="ldl"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('cholesterolRatio.trigLabel') }}</label>
+        <input v-model.number="trig" type="number" step="0.01" :placeholder="unit === 'mg' ? '150' : '1.7'" data-testid="trig"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+    <p class="text-xs text-stone-400 mt-2">{{ t('cholesterolRatio.friedewaldHint') }}</p>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-6">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="result-total-hdl">{{ fmt(result.totalHdl) }}</span>
+      <span class="text-lg text-stone-400">{{ t('cholesterolRatio.totalHdlSuffix') }}</span>
+      <span :class="classificationColor" class="text-lg font-semibold" data-testid="result-classification">{{ result.classification }}</span>
+    </div>
+
+    <div v-if="result.classification !== 'invalid'" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('cholesterolRatio.totalHdlLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ fmt(result.totalHdl) }}</p>
+        <p class="text-xs text-stone-500 mt-1">{{ t('cholesterolRatio.targetTotalHdl') }}</p>
+      </div>
+      <div v-if="result.ldlHdl != null" class="bg-stone-50 rounded-lg p-4" data-testid="result-ldl-hdl">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('cholesterolRatio.ldlHdlLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ fmt(result.ldlHdl) }}</p>
+        <p class="text-xs text-stone-500 mt-1">{{ t('cholesterolRatio.ldlBand_' + ldlBand(result.ldlHdl)) }}</p>
+      </div>
+      <div v-if="result.trigHdl != null" class="bg-stone-50 rounded-lg p-4" data-testid="result-trig-hdl">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('cholesterolRatio.trigHdlLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ fmt(result.trigHdl) }}</p>
+        <p class="text-xs text-stone-500 mt-1">{{ t('cholesterolRatio.trigBand_' + trigBand(result.trigHdl)) }}</p>
+      </div>
+    </div>
+
+    <div v-if="result.friedewaldUsed" class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-3 text-sm text-blue-900" data-testid="friedewald-used">
+      {{ t('cholesterolRatio.friedewaldUsed', { ldl: fmt(result.ldl, 0) }) }}
+    </div>
+
+    <div v-if="result.warnings && result.warnings.length" class="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-900" data-testid="warnings">
+      <ul class="list-disc list-inside space-y-1">
+        <li v-for="w in result.warnings" :key="w">{{ t('cholesterolRatio.warning_' + w) }}</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('cholesterolRatio.refRatio') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('cholesterolRatio.refOptimal') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('cholesterolRatio.refModerate') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('cholesterolRatio.refHigh') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('cholesterolRatio.totalHdlLabel') }}</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 3.5</td>
+          <td class="px-6 py-3 text-stone-600">3.5 – 5.0</td>
+          <td class="px-6 py-3 text-stone-600">&gt; 5.0</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('cholesterolRatio.ldlHdlLabel') }}</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 2.5</td>
+          <td class="px-6 py-3 text-stone-600">2.5 – 3.5</td>
+          <td class="px-6 py-3 text-stone-600">&gt; 3.5</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('cholesterolRatio.trigHdlLabel') }}</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 2</td>
+          <td class="px-6 py-3 text-stone-600">2 – 4</td>
+          <td class="px-6 py-3 text-stone-600">&gt; 4</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('cholesterolRatio.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('cholesterolRatio.howItWorksText') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="cholesterolRatio" />
+</template>

--- a/src/pages/blog/CholesterolVerhaeltnisRechner.vue
+++ b/src/pages/blog/CholesterolVerhaeltnisRechner.vue
@@ -1,0 +1,194 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Was sagt das Cholesterin-Verhältnis aus?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Das Total/HDL-Verhältnis ist nach Framingham- und INTERHEART-Studien ein präziserer Prädiktor für Herzinfarkte als das absolute Cholesterin. Es berücksichtigt das schützende HDL.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Welcher Wert gilt als optimal?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Total/HDL unter 3.5 ist nach AHA/ESC 2023 optimal. 3.5–5.0 gilt als moderat, über 5.0 als erhöht.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Was ist die Friedewald-Formel?',
+      acceptedAnswer: { '@type': 'Answer', text: 'LDL = Gesamt − HDL − Triglyceride/5 (nur valide bei Triglyceriden < 400 mg/dL).' },
+    },
+  ],
+}
+
+const howToJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'Cholesterin-Verhältnis berechnen',
+  step: [
+    { '@type': 'HowToStep', name: 'Werte eintragen', text: 'Gesamtcholesterin, HDL, LDL und Triglyceride aus deinem Laborbefund eingeben.' },
+    { '@type': 'HowToStep', name: 'Einheit wählen', text: 'mg/dL oder mmol/L. Der Rechner konvertiert automatisch.' },
+    { '@type': 'HowToStep', name: 'Verhältnisse ablesen', text: 'Total/HDL als Hauptmarker, LDL/HDL und Triglyceride/HDL als Zusatzinformation.' },
+    { '@type': 'HowToStep', name: 'Risiko einordnen', text: 'Optimal < 3.5, moderat 3.5–5.0, erhöht > 5.0 (Total/HDL nach AHA/ESC).' },
+  ],
+}
+
+useHead({
+  title: 'Cholesterin-Verhältnis berechnen: Total/HDL, LDL/HDL & Triglyceride/HDL | Health Calculators',
+  description: 'Cholesterin-Verhältnis berechnen — Total/HDL, LDL/HDL und atherogener Index. Risikoeinordnung nach AHA/ESC, Friedewald-Formel und Tipps zur Verbesserung.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Cholesterin-Verhältnis berechnen: Was deine Blutwerte wirklich aussagen',
+      description: 'Cholesterin-Verhältnis berechnen — Total/HDL, LDL/HDL und atherogener Index. Risikoeinordnung nach AHA/ESC, Friedewald-Formel und Tipps zur Verbesserung.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-04-30',
+      dateModified: '2026-04-30',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/cholesterol-verhaeltnis-rechner',
+      },
+    },
+    faqJsonLd,
+    howToJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Cholesterin-Verhältnis berechnen: Was deine Blutwerte wirklich aussagen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">30. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das absolute <strong>Gesamtcholesterin</strong> ist nur die halbe Wahrheit. Das <strong>Cholesterin-Verhältnis</strong> — insbesondere das Total/HDL-Verhältnis — sagt deutlich präziser voraus, wie hoch dein Risiko für Herzinfarkt und Schlaganfall ist.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt die drei wichtigsten Verhältnisse, die Friedewald-Formel und wie du deine Werte verbesserst.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die drei Cholesterin-Verhältnisse</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p class="mb-2"><strong>Total/HDL</strong> = Gesamtcholesterin / HDL</p>
+          <p class="mb-2"><strong>LDL/HDL</strong> = LDL / HDL</p>
+          <p><strong>Triglyceride/HDL</strong> = Triglyceride / HDL (atherogener Index)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Studien wie <strong>Framingham</strong> und <strong>INTERHEART</strong> zeigen: Diese Verhältnisse sind robustere Marker als das Gesamtcholesterin alleine, weil sie das schützende HDL berücksichtigen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Zielwerte nach AHA/ESC 2023</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Verhältnis</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Optimal</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Moderat</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Erhöht</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Total/HDL</td><td class="px-6 py-3 text-stone-600">&lt; 3.5</td><td class="px-6 py-3 text-stone-600">3.5 – 5.0</td><td class="px-6 py-3 text-stone-600">&gt; 5.0</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">LDL/HDL</td><td class="px-6 py-3 text-stone-600">&lt; 2.5</td><td class="px-6 py-3 text-stone-600">2.5 – 3.5</td><td class="px-6 py-3 text-stone-600">&gt; 3.5</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Triglyceride/HDL</td><td class="px-6 py-3 text-stone-600">&lt; 2</td><td class="px-6 py-3 text-stone-600">2 – 4</td><td class="px-6 py-3 text-stone-600">&gt; 4</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Friedewald-Formel: LDL ohne direkte Messung</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wenn dein Laborbefund kein direkt gemessenes LDL enthält, lässt es sich schätzen:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p><strong>LDL</strong> = Gesamtcholesterin &minus; HDL &minus; (Triglyceride / 5)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wichtig: Bei Triglyceriden ab 400 mg/dL wird die Schätzung ungenau und sollte nicht verwendet werden — dann muss LDL direkt gemessen werden.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Triglyceride/HDL — der atherogene Index</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das Triglyceride/HDL-Verhältnis ist ein Marker für <strong>Insulinresistenz</strong> und das metabolische Syndrom. Hohe Werte (&gt; 4) korrelieren stark mit kleinen, dichten LDL-Partikeln, die besonders gefäßschädigend wirken — auch bei normalem LDL-Cholesterin.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wie du dein Verhältnis verbesserst</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">HDL erhöhen</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Ausdauersport (3–4×/Woche), Olivenöl, fetter Fisch, moderater Alkoholkonsum, Verzicht auf Transfette.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">LDL senken</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Lösliche Ballaststoffe (Hafer, Hülsenfrüchte), Pflanzensterole, weniger gesättigte Fette, Gewichtsabnahme.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Triglyceride senken</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Weniger Zucker und Alkohol, Omega-3 (Lachs, Leinöl), regelmäßige Bewegung.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt dein Cholesterin-Verhältnis berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Total/HDL, LDL/HDL und atherogener Index — mit Risikoeinordnung und Friedewald-Fallback. Kostenlos, sofort, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('cholesterolRatio')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Dein Cholesterin hängt eng mit Gewicht und Lebensstil zusammen. Prüfe deinen
+          <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link>,
+          deinen
+          <router-link :to="localeBlogPath('blutdruck-richtig-messen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Blutdruck</router-link>
+          und dein
+          <router-link :to="localeBlogPath('diabetes-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko</router-link>
+          — drei Werte, die zusammen das kardiometabolische Gesamtrisiko abbilden.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das Total/HDL-Verhältnis ist ein robusterer Risikomarker als das absolute Cholesterin. Ergänzt durch LDL/HDL und Triglyceride/HDL ergibt sich ein klareres Bild deines kardiovaskulären Risikos. Berechne deine Werte mit unserem
+          <router-link :to="localePath('cholesterolRatio')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Cholesterin-Verhältnis-Rechner</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticles slug="cholesterol-verhaeltnis-rechner" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/CholesterolRatio.vue
+++ b/src/pages/blog/en/CholesterolRatio.vue
@@ -1,0 +1,191 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What does the cholesterol ratio tell you?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The Total/HDL ratio predicts heart attacks more accurately than total cholesterol alone, per Framingham and INTERHEART studies. It accounts for protective HDL.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What value is optimal?',
+      acceptedAnswer: { '@type': 'Answer', text: 'AHA/ESC 2023: Total/HDL below 3.5 is optimal, 3.5–5.0 moderate, above 5.0 elevated risk.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the Friedewald formula?',
+      acceptedAnswer: { '@type': 'Answer', text: 'LDL = Total − HDL − Triglycerides/5 (only valid when triglycerides < 400 mg/dL).' },
+    },
+  ],
+}
+
+const howToJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to calculate your cholesterol ratio',
+  step: [
+    { '@type': 'HowToStep', name: 'Enter your values', text: 'Enter total cholesterol, HDL, LDL and triglycerides from your lab report.' },
+    { '@type': 'HowToStep', name: 'Choose units', text: 'mg/dL or mmol/L. The calculator converts automatically.' },
+    { '@type': 'HowToStep', name: 'Read your ratios', text: 'Total/HDL is the primary marker. LDL/HDL and Triglyceride/HDL provide additional context.' },
+    { '@type': 'HowToStep', name: 'Classify your risk', text: 'Optimal < 3.5, moderate 3.5–5.0, elevated > 5.0 (Total/HDL per AHA/ESC).' },
+  ],
+}
+
+useHead({
+  title: 'Cholesterol Ratio Calculator: Total/HDL, LDL/HDL & Triglyceride/HDL | Health Calculators',
+  description: 'Calculate your cholesterol ratios — Total/HDL, LDL/HDL and the atherogenic index. AHA/ESC risk classification, Friedewald formula and tips to improve.',
+  path: '/en/blog/cholesterol-ratio',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Cholesterol Ratio Explained: What Your Blood Work Really Tells You',
+      description: 'Calculate your cholesterol ratios — Total/HDL, LDL/HDL and the atherogenic index. AHA/ESC risk classification, Friedewald formula and tips to improve.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-04-30',
+      dateModified: '2026-04-30',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/cholesterol-ratio',
+      },
+    },
+    faqJsonLd,
+    howToJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link to="/en/blog" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Cholesterol Ratio Explained: What Your Blood Work Really Tells You</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 30, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Total cholesterol alone is only half the story. The <strong>cholesterol ratio</strong> — especially Total/HDL — predicts your risk of heart attack and stroke more accurately than absolute numbers.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains the three key ratios, the Friedewald formula, and how to improve your numbers.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The three cholesterol ratios</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p class="mb-2"><strong>Total/HDL</strong> = Total cholesterol / HDL</p>
+          <p class="mb-2"><strong>LDL/HDL</strong> = LDL / HDL</p>
+          <p><strong>Triglyceride/HDL</strong> = Triglycerides / HDL (atherogenic index)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Studies like <strong>Framingham</strong> and <strong>INTERHEART</strong> show these ratios are more robust markers than total cholesterol alone, because they account for protective HDL.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Target values per AHA/ESC 2023</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Ratio</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Optimal</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Moderate</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Elevated</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Total/HDL</td><td class="px-6 py-3 text-stone-600">&lt; 3.5</td><td class="px-6 py-3 text-stone-600">3.5 – 5.0</td><td class="px-6 py-3 text-stone-600">&gt; 5.0</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">LDL/HDL</td><td class="px-6 py-3 text-stone-600">&lt; 2.5</td><td class="px-6 py-3 text-stone-600">2.5 – 3.5</td><td class="px-6 py-3 text-stone-600">&gt; 3.5</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Triglyceride/HDL</td><td class="px-6 py-3 text-stone-600">&lt; 2</td><td class="px-6 py-3 text-stone-600">2 – 4</td><td class="px-6 py-3 text-stone-600">&gt; 4</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Friedewald formula: LDL without direct measurement</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          When your lab report doesn't include directly measured LDL, you can estimate it:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p><strong>LDL</strong> = Total cholesterol &minus; HDL &minus; (Triglycerides / 5)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Important: When triglycerides are at or above 400 mg/dL, the estimate becomes inaccurate and should not be used — LDL must be measured directly.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Triglyceride/HDL — the atherogenic index</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The Triglyceride/HDL ratio is a marker for <strong>insulin resistance</strong> and metabolic syndrome. High values (&gt; 4) correlate strongly with small dense LDL particles, which are particularly damaging — even when total LDL looks normal.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How to improve your ratio</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Raise HDL</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Endurance exercise (3–4×/week), olive oil, fatty fish, moderate alcohol, avoid trans fats.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lower LDL</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Soluble fiber (oats, legumes), plant sterols, less saturated fat, weight loss.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lower triglycerides</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">Less sugar and alcohol, omega-3 (salmon, flaxseed), regular exercise.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your cholesterol ratio now</h3>
+        <p class="text-stone-300 text-sm mb-5">Total/HDL, LDL/HDL and the atherogenic index — with risk classification and Friedewald fallback. Free and no sign-up.</p>
+        <router-link
+          to="/en/cholesterol-ratio"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Cholesterol is closely tied to weight and lifestyle. Check your
+          <router-link to="/en/blog/calculate-bmi" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link>,
+          your
+          <router-link to="/en/blog/measure-blood-pressure" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">blood pressure</router-link>,
+          and your
+          <router-link to="/en/blog/diabetes-risk-score" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">diabetes risk</router-link>
+          — three numbers that together capture cardiometabolic risk.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conclusion</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The Total/HDL ratio is a more robust risk marker than absolute cholesterol. Combined with LDL/HDL and Triglyceride/HDL, it gives a clearer picture of your cardiovascular risk. Calculate yours with our
+          <router-link to="/en/cholesterol-ratio" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Cholesterol Ratio Calculator</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="cholesterol-ratio" />
+    </div>
+  </article>
+</template>

--- a/src/pages/cholesterolRatio.meta.js
+++ b/src/pages/cholesterolRatio.meta.js
@@ -1,0 +1,16 @@
+import Component from './CholesterolRatioCalculator.vue'
+import BlogDe from './blog/CholesterolVerhaeltnisRechner.vue'
+import BlogEn from './blog/en/CholesterolRatio.vue'
+
+export default {
+  key: 'cholesterolRatio',
+  component: Component,
+  slugs: { de: 'cholesterol-verhaeltnis-rechner', en: 'cholesterol-ratio' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 26,
+  blog: {
+    de: { slug: 'cholesterol-verhaeltnis-rechner', component: BlogDe },
+    en: { slug: 'cholesterol-ratio', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-121-cholesterol-ratio
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-121-cholesterol-ratio-20260430-040023`
**Cost:** $7.053143250000001

Closes jenslaufer/health-calculators#121

### Prompt
> RETRY: the previous run produced NO DIFF (silent failure — planned but created no files).
This run MUST create new files and commit them. Before finishing, run `git status` — if no new files are staged, you failed — do NOT push.

Implement the Cholesterol Ratio Calculator as described in issue #121.

Follow the EXACT same pattern as existing calculators in the repo.
HC auto-discovers calculators from `src/pages/*.meta.js` — no shared file modifications needed.

Reference pattern: look at `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js` + blog pages (`src/pages/blog/PromilleBerechnen.vue` DE + `src/pages/blog/en/BloodAlcoholCalculator.vue` EN) as the closest sibling pattern for a pure-formula calculator.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/__tests__/cholesterolRatio.test.js` with 6+ test cases (see Calculation logic + test values below). Copy the inline-function-under-test pattern from `src/__tests__/bac.test.js`. Run `npm test -- cholesterolRatio` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Either keep it inline in the test OR extract to `src/utils/cholesterolRatio.js` if the repo has a utils pattern — check `ls src/utils/` first; if empty, keep computation inside the component + test file. Re-run — all green.
3. **Calculator page.** Create `src/pages/CholesterolRatioCalculator.vue` mirroring `BacCalculator.vue` skeleton: i18n + useHead + AdSlot + AffiliateBanner + CalculatorFAQ + BlogBanner. Inputs: Total Cholesterol (mg/dL or mmol/L toggle), HDL, LDL (optional — derive via Friedewald if missing), Triglycerides. Outputs: Total/HDL ratio, LDL/HDL ratio, Triglyceride/HDL ratio + risk classification. Use `data-testid="result-classification"` on the risk bucket and `data-testid="result-total-hdl"` on the primary ratio.
4. **Meta file.** Create `src/pages/cholesterolRatio.meta.js` — mirror `bac.meta.js` shape exactly: key, component, slugs (de: `cholesterol-verhaeltnis-rechner`, en: `cholesterol-ratio`), group (pick an existing group from other meta.js — do NOT invent), groupOrder, order, blog block.
5. **E2E test.** Create `e2e/cholesterolRatio.spec.js` (Playwright, strict selectors — see rules below).
6. **Blog articles.** Create `src/pages/blog/CholesterolVerhaeltnisRechner.vue` (DE) + `src/pages/blog/en/CholesterolRatio.vue` (EN) with FAQPage JSON-LD + HowTo schema. Match existing blog structure (hero → intro → formula → clinical context → FAQ → related calculators).
7. **Locale files.** The repo uses per-language subfolders — verify with `ls src/locales/calculators/de/ src/locales/calculators/en/` before writing. Create BOTH `src/locales/calculators/de/cholesterolRatio.json` AND `src/locales/calculators/en/cholesterolRatio.json`. Each file has flat top-level keys (NOT wrapped in `de`/`en`). Mirror the exact shape of `src/locales/calculators/de/bac.json` (and `en/bac.json`): top-level `home.calculators.cholesterolRatio` (name + description) plus top-level `cholesterolRatio` block (meta.title, meta.description, title, description, input labels, result labels, classifications, warnings, faq array). Without these JSON files the calculator will not auto-discover and the run will silent-no-diff.
8. **Bump blog-discovery assertions.** Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and `discovers all N English blog components` assert `toHaveLength(N)`. Read current N first (`grep -E "toHaveLength\\([0-9]+\\)" src/__tests__/auto-discovery.test.js`), bump BOTH to N+1. Also append your new DE slug (`cholesterol-verhaeltnis-rechner`) to `EXPECTED_BLOG_SLUGS_DE` and EN slug (`cholesterol-ratio`) to `EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` will red-fail the blog-count check.
9. **Final verification.** Run `git status` → confirm new files. Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Calculation logic (Cholesterol ratios, AHA/ESC 2023 guidelines)
Unit conversion:
- mg/dL → mmol/L for total/LDL/HDL cholesterol: divide by 38.67
- mg/dL → mmol/L for triglycerides: divide by 88.57
- Accept either unit on input, normalize to mg/dL internally for risk thresholds.

Ratios:
- **Total/HDL ratio** = Total Cholesterol ÷ HDL. Optimal <3.5, Moderate 3.5-5.0, High risk >5.0. (AHA: target <5, ideal <3.5.)
- **LDL/HDL ratio** = LDL ÷ HDL. Optimal <2.5, Borderline 2.5-3.5, High >3.5.
- **Triglyceride/HDL ratio** (atherogenic index) = Trig ÷ HDL (mg/dL). Optimal <2, Borderline 2-4, High >4 (metabolic syndrome marker).
- **Friedewald fallback (if LDL missing AND Trig < 400 mg/dL):** LDL = Total − HDL − (Trig/5). If Trig ≥ 400, skip LDL-ratio and show warning.

Plausibility warnings (not errors — informational):
- Total < 100 mg/dL or > 400 mg/dL → warn "Außerhalb des klinisch plausiblen Bereichs".
- HDL < 20 or > 120 mg/dL → warn.
- LDL < 30 or > 300 mg/dL → warn.
- Triglycerides < 30 or > 1000 mg/dL → warn.

Risk classification (primary result, based on Total/HDL ratio):
- `optimal` if <3.5
- `moderate` if 3.5 ≤ ratio ≤ 5.0
- `high` if >5.0
- `invalid` if HDL = 0 (division guard)

### Test cases (mindestens 6)
1. Total=150, HDL=50, LDL=80, Trig=100 (mg/dL) → Total/HDL = 3.0, LDL/HDL = 1.6, classification = optimal.
2. Total=220, HDL=40, LDL=150, Trig=150 → Total/HDL = 5.5, classification = high.
3. Total=190, HDL=50, LDL=null, Trig=150 → Friedewald: LDL = 190-50-30 = 110, LDL/HDL = 2.2, optimal.
4. Total=250, HDL=40, LDL=null, Trig=450 → Friedewald NOT applied (Trig too high), LDL-ratio omitted, warning present.
5. mmol/L input: Total=5.17, HDL=1.3, LDL=3.1, Trig=1.1 → after conversion classification = optimal (same as test 1).
6. Edge: HDL=0 → division guard, classification = 'invalid', warning 'HDL cannot be 0'.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- mg/dL ↔ mmol/L toggle
- FAQPage JSON-LD + HowTo JSON-LD in both blog articles
- Unit tests ≥6 cases
- E2E: happy-path (Test 1) + Friedewald-fallback (Test 3) + high-risk (Test 2)
- SSG pre-rendering must work — meta.js must include slugs for both locales

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes from meta.js slugs)
- Blog article → 2-3 thematically related calculators (BMI, BloodPressure, DiabetesRisk — verify each route exists via `src/pages/*.meta.js` before linking)
- Calculator page → this blog article (DE + EN)
- Verify every target route exists via existing meta.js files — do NOT invent slugs

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration (EXCEPTION: `src/__tests__/auto-discovery.test.js` blog-count + EXPECTED_BLOG_SLUGS_DE/EN bump per step 8)
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern (HC auto-discovers from `src/pages/*.meta.js`)
- Run existing tests to verify nothing breaks

## File-Checklist verification (CRITICAL)
Before `git push`: run `git status` and confirm ALL expected files are staged:
- `src/pages/CholesterolRatioCalculator.vue`
- `src/pages/cholesterolRatio.meta.js`
- `src/__tests__/cholesterolRatio.test.js`
- `e2e/cholesterolRatio.spec.js`
- `src/pages/blog/CholesterolVerhaeltnisRechner.vue` (DE blog)
- `src/pages/blog/en/CholesterolRatio.vue` (EN blog)
- `src/locales/calculators/de/cholesterolRatio.json`
- `src/locales/calculators/en/cholesterolRatio.json`
If any checklist item is missing, DO NOT push — fix the gap first.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'cholesterolRatio',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode)
Playwright strict-mode FAILS any locator matching >1 element.
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- Assert the risk bucket via `getByTestId('result-classification')` with exact text ('optimal' | 'moderate' | 'high' | 'invalid').
- Use regex anchors (`/^optimal$/`) if adding test-ids is not possible.