### PR TITLE
hc-145: add Testosterone Level Calculator (Vermeulen free T)

### DIFF
--- a/e2e/testosteroneLevel.spec.js
+++ b/e2e/testosteroneLevel.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/testosteron-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Testosteron/)
+})
+
+test('normal values: total 18, SHBG 30, albumin 43 → normal', async ({ page }) => {
+  await page.getByTestId('total-t').fill('18')
+  await page.getByTestId('shbg').fill('30')
+  await page.getByTestId('albumin').fill('43')
+
+  await expect(page.getByTestId('result-total')).toBeVisible()
+  await expect(page.getByTestId('result-total-category')).toHaveText('Normal')
+  await expect(page.getByTestId('result-free-category')).toHaveText('Normal')
+  await expect(page.getByTestId('hypogonadism-status')).toContainText('Normalbereich')
+})
+
+test('low total testosterone: total 6 → low + hypogonadism flag', async ({ page }) => {
+  await page.getByTestId('total-t').fill('6')
+  await page.getByTestId('shbg').fill('30')
+  await page.getByTestId('albumin').fill('43')
+
+  await expect(page.getByTestId('result-total-category')).toHaveText('Niedrig')
+  await expect(page.getByTestId('hypogonadism-status')).toContainText('Hypogonadismus')
+})
+
+test('high SHBG lowers free testosterone', async ({ page }) => {
+  await page.getByTestId('total-t').fill('18')
+  await page.getByTestId('shbg').fill('80')
+  await page.getByTestId('albumin').fill('43')
+
+  const free = page.getByTestId('result-free')
+  await expect(free).toBeVisible()
+  const value = parseInt(await free.textContent(), 10)
+  expect(value).toBeLessThan(300)
+})
+
+test('ng/dL unit conversion produces same result as nmol/L', async ({ page }) => {
+  await page.getByTestId('total-t').fill('18')
+  await page.getByTestId('shbg').fill('30')
+  await page.getByTestId('albumin').fill('43')
+  const nmolFree = parseInt(await page.getByTestId('result-free').textContent(), 10)
+
+  await page.getByTestId('unit-ngdl').click()
+  await page.getByTestId('total-t').fill('519')
+  const ngdlFree = parseInt(await page.getByTestId('result-free').textContent(), 10)
+
+  expect(Math.abs(ngdlFree - nmolFree)).toBeLessThan(20)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -20,7 +20,7 @@ const EXPECTED_KEYS = [
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
-  'prostateRisk', 'pcosSymptoms',
+  'prostateRisk', 'pcosSymptoms', 'testosteroneLevel',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -71,6 +71,7 @@ const EXPECTED_ROUTE_MAP = {
   cholesterolRatio: { de: 'cholesterol-verhaeltnis-rechner', en: 'cholesterol-ratio' },
   prostateRisk: { de: 'prostatakrebs-risiko-rechner', en: 'prostate-cancer-risk-calculator' },
   pcosSymptoms: { de: 'pcos-symptome-rechner', en: 'pcos-symptom-checker' },
+  testosteroneLevel: { de: 'testosteron-rechner', en: 'testosterone-level-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -109,6 +110,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'cholesterol-verhaeltnis-rechner',
   'prostatakrebs-risiko-berechnen',
   'pcos-symptome-erkennen',
+  'testosteronwert-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -147,19 +149,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'cholesterol-ratio',
   'prostate-cancer-risk',
   'pcos-symptom-checker',
+  'testosterone-level-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 49 calculators', () => {
-    expect(calculatorMetas).toHaveLength(49)
+  it('discovers all 50 calculators', () => {
+    expect(calculatorMetas).toHaveLength(50)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 49 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(49)
+  it('builds calculatorComponents map for all 50 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(50)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -182,15 +185,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 47 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(47)
+  it('discovers all 48 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(48)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 47 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(47)
+  it('discovers all 48 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(48)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -206,10 +209,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 49 calculators with no duplicates', () => {
+  it('groups contain all 50 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(49)
-    expect(new Set(allKeys).size).toBe(49)
+    expect(allKeys).toHaveLength(50)
+    expect(new Set(allKeys).size).toBe(50)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -230,7 +233,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel',
     ])
   })
 
@@ -278,8 +281,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 281 routes', () => {
-    expect(routes).toHaveLength(281)
+  it('generates exactly 286 routes', () => {
+    expect(routes).toHaveLength(286)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 192 links (49 calcs × 2 locales + 47 blogs × 2 locales)', () => {
+  it('generates 196 links (50 calcs × 2 locales + 48 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(192)
+    expect(links).toHaveLength(196)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -53,6 +53,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'cholesterol-verhaeltnis-rechner',
   'prostatakrebs-risiko-berechnen',
   'pcos-symptome-erkennen',
+  'testosteronwert-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -90,12 +91,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'cholesterol-ratio',
   'prostate-cancer-risk',
   'pcos-symptom-checker',
+  'testosterone-level-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 49 calculator meta files', () => {
+  it('discovers all 50 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(49)
+    expect(metas).toHaveLength(50)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -133,19 +135,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 47 DE blog slugs', () => {
+  it('returns all 48 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(47)
+    expect(de).toHaveLength(48)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 47 EN blog slugs', () => {
+  it('returns all 48 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(47)
+    expect(en).toHaveLength(48)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -213,9 +215,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 98 calcs + 2 blog index + 94 blog articles = 196)', () => {
+  it('generates correct total URL count (2 home + 100 calcs + 2 blog index + 96 blog articles = 200)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(196)
+    expect(urlCount).toBe(200)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/__tests__/testosteroneLevel.test.js
+++ b/src/__tests__/testosteroneLevel.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcFreeTestosterone,
+  classifyTotalTestosterone,
+  classifyFreeTestosterone,
+  calcTestosteroneStatus,
+} from '../utils/testosteroneLevel.js'
+
+// Free testosterone uses the Vermeulen equation (the de-facto reference for
+// non-mass-spectrometry estimation). All inputs in SI / nmol/L for total T,
+// nmol/L for SHBG, g/L for albumin. Output: nmol/L (free) and pmol/L convenience.
+//
+// Reference adult male ranges (Vermeulen / Endocrine Society):
+//   Total testosterone: 8.6 – 29.0 nmol/L
+//   Free testosterone: 0.20 – 0.62 nmol/L (≈ 200 – 620 pmol/L)
+
+describe('Free testosterone (Vermeulen)', () => {
+  it('computes a plausible value for total 18, SHBG 30, albumin 43', () => {
+    const r = calcFreeTestosterone({ totalT: 18, shbg: 30, albumin: 43 })
+    // Expected ≈ 0.36 nmol/L based on Vermeulen — must be within physiological range.
+    expect(r).toBeGreaterThan(0.25)
+    expect(r).toBeLessThan(0.55)
+  })
+
+  it('decreases when SHBG rises (more T bound)', () => {
+    const low = calcFreeTestosterone({ totalT: 18, shbg: 30, albumin: 43 })
+    const high = calcFreeTestosterone({ totalT: 18, shbg: 70, albumin: 43 })
+    expect(high).toBeLessThan(low)
+  })
+
+  it('increases when total testosterone rises', () => {
+    const lowT = calcFreeTestosterone({ totalT: 10, shbg: 30, albumin: 43 })
+    const highT = calcFreeTestosterone({ totalT: 25, shbg: 30, albumin: 43 })
+    expect(highT).toBeGreaterThan(lowT)
+  })
+
+  it('returns null for missing or invalid inputs', () => {
+    expect(calcFreeTestosterone({ totalT: null, shbg: 30, albumin: 43 })).toBeNull()
+    expect(calcFreeTestosterone({ totalT: 18, shbg: 0, albumin: 43 })).toBeNull()
+    expect(calcFreeTestosterone({ totalT: 18, shbg: 30, albumin: -1 })).toBeNull()
+  })
+
+  it('uses default albumin of 43 g/L when not provided', () => {
+    const explicit = calcFreeTestosterone({ totalT: 18, shbg: 30, albumin: 43 })
+    const fallback = calcFreeTestosterone({ totalT: 18, shbg: 30 })
+    expect(fallback).toBeCloseTo(explicit, 3)
+  })
+})
+
+describe('Total testosterone classification (adult male)', () => {
+  it('flags 5 nmol/L as low', () => {
+    expect(classifyTotalTestosterone(5)).toBe('low')
+  })
+  it('flags 8 nmol/L as borderline', () => {
+    expect(classifyTotalTestosterone(8)).toBe('borderline')
+  })
+  it('flags 15 nmol/L as normal', () => {
+    expect(classifyTotalTestosterone(15)).toBe('normal')
+  })
+  it('flags 35 nmol/L as high', () => {
+    expect(classifyTotalTestosterone(35)).toBe('high')
+  })
+  it('returns null for invalid input', () => {
+    expect(classifyTotalTestosterone(null)).toBeNull()
+    expect(classifyTotalTestosterone(-1)).toBeNull()
+  })
+})
+
+describe('Free testosterone classification (adult male)', () => {
+  it('flags 0.10 nmol/L as low', () => {
+    expect(classifyFreeTestosterone(0.10)).toBe('low')
+  })
+  it('flags 0.40 nmol/L as normal', () => {
+    expect(classifyFreeTestosterone(0.40)).toBe('normal')
+  })
+  it('flags 0.80 nmol/L as high', () => {
+    expect(classifyFreeTestosterone(0.80)).toBe('high')
+  })
+  it('returns null for invalid input', () => {
+    expect(classifyFreeTestosterone(null)).toBeNull()
+  })
+})
+
+describe('Combined testosterone status', () => {
+  it('returns total + free + classifications', () => {
+    const r = calcTestosteroneStatus({ totalT: 18, shbg: 30, albumin: 43 })
+    expect(r).not.toBeNull()
+    expect(r.totalT).toBe(18)
+    expect(r.freeT).toBeGreaterThan(0)
+    expect(r.freeTpmol).toBeGreaterThan(0)
+    expect(r.totalCategory).toBe('normal')
+    expect(r.freeCategory).toBe('normal')
+  })
+
+  it('flags hypogonadism when total < 8', () => {
+    const r = calcTestosteroneStatus({ totalT: 6, shbg: 30, albumin: 43 })
+    expect(r.totalCategory).toBe('low')
+    expect(r.hypogonadism).toBe(true)
+  })
+
+  it('returns null when any required input is missing', () => {
+    expect(calcTestosteroneStatus({ totalT: null, shbg: 30 })).toBeNull()
+    expect(calcTestosteroneStatus({ totalT: 18, shbg: null })).toBeNull()
+  })
+
+  it('accepts ng/dL total testosterone via unit conversion', () => {
+    // 519 ng/dL × 0.0347 ≈ 18.0 nmol/L
+    const a = calcTestosteroneStatus({ totalT: 18, shbg: 30, albumin: 43 })
+    const b = calcTestosteroneStatus({ totalT: 519, totalUnit: 'ng/dL', shbg: 30, albumin: 43 })
+    expect(b.totalT).toBeCloseTo(a.totalT, 0)
+    expect(b.freeT).toBeCloseTo(a.freeT, 2)
+  })
+})

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -422,6 +422,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'pcosSymptoms',
     related: ['calculate-ovulation', 'period-calculator-guide', 'diabetes-risk-score'],
   },
+  {
+    slug: 'testosterone-level-calculator',
+    title: 'Testosterone Level Calculator: Free vs Bound, SHBG and What Your Numbers Mean',
+    description: 'Calculate free testosterone from total T, SHBG and albumin using the Vermeulen formula. Reference ranges, low-T symptoms, and natural ways to raise it.',
+    date: '2026-05-01',
+    readTime: '8 min',
+    calculatorKey: 'testosteroneLevel',
+    related: ['prostate-cancer-risk', 'biological-age-calculator', 'protein-requirements-guide'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -422,6 +422,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'pcosSymptoms',
     related: ['eisprung-berechnen', 'zyklusrechner-guide', 'diabetes-risiko-berechnen'],
   },
+  {
+    slug: 'testosteronwert-berechnen',
+    title: 'Testosteronwert berechnen: Frei vs. gebunden, SHBG und was die Werte bedeuten',
+    description: 'Freies Testosteron aus Gesamt-T, SHBG und Albumin berechnen — mit der Vermeulen-Formel. Referenzbereiche, Symptome bei Mangel und natürliche Maßnahmen.',
+    date: '2026-05-01',
+    readTime: '8 min',
+    calculatorKey: 'testosteroneLevel',
+    related: ['prostatakrebs-risiko-berechnen', 'biologisches-alter-berechnen', 'proteinbedarf-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/testosteroneLevel.json
+++ b/src/locales/calculators/de/testosteroneLevel.json
@@ -1,0 +1,66 @@
+{
+  "home": {
+    "calculators": {
+      "testosteroneLevel": {
+        "name": "Testosteron-Rechner",
+        "description": "Berechne freies Testosteron aus Gesamt-T, SHBG und Albumin (Vermeulen-Formel)."
+      }
+    }
+  },
+  "testosteroneLevel": {
+    "meta": {
+      "title": "Testosteron-Rechner — Freies Testosteron berechnen (Vermeulen)",
+      "description": "Freies Testosteron aus Gesamt-Testosteron, SHBG und Albumin berechnen — mit der Vermeulen-Formel. Referenzbereiche, Hypogonadismus-Hinweis. Kostenlos und sofort."
+    },
+    "title": "Testosteron-Rechner",
+    "description": "Berechne dein freies Testosteron aus Gesamt-Testosteron, SHBG und Albumin nach Vermeulen.",
+    "totalLabel": "Gesamt-Testosteron ({unit})",
+    "shbgLabel": "SHBG (nmol/L)",
+    "albuminLabel": "Albumin (g/L)",
+    "albuminHint": "Standard: 43 g/L. Anpassen nur bei bekanntem Albumin-Wert (z. B. aus Blutbild).",
+    "results": "Ergebnis",
+    "totalResult": "Gesamt-Testosteron",
+    "freeResult": "Freies Testosteron",
+    "category_low": "Niedrig",
+    "category_borderline": "Grenzwertig",
+    "category_normal": "Normal",
+    "category_high": "Erhöht",
+    "hypogonadismLikely": "Hinweis auf Hypogonadismus — bitte einen Endokrinologen oder Urologen aufsuchen.",
+    "hypogonadismUnlikely": "Werte im Normalbereich — keine Hinweise auf Testosteronmangel.",
+    "refTitle": "Referenzbereiche (erwachsene Männer)",
+    "refMarker": "Marker",
+    "refRange": "Bereich",
+    "refInterpretation": "Bedeutung",
+    "refRangeNormal": "Normal — keine Maßnahme nötig",
+    "refRangeLow": "Hypogonadismus möglich",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner verwendet die Vermeulen-Formel (Vermeulen et al., JCEM 1999) zur Berechnung des freien Testosterons aus Gesamt-Testosteron, SHBG und Albumin. Im Blut ist nur etwa 1–3 % des Gesamt-Testosterons biologisch aktiv (frei) — der Rest ist an SHBG (~44 %) oder Albumin (~54 %) gebunden. Die Formel löst eine quadratische Gleichung mit den Bindungskonstanten KT (SHBG) = 1·10⁹ L/mol und KA (Albumin) = 3,6·10⁴ L/mol. Referenzbereiche für erwachsene Männer: Gesamt 8,6–29 nmol/L, frei 0,20–0,62 nmol/L (200–620 pmol/L). Werte unter 8 nmol/L (Gesamt) gelten nach Endocrine-Society-Leitlinie als Hypogonadismus.",
+    "disclaimer": "Dieser Rechner ersetzt keine ärztliche Diagnose. Bei niedrigen Werten oder Symptomen einer Testosteron-Insuffizienz (Müdigkeit, Libidoverlust, Muskelabbau) bitte einen Arzt aufsuchen.",
+    "faq": [
+      {
+        "q": "Was ist freies Testosteron?",
+        "a": "Freies Testosteron ist der ungebundene, biologisch aktive Anteil deines Testosterons. Nur etwa 1–3 % zirkulieren frei im Blut — der Rest ist an SHBG (Sexualhormon-bindendes Globulin) oder Albumin gebunden und ist physiologisch weniger wirksam."
+      },
+      {
+        "q": "Warum nicht nur Gesamt-Testosteron messen?",
+        "a": "Bei normalem Gesamt-Testosteron, aber hohem SHBG, kann das freie Testosteron im Mangel sein. Symptome eines Testosteronmangels korrelieren oft besser mit dem freien Testosteron als mit dem Gesamtwert."
+      },
+      {
+        "q": "Wann sollte ich Testosteron messen lassen?",
+        "a": "Morgens zwischen 7 und 10 Uhr (Tagesspitze), nüchtern, nach gutem Schlaf. Bei Verdacht auf Hypogonadismus (Müdigkeit, Libidoverlust, Muskelschwund) zwei Messungen an verschiedenen Tagen."
+      },
+      {
+        "q": "Was beeinflusst den SHBG-Wert?",
+        "a": "SHBG steigt durch Schilddrüsenüberfunktion, Lebererkrankungen, Östrogen-Therapie und mit zunehmendem Alter. SHBG sinkt bei Adipositas, Insulinresistenz, Hypothyreose und Cushing-Syndrom."
+      },
+      {
+        "q": "Was bedeuten niedrige Werte?",
+        "a": "Gesamt-Testosteron unter 8 nmol/L gilt nach Endocrine-Society-Leitlinie (2018) als Hypogonadismus. Im Bereich 8–12 nmol/L liegt eine Grauzone — kombiniere mit klinischen Symptomen und freiem Testosteron."
+      },
+      {
+        "q": "Wie kann ich Testosteron natürlich steigern?",
+        "a": "Krafttraining (vor allem schwere Verbundübungen), 7–9 Stunden Schlaf, Vitamin-D- und Zink-Versorgung sicherstellen, Übergewicht abbauen, Alkohol reduzieren. Diese Maßnahmen heben Testosteron um 10–20 % bei einem Mangel."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/testosteroneLevel.json
+++ b/src/locales/calculators/en/testosteroneLevel.json
@@ -1,0 +1,66 @@
+{
+  "home": {
+    "calculators": {
+      "testosteroneLevel": {
+        "name": "Testosterone Level Calculator",
+        "description": "Calculate free testosterone from total T, SHBG and albumin (Vermeulen formula)."
+      }
+    }
+  },
+  "testosteroneLevel": {
+    "meta": {
+      "title": "Testosterone Level Calculator — Free T from Total T & SHBG (Vermeulen)",
+      "description": "Calculate free testosterone from total testosterone, SHBG and albumin using the Vermeulen equation. Reference ranges and hypogonadism flag. Free, instant, no sign-up."
+    },
+    "title": "Testosterone Level Calculator",
+    "description": "Calculate your free testosterone from total testosterone, SHBG and albumin using the Vermeulen equation.",
+    "totalLabel": "Total testosterone ({unit})",
+    "shbgLabel": "SHBG (nmol/L)",
+    "albuminLabel": "Albumin (g/L)",
+    "albuminHint": "Default: 43 g/L. Adjust only if you know your albumin (e.g. from blood panel).",
+    "results": "Result",
+    "totalResult": "Total testosterone",
+    "freeResult": "Free testosterone",
+    "category_low": "Low",
+    "category_borderline": "Borderline",
+    "category_normal": "Normal",
+    "category_high": "High",
+    "hypogonadismLikely": "Possible hypogonadism — please consult an endocrinologist or urologist.",
+    "hypogonadismUnlikely": "Values in normal range — no signs of testosterone deficiency.",
+    "refTitle": "Reference ranges (adult men)",
+    "refMarker": "Marker",
+    "refRange": "Range",
+    "refInterpretation": "Interpretation",
+    "refRangeNormal": "Normal — no action needed",
+    "refRangeLow": "Possible hypogonadism",
+    "howItWorks": "How it works",
+    "howItWorksText": "This calculator uses the Vermeulen equation (Vermeulen et al., JCEM 1999) to compute free testosterone from total testosterone, SHBG and albumin. In blood, only about 1–3 % of total testosterone is biologically active (free) — the rest is bound to SHBG (~44 %) or albumin (~54 %). The formula solves a quadratic with binding constants KT (SHBG) = 1·10⁹ L/mol and KA (albumin) = 3.6·10⁴ L/mol. Adult-male reference ranges: total 8.6–29 nmol/L, free 0.20–0.62 nmol/L (200–620 pmol/L). Total testosterone below 8 nmol/L is classified as hypogonadism per the Endocrine Society guideline.",
+    "disclaimer": "This calculator is not a medical diagnosis. If your values are low or you have symptoms of testosterone deficiency (fatigue, low libido, muscle loss), please see a doctor.",
+    "faq": [
+      {
+        "q": "What is free testosterone?",
+        "a": "Free testosterone is the unbound, biologically active fraction of your testosterone. Only about 1–3 % circulates freely — the rest is bound to SHBG (sex hormone-binding globulin) or albumin and is physiologically less active."
+      },
+      {
+        "q": "Why isn't total testosterone enough?",
+        "a": "If total testosterone is normal but SHBG is high, free testosterone may be in deficit. Symptoms of low testosterone often correlate better with free testosterone than with the total."
+      },
+      {
+        "q": "When should I get tested?",
+        "a": "In the morning between 7–10am (peak), fasting, after good sleep. If hypogonadism is suspected (fatigue, low libido, muscle loss), do two separate-day measurements."
+      },
+      {
+        "q": "What affects SHBG?",
+        "a": "SHBG rises with hyperthyroidism, liver disease, estrogen therapy, and age. SHBG drops with obesity, insulin resistance, hypothyroidism, and Cushing's syndrome."
+      },
+      {
+        "q": "What do low values mean?",
+        "a": "Total testosterone below 8 nmol/L (≈ 230 ng/dL) is classified as hypogonadism per the Endocrine Society guideline (2018). 8–12 nmol/L is a gray zone — combine with clinical symptoms and free testosterone."
+      },
+      {
+        "q": "Can I raise testosterone naturally?",
+        "a": "Resistance training (especially compound lifts), 7–9 hours of sleep, sufficient vitamin D and zinc, weight loss if overweight, reduced alcohol. These measures raise testosterone by 10–20 % in deficient men."
+      }
+    ]
+  }
+}

--- a/src/pages/TestosteroneLevelCalculator.vue
+++ b/src/pages/TestosteroneLevelCalculator.vue
@@ -1,0 +1,182 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcTestosteroneStatus } from '../utils/testosteroneLevel.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('testosteroneLevel.faq') || [])
+
+useHead(() => ({
+  title: t('testosteroneLevel.meta.title'),
+  description: t('testosteroneLevel.meta.description'),
+  routeKey: 'testosteroneLevel',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Testosterone Level Calculator',
+    url: 'https://healthcalculator.app/testosterone-level-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const totalT = ref(null)
+const totalUnit = ref('nmol/L')
+const shbg = ref(null)
+const albumin = ref(43)
+
+const result = computed(() =>
+  calcTestosteroneStatus({
+    totalT: totalT.value,
+    totalUnit: totalUnit.value,
+    shbg: shbg.value,
+    albumin: albumin.value || 43,
+  })
+)
+
+const totalColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.totalCategory) {
+    case 'low': return 'text-red-600'
+    case 'borderline': return 'text-orange-500'
+    case 'normal': return 'text-green-600'
+    case 'high': return 'text-yellow-600'
+    default: return 'text-stone-600'
+  }
+})
+
+const freeColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.freeCategory) {
+    case 'low': return 'text-red-600'
+    case 'normal': return 'text-green-600'
+    case 'high': return 'text-yellow-600'
+    default: return 'text-stone-600'
+  }
+})
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('testosteroneLevel.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('testosteroneLevel.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="totalUnit = 'nmol/L'"
+        data-testid="unit-nmol"
+        :class="totalUnit === 'nmol/L' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >nmol/L</button>
+      <button
+        @click="totalUnit = 'ng/dL'"
+        data-testid="unit-ngdl"
+        :class="totalUnit === 'ng/dL' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >ng/dL</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('testosteroneLevel.totalLabel', { unit: totalUnit }) }}
+        </label>
+        <input v-model.number="totalT" type="number" step="0.1" min="0"
+          :placeholder="totalUnit === 'nmol/L' ? '18' : '519'"
+          data-testid="total-t"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('testosteroneLevel.shbgLabel') }}</label>
+        <input v-model.number="shbg" type="number" step="0.1" min="0" placeholder="30" data-testid="shbg"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+
+    <div>
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('testosteroneLevel.albuminLabel') }}</label>
+      <input v-model.number="albumin" type="number" step="0.1" min="0" placeholder="43" data-testid="albumin"
+        class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      <p class="text-xs text-stone-400 mt-2">{{ t('testosteroneLevel.albuminHint') }}</p>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('testosteroneLevel.results') }}</p>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+      <div>
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('testosteroneLevel.totalResult') }}</p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight" data-testid="result-total">{{ result.totalT.toFixed(1) }}</span>
+          <span class="text-base text-stone-400">nmol/L</span>
+        </div>
+        <span :class="totalColor" class="mt-2 inline-block text-sm font-semibold" data-testid="result-total-category">{{ t('testosteroneLevel.category_' + result.totalCategory) }}</span>
+      </div>
+      <div>
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('testosteroneLevel.freeResult') }}</p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight" data-testid="result-free">{{ result.freeTpmol }}</span>
+          <span class="text-base text-stone-400">pmol/L</span>
+        </div>
+        <span :class="freeColor" class="mt-2 inline-block text-sm font-semibold" data-testid="result-free-category">{{ t('testosteroneLevel.category_' + result.freeCategory) }}</span>
+      </div>
+    </div>
+
+    <div
+      class="rounded-lg p-4 text-sm font-medium"
+      :class="result.hypogonadism ? 'bg-red-50 text-red-900 border border-red-200' : 'bg-green-50 text-green-900 border border-green-200'"
+      data-testid="hypogonadism-status"
+    >
+      {{ result.hypogonadism ? t('testosteroneLevel.hypogonadismLikely') : t('testosteroneLevel.hypogonadismUnlikely') }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('testosteroneLevel.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('testosteroneLevel.refMarker') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('testosteroneLevel.refRange') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('testosteroneLevel.refInterpretation') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('testosteroneLevel.totalResult') }}</td><td class="px-6 py-3 text-stone-600">8.6 – 29.0 nmol/L</td><td class="px-6 py-3 text-stone-600">{{ t('testosteroneLevel.refRangeNormal') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('testosteroneLevel.totalResult') }}</td><td class="px-6 py-3 text-stone-600">&lt; 8 nmol/L</td><td class="px-6 py-3 text-stone-600">{{ t('testosteroneLevel.refRangeLow') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('testosteroneLevel.freeResult') }}</td><td class="px-6 py-3 text-stone-600">200 – 620 pmol/L</td><td class="px-6 py-3 text-stone-600">{{ t('testosteroneLevel.refRangeNormal') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('testosteroneLevel.freeResult') }}</td><td class="px-6 py-3 text-stone-600">&lt; 200 pmol/L</td><td class="px-6 py-3 text-stone-600">{{ t('testosteroneLevel.refRangeLow') }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('testosteroneLevel.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('testosteroneLevel.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('testosteroneLevel.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="testosteroneLevel" />
+</template>

--- a/src/pages/blog/TestosteronwertBerechnen.vue
+++ b/src/pages/blog/TestosteronwertBerechnen.vue
@@ -1,0 +1,193 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Testosteronwert berechnen: Frei vs. gebunden, SHBG und was die Werte bedeuten | Health Calculators',
+  description: 'Freies Testosteron aus Gesamt-T, SHBG und Albumin berechnen — mit der Vermeulen-Formel. Referenzbereiche, Symptome bei Mangel und natürliche Maßnahmen.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Testosteronwert berechnen: Frei vs. gebunden, SHBG und was die Werte bedeuten',
+    description: 'Freies Testosteron aus Gesamt-T, SHBG und Albumin berechnen — mit der Vermeulen-Formel. Referenzbereiche, Symptome bei Mangel und natürliche Maßnahmen.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-01',
+    dateModified: '2026-05-01',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/testosteronwert-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Testosteronwert berechnen: Frei vs. gebunden, SHBG und was die Werte bedeuten</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">1. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein normaler <strong>Gesamt-Testosteron</strong>-Wert sagt nicht das ganze Bild. Entscheidend ist das <strong>freie Testosteron</strong> — die biologisch aktive Fraktion, die deine Muskeln, Libido und Energie tatsächlich erreicht. Bei hohem SHBG kann der freie Anteil im Mangel sein, obwohl Gesamt-T „normal" aussieht.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt die <strong>Vermeulen-Formel</strong>, die Referenzbereiche und was niedrige Werte für deine Gesundheit bedeuten.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wie Testosteron im Blut zirkuliert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Im Blut verteilt sich Testosteron auf drei Fraktionen:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Fraktion</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Anteil</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Aktivität</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Frei</td><td class="px-6 py-3 text-stone-600">1–3 %</td><td class="px-6 py-3 text-stone-600">Voll wirksam</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Albumin-gebunden</td><td class="px-6 py-3 text-stone-600">~54 %</td><td class="px-6 py-3 text-stone-600">Schwach wirksam (bioverfügbar)</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SHBG-gebunden</td><td class="px-6 py-3 text-stone-600">~44 %</td><td class="px-6 py-3 text-stone-600">Inaktiv</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          SHBG (sexualhormon-bindendes Globulin) bindet Testosteron mit hoher Affinität. Steigt SHBG, sinkt das freie Testosteron — auch wenn die Produktion gleich bleibt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Vermeulen-Formel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die 1999 publizierte Formel von Alex Vermeulen ist heute der Goldstandard zur Berechnung des freien Testosterons aus Routine-Laborwerten — und liefert Werte, die hochkorreliert mit der direkten Massenspektrometrie sind.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p class="mb-2"><strong>N</strong> = K<sub>A</sub> &times; (Albumin / 69 000) + 1</p>
+          <p class="mb-2"><strong>a</strong> &times; FT² + <strong>b</strong> &times; FT + c = 0</p>
+          <p class="mb-2">a = N &times; K<sub>T</sub></p>
+          <p class="mb-2">b = N + K<sub>T</sub> &times; (SHBG &minus; Total)</p>
+          <p>c = &minus;Total</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          K<sub>T</sub> = 1·10⁹ L/mol (SHBG-Bindung), K<sub>A</sub> = 3,6·10⁴ L/mol (Albumin-Bindung). Die quadratische Lösung liefert das freie Testosteron in nmol/L.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Referenzbereiche (Erwachsene Männer)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Marker</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Normal</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Niedrig</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Gesamt-T</td><td class="px-6 py-3 text-stone-600">8,6 – 29 nmol/L</td><td class="px-6 py-3 text-stone-600">&lt; 8 nmol/L</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Freies T</td><td class="px-6 py-3 text-stone-600">200 – 620 pmol/L</td><td class="px-6 py-3 text-stone-600">&lt; 200 pmol/L</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SHBG</td><td class="px-6 py-3 text-stone-600">10 – 57 nmol/L</td><td class="px-6 py-3 text-stone-600">&lt; 10 oder &gt; 70</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die <strong>Endocrine Society</strong> definiert Hypogonadismus als Gesamt-Testosteron &lt; 8 nmol/L (≈ 230 ng/dL) plus klinische Symptome. Werte zwischen 8 und 12 nmol/L liegen in der Grauzone.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Symptome bei niedrigem Testosteron</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Sexuell</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Libidoverlust, erektile Dysfunktion, ausbleibende Morgenerektionen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Körperlich</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Muskelschwund trotz Training, Zunahme von Bauchfett, geringere Knochendichte, Hitzewallungen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Mental</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Antriebslosigkeit, depressive Verstimmung, Konzentrationsprobleme, Schlafstörungen.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was die Werte beeinflusst</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Testosteron unterliegt einer ausgeprägten <strong>Tagesrhythmik</strong>. Die Spitze liegt zwischen 7 und 10 Uhr morgens, der Tiefpunkt am späten Nachmittag. Einmalige Messungen am Nachmittag können um 20–40 % unter dem Morgenwert liegen — und so falsch-positiv einen Mangel suggerieren.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>SHBG</strong> wird durch Schilddrüsenüberfunktion, Östrogen-Therapie, fortgeschrittenes Alter und Lebererkrankungen erhöht. Es sinkt bei Adipositas, Insulinresistenz und Cushing-Syndrom — letzteres kann das freie T künstlich anheben, obwohl die hormonelle Achse gestört ist.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt freies Testosteron berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Sofortergebnis mit Vermeulen-Formel, Referenzbereich-Vergleich und Hypogonadismus-Hinweis — kostenlos und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('testosteroneLevel')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Natürliche Maßnahmen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei einem leichten Mangel zeigen Studien 10–20 % höhere Testosteronspiegel durch:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Krafttraining</strong> mit schweren Verbundübungen (Kniebeuge, Kreuzheben, Bankdrücken) 3× pro Woche</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Schlaf</strong>: 7–9 Stunden pro Nacht — schon eine Woche mit 5 Stunden senkt T um 10–15 %</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Vitamin D</strong> auf 40–60 ng/mL halten und Zink-Versorgung sicherstellen</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Gewichtsabnahme</strong> bei Adipositas — pro 10 kg Verlust steigt Testosteron um ca. 2 nmol/L</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Alkohol reduzieren</strong> — chronischer Konsum senkt T um 15–25 %</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Niedriges Testosteron tritt häufig zusammen mit anderen Risikofaktoren auf. Prüfe deinen <router-link :to="localeBlogPath('prostatakrebs-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Prostatakrebs-Risiko-Score</router-link> ab 45, dein <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biologisches Alter</router-link> als Ganzheits-Marker und decke deinen <router-link :to="localeBlogPath('proteinbedarf-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Proteinbedarf</router-link>, um den Muskelaufbau zu unterstützen.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Gesamt-Testosteron allein reicht nicht — das freie Testosteron ist der bessere Marker für tatsächliche Symptome. Mit der Vermeulen-Formel kannst du es aus Routine-Laborwerten ableiten. Bei niedrigen Werten und Symptomen lohnt der Gang zum Endokrinologen oder Urologen. Nutze unseren <router-link :to="localePath('testosteroneLevel')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Testosteron-Rechner</router-link> für eine erste Einordnung.
+        </p>
+      </div>
+
+      <RelatedArticles slug="testosteronwert-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/TestosteroneLevelCalculator.vue
+++ b/src/pages/blog/en/TestosteroneLevelCalculator.vue
@@ -1,0 +1,193 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Testosterone Level Calculator: Free vs Bound, SHBG and What Your Numbers Mean | Health Calculators',
+  description: 'Calculate free testosterone from total T, SHBG and albumin using the Vermeulen formula. Reference ranges, low-T symptoms, and natural ways to raise it.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Testosterone Level Calculator: Free vs Bound, SHBG and What Your Numbers Mean',
+    description: 'Calculate free testosterone from total T, SHBG and albumin using the Vermeulen formula. Reference ranges, low-T symptoms, and natural ways to raise it.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-01',
+    dateModified: '2026-05-01',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/testosterone-level-calculator',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Testosterone Level Calculator: Free vs Bound, SHBG and What Your Numbers Mean</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 1, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A normal <strong>total testosterone</strong> result doesn't tell the full story. What matters is <strong>free testosterone</strong> — the biologically active fraction that actually reaches your muscles, libido and energy. With high SHBG, the free fraction can be deficient even if total T looks "normal."
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article explains the <strong>Vermeulen equation</strong>, reference ranges, and what low values mean for your health.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How testosterone circulates in blood</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Testosterone exists in three fractions in the bloodstream:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Fraction</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Share</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Activity</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Free</td><td class="px-6 py-3 text-stone-600">1–3 %</td><td class="px-6 py-3 text-stone-600">Fully active</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Albumin-bound</td><td class="px-6 py-3 text-stone-600">~54 %</td><td class="px-6 py-3 text-stone-600">Weakly active (bioavailable)</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SHBG-bound</td><td class="px-6 py-3 text-stone-600">~44 %</td><td class="px-6 py-3 text-stone-600">Inactive</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          SHBG (sex hormone-binding globulin) binds testosterone with high affinity. When SHBG rises, free testosterone falls — even if production is unchanged.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The Vermeulen equation</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Published in 1999 by Alex Vermeulen, this equation is today the gold standard for estimating free testosterone from routine lab values — and it correlates strongly with direct measurement by mass spectrometry.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p class="mb-2"><strong>N</strong> = K<sub>A</sub> &times; (Albumin / 69 000) + 1</p>
+          <p class="mb-2"><strong>a</strong> &times; FT² + <strong>b</strong> &times; FT + c = 0</p>
+          <p class="mb-2">a = N &times; K<sub>T</sub></p>
+          <p class="mb-2">b = N + K<sub>T</sub> &times; (SHBG &minus; Total)</p>
+          <p>c = &minus;Total</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          K<sub>T</sub> = 1·10⁹ L/mol (SHBG binding), K<sub>A</sub> = 3.6·10⁴ L/mol (albumin binding). Solving the quadratic yields free testosterone in nmol/L.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Reference ranges (adult men)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Marker</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Normal</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Low</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Total T</td><td class="px-6 py-3 text-stone-600">8.6 – 29 nmol/L</td><td class="px-6 py-3 text-stone-600">&lt; 8 nmol/L</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Free T</td><td class="px-6 py-3 text-stone-600">200 – 620 pmol/L</td><td class="px-6 py-3 text-stone-600">&lt; 200 pmol/L</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SHBG</td><td class="px-6 py-3 text-stone-600">10 – 57 nmol/L</td><td class="px-6 py-3 text-stone-600">&lt; 10 or &gt; 70</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The <strong>Endocrine Society</strong> defines hypogonadism as total testosterone &lt; 8 nmol/L (≈ 230 ng/dL) plus clinical symptoms. The 8–12 nmol/L range is a gray zone.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Symptoms of low testosterone</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Sexual</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Low libido, erectile dysfunction, absent morning erections.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Physical</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Loss of muscle despite training, central body fat gain, reduced bone density, hot flashes.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Mental</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Low motivation, depressed mood, poor concentration, sleep problems.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What affects your numbers</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Testosterone has a strong <strong>diurnal rhythm</strong>. Peak is between 7 and 10am, trough in late afternoon. A single afternoon measurement can run 20–40 % below the morning value — falsely suggesting deficiency.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>SHBG</strong> rises with hyperthyroidism, estrogen therapy, age, and liver disease. It drops with obesity, insulin resistance and Cushing's syndrome — the latter can artificially raise free T even though the hormonal axis is disturbed.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your free testosterone now</h3>
+        <p class="text-stone-300 text-sm mb-5">Instant result with Vermeulen formula, reference-range comparison and hypogonadism flag — free, no sign-up.</p>
+        <router-link
+          :to="localePath('testosteroneLevel')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate now &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Natural ways to raise testosterone</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          For mild deficiency, studies show 10–20 % higher levels through:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Resistance training</strong> with heavy compound lifts (squats, deadlifts, bench press) 3× per week</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Sleep</strong>: 7–9 hours per night — even one week of 5 hours drops T by 10–15 %</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Vitamin D</strong> at 40–60 ng/mL plus adequate zinc intake</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Weight loss</strong> if obese — every 10 kg lost adds about 2 nmol/L to total testosterone</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Reduce alcohol</strong> — chronic intake lowers T by 15–25 %</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Low testosterone often clusters with other risk factors. Check your <router-link :to="localeBlogPath('prostate-cancer-risk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">prostate cancer risk</router-link> after age 45, your <router-link :to="localeBlogPath('biological-age-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biological age</router-link> as a whole-body marker, and cover your <router-link :to="localeBlogPath('protein-requirements-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">protein requirements</router-link> to support muscle maintenance.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Total testosterone alone isn't enough — free testosterone is the better marker for actual symptoms. The Vermeulen equation lets you derive it from routine lab values. If your numbers are low and you have symptoms, see an endocrinologist or urologist. Use our <router-link :to="localePath('testosteroneLevel')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">testosterone calculator</router-link> for a quick first read.
+        </p>
+      </div>
+
+      <RelatedArticles slug="testosterone-level-calculator" />
+    </div>
+  </article>
+</template>

--- a/src/pages/testosteroneLevel.meta.js
+++ b/src/pages/testosteroneLevel.meta.js
@@ -1,0 +1,16 @@
+import Component from './TestosteroneLevelCalculator.vue'
+import BlogDe from './blog/TestosteronwertBerechnen.vue'
+import BlogEn from './blog/en/TestosteroneLevelCalculator.vue'
+
+export default {
+  key: 'testosteroneLevel',
+  component: Component,
+  slugs: { de: 'testosteron-rechner', en: 'testosterone-level-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 28,
+  blog: {
+    de: { slug: 'testosteronwert-berechnen', component: BlogDe },
+    en: { slug: 'testosterone-level-calculator', component: BlogEn },
+  },
+}

--- a/src/utils/testosteroneLevel.js
+++ b/src/utils/testosteroneLevel.js
@@ -1,0 +1,66 @@
+// Free testosterone via the Vermeulen equation (de Ronde / Vermeulen 1999).
+// All inputs in SI units:
+//   totalT  — nmol/L (or convertible via totalUnit)
+//   shbg    — nmol/L
+//   albumin — g/L (default 43)
+// Output: nmol/L (free) and pmol/L convenience.
+
+const KT = 1e9      // testosterone-SHBG association constant, L/mol
+const KA = 3.6e4    // testosterone-albumin association constant, L/mol
+const NG_DL_TO_NMOL_L = 0.0347  // total testosterone unit factor
+
+function isPositive(x) {
+  return Number.isFinite(x) && x > 0
+}
+
+export function calcFreeTestosterone({ totalT, shbg, albumin = 43, totalUnit = 'nmol/L' } = {}) {
+  let total = totalT
+  if (totalUnit === 'ng/dL') total = totalT * NG_DL_TO_NMOL_L
+  if (!isPositive(total) || !isPositive(shbg) || !isPositive(albumin)) return null
+
+  // Vermeulen quadratic: solves [Free T] from total, SHBG, albumin
+  const N = KA * (albumin / 69_000) + 1   // 69 kDa albumin → mol/L
+  const a = N * KT
+  const b = N + KT * (shbg - total) * 1e-9
+  const c = -total * 1e-9
+
+  const free = (-b + Math.sqrt(b * b - 4 * a * c)) / (2 * a)
+  return free * 1e9    // mol/L → nmol/L
+}
+
+export function classifyTotalTestosterone(totalT) {
+  if (!isPositive(totalT)) return null
+  if (totalT < 8) return 'low'
+  if (totalT < 12) return 'borderline'
+  if (totalT <= 30) return 'normal'
+  return 'high'
+}
+
+export function classifyFreeTestosterone(freeT) {
+  if (!isPositive(freeT)) return null
+  if (freeT < 0.20) return 'low'
+  if (freeT <= 0.62) return 'normal'
+  return 'high'
+}
+
+export function calcTestosteroneStatus({ totalT, shbg, albumin = 43, totalUnit = 'nmol/L' } = {}) {
+  let total = totalT
+  if (totalUnit === 'ng/dL' && isPositive(totalT)) total = totalT * NG_DL_TO_NMOL_L
+
+  if (!isPositive(total) || !isPositive(shbg) || !isPositive(albumin)) return null
+
+  const freeT = calcFreeTestosterone({ totalT: total, shbg, albumin })
+  if (freeT == null) return null
+
+  const totalCategory = classifyTotalTestosterone(total)
+  const freeCategory = classifyFreeTestosterone(freeT)
+
+  return {
+    totalT: Number(total.toFixed(2)),
+    freeT: Number(freeT.toFixed(3)),
+    freeTpmol: Math.round(freeT * 1000),
+    totalCategory,
+    freeCategory,
+    hypogonadism: totalCategory === 'low' || freeCategory === 'low',
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Testosterone Level Calculator: free testosterone via Vermeulen equation from total T, SHBG, albumin
- Metric/imperial unit toggle (nmol/L ↔ ng/dL); adult-male reference ranges; hypogonadism flag
- DE + EN blog articles with cross-links to prostateRisk, biologicalAge, protein/proteinNeed

## Implementation
- TDD: 18 unit tests in `src/__tests__/testosteroneLevel.test.js` (red → green)
- Auto-discovery via `src/pages/testosteroneLevel.meta.js` — no router/discovery changes
- 6 E2E tests (Playwright, strict-mode test-id selectors)
- Article entries appended to `articles.js` + `articles-en.js`
- Bumped count assertions in auto-discovery, sitemap, llms-txt tests

## Test plan
- [x] `npm test` — all 1300 unit tests pass
- [x] `npm run build` — SSG generates testosterone routes (de + en, calc + blog)
- [x] `npx playwright test e2e/testosteroneLevel.spec.js` — 6/6 pass
- [x] No new regressions in full E2E suite (pre-existing main failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)