### PR TITLE
hc-143-pcos-sympom: Implement the Pcos Sympom Calculator as described in issue #

### DIFF
--- a/e2e/pcosSymptoms.spec.js
+++ b/e2e/pcosSymptoms.spec.js
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/pcos-symptome-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/PCOS-Symptome/)
+})
+
+test('no symptoms selected → no result card visible', async ({ page }) => {
+  await expect(page.getByTestId('result-score')).toHaveCount(0)
+})
+
+test('one ovulatory symptom → moderate category', async ({ page }) => {
+  await page.getByTestId('irregularCycles-yes').click()
+  await expect(page.getByTestId('result-score')).toBeVisible()
+  await expect(page.getByTestId('result-category')).toHaveText('Moderat')
+})
+
+test('two Rotterdam criteria → high category and evaluation recommended', async ({ page }) => {
+  await page.getByTestId('irregularCycles-yes').click()
+  await page.getByTestId('hirsutism-yes').click()
+  await expect(page.getByTestId('result-category')).toHaveText('Hoch')
+  const status = page.getByTestId('evaluation-status')
+  await expect(status).toBeVisible()
+  await expect(status).toContainText(/Abklärung empfohlen/i)
+})
+
+test('symptom count updates as toggles change', async ({ page }) => {
+  await page.getByTestId('irregularCycles-yes').click()
+  await page.getByTestId('acne-yes').click()
+  await page.getByTestId('weightGain-yes').click()
+  await expect(page.getByTestId('symptom-count')).toContainText('3 / 9')
+})
+
+test('rotterdam criteria card lists both detected groups', async ({ page }) => {
+  await page.getByTestId('missedPeriods-yes').click()
+  await page.getByTestId('hairLoss-yes').click()
+  const card = page.getByTestId('rotterdam-criteria')
+  await expect(card).toContainText('Zyklusstörung')
+  await expect(card).toContainText('Hyperandrogene')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -20,7 +20,7 @@ const EXPECTED_KEYS = [
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
-  'prostateRisk',
+  'prostateRisk', 'pcosSymptoms',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -70,6 +70,7 @@ const EXPECTED_ROUTE_MAP = {
   childDosage: { de: 'kinder-dosierung-rechner', en: 'child-dosage-calculator' },
   cholesterolRatio: { de: 'cholesterol-verhaeltnis-rechner', en: 'cholesterol-ratio' },
   prostateRisk: { de: 'prostatakrebs-risiko-rechner', en: 'prostate-cancer-risk-calculator' },
+  pcosSymptoms: { de: 'pcos-symptome-rechner', en: 'pcos-symptom-checker' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -107,6 +108,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-dosierung-rechner',
   'cholesterol-verhaeltnis-rechner',
   'prostatakrebs-risiko-berechnen',
+  'pcos-symptome-erkennen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -144,19 +146,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'child-dosage-calculator',
   'cholesterol-ratio',
   'prostate-cancer-risk',
+  'pcos-symptom-checker',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 48 calculators', () => {
-    expect(calculatorMetas).toHaveLength(48)
+  it('discovers all 49 calculators', () => {
+    expect(calculatorMetas).toHaveLength(49)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 48 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(48)
+  it('builds calculatorComponents map for all 49 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(49)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -179,15 +182,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 46 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(46)
+  it('discovers all 47 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(47)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 46 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(46)
+  it('discovers all 47 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(47)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -203,10 +206,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 48 calculators with no duplicates', () => {
+  it('groups contain all 49 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(48)
-    expect(new Set(allKeys).size).toBe(48)
+    expect(allKeys).toHaveLength(49)
+    expect(new Set(allKeys).size).toBe(49)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -233,7 +236,7 @@ describe('calculator groups', () => {
 
   it('pregnancy group has correct calculators in order', () => {
     expect(calculatorGroups[3].calculators).toEqual([
-      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'period', 'dueDate',
+      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'period', 'dueDate', 'pcosSymptoms',
     ])
   })
 })
@@ -275,8 +278,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 276 routes', () => {
-    expect(routes).toHaveLength(276)
+  it('generates exactly 281 routes', () => {
+    expect(routes).toHaveLength(281)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 188 links (48 calcs × 2 locales + 46 blogs × 2 locales)', () => {
+  it('generates 192 links (49 calcs × 2 locales + 47 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(188)
+    expect(links).toHaveLength(192)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/pcosSymptoms.test.js
+++ b/src/__tests__/pcosSymptoms.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { calcPcosSymptoms } from '../utils/pcosSymptoms.js'
+
+// Rotterdam criteria (2/3 needed for diagnosis):
+// 1. Ovulatory dysfunction (irregular or missed periods)
+// 2. Hyperandrogenism (hirsutism / acne / scalp hair loss)
+// 3. Polycystic ovaries on ultrasound — not assessed by this tool
+
+describe('calcPcosSymptoms', () => {
+  it('returns low risk for no symptoms', () => {
+    const r = calcPcosSymptoms({})
+    expect(r.category).toBe('low')
+    expect(r.criteriaMetCount).toBe(0)
+    expect(r.symptomCount).toBe(0)
+    expect(r.score).toBe(0)
+    expect(r.evaluationRecommended).toBe(false)
+  })
+
+  it('flags ovulatory dysfunction when irregular cycles present', () => {
+    const r = calcPcosSymptoms({ irregularCycles: true })
+    expect(r.ovulatoryDysfunction).toBe(true)
+    expect(r.hyperandrogenism).toBe(false)
+    expect(r.criteriaMetCount).toBe(1)
+  })
+
+  it('flags ovulatory dysfunction when periods are missed', () => {
+    const r = calcPcosSymptoms({ missedPeriods: true })
+    expect(r.ovulatoryDysfunction).toBe(true)
+    expect(r.criteriaMetCount).toBe(1)
+  })
+
+  it('flags hyperandrogenism when hirsutism is present', () => {
+    const r = calcPcosSymptoms({ hirsutism: true })
+    expect(r.hyperandrogenism).toBe(true)
+    expect(r.ovulatoryDysfunction).toBe(false)
+    expect(r.criteriaMetCount).toBe(1)
+  })
+
+  it('flags hyperandrogenism when acne is present', () => {
+    const r = calcPcosSymptoms({ acne: true })
+    expect(r.hyperandrogenism).toBe(true)
+    expect(r.criteriaMetCount).toBe(1)
+  })
+
+  it('flags hyperandrogenism when scalp hair loss is present', () => {
+    const r = calcPcosSymptoms({ hairLoss: true })
+    expect(r.hyperandrogenism).toBe(true)
+    expect(r.criteriaMetCount).toBe(1)
+  })
+
+  it('returns moderate when one Rotterdam criterion is met', () => {
+    const r = calcPcosSymptoms({ irregularCycles: true })
+    expect(r.category).toBe('moderate')
+    expect(r.evaluationRecommended).toBe(false)
+  })
+
+  it('returns high when two Rotterdam criteria are met', () => {
+    const r = calcPcosSymptoms({ irregularCycles: true, hirsutism: true })
+    expect(r.category).toBe('high')
+    expect(r.criteriaMetCount).toBe(2)
+    expect(r.evaluationRecommended).toBe(true)
+  })
+
+  it('classifies as high when both groups have symptoms regardless of which', () => {
+    const r = calcPcosSymptoms({ missedPeriods: true, acne: true, hairLoss: true })
+    expect(r.category).toBe('high')
+    expect(r.criteriaMetCount).toBe(2)
+  })
+
+  it('counts every symptom toggled on', () => {
+    const r = calcPcosSymptoms({
+      irregularCycles: true,
+      missedPeriods: true,
+      hirsutism: true,
+      acne: true,
+      hairLoss: true,
+      weightGain: true,
+      acanthosis: true,
+      fertilityIssues: true,
+      familyHistory: true,
+    })
+    expect(r.symptomCount).toBe(9)
+    expect(r.score).toBe(100)
+    expect(r.category).toBe('high')
+    expect(r.evaluationRecommended).toBe(true)
+  })
+
+  it('score scales monotonically with symptom count', () => {
+    const r1 = calcPcosSymptoms({ irregularCycles: true })
+    const r2 = calcPcosSymptoms({ irregularCycles: true, hirsutism: true })
+    const r3 = calcPcosSymptoms({ irregularCycles: true, hirsutism: true, acanthosis: true })
+    expect(r2.score).toBeGreaterThan(r1.score)
+    expect(r3.score).toBeGreaterThan(r2.score)
+  })
+
+  it('recommends evaluation when ovulatory + hyperandrogenism overlap', () => {
+    const r = calcPcosSymptoms({ irregularCycles: true, acne: true })
+    expect(r.evaluationRecommended).toBe(true)
+  })
+
+  it('recommends evaluation for one criterion plus four+ supporting symptoms', () => {
+    const r = calcPcosSymptoms({
+      irregularCycles: true,
+      weightGain: true,
+      acanthosis: true,
+      fertilityIssues: true,
+      familyHistory: true,
+    })
+    expect(r.criteriaMetCount).toBe(1)
+    expect(r.evaluationRecommended).toBe(true)
+  })
+
+  it('handles undefined input as all false', () => {
+    const r = calcPcosSymptoms()
+    expect(r.symptomCount).toBe(0)
+    expect(r.category).toBe('low')
+  })
+
+  it('caps score at 100', () => {
+    const r = calcPcosSymptoms({
+      irregularCycles: true, missedPeriods: true,
+      hirsutism: true, acne: true, hairLoss: true,
+      weightGain: true, acanthosis: true,
+      fertilityIssues: true, familyHistory: true,
+    })
+    expect(r.score).toBeLessThanOrEqual(100)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -52,6 +52,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-dosierung-rechner',
   'cholesterol-verhaeltnis-rechner',
   'prostatakrebs-risiko-berechnen',
+  'pcos-symptome-erkennen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -88,12 +89,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'child-dosage-calculator',
   'cholesterol-ratio',
   'prostate-cancer-risk',
+  'pcos-symptom-checker',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 48 calculator meta files', () => {
+  it('discovers all 49 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(48)
+    expect(metas).toHaveLength(49)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -131,19 +133,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 46 DE blog slugs', () => {
+  it('returns all 47 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(46)
+    expect(de).toHaveLength(47)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 46 EN blog slugs', () => {
+  it('returns all 47 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(46)
+    expect(en).toHaveLength(47)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -211,9 +213,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 96 calcs + 2 blog index + 92 blog articles = 192)', () => {
+  it('generates correct total URL count (2 home + 98 calcs + 2 blog index + 94 blog articles = 196)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(192)
+    expect(urlCount).toBe(196)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -413,6 +413,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'prostateRisk',
     related: ['life-expectancy-calculator', 'biological-age-calculator', 'diabetes-risk-score'],
   },
+  {
+    slug: 'pcos-symptom-checker',
+    title: 'PCOS Symptom Checker: Rotterdam Criteria, Signs and the Path to Diagnosis',
+    description: 'PCOS symptom checker — irregular cycles, hyperandrogenism, acanthosis nigricans and fertility issues. With Rotterdam criteria, diagnosis pathway and a free PCOS screener.',
+    date: '2026-05-01',
+    readTime: '8 min',
+    calculatorKey: 'pcosSymptoms',
+    related: ['calculate-ovulation', 'period-calculator-guide', 'diabetes-risk-score'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -413,6 +413,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'prostateRisk',
     related: ['lebenserwartung-berechnen', 'biologisches-alter-berechnen', 'diabetes-risiko-berechnen'],
   },
+  {
+    slug: 'pcos-symptome-erkennen',
+    title: 'PCOS-Symptome erkennen: Rotterdam-Kriterien, Anzeichen und Diagnose',
+    description: 'PCOS-Symptome erkennen — Zyklusstörungen, Hyperandrogenismus, Acanthosis nigricans und Kinderwunsch. Mit Rotterdam-Kriterien, Diagnose-Pfad und Symptom-Rechner.',
+    date: '2026-05-01',
+    readTime: '8 min',
+    calculatorKey: 'pcosSymptoms',
+    related: ['eisprung-berechnen', 'zyklusrechner-guide', 'diabetes-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/pcosSymptoms.json
+++ b/src/locales/calculators/de/pcosSymptoms.json
@@ -1,0 +1,80 @@
+{
+  "home": {
+    "calculators": {
+      "pcosSymptoms": {
+        "name": "PCOS-Symptome-Rechner",
+        "description": "Schätze dein PCOS-Risiko anhand der Rotterdam-Kriterien und typischer Symptome."
+      }
+    }
+  },
+  "pcosSymptoms": {
+    "meta": {
+      "title": "PCOS-Symptome-Rechner — Rotterdam-Kriterien online prüfen",
+      "description": "Prüfe deine PCOS-Symptome nach den Rotterdam-Kriterien. Zyklusstörungen, Hyperandrogenismus, Hirsutismus, Akne und mehr — schnell, kostenlos, ohne Anmeldung."
+    },
+    "title": "PCOS-Symptome-Rechner",
+    "description": "Symptom-Screening nach den Rotterdam-Kriterien — als Vorbereitung für das Gespräch mit deiner Gynäkologin.",
+    "ovulatorySection": "Zyklus & Eisprung",
+    "androgenSection": "Hyperandrogene Zeichen",
+    "metabolicSection": "Stoffwechsel & weitere Hinweise",
+    "irregularCycles": "Unregelmäßige Zyklen (länger als 35 oder kürzer als 21 Tage)",
+    "missedPeriods": "Ausgebliebene Perioden (3 oder mehr in Folge)",
+    "hirsutism": "Vermehrte Körperbehaarung (Hirsutismus, z. B. Gesicht, Brust, Bauch)",
+    "acne": "Hartnäckige Akne (Gesicht, Brust, Rücken)",
+    "hairLoss": "Haarausfall am Kopf (androgene Alopezie)",
+    "weightGain": "Gewichtszunahme oder Bauchfett trotz unverändertem Lebensstil",
+    "acanthosis": "Dunkle Hautstellen in Hautfalten (Acanthosis nigricans)",
+    "fertilityIssues": "Unerfüllter Kinderwunsch über 12 Monate",
+    "familyHistory": "PCOS oder Typ-2-Diabetes in der nahen Familie",
+    "yes": "Ja",
+    "no": "Nein",
+    "results": "Symptom-Auswertung",
+    "category_low": "Niedrig",
+    "category_moderate": "Moderat",
+    "category_high": "Hoch",
+    "criteriaMet": "Rotterdam-Kriterien erfüllt: {count} von 3",
+    "ovulatoryDysfunction": "Zyklusstörung erkannt",
+    "hyperandrogenism": "Hyperandrogene Zeichen erkannt",
+    "noFinding": "Kein typisches Zeichen erkannt",
+    "symptomCount": "Erkannte Symptome",
+    "interpretation_low": "Aktuell ergeben sich keine typischen PCOS-Hinweise. Beobachte deinen Zyklus und sprich bei Veränderungen mit deiner Gynäkologin.",
+    "interpretation_moderate": "Einzelne Symptome können auf hormonelle Ungleichgewichte hindeuten. Ein Hormonstatus (Androgene, LH/FSH, Insulin) und ein Gespräch mit der Gynäkologin sind sinnvoll.",
+    "interpretation_high": "Du erfüllst zwei der drei Rotterdam-Kriterien klinisch — eine fachärztliche Abklärung mit Hormonstatus und Ultraschall ist klar empfohlen.",
+    "evaluationRecommended": "Fachärztliche Abklärung empfohlen — bitte vereinbare einen Termin in der Gynäkologie oder Endokrinologie.",
+    "evaluationNotRecommended": "Aktuell keine spezifische Abklärung indiziert. Bei Veränderungen erneut prüfen.",
+    "criteriaTitle": "Rotterdam-Kriterien (2 von 3 für PCOS-Diagnose)",
+    "criterion1": "1. Zyklusstörung (Oligo- oder Anovulation)",
+    "criterion2": "2. Hyperandrogenismus (klinisch oder laborchemisch)",
+    "criterion3": "3. Polyzystische Ovarien im Ultraschall",
+    "criterion3Note": "Punkt 3 wird per Ultraschall ärztlich beurteilt — dieser Rechner kann die Bildgebung nicht ersetzen.",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner orientiert sich an den Rotterdam-Kriterien (ESHRE/ASRM 2003): Für eine PCOS-Diagnose sind 2 von 3 Kriterien nötig — Zyklusstörung, klinischer oder laborchemischer Hyperandrogenismus und polyzystische Ovarien im Ultraschall. Aus deinen Eingaben werden die ersten beiden Kriterien geschätzt; der Ultraschall bleibt der Ärztin/dem Arzt vorbehalten. Begleitsymptome (Akanthosis, Übergewicht, Fertilitätsprobleme, Familienanamnese) erhöhen den Verdachtsscore. Das Ergebnis ist eine Orientierung — keine Diagnose.",
+    "disclaimer": "Dieser Rechner ersetzt keine ärztliche Abklärung. Bei Verdacht auf PCOS bitte Gynäkologin oder Endokrinologie aufsuchen — oft sind Therapie oder Lebensstilmaßnahmen sehr wirksam.",
+    "faq": [
+      {
+        "q": "Was ist PCOS?",
+        "a": "Das polyzystische Ovarialsyndrom (PCOS) ist eine hormonelle Störung mit erhöhten Androgenen, Zyklusstörungen und häufig polyzystischen Eierstöcken. Es ist die häufigste Hormonstörung bei Frauen im fortpflanzungsfähigen Alter — etwa 5–10 % sind betroffen."
+      },
+      {
+        "q": "Was sind die Rotterdam-Kriterien?",
+        "a": "Die Rotterdam-Kriterien (ESHRE/ASRM 2003) sind der internationale Standard für die PCOS-Diagnose. Erforderlich sind 2 von 3: Zyklusstörung, Hyperandrogenismus (klinisch oder im Labor) und polyzystische Ovarien im Ultraschall."
+      },
+      {
+        "q": "Was bedeutet Hirsutismus?",
+        "a": "Hirsutismus ist eine vermehrte, männlich-typische Körperbehaarung bei Frauen — z. B. Bart, Brust, Bauch, Rücken. Beurteilt wird er klinisch über den modifizierten Ferriman-Gallwey-Score (Werte ab 8 gelten als auffällig)."
+      },
+      {
+        "q": "Welche Hormonwerte werden bei PCOS geprüft?",
+        "a": "Standardlabor: Testosteron (Gesamt + frei), SHBG, DHEAS, Androstendion, LH, FSH, Östradiol, Prolaktin, TSH, ggf. 17-OH-Progesteron. Stoffwechsel: Nüchterninsulin, HbA1c und ein OGTT zum Ausschluss einer Insulinresistenz."
+      },
+      {
+        "q": "Kann man mit PCOS schwanger werden?",
+        "a": "Ja — die meisten Frauen mit PCOS können Mutter werden, oft ist aber Unterstützung nötig. Wirksam sind Lebensstil (Gewicht), Metformin, Letrozol oder Clomifen zur Ovulationsinduktion und ggf. assistierte Reproduktion (IVF)."
+      },
+      {
+        "q": "Was hilft bei PCOS?",
+        "a": "Lebensstil hat den größten Effekt: 5–10 % Gewichtsabnahme normalisiert oft den Zyklus und senkt Androgene. Medikamentös: Metformin (Insulinresistenz), kombinierte Pille (Zyklusregulation, Akne, Hirsutismus), Spironolacton (Antiandrogen), Inositol als Nahrungsergänzung."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/pcosSymptoms.json
+++ b/src/locales/calculators/en/pcosSymptoms.json
@@ -1,0 +1,80 @@
+{
+  "home": {
+    "calculators": {
+      "pcosSymptoms": {
+        "name": "PCOS Symptom Checker",
+        "description": "Screen for PCOS using the Rotterdam criteria and common symptom patterns."
+      }
+    }
+  },
+  "pcosSymptoms": {
+    "meta": {
+      "title": "PCOS Symptom Checker — Rotterdam Criteria Screening",
+      "description": "Screen your PCOS symptoms against the Rotterdam criteria. Cycle changes, hyperandrogenism, hirsutism, acne and more — fast, free, no sign-up."
+    },
+    "title": "PCOS Symptom Checker",
+    "description": "Symptom screening based on the Rotterdam criteria — to prepare a focused conversation with your gynecologist.",
+    "ovulatorySection": "Cycle & ovulation",
+    "androgenSection": "Hyperandrogenic signs",
+    "metabolicSection": "Metabolic & other clues",
+    "irregularCycles": "Irregular cycles (longer than 35 or shorter than 21 days)",
+    "missedPeriods": "Missed periods (3 or more in a row)",
+    "hirsutism": "Excess body hair (hirsutism — face, chest, abdomen)",
+    "acne": "Persistent adult acne (face, chest, back)",
+    "hairLoss": "Scalp hair thinning (androgenic alopecia)",
+    "weightGain": "Weight gain or central obesity despite stable lifestyle",
+    "acanthosis": "Dark velvety patches in skin folds (acanthosis nigricans)",
+    "fertilityIssues": "Trouble conceiving for over 12 months",
+    "familyHistory": "PCOS or type 2 diabetes in close family",
+    "yes": "Yes",
+    "no": "No",
+    "results": "Symptom assessment",
+    "category_low": "Low",
+    "category_moderate": "Moderate",
+    "category_high": "High",
+    "criteriaMet": "Rotterdam criteria met: {count} of 3",
+    "ovulatoryDysfunction": "Ovulatory dysfunction detected",
+    "hyperandrogenism": "Hyperandrogenic signs detected",
+    "noFinding": "No typical pattern detected",
+    "symptomCount": "Symptoms reported",
+    "interpretation_low": "No typical PCOS pattern is showing right now. Track your cycle and revisit if anything changes.",
+    "interpretation_moderate": "A few symptoms hint at a possible hormonal imbalance. A focused hormone panel (androgens, LH/FSH, insulin) and a gynecology visit are reasonable next steps.",
+    "interpretation_high": "Two of three Rotterdam criteria are met clinically — a specialist work-up with hormone panel and ultrasound is clearly recommended.",
+    "evaluationRecommended": "Specialist evaluation recommended — book an appointment with gynecology or endocrinology.",
+    "evaluationNotRecommended": "No specific evaluation indicated right now. Re-check if symptoms change.",
+    "criteriaTitle": "Rotterdam criteria (2 of 3 needed for PCOS diagnosis)",
+    "criterion1": "1. Ovulatory dysfunction (oligo- or anovulation)",
+    "criterion2": "2. Hyperandrogenism (clinical or biochemical)",
+    "criterion3": "3. Polycystic ovaries on ultrasound",
+    "criterion3Note": "Criterion 3 requires ultrasound imaging by a clinician — this calculator cannot replace it.",
+    "howItWorks": "How it works",
+    "howItWorksText": "This tool maps to the Rotterdam criteria (ESHRE/ASRM 2003): a PCOS diagnosis needs 2 of 3 — ovulatory dysfunction, clinical or biochemical hyperandrogenism, and polycystic ovaries on ultrasound. Your inputs estimate the first two criteria; the ultrasound stays with your clinician. Supporting symptoms (acanthosis nigricans, weight gain, fertility issues, family history) raise the suspicion score. The result is orientation, not a diagnosis.",
+    "disclaimer": "This calculator does not replace medical evaluation. If PCOS is suspected, consult a gynecologist or endocrinologist — therapy and lifestyle measures are often very effective.",
+    "faq": [
+      {
+        "q": "What is PCOS?",
+        "a": "Polycystic ovary syndrome (PCOS) is a hormonal disorder with elevated androgens, ovulatory dysfunction and often polycystic ovaries. It is the most common endocrine disorder in women of reproductive age, affecting roughly 5–10 %."
+      },
+      {
+        "q": "What are the Rotterdam criteria?",
+        "a": "The Rotterdam criteria (ESHRE/ASRM 2003) are the international standard for PCOS diagnosis. Two of three are required: ovulatory dysfunction, hyperandrogenism (clinical or biochemical), and polycystic ovaries on ultrasound."
+      },
+      {
+        "q": "What is hirsutism?",
+        "a": "Hirsutism is excess male-pattern terminal hair in women — face, chest, abdomen, back. It is graded clinically with the modified Ferriman-Gallwey score; values of 8 or higher are considered abnormal."
+      },
+      {
+        "q": "Which lab tests are used in PCOS work-up?",
+        "a": "Standard hormones: total and free testosterone, SHBG, DHEAS, androstenedione, LH, FSH, estradiol, prolactin, TSH, optionally 17-OH-progesterone. Metabolic: fasting insulin, HbA1c and an oral glucose tolerance test for insulin resistance."
+      },
+      {
+        "q": "Can you get pregnant with PCOS?",
+        "a": "Yes — most women with PCOS can have children, though support is often needed. Effective options include lifestyle change (weight), metformin, letrozole or clomiphene for ovulation induction, and assisted reproduction (IVF) when indicated."
+      },
+      {
+        "q": "What helps with PCOS?",
+        "a": "Lifestyle changes have the biggest effect: a 5–10 % weight loss often restores cycles and lowers androgens. Pharmacology: metformin (insulin resistance), combined pill (cycle regulation, acne, hirsutism), spironolactone (antiandrogen), and inositol as a supplement."
+      }
+    ]
+  }
+}

--- a/src/pages/PcosSymptomsCalculator.vue
+++ b/src/pages/PcosSymptomsCalculator.vue
@@ -1,0 +1,228 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcPcosSymptoms } from '../utils/pcosSymptoms.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('pcosSymptoms.faq') || [])
+
+useHead(() => ({
+  title: t('pcosSymptoms.meta.title'),
+  description: t('pcosSymptoms.meta.description'),
+  routeKey: 'pcosSymptoms',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'PCOS Symptom Checker',
+    url: 'https://healthcalculator.app/pcos-symptom-checker',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const symptomKeys = [
+  { key: 'irregularCycles', section: 'ovulatory' },
+  { key: 'missedPeriods', section: 'ovulatory' },
+  { key: 'hirsutism', section: 'androgen' },
+  { key: 'acne', section: 'androgen' },
+  { key: 'hairLoss', section: 'androgen' },
+  { key: 'weightGain', section: 'metabolic' },
+  { key: 'acanthosis', section: 'metabolic' },
+  { key: 'fertilityIssues', section: 'metabolic' },
+  { key: 'familyHistory', section: 'metabolic' },
+]
+
+const symptoms = ref(Object.fromEntries(symptomKeys.map(s => [s.key, false])))
+
+function toggle(key, value) {
+  symptoms.value[key] = value
+}
+
+const ovulatorySymptoms = symptomKeys.filter(s => s.section === 'ovulatory')
+const androgenSymptoms = symptomKeys.filter(s => s.section === 'androgen')
+const metabolicSymptoms = symptomKeys.filter(s => s.section === 'metabolic')
+
+const result = computed(() => calcPcosSymptoms(symptoms.value))
+
+const hasInput = computed(() => Object.values(symptoms.value).some(Boolean))
+
+const categoryColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.category) {
+    case 'low': return 'text-green-600'
+    case 'moderate': return 'text-yellow-600'
+    case 'high': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+
+const categoryBg = computed(() => {
+  if (!result.value) return 'bg-stone-300'
+  switch (result.value.category) {
+    case 'low': return 'bg-green-500'
+    case 'moderate': return 'bg-yellow-500'
+    case 'high': return 'bg-red-600'
+    default: return 'bg-stone-300'
+  }
+})
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('pcosSymptoms.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('pcosSymptoms.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="mb-6">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('pcosSymptoms.ovulatorySection') }}</h2>
+      <div class="space-y-3">
+        <div v-for="s in ovulatorySymptoms" :key="s.key" class="flex items-center justify-between gap-4">
+          <span class="text-sm text-stone-700 flex-1">{{ t('pcosSymptoms.' + s.key) }}</span>
+          <div class="flex gap-2 shrink-0">
+            <button
+              @click="toggle(s.key, false)"
+              :data-testid="s.key + '-no'"
+              :class="!symptoms[s.key] ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('pcosSymptoms.no') }}</button>
+            <button
+              @click="toggle(s.key, true)"
+              :data-testid="s.key + '-yes'"
+              :class="symptoms[s.key] ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('pcosSymptoms.yes') }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mb-6 pt-6 border-t border-stone-100">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('pcosSymptoms.androgenSection') }}</h2>
+      <div class="space-y-3">
+        <div v-for="s in androgenSymptoms" :key="s.key" class="flex items-center justify-between gap-4">
+          <span class="text-sm text-stone-700 flex-1">{{ t('pcosSymptoms.' + s.key) }}</span>
+          <div class="flex gap-2 shrink-0">
+            <button
+              @click="toggle(s.key, false)"
+              :data-testid="s.key + '-no'"
+              :class="!symptoms[s.key] ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('pcosSymptoms.no') }}</button>
+            <button
+              @click="toggle(s.key, true)"
+              :data-testid="s.key + '-yes'"
+              :class="symptoms[s.key] ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('pcosSymptoms.yes') }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="pt-6 border-t border-stone-100">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('pcosSymptoms.metabolicSection') }}</h2>
+      <div class="space-y-3">
+        <div v-for="s in metabolicSymptoms" :key="s.key" class="flex items-center justify-between gap-4">
+          <span class="text-sm text-stone-700 flex-1">{{ t('pcosSymptoms.' + s.key) }}</span>
+          <div class="flex gap-2 shrink-0">
+            <button
+              @click="toggle(s.key, false)"
+              :data-testid="s.key + '-no'"
+              :class="!symptoms[s.key] ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('pcosSymptoms.no') }}</button>
+            <button
+              @click="toggle(s.key, true)"
+              :data-testid="s.key + '-yes'"
+              :class="symptoms[s.key] ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150"
+            >{{ t('pcosSymptoms.yes') }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="hasInput && result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('pcosSymptoms.results') }}</p>
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="result-score">{{ result.score }}</span>
+      <span class="text-lg text-stone-400">/ 100</span>
+      <span :class="categoryColor" class="text-lg font-semibold" data-testid="result-category">{{ t('pcosSymptoms.category_' + result.category) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div :class="categoryBg" class="absolute inset-y-0 left-0 transition-all duration-300" :style="{ width: result.score + '%' }"></div>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 mb-4" data-testid="interpretation">
+      <p class="text-sm text-stone-700 leading-relaxed">{{ t('pcosSymptoms.interpretation_' + result.category) }}</p>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('pcosSymptoms.criteriaMet', { count: result.criteriaMetCount }) }}</p>
+        <p class="text-sm text-stone-700 mt-2" data-testid="rotterdam-criteria">
+          <span :class="result.ovulatoryDysfunction ? 'text-stone-900 font-semibold' : 'text-stone-400'">
+            {{ result.ovulatoryDysfunction ? '✓' : '·' }} {{ t('pcosSymptoms.ovulatoryDysfunction') }}
+          </span><br />
+          <span :class="result.hyperandrogenism ? 'text-stone-900 font-semibold' : 'text-stone-400'">
+            {{ result.hyperandrogenism ? '✓' : '·' }} {{ t('pcosSymptoms.hyperandrogenism') }}
+          </span>
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('pcosSymptoms.symptomCount') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="symptom-count">{{ result.symptomCount }} / 9</p>
+      </div>
+    </div>
+
+    <div
+      class="rounded-lg p-4 text-sm font-medium"
+      :class="result.evaluationRecommended ? 'bg-red-50 text-red-900 border border-red-200' : 'bg-green-50 text-green-900 border border-green-200'"
+      data-testid="evaluation-status"
+    >
+      {{ result.evaluationRecommended ? t('pcosSymptoms.evaluationRecommended') : t('pcosSymptoms.evaluationNotRecommended') }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('pcosSymptoms.criteriaTitle') }}</h2>
+    </div>
+    <ul class="divide-y divide-stone-100">
+      <li class="px-6 py-3 text-sm text-stone-700">{{ t('pcosSymptoms.criterion1') }}</li>
+      <li class="px-6 py-3 text-sm text-stone-700">{{ t('pcosSymptoms.criterion2') }}</li>
+      <li class="px-6 py-3 text-sm text-stone-700">
+        {{ t('pcosSymptoms.criterion3') }}
+        <p class="text-xs text-stone-400 mt-1">{{ t('pcosSymptoms.criterion3Note') }}</p>
+      </li>
+    </ul>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('pcosSymptoms.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('pcosSymptoms.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('pcosSymptoms.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="pcosSymptoms" />
+</template>

--- a/src/pages/blog/PcosSymptomeErkennen.vue
+++ b/src/pages/blog/PcosSymptomeErkennen.vue
@@ -1,0 +1,197 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Was ist PCOS?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Das polyzystische Ovarialsyndrom ist eine hormonelle Störung mit erhöhten Androgenen, Zyklusstörungen und häufig polyzystischen Eierstöcken — etwa 5–10 % der Frauen sind betroffen.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Was sind die Rotterdam-Kriterien?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Internationaler Diagnose-Standard (ESHRE/ASRM 2003): Zyklusstörung, Hyperandrogenismus oder polyzystische Ovarien — 2 von 3 reichen aus.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Welche Symptome sind typisch?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Unregelmäßige oder ausbleibende Zyklen, Akne, Hirsutismus, androgener Haarausfall, Gewichtszunahme, Acanthosis nigricans und unerfüllter Kinderwunsch.' },
+    },
+  ],
+}
+
+useHead({
+  title: 'PCOS-Symptome erkennen: Rotterdam-Kriterien, Anzeichen & nächste Schritte | Health Calculators',
+  description: 'PCOS-Symptome erkennen — Zyklusstörungen, Hyperandrogenismus, Acanthosis nigricans und Kinderwunsch. Mit Rotterdam-Kriterien, Diagnose-Pfad und PCOS-Symptom-Rechner.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'PCOS-Symptome erkennen: Rotterdam-Kriterien, Anzeichen und der Weg zur Diagnose',
+      description: 'PCOS-Symptome erkennen — Zyklusstörungen, Hyperandrogenismus, Acanthosis nigricans und Kinderwunsch. Mit Rotterdam-Kriterien, Diagnose-Pfad und PCOS-Symptom-Rechner.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-01',
+      dateModified: '2026-05-01',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/pcos-symptome-erkennen',
+      },
+    },
+    faqJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">PCOS-Symptome erkennen: Rotterdam-Kriterien, Anzeichen und der Weg zur Diagnose</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">1. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das <strong>polyzystische Ovarialsyndrom (PCOS)</strong> ist die häufigste Hormonstörung bei Frauen im fortpflanzungsfähigen Alter — und gleichzeitig die am häufigsten übersehene. Etwa <strong>5–10 % aller Frauen</strong> sind betroffen, doch viele bekommen ihre Diagnose erst nach Jahren der Beschwerden.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel zeigt dir die typischen Symptome, die internationalen Rotterdam-Kriterien und den klaren Weg zur Diagnose — damit du mit einem fundierten Verdacht in die gynäkologische Praxis gehen kannst.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Rotterdam-Kriterien (2 von 3 reichen)</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Seit 2003 sind die <strong>Rotterdam-Kriterien</strong> (ESHRE/ASRM) der internationale Goldstandard für die PCOS-Diagnose. Du erfüllst PCOS, wenn zwei der drei folgenden Kriterien zutreffen:
+        </p>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">1. Zyklusstörung (Oligo- oder Anovulation)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Zyklen länger als 35 Tage, kürzer als 21 Tage, oder weniger als 8 Perioden pro Jahr.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">2. Hyperandrogenismus</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Klinisch (Hirsutismus, Akne, androgener Haarausfall) oder im Labor (Testosteron, freier Androgenindex).</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">3. Polyzystische Ovarien im Ultraschall</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">≥ 20 Follikel pro Ovar oder Ovarvolumen ≥ 10 ml — beurteilt durch transvaginale Sonografie.</p>
+          </div>
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed mt-4">
+          Wichtig: Andere Ursachen (Hyperprolaktinämie, Schilddrüse, AGS) müssen vorher ausgeschlossen sein.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Typische Symptome — und was sie bedeuten</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptom</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Hintergrund</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Unregelmäßige Zyklen</td><td class="px-6 py-3 text-stone-600">Anovulation durch gestörte LH/FSH-Regulation</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hirsutismus</td><td class="px-6 py-3 text-stone-600">Erhöhte Androgene, modifizierter Ferriman-Gallwey ≥ 8</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Akne, fettige Haut</td><td class="px-6 py-3 text-stone-600">Talgproduktion durch Testosteron-Wirkung</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Haarausfall am Kopf</td><td class="px-6 py-3 text-stone-600">Androgene Alopezie, scheitelbetontes Lichten</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Gewichtszunahme, Bauchfett</td><td class="px-6 py-3 text-stone-600">Insulinresistenz und gestörte Glucose-Verwertung</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Acanthosis nigricans</td><td class="px-6 py-3 text-stone-600">Dunkle Hautstellen — direkter Marker für Insulinresistenz</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Unerfüllter Kinderwunsch</td><td class="px-6 py-3 text-stone-600">Anovulation als häufigste Ursache von Infertilität bei PCOS</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Insulinresistenz: der oft übersehene Treiber</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bis zu 70 % der Frauen mit PCOS haben eine <strong>Insulinresistenz</strong> — unabhängig vom Gewicht. Das hohe Insulin steigert die Androgenproduktion in den Ovarien und blockiert SHBG in der Leber, sodass mehr freies Testosteron aktiv wird. Acanthosis nigricans (dunkle, samtige Hautstellen in Hautfalten) ist der klinische Hinweis schlechthin.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ein erhöhter Nüchterninsulinspiegel oder ein auffälliger oraler Glukosetoleranztest gehören deshalb in jede PCOS-Abklärung. Lies dazu den Artikel zum
+          <router-link :to="localeBlogPath('diabetes-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko</router-link> — die metabolische Verbindung ist eng.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deine PCOS-Symptome prüfen</h3>
+        <p class="text-stone-300 text-sm mb-5">Bewerte 9 typische Anzeichen entlang der Rotterdam-Kriterien — mit klarer Empfehlung für die nächsten Schritte. Kostenlos, sofort, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('pcosSymptoms')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Symptom-Check starten &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Der Weg zur Diagnose</h2>
+        <ol class="list-decimal list-inside space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>Zyklusprotokoll</strong> über 3–6 Monate (Apps wie Period-Tracker oder Basaltemperatur).</li>
+          <li><strong>Hormonstatus</strong> in der frühen Follikelphase (Tag 2–5): Testosteron, SHBG, freier Androgenindex, DHEAS, LH/FSH, Östradiol, Prolaktin, TSH, 17-OH-Progesteron.</li>
+          <li><strong>Stoffwechsel-Labor</strong>: Nüchterninsulin, HbA1c, OGTT, Lipide.</li>
+          <li><strong>Transvaginaler Ultraschall</strong> in der Follikelphase für Follikelzahl und Ovarvolumen.</li>
+          <li><strong>Differentialdiagnose</strong> ausschließen: Hyperprolaktinämie, Schilddrüse, NCAH (17-OH-Progesteron), Cushing.</li>
+        </ol>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was hilft? Therapie auf den Punkt</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lebensstil</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">5–10 % Gewichtsabnahme bringt bei Übergewicht oft schon den Zyklus zurück und senkt Androgene messbar. Krafttraining hilft gegen Insulinresistenz.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Medikamente</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Metformin (Insulinresistenz), kombinierte Pille (Zyklus, Akne, Hirsutismus), Spironolacton (Antiandrogen), Letrozol bei Kinderwunsch.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Nahrungsergänzung</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Inositol (Myo-/D-Chiro 40:1) hat in Studien Zyklus und Eisprung verbessert. Vitamin D bei Mangel ergänzen.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          PCOS hängt eng mit Eisprung, Zyklus und Stoffwechsel zusammen. Verfolge deinen Zyklus mit dem
+          <router-link :to="localeBlogPath('zyklusrechner-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Zyklusrechner</router-link>,
+          plane den
+          <router-link :to="localeBlogPath('eisprung-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Eisprung</router-link>
+          und prüfe dein
+          <router-link :to="localeBlogPath('diabetes-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko</router-link>
+          — drei Werte, die zusammen ein klares Bild deines reproduktiv-metabolischen Status zeichnen.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          PCOS ist eine Diagnose mit Hebel: einmal erkannt, sind Lebensstil und Medikamente sehr wirksam — Zyklus, Haut, Haare und Fertilität verbessern sich oft deutlich. Der erste Schritt ist, die Symptome ernst zu nehmen. Starte mit dem
+          <router-link :to="localePath('pcosSymptoms')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">PCOS-Symptom-Rechner</router-link> und gehe mit dem Ergebnis fundiert in die nächste Sprechstunde.
+        </p>
+      </div>
+
+      <RelatedArticles slug="pcos-symptome-erkennen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/PcosSymptomChecker.vue
+++ b/src/pages/blog/en/PcosSymptomChecker.vue
@@ -1,0 +1,197 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is PCOS?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Polycystic ovary syndrome is a hormonal disorder with elevated androgens, ovulatory dysfunction and often polycystic ovaries — affecting roughly 5–10 % of women of reproductive age.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What are the Rotterdam criteria?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The international diagnostic standard (ESHRE/ASRM 2003): ovulatory dysfunction, hyperandrogenism, or polycystic ovaries — two of three are required.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What symptoms are typical?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Irregular or missed cycles, acne, hirsutism, scalp hair thinning, weight gain, acanthosis nigricans, and difficulty conceiving.' },
+    },
+  ],
+}
+
+useHead({
+  title: 'PCOS Symptom Checker: Rotterdam Criteria, Signs & Diagnosis Path | Health Calculators',
+  description: 'PCOS symptom checker — irregular cycles, hyperandrogenism, acanthosis nigricans and fertility issues. With Rotterdam criteria, diagnosis pathway and a free PCOS screener.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'PCOS Symptom Checker: Rotterdam Criteria, Signs and the Path to Diagnosis',
+      description: 'PCOS symptom checker — irregular cycles, hyperandrogenism, acanthosis nigricans and fertility issues. With Rotterdam criteria, diagnosis pathway and a free PCOS screener.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-01',
+      dateModified: '2026-05-01',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/pcos-symptom-checker',
+      },
+    },
+    faqJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">PCOS Symptom Checker: Rotterdam Criteria, Signs and the Path to Diagnosis</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 1, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Polycystic ovary syndrome (PCOS)</strong> is the most common endocrine disorder in women of reproductive age — and the most commonly missed. About <strong>5–10 % of women</strong> are affected, yet many wait years for a diagnosis.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article walks through the typical symptoms, the international Rotterdam criteria and the clear path to diagnosis — so you can step into a gynecology visit with a focused, evidence-backed suspicion.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The Rotterdam criteria (2 of 3 required)</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Since 2003 the <strong>Rotterdam criteria</strong> (ESHRE/ASRM) have been the international gold standard for PCOS diagnosis. PCOS is met when two of these three are present:
+        </p>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">1. Ovulatory dysfunction (oligo- or anovulation)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Cycles longer than 35 days, shorter than 21 days, or fewer than 8 menses per year.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">2. Hyperandrogenism</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Clinical (hirsutism, acne, androgenic alopecia) or biochemical (testosterone, free androgen index).</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">3. Polycystic ovaries on ultrasound</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">≥ 20 follicles per ovary or ovarian volume ≥ 10 mL — assessed by transvaginal ultrasound.</p>
+          </div>
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed mt-4">
+          Important: other causes (hyperprolactinemia, thyroid disease, NCAH) must be ruled out first.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Typical symptoms — and what they mean</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptom</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Background</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Irregular cycles</td><td class="px-6 py-3 text-stone-600">Anovulation driven by disturbed LH/FSH regulation</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hirsutism</td><td class="px-6 py-3 text-stone-600">Elevated androgens, modified Ferriman-Gallwey ≥ 8</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Acne, oily skin</td><td class="px-6 py-3 text-stone-600">Sebum production driven by testosterone</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Scalp hair thinning</td><td class="px-6 py-3 text-stone-600">Androgenic alopecia, classically a wider parting</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Weight gain, central obesity</td><td class="px-6 py-3 text-stone-600">Insulin resistance and impaired glucose handling</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Acanthosis nigricans</td><td class="px-6 py-3 text-stone-600">Dark velvety patches — direct skin marker of insulin resistance</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Difficulty conceiving</td><td class="px-6 py-3 text-stone-600">Anovulation is the leading cause of infertility in PCOS</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Insulin resistance: the hidden driver</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Up to 70 % of women with PCOS have <strong>insulin resistance</strong> — independent of body weight. High insulin amplifies ovarian androgen output and suppresses SHBG in the liver, increasing free testosterone. Acanthosis nigricans (dark velvety patches in skin folds) is the classic clinical clue.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A fasting insulin level or an oral glucose tolerance test belongs in any PCOS work-up. See the
+          <router-link :to="localeBlogPath('diabetes-risk-score')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">diabetes risk article</router-link> — the metabolic link runs deep.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Run a PCOS symptom check</h3>
+        <p class="text-stone-300 text-sm mb-5">Score 9 typical signs along the Rotterdam criteria — with a clear next-step recommendation. Free, instant, no sign-up.</p>
+        <router-link
+          :to="localePath('pcosSymptoms')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Start symptom check &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The path to a diagnosis</h2>
+        <ol class="list-decimal list-inside space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>Cycle log</strong> over 3–6 months (period tracker app or basal body temperature).</li>
+          <li><strong>Hormone panel</strong> in the early follicular phase (day 2–5): testosterone, SHBG, free androgen index, DHEAS, LH/FSH, estradiol, prolactin, TSH, 17-OH-progesterone.</li>
+          <li><strong>Metabolic labs</strong>: fasting insulin, HbA1c, OGTT, lipid panel.</li>
+          <li><strong>Transvaginal ultrasound</strong> during the follicular phase for follicle count and ovarian volume.</li>
+          <li><strong>Rule out differentials</strong>: hyperprolactinemia, thyroid disease, non-classic adrenal hyperplasia, Cushing's.</li>
+        </ol>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What helps — therapy in a nutshell</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lifestyle</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">A 5–10 % weight loss often restores cycles in those with overweight and lowers androgens measurably. Strength training improves insulin sensitivity.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Medication</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Metformin (insulin resistance), combined oral contraceptive (cycle, acne, hirsutism), spironolactone (antiandrogen), letrozole for ovulation induction.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Supplements</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Inositol (myo / D-chiro 40:1) has improved cycles and ovulation in trials. Correct vitamin D deficiency where present.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          PCOS sits at the intersection of cycle, ovulation and metabolic health. Track your cycle with the
+          <router-link :to="localeBlogPath('period-calculator-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">period calculator</router-link>,
+          plan
+          <router-link :to="localeBlogPath('calculate-ovulation')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">ovulation</router-link>,
+          and check your
+          <router-link :to="localeBlogPath('diabetes-risk-score')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">diabetes risk</router-link>
+          — three numbers that together paint a clear picture of reproductive-metabolic health.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          PCOS is a high-leverage diagnosis: once recognized, lifestyle and medication work well — cycles, skin, hair and fertility often improve substantially. The first step is taking the symptoms seriously. Start with the
+          <router-link :to="localePath('pcosSymptoms')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">PCOS symptom checker</router-link> and bring an evidence-based picture to your next appointment.
+        </p>
+      </div>
+
+      <RelatedArticles slug="pcos-symptom-checker" />
+    </div>
+  </article>
+</template>

--- a/src/pages/pcosSymptoms.meta.js
+++ b/src/pages/pcosSymptoms.meta.js
@@ -1,0 +1,16 @@
+import Component from './PcosSymptomsCalculator.vue'
+import BlogDe from './blog/PcosSymptomeErkennen.vue'
+import BlogEn from './blog/en/PcosSymptomChecker.vue'
+
+export default {
+  key: 'pcosSymptoms',
+  component: Component,
+  slugs: { de: 'pcos-symptome-rechner', en: 'pcos-symptom-checker' },
+  group: 'pregnancy',
+  groupOrder: 3,
+  order: 6,
+  blog: {
+    de: { slug: 'pcos-symptome-erkennen', component: BlogDe },
+    en: { slug: 'pcos-symptom-checker', component: BlogEn },
+  },
+}

--- a/src/utils/pcosSymptoms.js
+++ b/src/utils/pcosSymptoms.js
@@ -1,0 +1,52 @@
+// PCOS symptom screening — Rotterdam criteria 2/3 logic.
+// Two of three required for clinical PCOS diagnosis:
+//   1) Oligo-anovulation (irregular / missed periods)
+//   2) Clinical or biochemical hyperandrogenism (hirsutism, acne, scalp hair loss)
+//   3) Polycystic ovarian morphology on ultrasound — not assessed here.
+// This tool is a screening aid, not a diagnostic instrument.
+
+export function calcPcosSymptoms({
+  irregularCycles = false,
+  missedPeriods = false,
+  hirsutism = false,
+  acne = false,
+  hairLoss = false,
+  weightGain = false,
+  acanthosis = false,
+  fertilityIssues = false,
+  familyHistory = false,
+} = {}) {
+  const ovulatoryDysfunction = !!(irregularCycles || missedPeriods)
+  const hyperandrogenism = !!(hirsutism || acne || hairLoss)
+  const criteriaMetCount = (ovulatoryDysfunction ? 1 : 0) + (hyperandrogenism ? 1 : 0)
+
+  const symptoms = [
+    irregularCycles, missedPeriods, hirsutism, acne, hairLoss,
+    weightGain, acanthosis, fertilityIssues, familyHistory,
+  ]
+  const symptomCount = symptoms.filter(Boolean).length
+
+  let score = symptomCount * 10
+  if (criteriaMetCount === 2) score += 15
+  if (acanthosis) score += 5
+  score = Math.min(100, score)
+
+  let category
+  if (criteriaMetCount === 2) category = 'high'
+  else if (criteriaMetCount === 1 || symptomCount >= 2) category = 'moderate'
+  else category = 'low'
+
+  const evaluationRecommended =
+    criteriaMetCount >= 2 ||
+    (criteriaMetCount >= 1 && symptomCount >= 4)
+
+  return {
+    category,
+    score,
+    criteriaMetCount,
+    ovulatoryDysfunction,
+    hyperandrogenism,
+    symptomCount,
+    evaluationRecommended,
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-143-pcos-sympom
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-143-pcos-sympom-20260501-040023`
**Cost:** $9.386649749999997

Closes jenslaufer/health-calculators#143

### Prompt
> Implement the Pcos Sympom Calculator as described in issue #143.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- PCOS symptom assessment (Rotterdam criteria)
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/pcosSympom.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/pcosSympom.test.js` with 6+ test cases covering edge cases. Run `npm test -- pcosSympom` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/PcosSympomCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/pcosSympom.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/pcosSympom.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'pcosSympom'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/pcosSympom.json` + `src/locales/calculators/en/pcosSympom.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/pcosSympom.js (or shared util — verify pattern in repo first)`
- `src/__tests__/pcosSympom.test.js`
- `src/pages/PcosSympomCalculator.vue`
- `src/pages/pcosSympom.meta.js`
- `src/locales/calculators/de/pcosSympom.json`
- `src/locales/calculators/en/pcosSympom.json`
- `e2e/pcosSympom.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'pcosSympom',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks