### PR TITLE
hc-144: Prostate Cancer Risk Calculator (PSA + age + family history)

### DIFF
--- a/e2e/prostateRisk.spec.js
+++ b/e2e/prostateRisk.spec.js
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/prostatakrebs-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Prostatakrebs/)
+})
+
+test('low risk: PSA 1.0, age 50, no family history', async ({ page }) => {
+  await page.getByTestId('psa').fill('1.0')
+  await page.getByTestId('age').fill('50')
+  await page.getByTestId('family-no').click()
+
+  const score = page.getByTestId('result-score')
+  await expect(score).toBeVisible()
+
+  const category = page.getByTestId('result-category')
+  await expect(category).toHaveText('Niedrig')
+})
+
+test('moderate risk: PSA 5.0, age 60, no family history', async ({ page }) => {
+  await page.getByTestId('psa').fill('5.0')
+  await page.getByTestId('age').fill('60')
+  await page.getByTestId('family-no').click()
+
+  const category = page.getByTestId('result-category')
+  await expect(category).toHaveText('Moderat')
+})
+
+test('high risk: PSA 12, age 65', async ({ page }) => {
+  await page.getByTestId('psa').fill('12')
+  await page.getByTestId('age').fill('65')
+  await page.getByTestId('family-no').click()
+
+  const category = page.getByTestId('result-category')
+  await expect(category).toHaveText('Hoch')
+
+  const biopsy = page.getByTestId('biopsy-status')
+  await expect(biopsy).toContainText('Biopsie empfohlen')
+})
+
+test('very high risk: PSA 25, age 70', async ({ page }) => {
+  await page.getByTestId('psa').fill('25')
+  await page.getByTestId('age').fill('70')
+  await page.getByTestId('family-yes').click()
+
+  const category = page.getByTestId('result-category')
+  await expect(category).toHaveText('Sehr hoch')
+})
+
+test('family history shifts borderline result up one band', async ({ page }) => {
+  await page.getByTestId('psa').fill('3.0')
+  await page.getByTestId('age').fill('55')
+  await page.getByTestId('family-no').click()
+  await expect(page.getByTestId('result-category')).toHaveText('Niedrig')
+
+  await page.getByTestId('family-yes').click()
+  await expect(page.getByTestId('result-category')).toHaveText('Moderat')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -20,6 +20,7 @@ const EXPECTED_KEYS = [
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
+  'prostateRisk',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -68,6 +69,7 @@ const EXPECTED_ROUTE_MAP = {
   bmiMaenner: { de: 'bmi-rechner-maenner', en: 'bmi-calculator-men' },
   childDosage: { de: 'kinder-dosierung-rechner', en: 'child-dosage-calculator' },
   cholesterolRatio: { de: 'cholesterol-verhaeltnis-rechner', en: 'cholesterol-ratio' },
+  prostateRisk: { de: 'prostatakrebs-risiko-rechner', en: 'prostate-cancer-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -104,6 +106,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'natrium-korrektur-berechnen',
   'kinder-dosierung-rechner',
   'cholesterol-verhaeltnis-rechner',
+  'prostatakrebs-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -140,19 +143,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'sodium-correction-calculator',
   'child-dosage-calculator',
   'cholesterol-ratio',
+  'prostate-cancer-risk',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 47 calculators', () => {
-    expect(calculatorMetas).toHaveLength(47)
+  it('discovers all 48 calculators', () => {
+    expect(calculatorMetas).toHaveLength(48)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 47 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(47)
+  it('builds calculatorComponents map for all 48 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(48)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -175,15 +179,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 45 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(45)
+  it('discovers all 46 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(46)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 45 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(45)
+  it('discovers all 46 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(46)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -199,10 +203,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 46 calculators with no duplicates', () => {
+  it('groups contain all 48 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(47)
-    expect(new Set(allKeys).size).toBe(47)
+    expect(allKeys).toHaveLength(48)
+    expect(new Set(allKeys).size).toBe(48)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -223,7 +227,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk',
     ])
   })
 
@@ -271,8 +275,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 271 routes', () => {
-    expect(routes).toHaveLength(271)
+  it('generates exactly 276 routes', () => {
+    expect(routes).toHaveLength(276)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 184 links (47 calcs × 2 locales + 45 blogs × 2 locales)', () => {
+  it('generates 188 links (48 calcs × 2 locales + 46 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(184)
+    expect(links).toHaveLength(188)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/prostateRisk.test.js
+++ b/src/__tests__/prostateRisk.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { calcAgeAdjustedPsaThreshold, calcProstateRisk } from '../utils/prostateRisk.js'
+
+// Age-adjusted PSA upper-limit reference (Oesterling et al., JAMA 1993):
+//  40-49 → 2.5 ng/mL
+//  50-59 → 3.5 ng/mL
+//  60-69 → 4.5 ng/mL
+//  70-79 → 6.5 ng/mL
+
+describe('Age-adjusted PSA threshold', () => {
+  it('returns 2.5 for age 45', () => {
+    expect(calcAgeAdjustedPsaThreshold(45)).toBe(2.5)
+  })
+  it('returns 3.5 for age 55', () => {
+    expect(calcAgeAdjustedPsaThreshold(55)).toBe(3.5)
+  })
+  it('returns 4.5 for age 65', () => {
+    expect(calcAgeAdjustedPsaThreshold(65)).toBe(4.5)
+  })
+  it('returns 6.5 for age 75', () => {
+    expect(calcAgeAdjustedPsaThreshold(75)).toBe(6.5)
+  })
+  it('uses 40-49 threshold for younger ages (clamped)', () => {
+    expect(calcAgeAdjustedPsaThreshold(35)).toBe(2.5)
+  })
+  it('uses 70-79 threshold for older ages (clamped)', () => {
+    expect(calcAgeAdjustedPsaThreshold(85)).toBe(6.5)
+  })
+})
+
+describe('Prostate cancer risk classification', () => {
+  it('low risk: PSA 1.0, age 50, no family history', () => {
+    const r = calcProstateRisk({ psa: 1.0, age: 50, familyHistory: false })
+    expect(r.category).toBe('low')
+    expect(r.threshold).toBe(3.5)
+    expect(r.score).toBeGreaterThan(0)
+  })
+
+  it('moderate risk: PSA 5.0, age 60, no family history (gray zone 4-10)', () => {
+    const r = calcProstateRisk({ psa: 5.0, age: 60, familyHistory: false })
+    expect(r.category).toBe('moderate')
+    expect(r.threshold).toBe(4.5)
+  })
+
+  it('high risk: PSA 12, age 65, no family history', () => {
+    const r = calcProstateRisk({ psa: 12, age: 65, familyHistory: false })
+    expect(r.category).toBe('high')
+  })
+
+  it('very high risk: PSA 25, age 70, family history positive', () => {
+    const r = calcProstateRisk({ psa: 25, age: 70, familyHistory: true })
+    expect(r.category).toBe('veryHigh')
+  })
+
+  it('family history elevates a borderline score by one band', () => {
+    const noFam = calcProstateRisk({ psa: 3.0, age: 55, familyHistory: false })
+    const withFam = calcProstateRisk({ psa: 3.0, age: 55, familyHistory: true })
+    // PSA 3.0 with age 55 (threshold 3.5) is below threshold → low
+    // With family history, risk raised to moderate
+    expect(noFam.category).toBe('low')
+    expect(withFam.category).toBe('moderate')
+  })
+
+  it('returns null for invalid PSA', () => {
+    expect(calcProstateRisk({ psa: null, age: 60, familyHistory: false })).toBeNull()
+    expect(calcProstateRisk({ psa: -1, age: 60, familyHistory: false })).toBeNull()
+  })
+
+  it('returns null for invalid age', () => {
+    expect(calcProstateRisk({ psa: 4, age: null, familyHistory: false })).toBeNull()
+    expect(calcProstateRisk({ psa: 4, age: 0, familyHistory: false })).toBeNull()
+  })
+
+  it('produces a numeric score that scales with PSA', () => {
+    const low = calcProstateRisk({ psa: 1.0, age: 60, familyHistory: false })
+    const high = calcProstateRisk({ psa: 15, age: 60, familyHistory: false })
+    expect(high.score).toBeGreaterThan(low.score)
+  })
+
+  it('flags PSA above 10 as biopsy-recommended', () => {
+    const r = calcProstateRisk({ psa: 11, age: 65, familyHistory: false })
+    expect(r.biopsyRecommended).toBe(true)
+  })
+
+  it('does not flag PSA below threshold as biopsy-recommended', () => {
+    const r = calcProstateRisk({ psa: 1.5, age: 60, familyHistory: false })
+    expect(r.biopsyRecommended).toBe(false)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -51,6 +51,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'anionenluecke-rechner',
   'kinder-dosierung-rechner',
   'cholesterol-verhaeltnis-rechner',
+  'prostatakrebs-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -86,12 +87,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'anion-gap',
   'child-dosage-calculator',
   'cholesterol-ratio',
+  'prostate-cancer-risk',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 47 calculator meta files', () => {
+  it('discovers all 48 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(47)
+    expect(metas).toHaveLength(48)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -129,19 +131,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 45 DE blog slugs', () => {
+  it('returns all 46 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(45)
+    expect(de).toHaveLength(46)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 45 EN blog slugs', () => {
+  it('returns all 46 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(45)
+    expect(en).toHaveLength(46)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -209,9 +211,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 94 calcs + 2 blog index + 90 blog articles = 188)', () => {
+  it('generates correct total URL count (2 home + 96 calcs + 2 blog index + 92 blog articles = 192)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(188)
+    expect(urlCount).toBe(192)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -404,6 +404,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'cholesterolRatio',
     related: ['calculate-bmi', 'measure-blood-pressure', 'diabetes-risk-score'],
   },
+  {
+    slug: 'prostate-cancer-risk',
+    title: 'Prostate Cancer Risk: What Your PSA, Age and Family History Really Mean',
+    description: 'Calculate your prostate cancer risk — PSA, age-adjusted thresholds and family history. Includes biopsy guidance per AUA / EAU recommendations.',
+    date: '2026-04-30',
+    readTime: '8 min',
+    calculatorKey: 'prostateRisk',
+    related: ['life-expectancy-calculator', 'biological-age-calculator', 'diabetes-risk-score'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -404,6 +404,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'cholesterolRatio',
     related: ['bmi-berechnen', 'blutdruck-richtig-messen', 'diabetes-risiko-berechnen'],
   },
+  {
+    slug: 'prostatakrebs-risiko-berechnen',
+    title: 'Prostatakrebs-Risiko berechnen: Was PSA, Alter und Familienanamnese wirklich aussagen',
+    description: 'Prostatakrebs-Risiko berechnen — PSA-Wert, altersadjustierte Schwellenwerte und Familienanamnese richtig einordnen. Mit Empfehlungen nach AWMF-Leitlinie.',
+    date: '2026-04-30',
+    readTime: '8 min',
+    calculatorKey: 'prostateRisk',
+    related: ['lebenserwartung-berechnen', 'biologisches-alter-berechnen', 'diabetes-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/prostateRisk.json
+++ b/src/locales/calculators/de/prostateRisk.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "calculators": {
+      "prostateRisk": {
+        "name": "Prostatakrebs-Risiko-Rechner",
+        "description": "Schätze dein Prostatakrebs-Risiko aus PSA, Alter und Familienanamnese."
+      }
+    }
+  },
+  "prostateRisk": {
+    "meta": {
+      "title": "Prostatakrebs-Risiko berechnen — PSA, Alter & Familienanamnese",
+      "description": "Berechne dein Prostatakrebs-Risiko aus PSA-Wert, Alter und Familienanamnese. Mit altersadjustiertem PSA-Schwellenwert nach Oesterling. Kostenlos, sofort, ohne Anmeldung."
+    },
+    "title": "Prostatakrebs-Risiko-Rechner",
+    "description": "Schätze dein Prostatakrebs-Risiko basierend auf PSA, Alter und Familienanamnese.",
+    "psaLabel": "PSA-Wert (ng/mL)",
+    "psaPlaceholder": "z. B. 2.5",
+    "ageLabel": "Alter (Jahre)",
+    "agePlaceholder": "z. B. 60",
+    "familyHistoryLabel": "Prostatakrebs in der Familie?",
+    "familyHistoryHint": "Vater, Bruder oder Sohn mit Prostatakrebs vor dem 65. Lebensjahr.",
+    "yes": "Ja",
+    "no": "Nein",
+    "results": "Risikoeinschätzung",
+    "categoryLabel": "Risikokategorie",
+    "scoreLabel": "Risiko-Score",
+    "thresholdLabel": "Altersadjustierter PSA-Schwellenwert",
+    "ratioLabel": "PSA / Schwellenwert",
+    "biopsyRecommended": "Biopsie empfohlen — bitte Urologen aufsuchen.",
+    "biopsyNotRecommended": "Aktuell keine Biopsie indiziert. Regelmäßige Kontrolle empfohlen.",
+    "category_low": "Niedrig",
+    "category_moderate": "Moderat",
+    "category_high": "Hoch",
+    "category_veryHigh": "Sehr hoch",
+    "interpretation_low": "PSA unter dem altersadjustierten Schwellenwert. Routinekontrolle nach AWMF-Leitlinie.",
+    "interpretation_moderate": "PSA im Graubereich. Verlaufskontrolle in 3–6 Monaten, ggf. freies PSA, MRT oder Biopsie diskutieren.",
+    "interpretation_high": "PSA deutlich erhöht. Urologische Abklärung mit MRT und ggf. Biopsie zeitnah indiziert.",
+    "interpretation_veryHigh": "PSA stark erhöht. Sofortige urologische Abklärung — Wahrscheinlichkeit eines klinisch signifikanten Karzinoms hoch.",
+    "refTitle": "Altersadjustierte PSA-Schwellenwerte (Oesterling)",
+    "ageRange": "Altersgruppe",
+    "psaThreshold": "PSA-Obergrenze (ng/mL)",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner verwendet altersadjustierte PSA-Schwellenwerte nach Oesterling et al. (JAMA, 1993): 40–49 → 2.5, 50–59 → 3.5, 60–69 → 4.5, 70–79 → 6.5 ng/mL. Risikokategorien: PSA < Schwellenwert = niedrig; Schwellenwert bis 10 ng/mL = moderat (Graubereich); 10–20 ng/mL = hoch; > 20 ng/mL = sehr hoch. Eine positive Familienanamnese (Vater/Bruder mit Prostatakrebs vor dem 65. Lebensjahr) erhöht das Risiko etwa um den Faktor 2 und kann eine niedrige Kategorie auf moderat heben. Dies ist eine Schätzung — die endgültige Diagnose erfolgt durch Urologen mittels MRT und Biopsie.",
+    "disclaimer": "Dieser Rechner ersetzt keine ärztliche Untersuchung. Bei erhöhtem PSA oder Familienanamnese unbedingt Urologen aufsuchen.",
+    "faq": [
+      {
+        "q": "Was ist der PSA-Wert?",
+        "a": "Das prostataspezifische Antigen (PSA) ist ein Eiweiß, das von Prostatazellen gebildet wird. Erhöhte Werte können auf Prostatakrebs, gutartige Vergrößerung (BPH) oder Prostatitis hindeuten — nicht jeder hohe Wert bedeutet Krebs."
+      },
+      {
+        "q": "Ab welchem Alter sollte ich PSA testen lassen?",
+        "a": "Die deutsche AWMF-Leitlinie empfiehlt ab 45 Jahren ein Beratungsgespräch (bei familiärer Belastung ab 40). Eine Routine-Bestimmung erfolgt nach individueller Aufklärung über Nutzen und Risiken."
+      },
+      {
+        "q": "Was bedeutet ein PSA-Wert über 4 ng/mL?",
+        "a": "PSA zwischen 4 und 10 ng/mL gilt als Graubereich — etwa 25–30 % dieser Männer haben Prostatakrebs. Eine MRT und ggf. Biopsie sind indiziert. Über 10 ng/mL steigt die Wahrscheinlichkeit auf 50–67 %."
+      },
+      {
+        "q": "Wie verändert eine Familienanamnese das Risiko?",
+        "a": "Hat ein erstgradiger Verwandter (Vater, Bruder) Prostatakrebs vor dem 65. Lebensjahr, verdoppelt sich das Risiko etwa. Bei zwei Betroffenen vervierfacht es sich. Empfohlen ist dann ein früheres Screening ab 40–45 Jahren."
+      },
+      {
+        "q": "Warum altersadjustierte PSA-Werte?",
+        "a": "Die Prostata wächst mit dem Alter, der PSA-Wert steigt physiologisch an. Altersadjustierte Schwellenwerte (Oesterling 1993) reduzieren falsch-positive Befunde bei älteren Männern und falsch-negative bei jüngeren."
+      },
+      {
+        "q": "Was passiert bei einem auffälligen Wert?",
+        "a": "Üblicherweise erfolgt eine Wiederholung des PSA-Tests, dann eine MRT-Untersuchung der Prostata. Nur bei MRT-Auffälligkeit ist eine gezielte Fusionsbiopsie nötig — die Praxis hat sich von der Standard-Biopsie weg entwickelt."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/prostateRisk.json
+++ b/src/locales/calculators/en/prostateRisk.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "calculators": {
+      "prostateRisk": {
+        "name": "Prostate Cancer Risk Calculator",
+        "description": "Estimate prostate cancer risk from PSA, age and family history."
+      }
+    }
+  },
+  "prostateRisk": {
+    "meta": {
+      "title": "Prostate Cancer Risk Calculator — PSA, Age & Family History",
+      "description": "Estimate your prostate cancer risk from PSA, age and family history. Uses age-adjusted PSA thresholds (Oesterling). Free, instant, no sign-up."
+    },
+    "title": "Prostate Cancer Risk Calculator",
+    "description": "Estimate prostate cancer risk based on PSA, age and family history.",
+    "psaLabel": "PSA value (ng/mL)",
+    "psaPlaceholder": "e.g. 2.5",
+    "ageLabel": "Age (years)",
+    "agePlaceholder": "e.g. 60",
+    "familyHistoryLabel": "Family history of prostate cancer?",
+    "familyHistoryHint": "Father, brother or son diagnosed with prostate cancer before age 65.",
+    "yes": "Yes",
+    "no": "No",
+    "results": "Risk assessment",
+    "categoryLabel": "Risk category",
+    "scoreLabel": "Risk score",
+    "thresholdLabel": "Age-adjusted PSA threshold",
+    "ratioLabel": "PSA / threshold",
+    "biopsyRecommended": "Biopsy workup recommended — see a urologist.",
+    "biopsyNotRecommended": "Biopsy not currently indicated. Routine follow-up advised.",
+    "category_low": "Low",
+    "category_moderate": "Moderate",
+    "category_high": "High",
+    "category_veryHigh": "Very high",
+    "interpretation_low": "PSA below the age-adjusted threshold. Routine screening per AUA / EAU guidelines.",
+    "interpretation_moderate": "PSA in the gray zone. Repeat in 3–6 months; consider free PSA, MRI or biopsy.",
+    "interpretation_high": "PSA clearly elevated. Urological work-up with MRI and likely biopsy advised.",
+    "interpretation_veryHigh": "PSA strongly elevated. Urgent urological evaluation — high probability of clinically significant cancer.",
+    "refTitle": "Age-adjusted PSA thresholds (Oesterling)",
+    "ageRange": "Age group",
+    "psaThreshold": "PSA upper limit (ng/mL)",
+    "howItWorks": "How it works",
+    "howItWorksText": "This calculator uses age-adjusted PSA thresholds per Oesterling et al. (JAMA, 1993): 40–49 → 2.5, 50–59 → 3.5, 60–69 → 4.5, 70–79 → 6.5 ng/mL. Categories: PSA < threshold = low; threshold to 10 ng/mL = moderate (gray zone); 10–20 ng/mL = high; > 20 ng/mL = very high. A positive family history (father or brother diagnosed before age 65) roughly doubles the baseline risk and may shift a low result to moderate. This is a screening estimate — definitive diagnosis requires urological work-up with MRI and biopsy.",
+    "disclaimer": "This calculator does not replace medical evaluation. With elevated PSA or a positive family history, see a urologist.",
+    "faq": [
+      {
+        "q": "What is PSA?",
+        "a": "Prostate-specific antigen (PSA) is a protein produced by prostate cells. Elevated values may indicate prostate cancer, benign hyperplasia (BPH) or prostatitis — a high value alone does not mean cancer."
+      },
+      {
+        "q": "At what age should I get tested?",
+        "a": "The American Urological Association recommends shared decision-making about PSA testing starting at age 50 for average-risk men, age 40–45 for those with a family history or African ancestry."
+      },
+      {
+        "q": "What does a PSA above 4 ng/mL mean?",
+        "a": "PSA between 4 and 10 ng/mL is the gray zone — about 25–30 % of these men have prostate cancer. MRI and possibly biopsy are indicated. Above 10 ng/mL the probability rises to 50–67 %."
+      },
+      {
+        "q": "How does family history change the risk?",
+        "a": "A first-degree relative (father, brother) diagnosed before age 65 roughly doubles your risk. With two affected relatives, the risk is roughly four-fold. Earlier screening from age 40–45 is recommended in those cases."
+      },
+      {
+        "q": "Why age-adjusted thresholds?",
+        "a": "The prostate enlarges with age, raising baseline PSA. Age-adjusted thresholds (Oesterling 1993) cut false-positives in older men and false-negatives in younger ones."
+      },
+      {
+        "q": "What happens with an abnormal value?",
+        "a": "Standard practice is to repeat the PSA, then perform a multiparametric MRI of the prostate. Targeted fusion biopsy is performed only if MRI shows a suspicious lesion — replacing the older blind systematic biopsy."
+      }
+    ]
+  }
+}

--- a/src/pages/ProstateRiskCalculator.vue
+++ b/src/pages/ProstateRiskCalculator.vue
@@ -1,0 +1,178 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcProstateRisk } from '../utils/prostateRisk.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('prostateRisk.faq') || [])
+
+useHead(() => ({
+  title: t('prostateRisk.meta.title'),
+  description: t('prostateRisk.meta.description'),
+  routeKey: 'prostateRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Prostate Cancer Risk Calculator',
+    url: 'https://healthcalculator.app/prostate-cancer-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const psa = ref(null)
+const age = ref(null)
+const familyHistory = ref(false)
+
+const result = computed(() =>
+  calcProstateRisk({
+    psa: psa.value,
+    age: age.value,
+    familyHistory: familyHistory.value,
+  })
+)
+
+const categoryColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.category) {
+    case 'low': return 'text-green-600'
+    case 'moderate': return 'text-yellow-600'
+    case 'high': return 'text-orange-600'
+    case 'veryHigh': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+
+const categoryBg = computed(() => {
+  if (!result.value) return 'bg-stone-300'
+  switch (result.value.category) {
+    case 'low': return 'bg-green-500'
+    case 'moderate': return 'bg-yellow-500'
+    case 'high': return 'bg-orange-500'
+    case 'veryHigh': return 'bg-red-600'
+    default: return 'bg-stone-300'
+  }
+})
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('prostateRisk.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('prostateRisk.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('prostateRisk.psaLabel') }}</label>
+        <input v-model.number="psa" type="number" step="0.1" min="0" :placeholder="t('prostateRisk.psaPlaceholder')" data-testid="psa"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('prostateRisk.ageLabel') }}</label>
+        <input v-model.number="age" type="number" min="0" :placeholder="t('prostateRisk.agePlaceholder')" data-testid="age"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+
+    <div>
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('prostateRisk.familyHistoryLabel') }}</label>
+      <div class="flex gap-2">
+        <button
+          @click="familyHistory = false"
+          data-testid="family-no"
+          :class="!familyHistory ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('prostateRisk.no') }}</button>
+        <button
+          @click="familyHistory = true"
+          data-testid="family-yes"
+          :class="familyHistory ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('prostateRisk.yes') }}</button>
+      </div>
+      <p class="text-xs text-stone-400 mt-2">{{ t('prostateRisk.familyHistoryHint') }}</p>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('prostateRisk.results') }}</p>
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="result-score">{{ result.score }}</span>
+      <span class="text-lg text-stone-400">/ 100</span>
+      <span :class="categoryColor" class="text-lg font-semibold" data-testid="result-category">{{ t('prostateRisk.category_' + result.category) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div :class="categoryBg" class="absolute inset-y-0 left-0 transition-all duration-300" :style="{ width: result.score + '%' }"></div>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 mb-4" data-testid="interpretation">
+      <p class="text-sm text-stone-700 leading-relaxed">{{ t('prostateRisk.interpretation_' + result.category) }}</p>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('prostateRisk.thresholdLabel') }}</p>
+        <p class="text-lg font-bold text-stone-900 tabular-nums">{{ result.threshold }} ng/mL</p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('prostateRisk.ratioLabel') }}</p>
+        <p class="text-lg font-bold text-stone-900 tabular-nums" data-testid="result-ratio">{{ result.ratio.toFixed(2) }}×</p>
+      </div>
+    </div>
+
+    <div
+      class="rounded-lg p-4 text-sm font-medium"
+      :class="result.biopsyRecommended ? 'bg-red-50 text-red-900 border border-red-200' : 'bg-green-50 text-green-900 border border-green-200'"
+      data-testid="biopsy-status"
+    >
+      {{ result.biopsyRecommended ? t('prostateRisk.biopsyRecommended') : t('prostateRisk.biopsyNotRecommended') }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('prostateRisk.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('prostateRisk.ageRange') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('prostateRisk.psaThreshold') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">40–49</td><td class="px-6 py-3 text-stone-600">2.5</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">50–59</td><td class="px-6 py-3 text-stone-600">3.5</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">60–69</td><td class="px-6 py-3 text-stone-600">4.5</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">70–79</td><td class="px-6 py-3 text-stone-600">6.5</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('prostateRisk.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('prostateRisk.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('prostateRisk.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="prostateRisk" />
+</template>

--- a/src/pages/blog/ProstatakrebsRisikoBerechnen.vue
+++ b/src/pages/blog/ProstatakrebsRisikoBerechnen.vue
@@ -1,0 +1,201 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Was ist der PSA-Wert?',
+      acceptedAnswer: { '@type': 'Answer', text: 'PSA (prostataspezifisches Antigen) ist ein Eiweiß der Prostata. Erhöhte Werte können auf Krebs, BPH oder Prostatitis hinweisen — nicht jeder hohe Wert bedeutet Krebs.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Welcher PSA-Wert ist normal?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Altersadjustierte Obergrenzen nach Oesterling: 40–49 → 2.5, 50–59 → 3.5, 60–69 → 4.5, 70–79 → 6.5 ng/mL.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Wie verändert eine Familienanamnese das Risiko?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Ein erstgradiger Verwandter (Vater, Bruder) mit Prostatakrebs vor dem 65. Lebensjahr verdoppelt das Risiko. Bei zwei Betroffenen vervierfacht es sich.' },
+    },
+  ],
+}
+
+const howToJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'Prostatakrebs-Risiko berechnen',
+  step: [
+    { '@type': 'HowToStep', name: 'PSA-Wert eingeben', text: 'PSA aus dem Laborbefund (in ng/mL) eintragen.' },
+    { '@type': 'HowToStep', name: 'Alter wählen', text: 'Alter eingeben — der Schwellenwert wird automatisch altersadjustiert.' },
+    { '@type': 'HowToStep', name: 'Familienanamnese angeben', text: 'Vater, Bruder oder Sohn mit Prostatakrebs vor dem 65. Lebensjahr — Risiko etwa doppelt so hoch.' },
+    { '@type': 'HowToStep', name: 'Risiko einordnen', text: 'Niedrig, moderat, hoch oder sehr hoch — mit klarer Empfehlung zur weiteren Abklärung.' },
+  ],
+}
+
+useHead({
+  title: 'Prostatakrebs-Risiko berechnen: PSA, Alter & Familienanamnese verstehen | Health Calculators',
+  description: 'Prostatakrebs-Risiko berechnen — PSA-Wert, altersadjustierte Schwellenwerte und Familienanamnese richtig einordnen. Mit Empfehlungen nach AWMF-Leitlinie.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Prostatakrebs-Risiko berechnen: Was PSA, Alter und Familienanamnese wirklich aussagen',
+      description: 'Prostatakrebs-Risiko berechnen — PSA-Wert, altersadjustierte Schwellenwerte und Familienanamnese richtig einordnen. Mit Empfehlungen nach AWMF-Leitlinie.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-04-30',
+      dateModified: '2026-04-30',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/prostatakrebs-risiko-berechnen',
+      },
+    },
+    faqJsonLd,
+    howToJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Prostatakrebs-Risiko berechnen: Was PSA, Alter und Familienanamnese wirklich aussagen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">30. April 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Prostatakrebs ist die häufigste Krebserkrankung bei Männern in Deutschland — und gleichzeitig eine, die bei früher Erkennung sehr gute Heilungschancen hat. Der <strong>PSA-Wert</strong> ist der wichtigste Screening-Marker, doch ein einzelner Zahlenwert reicht selten zur Einordnung.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt, wie du PSA, Alter und Familienanamnese gemeinsam interpretierst — und wann eine weitere Abklärung sinnvoll ist.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist der PSA-Wert?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das prostataspezifische Antigen (PSA) ist ein Eiweiß, das ausschließlich von Prostatazellen produziert wird. Bei Krebs, gutartiger Vergrößerung (BPH) oder Entzündung gelangt vermehrt PSA ins Blut. Das macht den Wert zu einem sensiblen, aber unspezifischen Marker — er steigt aus vielen Gründen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Altersadjustierte PSA-Schwellenwerte</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Prostata wächst mit zunehmendem Alter — der PSA-Wert steigt physiologisch mit. Die <strong>Oesterling-Schwellenwerte</strong> (JAMA 1993) berücksichtigen das:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Altersgruppe</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">PSA-Obergrenze</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">40–49 Jahre</td><td class="px-6 py-3 text-stone-600">2.5 ng/mL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">50–59 Jahre</td><td class="px-6 py-3 text-stone-600">3.5 ng/mL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">60–69 Jahre</td><td class="px-6 py-3 text-stone-600">4.5 ng/mL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">70–79 Jahre</td><td class="px-6 py-3 text-stone-600">6.5 ng/mL</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ein PSA von 3.0 ng/mL ist bei einem 45-Jährigen auffällig, bei einem 70-Jährigen aber im Normbereich.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risikokategorien nach PSA</h2>
+        <div class="space-y-3">
+          <div class="bg-green-50 border border-green-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Niedrig: PSA &lt; Schwellenwert</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Routinekontrolle nach AWMF-Leitlinie alle 2–4 Jahre, je nach Ausgangswert.</p>
+          </div>
+          <div class="bg-yellow-50 border border-yellow-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Moderat: Schwellenwert bis 10 ng/mL (Graubereich)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Etwa 25–30 % dieser Männer haben Prostatakrebs. Verlaufskontrolle in 3–6 Monaten, freies PSA, mpMRT erwägen.</p>
+          </div>
+          <div class="bg-orange-50 border border-orange-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Hoch: 10–20 ng/mL</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Karzinom-Wahrscheinlichkeit 50–67 %. Urologische Abklärung mit MRT und ggf. Fusionsbiopsie zeitnah indiziert.</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Sehr hoch: &gt; 20 ng/mL</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Klinisch signifikantes Karzinom hochwahrscheinlich. Sofortige urologische Abklärung mit Staging.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Familienanamnese: Der Risikofaktor mit dem größten Hebel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hat ein erstgradiger Verwandter (Vater, Bruder) Prostatakrebs vor dem 65. Lebensjahr, <strong>verdoppelt</strong> sich dein Risiko. Bei zwei Betroffenen <strong>vervierfacht</strong> es sich. Die AWMF-Leitlinie empfiehlt für diese Männer ein Beratungsgespräch ab 40 (statt 45) Jahren.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Auch BRCA1/2-Mutationen — sonst eher mit Brustkrebs assoziiert — erhöhen das Prostatakrebsrisiko deutlich.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was bei einem auffälligen Wert passiert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die moderne Diagnostik hat sich gewandelt — die Standard-Stanzbiopsie ist nicht mehr der erste Schritt. Heute gilt:
+        </p>
+        <ol class="list-decimal list-inside space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>PSA-Wiederholung</strong> nach 4–6 Wochen (auch nach längerer sexueller Abstinenz, ohne Radfahren).</li>
+          <li><strong>Freies PSA</strong> (% fPSA): unter 15 % Tumor-typisch, über 25 % spricht für BPH.</li>
+          <li><strong>Multiparametrische MRT</strong> der Prostata (mpMRT) als Triage.</li>
+          <li><strong>Gezielte Fusionsbiopsie</strong> nur bei MRT-Auffälligkeiten (PI-RADS 3–5).</li>
+        </ol>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt dein Prostatakrebs-Risiko berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">PSA-Wert, Alter und Familienanamnese — mit altersadjustierten Schwellenwerten und klarer Empfehlung. Kostenlos, sofort, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('prostateRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Krebsrisiko hängt eng mit Lebensstil und biologischem Altern zusammen. Vergleiche dein Ergebnis mit deiner
+          <router-link :to="localeBlogPath('lebenserwartung-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Lebenserwartung</router-link>,
+          deinem
+          <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biologischen Alter</router-link>
+          und deinem
+          <router-link :to="localeBlogPath('diabetes-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko</router-link>
+          — drei Werte, die zusammen ein klares Bild deines metabolischen Gesundheitsstatus geben.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der PSA-Wert allein sagt wenig. Erst die Kombination aus altersadjustiertem Schwellenwert, PSA-Verlauf und Familienanamnese macht eine seriöse Risikoeinschätzung möglich. Berechne deine Risikoeinordnung mit unserem
+          <router-link :to="localePath('prostateRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Prostatakrebs-Risiko-Rechner</router-link> — und besprich auffällige Werte zeitnah mit einem Urologen.
+        </p>
+      </div>
+
+      <RelatedArticles slug="prostatakrebs-risiko-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/ProstateCancerRisk.vue
+++ b/src/pages/blog/en/ProstateCancerRisk.vue
@@ -1,0 +1,198 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is PSA?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Prostate-specific antigen (PSA) is a protein produced by prostate cells. Elevated values may indicate cancer, BPH or prostatitis — a high value alone does not mean cancer.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What PSA value is normal?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Age-adjusted upper limits per Oesterling: 40–49 → 2.5, 50–59 → 3.5, 60–69 → 4.5, 70–79 → 6.5 ng/mL.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How does family history change the risk?',
+      acceptedAnswer: { '@type': 'Answer', text: 'A first-degree relative (father, brother) diagnosed before age 65 doubles your risk. Two affected relatives roughly quadruple it.' },
+    },
+  ],
+}
+
+const howToJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to estimate your prostate cancer risk',
+  step: [
+    { '@type': 'HowToStep', name: 'Enter your PSA', text: 'Enter the PSA value (ng/mL) from your lab report.' },
+    { '@type': 'HowToStep', name: 'Enter your age', text: 'Age sets the age-adjusted PSA threshold automatically.' },
+    { '@type': 'HowToStep', name: 'Family history', text: 'Father or brother with prostate cancer before age 65 roughly doubles your risk.' },
+    { '@type': 'HowToStep', name: 'Read your category', text: 'Low, moderate, high or very high — with a clear recommendation.' },
+  ],
+}
+
+useHead({
+  title: 'Prostate Cancer Risk: PSA, Age & Family History Explained | Health Calculators',
+  description: 'Calculate your prostate cancer risk — PSA, age-adjusted thresholds and family history. Includes biopsy guidance per AUA / EAU recommendations.',
+  path: '/en/blog/prostate-cancer-risk',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Prostate Cancer Risk: What Your PSA, Age and Family History Really Mean',
+      description: 'Calculate your prostate cancer risk — PSA, age-adjusted thresholds and family history. Includes biopsy guidance per AUA / EAU recommendations.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-04-30',
+      dateModified: '2026-04-30',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/prostate-cancer-risk',
+      },
+    },
+    faqJsonLd,
+    howToJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link to="/en/blog" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Prostate Cancer Risk: What Your PSA, Age and Family History Really Mean</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">April 30, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Prostate cancer is the most common male cancer in Western countries — and one with excellent outcomes when caught early. The <strong>PSA value</strong> is the primary screening marker, but a single number rarely tells the full story.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how to read PSA, age and family history together — and when further work-up is sensible.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is PSA?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Prostate-specific antigen (PSA) is a protein made only by prostate cells. Cancer, benign hyperplasia (BPH) or inflammation all release more PSA into the blood. That makes it a sensitive but non-specific marker — it rises for many reasons.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Age-adjusted PSA thresholds</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The prostate enlarges with age, raising baseline PSA. The <strong>Oesterling thresholds</strong> (JAMA 1993) account for that:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Age group</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">PSA upper limit</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">40–49</td><td class="px-6 py-3 text-stone-600">2.5 ng/mL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">50–59</td><td class="px-6 py-3 text-stone-600">3.5 ng/mL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">60–69</td><td class="px-6 py-3 text-stone-600">4.5 ng/mL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">70–79</td><td class="px-6 py-3 text-stone-600">6.5 ng/mL</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A PSA of 3.0 ng/mL is concerning at age 45 but well within range at 70.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risk categories by PSA</h2>
+        <div class="space-y-3">
+          <div class="bg-green-50 border border-green-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Low: PSA &lt; threshold</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Routine screening interval per AUA / EAU — typically every 2–4 years depending on baseline.</p>
+          </div>
+          <div class="bg-yellow-50 border border-yellow-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Moderate: threshold to 10 ng/mL (gray zone)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">About 25–30 % of these men have prostate cancer. Repeat PSA in 3–6 months; consider free PSA, mpMRI.</p>
+          </div>
+          <div class="bg-orange-50 border border-orange-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">High: 10–20 ng/mL</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Cancer probability 50–67 %. Urological work-up with MRI and likely targeted biopsy is advised promptly.</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Very high: &gt; 20 ng/mL</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Clinically significant cancer is highly likely. Urgent urological evaluation and staging.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Family history: the biggest single risk multiplier</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A first-degree relative (father, brother) diagnosed before age 65 <strong>doubles</strong> your risk. Two affected relatives <strong>quadruple</strong> it. AUA and EAU guidelines recommend starting shared decision-making about PSA at 40–45 (instead of 50) for these men.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          BRCA1/2 mutations — usually associated with breast cancer — also markedly raise prostate cancer risk.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What happens with an abnormal PSA</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Modern work-up has shifted away from blind systematic biopsy. Today the steps are:
+        </p>
+        <ol class="list-decimal list-inside space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>Repeat PSA</strong> after 4–6 weeks (avoid intercourse and cycling beforehand).</li>
+          <li><strong>Free PSA</strong> (% fPSA): &lt; 15 % suggests cancer; &gt; 25 % suggests BPH.</li>
+          <li><strong>Multiparametric MRI</strong> of the prostate (mpMRI) as triage.</li>
+          <li><strong>Targeted fusion biopsy</strong> only if MRI shows a suspicious lesion (PI-RADS 3–5).</li>
+        </ol>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your prostate cancer risk now</h3>
+        <p class="text-stone-300 text-sm mb-5">PSA, age and family history — with age-adjusted thresholds and a clear recommendation. Free, instant, no sign-up.</p>
+        <router-link
+          to="/en/prostate-cancer-risk-calculator"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Cancer risk is closely tied to overall metabolic and biological aging. Compare your result to your
+          <router-link to="/en/blog/life-expectancy-calculator" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">life expectancy</router-link>,
+          your
+          <router-link to="/en/blog/biological-age-calculator" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biological age</router-link>
+          and your
+          <router-link to="/en/blog/diabetes-risk-score" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">diabetes risk</router-link>
+          — three numbers that together capture your metabolic health picture.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conclusion</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          PSA alone tells you very little. Only the combination of age-adjusted threshold, PSA trend and family history yields a meaningful risk estimate. Calculate yours with our
+          <router-link to="/en/prostate-cancer-risk-calculator" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Prostate Cancer Risk Calculator</router-link> — and discuss any abnormal value with a urologist promptly.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="prostate-cancer-risk" />
+    </div>
+  </article>
+</template>

--- a/src/pages/prostateRisk.meta.js
+++ b/src/pages/prostateRisk.meta.js
@@ -1,0 +1,16 @@
+import Component from './ProstateRiskCalculator.vue'
+import BlogDe from './blog/ProstatakrebsRisikoBerechnen.vue'
+import BlogEn from './blog/en/ProstateCancerRisk.vue'
+
+export default {
+  key: 'prostateRisk',
+  component: Component,
+  slugs: { de: 'prostatakrebs-risiko-rechner', en: 'prostate-cancer-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 27,
+  blog: {
+    de: { slug: 'prostatakrebs-risiko-berechnen', component: BlogDe },
+    en: { slug: 'prostate-cancer-risk', component: BlogEn },
+  },
+}

--- a/src/utils/prostateRisk.js
+++ b/src/utils/prostateRisk.js
@@ -1,0 +1,54 @@
+// Prostate cancer risk estimation from PSA, age and family history.
+// Age-adjusted PSA upper-limit reference per Oesterling et al., JAMA 1993.
+// This is a screening-aid heuristic — not a diagnostic tool.
+
+export function calcAgeAdjustedPsaThreshold(age) {
+  if (age < 50) return 2.5
+  if (age < 60) return 3.5
+  if (age < 70) return 4.5
+  return 6.5
+}
+
+export function calcProstateRisk({ psa, age, familyHistory }) {
+  if (psa == null || !Number.isFinite(psa) || psa < 0) return null
+  if (age == null || !Number.isFinite(age) || age <= 0) return null
+
+  const threshold = calcAgeAdjustedPsaThreshold(age)
+  const ratio = psa / threshold
+
+  // Base score: 0 (very low) → 100 (very high) on a soft scale.
+  // Anchor points: ratio 0 → 0; ratio 1 → 35; ratio 2 → 60; ratio 3+ → 80+.
+  let score = Math.min(100, ratio * 30)
+
+  // Absolute PSA contributions on top of age-adjusted ratio:
+  // PSA > 10 indicates biopsy-recommended range regardless of age.
+  if (psa > 10) score += 20
+  if (psa > 20) score += 10
+
+  // Family history boost: roughly doubles risk of clinically significant
+  // prostate cancer in epidemiological studies — represented as +15 score.
+  if (familyHistory) score += 15
+
+  score = Math.min(100, score)
+
+  let category
+  if (psa > 20) category = 'veryHigh'
+  else if (psa > 10) category = 'high'
+  else if (psa >= threshold) category = 'moderate'
+  else if (familyHistory && psa >= threshold * 0.8) category = 'moderate'
+  else category = 'low'
+
+  // Family-history rule: if normally low and family history is positive,
+  // bump to moderate when PSA approaches the threshold.
+  // (covered by the 0.8×threshold check above)
+
+  const biopsyRecommended = psa > 10 || (psa >= threshold && familyHistory)
+
+  return {
+    category,
+    score: Math.round(score),
+    threshold,
+    ratio: Number(ratio.toFixed(2)),
+    biopsyRecommended,
+  }
+}


### PR DESCRIPTION
## Summary
- New **Prostate Cancer Risk Calculator** at `/de/prostatakrebs-risiko-rechner` and `/en/prostate-cancer-risk-calculator`
- Estimates risk from PSA + age + family history using Oesterling age-adjusted thresholds
- Returns category (low / moderate / high / very high), score, threshold, ratio and biopsy recommendation
- DE + EN locales, blog articles, FAQ, JSON-LD (WebApplication, Article, FAQPage, HowTo)
- Pure logic in `src/utils/prostateRisk.js` with 16 unit tests, 7 Playwright E2E tests
- Wired through auto-discovery (`prostateRisk.meta.js`) — no router or shared file changes
- Internal links: blog → calculator + 3 thematically related blogs (life-expectancy, biological-age, diabetes-risk); calculator → blog via `BlogArticleLink`
- Discovery / sitemap / llms.txt test counts bumped (47→48 calcs, 45→46 blogs, 271→276 routes)

## Test plan
- [x] `npm test` — 1257 / 1257 pass
- [x] `npm run build` — SSG build succeeds, 192 sitemap URLs, 188 llms.txt links
- [x] `npx playwright test e2e/prostateRisk.spec.js` — 7 / 7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)