### PR TITLE
hc-146-erectile-dysfunction: Implement the Erectile Dysfunction Calculator as described i

### DIFF
--- a/e2e/erectileDysfunction.spec.js
+++ b/e2e/erectileDysfunction.spec.js
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/erektile-dysfunktion-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Erektile.Dysfunktion|IIEF-5/)
+})
+
+async function answerAll(page, value) {
+  for (let q = 1; q <= 5; q++) {
+    await page.getByTestId(`q${q}-option-${value}`).click()
+  }
+}
+
+test('all 5s → score 25, no ED', async ({ page }) => {
+  await answerAll(page, 5)
+  const score = page.getByTestId('iief5-score')
+  await expect(score).toBeVisible()
+  await expect(score).toHaveText('25')
+  await expect(page.getByTestId('result-status')).toHaveText('Keine erektile Dysfunktion')
+})
+
+test('all 1s → score 5, severe ED', async ({ page }) => {
+  await answerAll(page, 1)
+  await expect(page.getByTestId('iief5-score')).toHaveText('5')
+  await expect(page.getByTestId('result-status')).toHaveText('Schwere ED')
+})
+
+test('all 3s → score 15, mild–moderate', async ({ page }) => {
+  await answerAll(page, 3)
+  await expect(page.getByTestId('iief5-score')).toHaveText('15')
+  await expect(page.getByTestId('result-status')).toHaveText('Leicht bis mittelschwer')
+})
+
+test('result hidden until all questions answered', async ({ page }) => {
+  await page.getByTestId('q1-option-5').click()
+  await page.getByTestId('q2-option-5').click()
+  await expect(page.getByTestId('iief5-score')).not.toBeVisible()
+})
+
+test('shows severity message after completion', async ({ page }) => {
+  await answerAll(page, 4)
+  await expect(page.getByTestId('severity-message')).toBeVisible()
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -20,7 +20,7 @@ const EXPECTED_KEYS = [
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
-  'prostateRisk', 'pcosSymptoms', 'testosteroneLevel',
+  'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -72,6 +72,7 @@ const EXPECTED_ROUTE_MAP = {
   prostateRisk: { de: 'prostatakrebs-risiko-rechner', en: 'prostate-cancer-risk-calculator' },
   pcosSymptoms: { de: 'pcos-symptome-rechner', en: 'pcos-symptom-checker' },
   testosteroneLevel: { de: 'testosteron-rechner', en: 'testosterone-level-calculator' },
+  erectileDysfunction: { de: 'erektile-dysfunktion-rechner', en: 'erectile-dysfunction-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -111,6 +112,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'prostatakrebs-risiko-berechnen',
   'pcos-symptome-erkennen',
   'testosteronwert-berechnen',
+  'erektile-dysfunktion-test',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -150,19 +152,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'prostate-cancer-risk',
   'pcos-symptom-checker',
   'testosterone-level-calculator',
+  'erectile-dysfunction-iief-5',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 50 calculators', () => {
-    expect(calculatorMetas).toHaveLength(50)
+  it('discovers all 51 calculators', () => {
+    expect(calculatorMetas).toHaveLength(51)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 50 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(50)
+  it('builds calculatorComponents map for all 51 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(51)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -185,15 +188,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 48 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(48)
+  it('discovers all 49 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(49)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 48 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(48)
+  it('discovers all 49 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(49)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -209,10 +212,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 50 calculators with no duplicates', () => {
+  it('groups contain all 51 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(50)
-    expect(new Set(allKeys).size).toBe(50)
+    expect(allKeys).toHaveLength(51)
+    expect(new Set(allKeys).size).toBe(51)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -233,7 +236,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction',
     ])
   })
 
@@ -281,8 +284,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 286 routes', () => {
-    expect(routes).toHaveLength(286)
+  it('generates exactly 291 routes', () => {
+    expect(routes).toHaveLength(291)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/erectileDysfunction.test.js
+++ b/src/__tests__/erectileDysfunction.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { calcIief5Score, classifyIief5, calcIief5Result } from '../utils/erectileDysfunction.js'
+
+describe('IIEF-5 score calculation', () => {
+  it('all 5s → 25 (no ED)', () => {
+    expect(calcIief5Score([5, 5, 5, 5, 5])).toBe(25)
+  })
+
+  it('all 1s → 5 (severe ED)', () => {
+    expect(calcIief5Score([1, 1, 1, 1, 1])).toBe(5)
+  })
+
+  it('mixed answers → correct sum', () => {
+    expect(calcIief5Score([4, 3, 5, 2, 4])).toBe(18)
+  })
+
+  it('returns null when any answer missing (null)', () => {
+    expect(calcIief5Score([5, null, 5, 5, 5])).toBeNull()
+  })
+
+  it('returns null when fewer than 5 answers', () => {
+    expect(calcIief5Score([5, 5, 5, 5])).toBeNull()
+  })
+
+  it('returns null for out-of-range values (0 or 6)', () => {
+    expect(calcIief5Score([0, 5, 5, 5, 5])).toBeNull()
+    expect(calcIief5Score([5, 6, 5, 5, 5])).toBeNull()
+  })
+})
+
+describe('IIEF-5 severity classification', () => {
+  it('25 → noEd', () => {
+    expect(classifyIief5(25)).toBe('noEd')
+  })
+
+  it('22 → noEd (lower bound)', () => {
+    expect(classifyIief5(22)).toBe('noEd')
+  })
+
+  it('21 → mild', () => {
+    expect(classifyIief5(21)).toBe('mild')
+  })
+
+  it('17 → mild (lower bound)', () => {
+    expect(classifyIief5(17)).toBe('mild')
+  })
+
+  it('16 → mildModerate', () => {
+    expect(classifyIief5(16)).toBe('mildModerate')
+  })
+
+  it('12 → mildModerate (lower bound)', () => {
+    expect(classifyIief5(12)).toBe('mildModerate')
+  })
+
+  it('11 → moderate', () => {
+    expect(classifyIief5(11)).toBe('moderate')
+  })
+
+  it('8 → moderate (lower bound)', () => {
+    expect(classifyIief5(8)).toBe('moderate')
+  })
+
+  it('7 → severe', () => {
+    expect(classifyIief5(7)).toBe('severe')
+  })
+
+  it('5 → severe (lower bound)', () => {
+    expect(classifyIief5(5)).toBe('severe')
+  })
+
+  it('out-of-range or null → null', () => {
+    expect(classifyIief5(null)).toBeNull()
+    expect(classifyIief5(4)).toBeNull()
+    expect(classifyIief5(26)).toBeNull()
+  })
+})
+
+describe('IIEF-5 combined result', () => {
+  it('all 5s → score 25, noEd, hasEd=false', () => {
+    const r = calcIief5Result([5, 5, 5, 5, 5])
+    expect(r.score).toBe(25)
+    expect(r.severity).toBe('noEd')
+    expect(r.hasEd).toBe(false)
+  })
+
+  it('all 3s → score 15, mildModerate, hasEd=true', () => {
+    const r = calcIief5Result([3, 3, 3, 3, 3])
+    expect(r.score).toBe(15)
+    expect(r.severity).toBe('mildModerate')
+    expect(r.hasEd).toBe(true)
+  })
+
+  it('all 1s → score 5, severe, hasEd=true', () => {
+    const r = calcIief5Result([1, 1, 1, 1, 1])
+    expect(r.score).toBe(5)
+    expect(r.severity).toBe('severe')
+    expect(r.hasEd).toBe(true)
+  })
+
+  it('returns null when answers incomplete', () => {
+    expect(calcIief5Result([5, 5, null, 5, 5])).toBeNull()
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 196 links (50 calcs × 2 locales + 48 blogs × 2 locales)', () => {
+  it('generates 200 links (51 calcs × 2 locales + 49 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(196)
+    expect(links).toHaveLength(200)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -54,6 +54,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'prostatakrebs-risiko-berechnen',
   'pcos-symptome-erkennen',
   'testosteronwert-berechnen',
+  'erektile-dysfunktion-test',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -92,12 +93,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'prostate-cancer-risk',
   'pcos-symptom-checker',
   'testosterone-level-calculator',
+  'erectile-dysfunction-iief-5',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 50 calculator meta files', () => {
+  it('discovers all 51 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(50)
+    expect(metas).toHaveLength(51)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -135,19 +137,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 48 DE blog slugs', () => {
+  it('returns all 49 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(48)
+    expect(de).toHaveLength(49)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 48 EN blog slugs', () => {
+  it('returns all 49 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(48)
+    expect(en).toHaveLength(49)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -215,9 +217,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 100 calcs + 2 blog index + 96 blog articles = 200)', () => {
+  it('generates correct total URL count (2 home + 102 calcs + 2 blog index + 98 blog articles = 204)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(200)
+    expect(urlCount).toBe(204)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -431,6 +431,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'testosteroneLevel',
     related: ['prostate-cancer-risk', 'biological-age-calculator', 'protein-requirements-guide'],
   },
+  {
+    slug: 'erectile-dysfunction-iief-5',
+    title: 'Erectile Dysfunction Test (IIEF-5): Score, Causes and What Works',
+    description: 'Assess erectile dysfunction with the IIEF-5 (SHIM). Causes, severity bands by Cappelleri & Rosen, evidence-based interventions — anonymous and free.',
+    date: '2026-05-01',
+    readTime: '8 min',
+    calculatorKey: 'erectileDysfunction',
+    related: ['testosterone-level-calculator', 'diabetes-risk-score', 'biological-age-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -431,6 +431,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'testosteroneLevel',
     related: ['prostatakrebs-risiko-berechnen', 'biologisches-alter-berechnen', 'proteinbedarf-berechnen'],
   },
+  {
+    slug: 'erektile-dysfunktion-test',
+    title: 'Erektile Dysfunktion testen: IIEF-5-Fragebogen, Ursachen und was hilft',
+    description: 'Erektile Dysfunktion mit dem IIEF-5 (SHIM) einschätzen. Ursachen, Schweregrade nach Cappelleri & Rosen, evidenzbasierte Maßnahmen — anonym und kostenlos.',
+    date: '2026-05-01',
+    readTime: '8 min',
+    calculatorKey: 'erectileDysfunction',
+    related: ['testosteronwert-berechnen', 'diabetes-risiko-berechnen', 'biologisches-alter-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/erectileDysfunction.json
+++ b/src/locales/calculators/de/erectileDysfunction.json
@@ -1,0 +1,106 @@
+{
+  "home": {
+    "calculators": {
+      "erectileDysfunction": {
+        "name": "Erektile-Dysfunktion-Test",
+        "description": "IIEF-5-Fragebogen — wissenschaftlich validierter Test zur Einschätzung von Erektionsstörungen (5 Fragen)."
+      }
+    }
+  },
+  "erectileDysfunction": {
+    "meta": {
+      "title": "Erektile-Dysfunktion-Test (IIEF-5) — Selbstcheck mit Score | Health Calculators",
+      "description": "Erektile Dysfunktion einschätzen mit dem IIEF-5-Fragebogen (SHIM). 5 Fragen, sofortiger Score, Schweregrad nach Cappelleri & Rosen. Anonym, kostenlos, ohne Anmeldung."
+    },
+    "title": "Erektile-Dysfunktion-Test (IIEF-5)",
+    "description": "Selbsteinschätzung mit dem International Index of Erectile Function (Kurzform). 5 Fragen zu den letzten 6 Monaten — Score, Schweregrad und Empfehlung in unter 2 Minuten.",
+    "instructionsLabel": "Anleitung",
+    "instructions": "Beantworte jede Frage zu den letzten 6 Monaten ehrlich. Für jede Frage gibt es 5 Antwortmöglichkeiten — wähle diejenige, die deine Erfahrung am besten beschreibt.",
+    "results": "Dein IIEF-5-Score",
+    "reset": "Zurücksetzen",
+    "questions": {
+      "q1": {
+        "text": "Wie schätzt du dein Vertrauen ein, eine Erektion zu bekommen und aufrechtzuerhalten?",
+        "opt1": "Sehr gering",
+        "opt2": "Gering",
+        "opt3": "Mittelmäßig",
+        "opt4": "Hoch",
+        "opt5": "Sehr hoch"
+      },
+      "q2": {
+        "text": "Wenn du Erektionen durch sexuelle Stimulation hattest, wie oft waren sie hart genug für die Penetration?",
+        "opt1": "Fast nie / nie",
+        "opt2": "Selten (deutlich weniger als die Hälfte der Versuche)",
+        "opt3": "Manchmal (etwa die Hälfte der Versuche)",
+        "opt4": "Meistens (deutlich mehr als die Hälfte der Versuche)",
+        "opt5": "Fast immer / immer"
+      },
+      "q3": {
+        "text": "Beim Geschlechtsverkehr — wie oft konntest du deine Erektion bis zum Ende halten?",
+        "opt1": "Fast nie / nie",
+        "opt2": "Selten (deutlich weniger als die Hälfte der Versuche)",
+        "opt3": "Manchmal (etwa die Hälfte der Versuche)",
+        "opt4": "Meistens (deutlich mehr als die Hälfte der Versuche)",
+        "opt5": "Fast immer / immer"
+      },
+      "q4": {
+        "text": "Wie schwierig war es während des Geschlechtsverkehrs, die Erektion bis zum Abschluss aufrechtzuerhalten?",
+        "opt1": "Extrem schwierig",
+        "opt2": "Sehr schwierig",
+        "opt3": "Schwierig",
+        "opt4": "Etwas schwierig",
+        "opt5": "Nicht schwierig"
+      },
+      "q5": {
+        "text": "Wenn du Geschlechtsverkehr versucht hast, wie oft war er befriedigend für dich?",
+        "opt1": "Fast nie / nie",
+        "opt2": "Selten (deutlich weniger als die Hälfte der Versuche)",
+        "opt3": "Manchmal (etwa die Hälfte der Versuche)",
+        "opt4": "Meistens (deutlich mehr als die Hälfte der Versuche)",
+        "opt5": "Fast immer / immer"
+      }
+    },
+    "severity_noEd": "Keine erektile Dysfunktion",
+    "severity_mild": "Leichte ED",
+    "severity_mildModerate": "Leicht bis mittelschwer",
+    "severity_moderate": "Mittelschwere ED",
+    "severity_severe": "Schwere ED",
+    "advice_noEd": "Deine Werte sprechen nicht für eine erektile Dysfunktion. Bei gelegentlichen Schwierigkeiten — Stress, Alkohol oder Müdigkeit — keine Sorge: das ist normal.",
+    "advice_mild": "Leichte Hinweise auf eine ED. Häufig durch Lebensstil-Faktoren bedingt — Schlaf, Bewegung, Stressreduktion und ggf. Alkohol-/Nikotinverzicht zeigen oft schnell Wirkung. Bei anhaltenden Beschwerden: ärztlich abklären.",
+    "advice_mildModerate": "Mäßige ED. Bitte mit deinem Hausarzt oder Urologen sprechen — häufig stehen vaskuläre, hormonelle (Testosteron) oder psychogene Ursachen dahinter, die gut behandelbar sind.",
+    "advice_moderate": "Mittelschwere ED. Eine ärztliche Abklärung wird empfohlen. Häufig liegen Begleiterkrankungen (Herz-Kreislauf, Diabetes, Hormonmangel) vor, die ohnehin behandelt werden sollten.",
+    "advice_severe": "Schwere ED. Bitte zeitnah einen Urologen aufsuchen. ED ist oft ein früher Marker für Herz-Kreislauf-Erkrankungen — eine vollständige Abklärung schützt deine Gesundheit insgesamt.",
+    "refTitle": "Schweregrad-Tabelle (Cappelleri & Rosen 2005)",
+    "refScore": "Score",
+    "refSeverity": "Bedeutung",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der IIEF-5 (auch SHIM — Sexual Health Inventory for Men) ist die international validierte 5-Fragen-Kurzform des International Index of Erectile Function. Entwickelt von Rosen et al. (1999) und 2005 von Cappelleri & Rosen mit Schweregrad-Bändern versehen, wird er weltweit in Klinik und Forschung als Screening-Instrument eingesetzt. Jede der 5 Fragen wird mit 1–5 Punkten bewertet — der Gesamtscore reicht von 5 bis 25. Werte ab 22 sprechen gegen eine ED, Werte unter 8 gelten als schwere Form. Sensitivität: 98 %, Spezifität: 88 % bei einem Cutoff von ≤ 21 für die ED-Diagnose.",
+    "disclaimer": "Dieser Test ersetzt keine ärztliche Diagnose. ED ist häufig ein früher Indikator für Gefäßerkrankungen, Diabetes oder Hormonmangel — bei auffälligem Score bitte den Hausarzt oder Urologen konsultieren. Niedrige Werte bedeuten nicht, dass du eine Krankheit hast — sie sind ein Anlass, gemeinsam mit dem Arzt nach Ursachen zu suchen.",
+    "faq": [
+      {
+        "q": "Was ist der IIEF-5?",
+        "a": "Der IIEF-5 ist die validierte Kurzform des International Index of Erectile Function — ein 5-Fragen-Selbstcheck zur Einschätzung der Erektionsfähigkeit über die letzten 6 Monate. Entwickelt 1999 von Rosen et al., heute weltweiter Standard im Screening."
+      },
+      {
+        "q": "Wie verlässlich ist das Ergebnis?",
+        "a": "Bei einem Cutoff von ≤ 21 erreicht der IIEF-5 eine Sensitivität von 98 % und eine Spezifität von 88 %. Das heißt: er entdeckt fast alle ED-Fälle und liefert wenige Fehlalarme. Eine ärztliche Untersuchung bleibt aber für die Ursachenabklärung notwendig."
+      },
+      {
+        "q": "Sind meine Antworten anonym?",
+        "a": "Ja — der Rechner läuft komplett im Browser. Es werden keine Daten an einen Server übermittelt, nichts gespeichert und nichts geteilt. Schließe einfach den Tab und alle Antworten sind weg."
+      },
+      {
+        "q": "Was sind die häufigsten Ursachen einer ED?",
+        "a": "ED hat meist mehrere Ursachen: vaskulär (Herz-Kreislauf-Erkrankungen, Atherosklerose, Bluthochdruck), endokrin (Testosteronmangel, Diabetes), neurogen (nach Operationen oder bei Multiple Sklerose), medikamentös (Betablocker, SSRI) und psychogen (Stress, Beziehungsprobleme, Versagensangst)."
+      },
+      {
+        "q": "Was hilft natürlich gegen ED?",
+        "a": "Studienevidenz für: regelmäßige Bewegung (40 % Risikoreduktion), Gewichtsabnahme bei Übergewicht, Mediterrane Ernährung, Rauchstopp, Alkohol begrenzen, ausreichend Schlaf, Stressreduktion. Bei Testosteronmangel kann Substitution helfen, bei vaskulären Ursachen PDE-5-Hemmer."
+      },
+      {
+        "q": "Wann sollte ich zum Arzt?",
+        "a": "Ab einem Score von 21 oder niedriger — und immer dann, wenn dich die Situation belastet. ED ist auch bei jüngeren Männern häufig ein früher Marker für Herz-Kreislauf-Erkrankungen, daher lohnt sich die Abklärung unabhängig vom Alter."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/erectileDysfunction.json
+++ b/src/locales/calculators/en/erectileDysfunction.json
@@ -1,0 +1,106 @@
+{
+  "home": {
+    "calculators": {
+      "erectileDysfunction": {
+        "name": "Erectile Dysfunction Calculator",
+        "description": "IIEF-5 (SHIM) questionnaire — validated 5-question screening tool for erectile dysfunction."
+      }
+    }
+  },
+  "erectileDysfunction": {
+    "meta": {
+      "title": "Erectile Dysfunction Calculator (IIEF-5) — Free Online Self-Check | Health Calculators",
+      "description": "Assess erectile dysfunction with the IIEF-5 (SHIM) questionnaire. 5 questions, instant score, severity classification by Cappelleri & Rosen. Anonymous, free, no sign-up."
+    },
+    "title": "Erectile Dysfunction Calculator (IIEF-5)",
+    "description": "Self-assessment using the International Index of Erectile Function (short form). 5 questions about the last 6 months — score, severity grade and guidance in under 2 minutes.",
+    "instructionsLabel": "Instructions",
+    "instructions": "Answer each question honestly about your last 6 months. Each question has 5 options — pick the one that best matches your experience.",
+    "results": "Your IIEF-5 score",
+    "reset": "Reset",
+    "questions": {
+      "q1": {
+        "text": "How do you rate your confidence that you could get and keep an erection?",
+        "opt1": "Very low",
+        "opt2": "Low",
+        "opt3": "Moderate",
+        "opt4": "High",
+        "opt5": "Very high"
+      },
+      "q2": {
+        "text": "When you had erections with sexual stimulation, how often were they hard enough for penetration?",
+        "opt1": "Almost never / never",
+        "opt2": "A few times (much less than half the time)",
+        "opt3": "Sometimes (about half the time)",
+        "opt4": "Most times (much more than half the time)",
+        "opt5": "Almost always / always"
+      },
+      "q3": {
+        "text": "During sexual intercourse, how often were you able to maintain your erection after penetration?",
+        "opt1": "Almost never / never",
+        "opt2": "A few times (much less than half the time)",
+        "opt3": "Sometimes (about half the time)",
+        "opt4": "Most times (much more than half the time)",
+        "opt5": "Almost always / always"
+      },
+      "q4": {
+        "text": "During sexual intercourse, how difficult was it to maintain your erection to completion?",
+        "opt1": "Extremely difficult",
+        "opt2": "Very difficult",
+        "opt3": "Difficult",
+        "opt4": "Slightly difficult",
+        "opt5": "Not difficult"
+      },
+      "q5": {
+        "text": "When you attempted intercourse, how often was it satisfactory for you?",
+        "opt1": "Almost never / never",
+        "opt2": "A few times (much less than half the time)",
+        "opt3": "Sometimes (about half the time)",
+        "opt4": "Most times (much more than half the time)",
+        "opt5": "Almost always / always"
+      }
+    },
+    "severity_noEd": "No erectile dysfunction",
+    "severity_mild": "Mild ED",
+    "severity_mildModerate": "Mild to moderate",
+    "severity_moderate": "Moderate ED",
+    "severity_severe": "Severe ED",
+    "advice_noEd": "Your answers don't suggest erectile dysfunction. Occasional difficulty — from stress, alcohol or fatigue — is normal and not a concern.",
+    "advice_mild": "Mild signs of ED. Often driven by lifestyle factors — sleep, exercise, stress reduction, cutting alcohol/nicotine usually help quickly. If symptoms persist, see a doctor.",
+    "advice_mildModerate": "Mild-to-moderate ED. Worth talking to your GP or urologist — vascular, hormonal (testosterone) or psychogenic causes are common and treatable.",
+    "advice_moderate": "Moderate ED. A medical evaluation is recommended. Underlying conditions (cardiovascular disease, diabetes, hormone deficiency) are common and warrant treatment regardless.",
+    "advice_severe": "Severe ED. Please see a urologist soon. ED is often an early marker of cardiovascular disease — a full workup protects your overall health.",
+    "refTitle": "Severity bands (Cappelleri & Rosen 2005)",
+    "refScore": "Score",
+    "refSeverity": "Interpretation",
+    "howItWorks": "How it works",
+    "howItWorksText": "The IIEF-5 (also called SHIM — Sexual Health Inventory for Men) is the internationally validated 5-question short form of the International Index of Erectile Function. Developed by Rosen et al. (1999) and given severity bands by Cappelleri & Rosen (2005), it's the global standard screening tool in clinical practice and research. Each of the 5 questions is scored 1–5; total range is 5–25. Scores of 22+ rule out ED, scores below 8 indicate severe ED. Sensitivity: 98 %, specificity: 88 % at a cutoff of ≤ 21.",
+    "disclaimer": "This test does not replace a medical diagnosis. ED is often an early indicator of vascular disease, diabetes or hormone deficiency — if your score is concerning, please see a GP or urologist. A low score doesn't mean you have a disease — it's a reason to investigate causes with your doctor.",
+    "faq": [
+      {
+        "q": "What is the IIEF-5?",
+        "a": "The IIEF-5 is the validated short form of the International Index of Erectile Function — a 5-question self-check that assesses erectile function over the last 6 months. Developed by Rosen et al. in 1999, it's the global standard for ED screening."
+      },
+      {
+        "q": "How accurate is the result?",
+        "a": "At a cutoff of ≤ 21, the IIEF-5 achieves 98 % sensitivity and 88 % specificity. It catches almost all ED cases with few false positives. A medical evaluation is still needed to identify the underlying cause."
+      },
+      {
+        "q": "Are my answers private?",
+        "a": "Yes — the calculator runs entirely in your browser. Nothing is sent to a server, nothing is stored, nothing is shared. Just close the tab and your answers are gone."
+      },
+      {
+        "q": "What are the most common causes of ED?",
+        "a": "ED usually has multiple causes: vascular (cardiovascular disease, atherosclerosis, hypertension), endocrine (low testosterone, diabetes), neurogenic (post-surgery or with multiple sclerosis), drug-induced (beta-blockers, SSRIs), and psychogenic (stress, relationship issues, performance anxiety)."
+      },
+      {
+        "q": "What helps ED naturally?",
+        "a": "Strong evidence for: regular exercise (40 % risk reduction), weight loss if overweight, Mediterranean diet, smoking cessation, limiting alcohol, sufficient sleep, stress reduction. If testosterone is low, replacement therapy can help; for vascular causes, PDE-5 inhibitors are first-line."
+      },
+      {
+        "q": "When should I see a doctor?",
+        "a": "Score of 21 or below — and any time the situation is causing you distress. Even in younger men, ED can be an early marker of cardiovascular disease, so it's worth investigating regardless of age."
+      }
+    ]
+  }
+}

--- a/src/pages/ErectileDysfunctionCalculator.vue
+++ b/src/pages/ErectileDysfunctionCalculator.vue
@@ -1,0 +1,161 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcIief5Result } from '../utils/erectileDysfunction.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('erectileDysfunction.faq') || [])
+
+useHead(() => ({
+  title: t('erectileDysfunction.meta.title'),
+  description: t('erectileDysfunction.meta.description'),
+  routeKey: 'erectileDysfunction',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Erectile Dysfunction Calculator',
+    url: 'https://healthcalculator.app/erectile-dysfunction-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const questionKeys = ['q1', 'q2', 'q3', 'q4', 'q5']
+const answers = ref([null, null, null, null, null])
+
+const result = computed(() => calcIief5Result(answers.value))
+
+const severityColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.severity) {
+    case 'noEd': return 'text-green-600'
+    case 'mild': return 'text-yellow-600'
+    case 'mildModerate': return 'text-orange-500'
+    case 'moderate': return 'text-red-500'
+    case 'severe': return 'text-red-700'
+    default: return 'text-stone-600'
+  }
+})
+
+const severityBg = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.severity) {
+    case 'noEd': return 'bg-green-50 border-green-200 text-green-900'
+    case 'mild': return 'bg-yellow-50 border-yellow-200 text-yellow-900'
+    case 'mildModerate': return 'bg-orange-50 border-orange-200 text-orange-900'
+    case 'moderate': return 'bg-red-50 border-red-200 text-red-900'
+    case 'severe': return 'bg-red-100 border-red-300 text-red-900'
+    default: return 'bg-stone-50 border-stone-200 text-stone-900'
+  }
+})
+
+function reset() {
+  answers.value = [null, null, null, null, null]
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('erectileDysfunction.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('erectileDysfunction.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('erectileDysfunction.instructionsLabel') }}</p>
+    <p class="text-sm text-stone-600 leading-relaxed mb-6">{{ t('erectileDysfunction.instructions') }}</p>
+
+    <div v-for="(qKey, qIdx) in questionKeys" :key="qKey" class="mb-6 pb-6 border-b border-stone-100 last:border-b-0 last:pb-0 last:mb-0">
+      <p class="text-sm font-semibold text-stone-900 mb-3">
+        <span class="text-stone-400">{{ qIdx + 1 }}.</span>
+        {{ t('erectileDysfunction.questions.' + qKey + '.text') }}
+      </p>
+      <div class="grid grid-cols-1 md:grid-cols-5 gap-2">
+        <button
+          v-for="opt in 5"
+          :key="opt"
+          @click="answers[qIdx] = opt"
+          :data-testid="qKey + '-option-' + opt"
+          :class="answers[qIdx] === opt ? 'bg-stone-900 text-white border-stone-900' : 'bg-white text-stone-600 border-stone-200 hover:bg-stone-50'"
+          class="text-left text-sm px-4 py-3 rounded-lg border transition-colors duration-150"
+        >
+          <span class="font-semibold mr-1">{{ opt }}.</span>
+          <span>{{ t('erectileDysfunction.questions.' + qKey + '.opt' + opt) }}</span>
+        </button>
+      </div>
+    </div>
+
+    <button
+      @click="reset"
+      class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150"
+    >&times; {{ t('erectileDysfunction.reset') }}</button>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('erectileDysfunction.results') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="iief5-score">{{ result.score }}</span>
+      <span class="text-lg text-stone-400">/ 25</span>
+      <span :class="severityColor" class="text-lg font-semibold" data-testid="result-status">{{ t('erectileDysfunction.severity_' + result.severity) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-red-700 via-red-500 via-orange-500 via-yellow-500 to-green-500 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: ((result.score - 5) / 20 * 100) + '%' }"></div>
+    </div>
+
+    <div
+      class="rounded-lg p-4 text-sm font-medium border mb-4"
+      :class="severityBg"
+      data-testid="severity-message"
+    >
+      {{ t('erectileDysfunction.advice_' + result.severity) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('erectileDysfunction.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('erectileDysfunction.refScore') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('erectileDysfunction.refSeverity') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">22 – 25</td><td class="px-6 py-3 text-stone-600">{{ t('erectileDysfunction.severity_noEd') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">17 – 21</td><td class="px-6 py-3 text-stone-600">{{ t('erectileDysfunction.severity_mild') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">12 – 16</td><td class="px-6 py-3 text-stone-600">{{ t('erectileDysfunction.severity_mildModerate') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">8 – 11</td><td class="px-6 py-3 text-stone-600">{{ t('erectileDysfunction.severity_moderate') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">5 – 7</td><td class="px-6 py-3 text-stone-600">{{ t('erectileDysfunction.severity_severe') }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('erectileDysfunction.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('erectileDysfunction.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('erectileDysfunction.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="erectileDysfunction" />
+</template>

--- a/src/pages/blog/ErektileDysfunktionTest.vue
+++ b/src/pages/blog/ErektileDysfunktionTest.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Erektile Dysfunktion testen: IIEF-5-Fragebogen, Ursachen und was hilft | Health Calculators',
+  description: 'Erektile Dysfunktion mit dem IIEF-5 (SHIM) einschätzen. Ursachen, Schweregrade nach Cappelleri & Rosen, evidenzbasierte Maßnahmen — anonym und kostenlos.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Erektile Dysfunktion testen: IIEF-5-Fragebogen, Ursachen und was hilft',
+    description: 'Erektile Dysfunktion mit dem IIEF-5 (SHIM) einschätzen. Ursachen, Schweregrade nach Cappelleri & Rosen, evidenzbasierte Maßnahmen — anonym und kostenlos.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-01',
+    dateModified: '2026-05-01',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/erektile-dysfunktion-test',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Erektile Dysfunktion testen: IIEF-5-Fragebogen, Ursachen und was hilft</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">1. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Erektile Dysfunktion (ED) ist häufiger als die meisten Männer denken: weltweit sind etwa <strong>52 % aller Männer zwischen 40 und 70</strong> davon betroffen — meist unausgesprochen. Mit dem <strong>IIEF-5</strong> kannst du in 2 Minuten einschätzen, ob deine Erektionsprobleme im klinisch relevanten Bereich liegen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt den Test, die Schweregrade nach <strong>Cappelleri & Rosen (2005)</strong>, die häufigsten Ursachen und was wirklich hilft.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist der IIEF-5?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <strong>International Index of Erectile Function (IIEF-5)</strong> — auch <strong>SHIM</strong> (Sexual Health Inventory for Men) genannt — ist die wissenschaftlich validierte 5-Fragen-Kurzform des längeren IIEF-15. Entwickelt 1999 von Raymond Rosen et al., ist er heute der weltweite Standard im Screening auf erektile Dysfunktion.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Jede der 5 Fragen wird auf einer Skala von 1 bis 5 beantwortet. Der Gesamtscore reicht von 5 (schwere ED) bis 25 (keine ED).
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-sm text-stone-600 leading-relaxed mb-2"><strong>Sensitivität:</strong> 98 % — der Test entdeckt fast alle ED-Fälle.</p>
+          <p class="text-sm text-stone-600 leading-relaxed"><strong>Spezifität:</strong> 88 % — wenige Fehlalarme bei einem Cutoff von ≤ 21.</p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Schweregrade nach Cappelleri & Rosen</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Schweregrad</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfehlung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">22 – 25</td><td class="px-6 py-3 text-stone-600">Keine ED</td><td class="px-6 py-3 text-stone-600">Beobachten</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">17 – 21</td><td class="px-6 py-3 text-stone-600">Leicht</td><td class="px-6 py-3 text-stone-600">Lebensstil-Anpassung</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">12 – 16</td><td class="px-6 py-3 text-stone-600">Leicht bis mittelschwer</td><td class="px-6 py-3 text-stone-600">Hausarzt</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">8 – 11</td><td class="px-6 py-3 text-stone-600">Mittelschwer</td><td class="px-6 py-3 text-stone-600">Urologe + Diagnostik</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">5 – 7</td><td class="px-6 py-3 text-stone-600">Schwer</td><td class="px-6 py-3 text-stone-600">Urologe zeitnah</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der Cutoff von ≤ 21 ist klinisch etabliert — darunter wird eine ärztliche Abklärung empfohlen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die häufigsten Ursachen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          ED ist selten rein psychogen. In über 80 % der Fälle liegt eine organische Mitursache vor:
+        </p>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Vaskulär (häufigste Ursache)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Atherosklerose, Bluthochdruck, hohe Cholesterinwerte und Rauchen schädigen die kleinen Penisarterien — oft Jahre bevor andere Symptome auftreten. ED gilt als <strong>Frühmarker für Herz-Kreislauf-Erkrankungen</strong> mit 3–5 Jahren Vorlauf.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Endokrin / Hormonell</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              <strong>Testosteronmangel</strong> (Hypogonadismus) und Diabetes mellitus sind häufig. 50 % der Diabetiker entwickeln innerhalb von 10 Jahren eine ED — vor allem durch Schädigung der Nervenfasern und Gefäße.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Medikamentös</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Betablocker, Thiazide, SSRI-Antidepressiva, Finasterid, Opioide und einige Antipsychotika können Erektionsstörungen verursachen — bei Verdacht mit dem Arzt sprechen, nie eigenmächtig absetzen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Psychogen</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Versagensangst, Stress, Beziehungskonflikte, Depression — typisches Zeichen: Morgenerektionen sind erhalten, aber bei Geschlechtsverkehr versagt die Erektion. Häufiger bei jüngeren Männern.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">ED als Frühwarnzeichen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eine Studie im <em>Journal of the American Medical Association</em> (Inman et al. 2009) zeigte: Männer unter 50 mit ED haben <strong>50-fach erhöhtes Risiko</strong> für einen Herzinfarkt in den nächsten 5–10 Jahren — verglichen mit Gleichaltrigen ohne ED. Die Penisarterien sind nur 1–2 mm dick und reagieren früher auf Atherosklerose als die 3–4 mm dicken Koronararterien.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Deshalb gehört zur ED-Abklärung immer ein Check der kardiovaskulären Risikofaktoren — Blutdruck, Cholesterin, Blutzucker, Bauchumfang und Rauchstatus.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt IIEF-5-Score berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">5 Fragen, sofortiger Schweregrad nach Cappelleri & Rosen, anonym und ohne Anmeldung — direkt im Browser.</p>
+        <router-link
+          :to="localePath('erectileDysfunction')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos testen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was wirklich hilft</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Studien zeigen: bei leichter bis mittelschwerer ED ist Lebensstil-Modifikation oft wirksam wie Medikamente:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Bewegung:</strong> 150 Minuten moderate Aktivität pro Woche senken das ED-Risiko um 40 %</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Gewichtsabnahme:</strong> bei BMI &gt; 30 verbessert eine 10-%-Reduktion die Erektionsfähigkeit deutlich</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mediterrane Ernährung:</strong> Olivenöl, Fisch, Nüsse, viel Gemüse — verbessert Endothelfunktion</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Rauchstopp:</strong> Nikotin ist einer der stärksten ED-Risikofaktoren</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Schlaf:</strong> 7–9 Stunden — Schlafapnoe ist eine unterdiagnostizierte ED-Ursache</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Beckenbodentraining:</strong> Kegel-Übungen verbesserten in einer Studie 40 % der Männer mit leichter ED</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei Testosteronmangel kann Substitution helfen, bei vaskulären Ursachen sind PDE-5-Hemmer (Sildenafil, Tadalafil) erste Wahl — verschreibungspflichtig und nur nach ärztlicher Abklärung.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Da ED häufig zusammen mit anderen Risikofaktoren auftritt, lohnt sich ein Blick auf den
+          <router-link :to="localeBlogPath('testosteronwert-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Testosteron-Rechner</router-link>
+          (Hypogonadismus ausschließen),
+          den <router-link :to="localeBlogPath('diabetes-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko-Rechner</router-link>
+          (FINDRISC-Score) und das
+          <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biologische Alter</router-link>
+          als Gesamt-Marker für deinen Gesundheitszustand.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der IIEF-5 ist ein zuverlässiges Screening — aber nur der erste Schritt. Bei einem Score unter 22 lohnt sich die ärztliche Abklärung, denn ED ist häufig die Spitze eines Eisbergs aus vaskulären, hormonellen oder metabolischen Risikofaktoren. Nutze unseren
+          <router-link :to="localePath('erectileDysfunction')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">IIEF-5-Rechner</router-link>
+          für die anonyme Selbsteinschätzung — und sprich bei auffälligen Werten mit deinem Arzt.
+        </p>
+      </div>
+
+      <RelatedArticles slug="erektile-dysfunktion-test" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/ErectileDysfunctionIief5.vue
+++ b/src/pages/blog/en/ErectileDysfunctionIief5.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Erectile Dysfunction Test (IIEF-5): Score, Causes and What Works | Health Calculators',
+  description: 'Assess erectile dysfunction with the IIEF-5 (SHIM). Causes, severity bands by Cappelleri & Rosen, evidence-based interventions — anonymous and free.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Erectile Dysfunction Test (IIEF-5): Score, Causes and What Works',
+    description: 'Assess erectile dysfunction with the IIEF-5 (SHIM). Causes, severity bands by Cappelleri & Rosen, evidence-based interventions — anonymous and free.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-01',
+    dateModified: '2026-05-01',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/erectile-dysfunction-iief-5',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Erectile Dysfunction Test (IIEF-5): Score, Causes and What Works</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 1, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Erectile dysfunction (ED) is far more common than most men think: roughly <strong>52 % of men aged 40–70</strong> experience it — usually in silence. With the <strong>IIEF-5</strong> you can self-assess in under 2 minutes whether your symptoms are in the clinically relevant range.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article explains the test, the severity bands published by <strong>Cappelleri & Rosen (2005)</strong>, the most common causes, and what actually helps.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is the IIEF-5?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>International Index of Erectile Function (IIEF-5)</strong> — also known as <strong>SHIM</strong> (Sexual Health Inventory for Men) — is the validated 5-question short form of the longer IIEF-15. Developed by Raymond Rosen and colleagues in 1999, it is now the global standard for ED screening.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Each of the 5 questions is rated on a 1–5 scale. The total score ranges from 5 (severe ED) to 25 (no ED).
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-sm text-stone-600 leading-relaxed mb-2"><strong>Sensitivity:</strong> 98 % — catches almost every case of ED.</p>
+          <p class="text-sm text-stone-600 leading-relaxed"><strong>Specificity:</strong> 88 % — few false positives at a cutoff of ≤ 21.</p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Severity bands (Cappelleri & Rosen)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Severity</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Action</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">22 – 25</td><td class="px-6 py-3 text-stone-600">No ED</td><td class="px-6 py-3 text-stone-600">Monitor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">17 – 21</td><td class="px-6 py-3 text-stone-600">Mild</td><td class="px-6 py-3 text-stone-600">Lifestyle changes</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">12 – 16</td><td class="px-6 py-3 text-stone-600">Mild to moderate</td><td class="px-6 py-3 text-stone-600">See your GP</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">8 – 11</td><td class="px-6 py-3 text-stone-600">Moderate</td><td class="px-6 py-3 text-stone-600">Urologist + workup</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">5 – 7</td><td class="px-6 py-3 text-stone-600">Severe</td><td class="px-6 py-3 text-stone-600">See a urologist soon</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A cutoff of ≤ 21 is the established clinical threshold for medical evaluation.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The most common causes</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          ED is rarely purely psychological. In more than 80 % of cases, an organic factor is involved:
+        </p>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Vascular (most common)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Atherosclerosis, hypertension, high cholesterol and smoking damage the small penile arteries — often years before other symptoms emerge. ED is considered an <strong>early marker for cardiovascular disease</strong> with a 3–5 year lead time.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Endocrine / hormonal</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              <strong>Low testosterone</strong> (hypogonadism) and diabetes are common. About 50 % of diabetic men develop ED within 10 years — primarily through nerve and vascular damage.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Drug-induced</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Beta-blockers, thiazide diuretics, SSRI antidepressants, finasteride, opioids and some antipsychotics can trigger ED. If you suspect a medication, talk to your doctor — never stop on your own.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Psychogenic</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Performance anxiety, stress, relationship issues, depression — typical sign: morning erections are present but fail during sex. More common in younger men.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">ED as an early warning sign</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A landmark study in <em>JAMA</em> (Inman et al., 2009) showed that men under 50 with ED have a <strong>50-fold higher risk</strong> of heart attack within 5–10 years compared to peers without ED. Penile arteries are only 1–2 mm in diameter and react to atherosclerosis earlier than the 3–4 mm coronary arteries.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          That's why ED workup should always include cardiovascular risk factors — blood pressure, cholesterol, blood glucose, waist circumference and smoking status.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your IIEF-5 score now</h3>
+        <p class="text-stone-300 text-sm mb-5">5 questions, instant Cappelleri & Rosen severity, anonymous and no sign-up — runs entirely in your browser.</p>
+        <router-link
+          :to="localePath('erectileDysfunction')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Take the test for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What actually works</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Studies show that for mild-to-moderate ED, lifestyle interventions are often as effective as medication:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Exercise:</strong> 150 minutes of moderate activity per week reduce ED risk by 40 %</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Weight loss:</strong> if BMI &gt; 30, a 10 % reduction markedly improves erectile function</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mediterranean diet:</strong> olive oil, fish, nuts, plenty of vegetables — improves endothelial function</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Quit smoking:</strong> nicotine is one of the strongest ED risk factors</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Sleep:</strong> 7–9 hours — sleep apnea is an underdiagnosed ED cause</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Pelvic floor training:</strong> Kegel exercises improved 40 % of men with mild ED in one trial</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For low testosterone, replacement therapy can help; for vascular causes, PDE-5 inhibitors (sildenafil, tadalafil) are first-line — prescription-only and only after medical evaluation.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Because ED clusters with other risk factors, it's worth checking your
+          <router-link :to="localeBlogPath('testosterone-level-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">testosterone level</router-link>
+          (rule out hypogonadism), your
+          <router-link :to="localeBlogPath('diabetes-risk-score')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">diabetes risk score</router-link>
+          (FINDRISC) and your
+          <router-link :to="localeBlogPath('biological-age-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biological age</router-link>
+          as a holistic health marker.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The IIEF-5 is a reliable screen — but only the first step. If your score is below 22, a medical evaluation is worth it: ED is often the tip of an iceberg of vascular, hormonal or metabolic risk factors. Use our
+          <router-link :to="localePath('erectileDysfunction')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">IIEF-5 calculator</router-link>
+          for an anonymous self-check — and bring concerning results to your doctor.
+        </p>
+      </div>
+
+      <RelatedArticles slug="erectile-dysfunction-iief-5" />
+    </div>
+  </article>
+</template>

--- a/src/pages/erectileDysfunction.meta.js
+++ b/src/pages/erectileDysfunction.meta.js
@@ -1,0 +1,16 @@
+import Component from './ErectileDysfunctionCalculator.vue'
+import BlogDe from './blog/ErektileDysfunktionTest.vue'
+import BlogEn from './blog/en/ErectileDysfunctionIief5.vue'
+
+export default {
+  key: 'erectileDysfunction',
+  component: Component,
+  slugs: { de: 'erektile-dysfunktion-rechner', en: 'erectile-dysfunction-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 29,
+  blog: {
+    de: { slug: 'erektile-dysfunktion-test', component: BlogDe },
+    en: { slug: 'erectile-dysfunction-iief-5', component: BlogEn },
+  },
+}

--- a/src/utils/erectileDysfunction.js
+++ b/src/utils/erectileDysfunction.js
@@ -1,0 +1,40 @@
+// IIEF-5 (Sexual Health Inventory for Men, SHIM) — Rosen et al. 1999.
+// Validated 5-question short form of the International Index of Erectile Function.
+// Each question scored 1–5. Total range: 5–25. Lower = more severe ED.
+//
+// Severity bands (Cappelleri & Rosen 2005):
+//   22–25  no ED
+//   17–21  mild
+//   12–16  mild–moderate
+//    8–11  moderate
+//    5–7   severe
+
+function isValidAnswer(a) {
+  return Number.isInteger(a) && a >= 1 && a <= 5
+}
+
+export function calcIief5Score(answers) {
+  if (!Array.isArray(answers) || answers.length !== 5) return null
+  if (!answers.every(isValidAnswer)) return null
+  return answers.reduce((sum, a) => sum + a, 0)
+}
+
+export function classifyIief5(score) {
+  if (!Number.isFinite(score) || score < 5 || score > 25) return null
+  if (score >= 22) return 'noEd'
+  if (score >= 17) return 'mild'
+  if (score >= 12) return 'mildModerate'
+  if (score >= 8) return 'moderate'
+  return 'severe'
+}
+
+export function calcIief5Result(answers) {
+  const score = calcIief5Score(answers)
+  if (score === null) return null
+  const severity = classifyIief5(score)
+  return {
+    score,
+    severity,
+    hasEd: severity !== 'noEd',
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-146-erectile-dysfunction
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-146-erectile-dysfunction-20260501-220026`
**Cost:** $6.820767749999997

Closes jenslaufer/health-calculators#146

### Prompt
> Implement the Erectile Dysfunction Calculator as described in issue #146.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- IIEF-5 erectile dysfunction severity score
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/erectileDysfunction.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/erectileDysfunction.test.js` with 6+ test cases covering edge cases. Run `npm test -- erectileDysfunction` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/ErectileDysfunctionCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/erectileDysfunction.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/erectileDysfunction.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'erectileDysfunction'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/erectileDysfunction.json` + `src/locales/calculators/en/erectileDysfunction.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/erectileDysfunction.js (or shared util — verify pattern in repo first)`
- `src/__tests__/erectileDysfunction.test.js`
- `src/pages/ErectileDysfunctionCalculator.vue`
- `src/pages/erectileDysfunction.meta.js`
- `src/locales/calculators/de/erectileDysfunction.json`
- `src/locales/calculators/en/erectileDysfunction.json`
- `e2e/erectileDysfunction.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'erectileDysfunction',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks