### PR TITLE
hc-147-male-pattern: Implement the Male Pattern Calculator as described in issue 

### DIFF
--- a/e2e/malePattern.spec.js
+++ b/e2e/malePattern.spec.js
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/haarausfall-rechner-maenner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Haarausfall|Norwood/)
+})
+
+async function answerAll(page, value) {
+  for (let q = 1; q <= 4; q++) {
+    await page.getByTestId(`q${q}-option-${value}`).click()
+  }
+}
+
+test('all 1s → score 4, stage 1', async ({ page }) => {
+  await answerAll(page, 1)
+  const stage = page.getByTestId('norwood-stage')
+  await expect(stage).toBeVisible()
+  await expect(stage).toHaveText('1')
+  await expect(page.getByTestId('result-status')).toHaveText('Stadium 1')
+})
+
+test('all 5s → score 20, stage 7', async ({ page }) => {
+  await answerAll(page, 5)
+  await expect(page.getByTestId('norwood-stage')).toHaveText('7')
+  await expect(page.getByTestId('result-status')).toHaveText('Stadium 7')
+})
+
+test('all 3s → score 12, stage 4', async ({ page }) => {
+  await answerAll(page, 3)
+  await expect(page.getByTestId('norwood-stage')).toHaveText('4')
+  await expect(page.getByTestId('result-status')).toHaveText('Stadium 4')
+})
+
+test('result hidden until all questions answered', async ({ page }) => {
+  await page.getByTestId('q1-option-3').click()
+  await page.getByTestId('q2-option-3').click()
+  await expect(page.getByTestId('norwood-stage')).not.toBeVisible()
+})
+
+test('shows stage advice after completion', async ({ page }) => {
+  await answerAll(page, 4)
+  await expect(page.getByTestId('stage-message')).toBeVisible()
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -21,6 +21,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
+  'malePattern',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -73,6 +74,7 @@ const EXPECTED_ROUTE_MAP = {
   pcosSymptoms: { de: 'pcos-symptome-rechner', en: 'pcos-symptom-checker' },
   testosteroneLevel: { de: 'testosteron-rechner', en: 'testosterone-level-calculator' },
   erectileDysfunction: { de: 'erektile-dysfunktion-rechner', en: 'erectile-dysfunction-calculator' },
+  malePattern: { de: 'haarausfall-rechner-maenner', en: 'male-pattern-baldness-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -113,6 +115,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'pcos-symptome-erkennen',
   'testosteronwert-berechnen',
   'erektile-dysfunktion-test',
+  'haarausfall-norwood-skala',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -153,19 +156,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pcos-symptom-checker',
   'testosterone-level-calculator',
   'erectile-dysfunction-iief-5',
+  'male-pattern-baldness-norwood',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 51 calculators', () => {
-    expect(calculatorMetas).toHaveLength(51)
+  it('discovers all 52 calculators', () => {
+    expect(calculatorMetas).toHaveLength(52)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 51 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(51)
+  it('builds calculatorComponents map for all 52 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(52)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -188,15 +192,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 49 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(49)
+  it('discovers all 50 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(50)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 49 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(49)
+  it('discovers all 50 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(50)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -214,8 +218,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 51 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(51)
-    expect(new Set(allKeys).size).toBe(51)
+    expect(allKeys).toHaveLength(52)
+    expect(new Set(allKeys).size).toBe(52)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -236,7 +240,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern',
     ])
   })
 
@@ -284,8 +288,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 291 routes', () => {
-    expect(routes).toHaveLength(291)
+  it('generates exactly 296 routes', () => {
+    expect(routes).toHaveLength(296)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 200 links (51 calcs × 2 locales + 49 blogs × 2 locales)', () => {
+  it('generates 204 links (52 calcs × 2 locales + 50 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(200)
+    expect(links).toHaveLength(204)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/malePattern.test.js
+++ b/src/__tests__/malePattern.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcNorwoodScore,
+  classifyNorwood,
+  calcMalePatternResult,
+  NORWOOD_STAGES,
+} from '../utils/malePattern.js'
+
+describe('Norwood score calculation', () => {
+  it('all 1s → 4 (no loss)', () => {
+    expect(calcNorwoodScore([1, 1, 1, 1])).toBe(4)
+  })
+
+  it('all 5s → 20 (most severe)', () => {
+    expect(calcNorwoodScore([5, 5, 5, 5])).toBe(20)
+  })
+
+  it('mixed answers → correct sum', () => {
+    expect(calcNorwoodScore([3, 4, 2, 5])).toBe(14)
+  })
+
+  it('returns null when any answer is null', () => {
+    expect(calcNorwoodScore([3, null, 3, 3])).toBeNull()
+  })
+
+  it('returns null when fewer than 4 answers', () => {
+    expect(calcNorwoodScore([3, 3, 3])).toBeNull()
+  })
+
+  it('returns null for out-of-range values', () => {
+    expect(calcNorwoodScore([0, 3, 3, 3])).toBeNull()
+    expect(calcNorwoodScore([3, 6, 3, 3])).toBeNull()
+  })
+
+  it('returns null when input is not an array', () => {
+    expect(calcNorwoodScore(null)).toBeNull()
+    expect(calcNorwoodScore('1234')).toBeNull()
+  })
+})
+
+describe('Norwood stage classification', () => {
+  it('4 → stage 1 (no loss)', () => {
+    expect(classifyNorwood(4)).toBe('1')
+  })
+
+  it('5 → stage 1 (upper bound)', () => {
+    expect(classifyNorwood(5)).toBe('1')
+  })
+
+  it('6 → stage 2 (mature hairline)', () => {
+    expect(classifyNorwood(6)).toBe('2')
+  })
+
+  it('7 → stage 2 (upper bound)', () => {
+    expect(classifyNorwood(7)).toBe('2')
+  })
+
+  it('9 → stage 3', () => {
+    expect(classifyNorwood(9)).toBe('3')
+  })
+
+  it('11 → stage 3v', () => {
+    expect(classifyNorwood(11)).toBe('3v')
+  })
+
+  it('13 → stage 4', () => {
+    expect(classifyNorwood(13)).toBe('4')
+  })
+
+  it('15 → stage 5', () => {
+    expect(classifyNorwood(15)).toBe('5')
+  })
+
+  it('17 → stage 6', () => {
+    expect(classifyNorwood(17)).toBe('6')
+  })
+
+  it('20 → stage 7 (most severe)', () => {
+    expect(classifyNorwood(20)).toBe('7')
+  })
+
+  it('out-of-range or null → null', () => {
+    expect(classifyNorwood(null)).toBeNull()
+    expect(classifyNorwood(3)).toBeNull()
+    expect(classifyNorwood(21)).toBeNull()
+  })
+})
+
+describe('Norwood combined result', () => {
+  it('all 1s → score 4, stage 1, no loss', () => {
+    const r = calcMalePatternResult([1, 1, 1, 1])
+    expect(r.score).toBe(4)
+    expect(r.stage).toBe('1')
+    expect(r.hasLoss).toBe(false)
+    expect(r.isAdvanced).toBe(false)
+  })
+
+  it('mid-range → moderate stage', () => {
+    const r = calcMalePatternResult([3, 3, 3, 3])
+    expect(r.score).toBe(12)
+    expect(r.stage).toBe('4')
+    expect(r.hasLoss).toBe(true)
+    expect(r.isAdvanced).toBe(true)
+  })
+
+  it('all 5s → score 20, stage 7, advanced', () => {
+    const r = calcMalePatternResult([5, 5, 5, 5])
+    expect(r.score).toBe(20)
+    expect(r.stage).toBe('7')
+    expect(r.hasLoss).toBe(true)
+    expect(r.isAdvanced).toBe(true)
+  })
+
+  it('returns null when answers incomplete', () => {
+    expect(calcMalePatternResult([5, 5, null, 5])).toBeNull()
+  })
+
+  it('exposes 8 Norwood stages in order', () => {
+    expect(NORWOOD_STAGES).toEqual(['1', '2', '3', '3v', '4', '5', '6', '7'])
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -55,6 +55,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'pcos-symptome-erkennen',
   'testosteronwert-berechnen',
   'erektile-dysfunktion-test',
+  'haarausfall-norwood-skala',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -94,12 +95,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pcos-symptom-checker',
   'testosterone-level-calculator',
   'erectile-dysfunction-iief-5',
+  'male-pattern-baldness-norwood',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 51 calculator meta files', () => {
+  it('discovers all 52 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(51)
+    expect(metas).toHaveLength(52)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -137,19 +139,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 49 DE blog slugs', () => {
+  it('returns all 50 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(49)
+    expect(de).toHaveLength(50)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 49 EN blog slugs', () => {
+  it('returns all 50 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(49)
+    expect(en).toHaveLength(50)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -217,9 +219,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 102 calcs + 2 blog index + 98 blog articles = 204)', () => {
+  it('generates correct total URL count (2 home + 104 calcs + 2 blog index + 100 blog articles = 208)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(204)
+    expect(urlCount).toBe(208)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -440,6 +440,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'erectileDysfunction',
     related: ['testosterone-level-calculator', 'diabetes-risk-score', 'biological-age-calculator'],
   },
+  {
+    slug: 'male-pattern-baldness-norwood',
+    title: 'Male Pattern Baldness: Norwood-Hamilton Scale, Causes and Treatment',
+    description: 'Assess male androgenetic alopecia with the Norwood-Hamilton scale. Stages, causes, minoxidil/finasteride and hair transplantation — evidence-based and free.',
+    date: '2026-05-02',
+    readTime: '9 min',
+    calculatorKey: 'malePattern',
+    related: ['testosterone-level-calculator', 'erectile-dysfunction-iief-5', 'biological-age-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -440,6 +440,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'erectileDysfunction',
     related: ['testosteronwert-berechnen', 'diabetes-risiko-berechnen', 'biologisches-alter-berechnen'],
   },
+  {
+    slug: 'haarausfall-norwood-skala',
+    title: 'Haarausfall bei Männern: Norwood-Hamilton-Skala, Ursachen und Behandlung',
+    description: 'Androgenetischen Haarausfall mit der Norwood-Hamilton-Skala einschätzen. Stadien, Ursachen, Minoxidil/Finasterid und Haartransplantation — evidenzbasiert und kostenlos.',
+    date: '2026-05-02',
+    readTime: '9 min',
+    calculatorKey: 'malePattern',
+    related: ['testosteronwert-berechnen', 'erektile-dysfunktion-test', 'biologisches-alter-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/malePattern.json
+++ b/src/locales/calculators/de/malePattern.json
@@ -1,0 +1,113 @@
+{
+  "home": {
+    "calculators": {
+      "malePattern": {
+        "name": "Haarausfall-Rechner (Norwood)",
+        "description": "Norwood-Hamilton-Skala — Selbsteinschätzung des androgenetischen Haarausfalls in 4 Fragen mit Stadium 1–7."
+      }
+    }
+  },
+  "malePattern": {
+    "meta": {
+      "title": "Haarausfall-Rechner für Männer (Norwood-Hamilton) — Stadium ermitteln | Health Calculators",
+      "description": "Androgenetischen Haarausfall einschätzen mit der Norwood-Hamilton-Skala. 4 Fragen, sofortiges Stadium (1–7), Empfehlungen — anonym, kostenlos, ohne Anmeldung."
+    },
+    "title": "Haarausfall-Rechner für Männer (Norwood-Hamilton)",
+    "description": "Selbsteinschätzung mit der Norwood-Hamilton-Skala — dem klinischen Standard zur Klassifikation des androgenetischen Haarausfalls. 4 Fragen — Stadium, Score und Empfehlung in unter 2 Minuten.",
+    "instructionsLabel": "Anleitung",
+    "instructions": "Schau in den Spiegel (am besten im Tageslicht, mit Frontal- und Aufsicht-Foto). Beantworte jede Frage anhand deiner aktuellen Haarsituation — wähle die Option, die deinem Bild am nächsten kommt.",
+    "results": "Dein Norwood-Stadium",
+    "scoreLabel": "Punktzahl",
+    "reset": "Zurücksetzen",
+    "questions": {
+      "q1": {
+        "text": "Wie stark sind die Geheimratsecken (Schläfen) zurückgewichen?",
+        "opt1": "Gar nicht — Haarlinie wie in der Jugend",
+        "opt2": "Leicht — kleine Schläfendreiecke, reife Haarlinie",
+        "opt3": "Deutlich — sichtbare M-Form an der Stirn",
+        "opt4": "Stark — tiefe Geheimratsecken bis zur Mitte des Kopfes",
+        "opt5": "Sehr stark — Schläfen und Stirn nahezu kahl"
+      },
+      "q2": {
+        "text": "Wie sieht es am Wirbel/Hinterkopf (Tonsur) aus?",
+        "opt1": "Volles Haar, keine sichtbare Verdünnung",
+        "opt2": "Leichte Ausdünnung, wenn ich die Haare nass mache",
+        "opt3": "Eine Tonsur ist sichtbar (rundlicher dünnerer Bereich)",
+        "opt4": "Deutliche Tonsur, Kopfhaut klar erkennbar",
+        "opt5": "Großer kahler Bereich am Hinterkopf"
+      },
+      "q3": {
+        "text": "Wie viel Kopfhaut sieht man auf der Oberseite (Scheitel/Stirnpartie)?",
+        "opt1": "Keine — Haar deckt vollständig",
+        "opt2": "Wenig — nur bei nassem Haar oder grellem Licht",
+        "opt3": "Mäßig — bei normalem Tageslicht sichtbar",
+        "opt4": "Deutlich — Kopfhaut dominiert über das Haar",
+        "opt5": "Fast vollständig — kaum noch Haar oben"
+      },
+      "q4": {
+        "text": "Wie verhält sich der Haarkranz (Seiten und Hinterkopf) zur Oberseite?",
+        "opt1": "Gleichmäßig dicht — kein Unterschied",
+        "opt2": "Seiten leicht dichter, oben minimal dünner",
+        "opt3": "Klarer Unterschied: Seiten dicht, oben dünn",
+        "opt4": "Nur noch ein schmaler Haarkranz an Seiten/Hinterkopf",
+        "opt5": "Spärlicher Haarkranz, Oberkopf komplett kahl"
+      }
+    },
+    "stage_1_name": "Stadium 1",
+    "stage_2_name": "Stadium 2",
+    "stage_3_name": "Stadium 3",
+    "stage_3v_name": "Stadium 3 Vertex",
+    "stage_4_name": "Stadium 4",
+    "stage_5_name": "Stadium 5",
+    "stage_6_name": "Stadium 6",
+    "stage_7_name": "Stadium 7",
+    "stage_1_desc": "Kein erkennbarer Haarausfall — jugendliche Haarlinie",
+    "stage_2_desc": "Reife Haarlinie — leichte Schläfendreiecke, klinisch nicht relevant",
+    "stage_3_desc": "Erstes klinisch relevantes Stadium — deutliche M-förmige Geheimratsecken",
+    "stage_3v_desc": "Geheimratsecken plus zusätzliche Verdünnung am Wirbel (Vertex)",
+    "stage_4_desc": "Fortgeschritten — Geheimratsecken vertieft, Tonsur deutlich, Haarband zwischen den Bereichen",
+    "stage_5_desc": "Stirn- und Scheitelregion verschmelzen — schmales Haarband bleibt",
+    "stage_6_desc": "Haarband verschwunden — größerer zusammenhängender kahler Bereich",
+    "stage_7_desc": "Schwerstes Stadium — nur noch spärliches Haar an Seiten und Hinterkopf",
+    "advice_1": "Keine Anzeichen für androgenetischen Haarausfall. Achte auf Stress, Eisen-/Vitamin-D-Versorgung und Schilddrüsen-Werte, falls dir Haarausfall trotzdem auffällt.",
+    "advice_2": "Reife Haarlinie — eine normale altersbedingte Veränderung, die fast jeder Mann erlebt. Kein Behandlungsbedarf, aber gute Gelegenheit für eine Foto-Baseline zur Verlaufskontrolle.",
+    "advice_3": "Stadium 3 — der Punkt, an dem viele Männer aktiv werden. Frühzeitige Behandlung mit Minoxidil 5 % oder Finasterid hat hier die beste Wirksamkeit. Hausarzt oder Dermatologe ansprechen.",
+    "advice_3v": "Frontale Geheimratsecken plus Wirbel-Verdünnung — der androgenetische Haarausfall ist klar manifest. Kombinationstherapie (Minoxidil + Finasterid) sollte mit dem Arzt besprochen werden.",
+    "advice_4": "Fortgeschrittener androgenetischer Haarausfall. Medikamentöse Therapie kann den Verlauf bremsen, aber selten Haar zurückbringen. Haartransplantation wird ab Stadium 4–5 zunehmend erwogen.",
+    "advice_5": "Stadien 5–7 sprechen meist nicht mehr stark auf Minoxidil/Finasterid an. Eine Haartransplantation oder kosmetische Lösungen (Mikropigmentierung, Toupet) sind realistische Optionen.",
+    "advice_6": "Sehr fortgeschritten — Spenderbereich kann für eine Transplantation noch ausreichen, aber realistische Erwartungen sind wichtig. Mikropigmentierung ist eine etablierte Alternative.",
+    "advice_7": "Endstadium der Norwood-Skala. Akzeptanz, Mikropigmentierung der Kopfhaut oder eine partielle Transplantation des Spenderhaars sind Optionen. Dermatologische Beratung empfohlen.",
+    "refTitle": "Norwood-Hamilton-Stadien",
+    "refStage": "Stadium",
+    "refDescription": "Beschreibung",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Die Norwood-Hamilton-Skala wurde von Hamilton (1951) entwickelt und 1975 von O'Tar Norwood erweitert. Sie ist der internationale klinische Standard zur Klassifikation des androgenetischen Haarausfalls bei Männern (MAGA — Male Androgenetic Alopecia). Die 8 Stadien (1, 2, 3, 3-Vertex, 4, 5, 6, 7) beschreiben den typischen Verlauf vom jugendlichen Haar bis zum vollständigen Verlust der Oberkopf-Haare. In dieser Selbsteinschätzung beantwortest du 4 Fragen zu Geheimratsecken, Tonsur (Wirbel), Kopfhaut-Sichtbarkeit und Haarkranz — daraus wird dein Stadium berechnet (Score 4–20). Sensitivität und Reproduzierbarkeit der Norwood-Skala wurden in mehreren Studien validiert (Kappa 0,77–0,82 bei Selbst-/Fremdbewertung).",
+    "disclaimer": "Diese Einschätzung ersetzt keine ärztliche Diagnose. Der androgenetische Haarausfall ist die häufigste Form, aber andere Ursachen (Eisenmangel, Schilddrüsenstörung, Alopecia areata, Stress, Medikamente) sind möglich und sollten bei plötzlichem oder ungewöhnlichem Haarausfall ausgeschlossen werden. Für Diagnose und Therapieentscheidung bitte einen Dermatologen aufsuchen.",
+    "faq": [
+      {
+        "q": "Was ist die Norwood-Hamilton-Skala?",
+        "a": "Die Norwood-Hamilton-Skala ist die international anerkannte Klassifikation des männlichen Haarausfalls. Hamilton beschrieb 1951 die Stadien, Norwood erweiterte sie 1975 um Zwischenstadien. Sie umfasst 8 Stufen (1, 2, 3, 3-Vertex, 4, 5, 6, 7) und wird in Klinik, Forschung und Haartransplantation als Standard genutzt."
+      },
+      {
+        "q": "Ab welchem Stadium sollte ich behandeln?",
+        "a": "Stadium 3 ist der typische Einstiegspunkt für eine medikamentöse Therapie. Minoxidil 5 % (topisch) und Finasterid 1 mg (oral) sind die einzigen FDA-zugelassenen Wirkstoffe. Beide wirken am besten in frühen Stadien — verlorenes Haar lässt sich schwer zurückgewinnen, der Verlust kann aber gestoppt werden."
+      },
+      {
+        "q": "Was ist der Unterschied zwischen Stadium 3 und 3-Vertex?",
+        "a": "Stadium 3 zeigt nur frontale Geheimratsecken (M-Form). Stadium 3-Vertex zeigt zusätzlich eine beginnende Tonsur am Wirbel. Beide Bereiche schreiten typischerweise unabhängig voneinander fort, weshalb Norwood diese Unterscheidung eingeführt hat."
+      },
+      {
+        "q": "Sind meine Antworten anonym?",
+        "a": "Ja — der Rechner läuft komplett im Browser. Es werden keine Daten an einen Server gesendet, nichts gespeichert und nichts geteilt. Schließe einfach den Tab und alle Antworten sind weg."
+      },
+      {
+        "q": "Welche Rolle spielt Genetik?",
+        "a": "Androgenetischer Haarausfall ist zu 80 % erblich bedingt. Der Hauptmechanismus ist eine erhöhte Empfindlichkeit der Haarfollikel gegenüber Dihydrotestosteron (DHT). Wenn Vater oder Großvater (mütterlicherseits) früh verkahlt waren, ist das Risiko erhöht — der Verlauf ist aber individuell."
+      },
+      {
+        "q": "Hilft eine Haartransplantation?",
+        "a": "Ja, ab Stadium 3–4 ist eine Transplantation eine etablierte Option. Voraussetzung: ausreichend dichter Spenderbereich am Hinterkopf und stabilisierter Verlust (idealerweise unter Finasterid). Methoden: FUE (Follicular Unit Extraction) und FUT (Streifentechnik). Realistisches Ergebnis: kein voller Schopf wie mit 18, sondern eine ästhetisch dichte Linie."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/malePattern.json
+++ b/src/locales/calculators/en/malePattern.json
@@ -1,0 +1,113 @@
+{
+  "home": {
+    "calculators": {
+      "malePattern": {
+        "name": "Male Pattern Baldness Calculator",
+        "description": "Norwood-Hamilton scale — self-assess male androgenetic alopecia in 4 questions, get stage 1–7."
+      }
+    }
+  },
+  "malePattern": {
+    "meta": {
+      "title": "Male Pattern Baldness Calculator (Norwood-Hamilton) — Stage 1–7 | Health Calculators",
+      "description": "Assess male pattern baldness with the Norwood-Hamilton scale. 4 questions, instant stage (1–7), evidence-based recommendations — anonymous, free, no sign-up."
+    },
+    "title": "Male Pattern Baldness Calculator (Norwood-Hamilton)",
+    "description": "Self-assessment using the Norwood-Hamilton scale — the clinical standard for classifying male androgenetic alopecia. 4 questions — stage, score and guidance in under 2 minutes.",
+    "instructionsLabel": "Instructions",
+    "instructions": "Look in the mirror in good daylight (front and top-down photos work best). Answer each question based on your current hair — pick the option that matches your image most closely.",
+    "results": "Your Norwood stage",
+    "scoreLabel": "Score",
+    "reset": "Reset",
+    "questions": {
+      "q1": {
+        "text": "How far has your hairline receded at the temples?",
+        "opt1": "Not at all — youthful hairline",
+        "opt2": "Slightly — small temple triangles, mature hairline",
+        "opt3": "Clearly — visible M-shape at the forehead",
+        "opt4": "Strongly — deep recession into mid-scalp",
+        "opt5": "Very strongly — temples and forehead nearly bare"
+      },
+      "q2": {
+        "text": "What does the crown / vertex (top-back of head) look like?",
+        "opt1": "Full hair, no visible thinning",
+        "opt2": "Slight thinning, only when hair is wet",
+        "opt3": "A bald spot is visible (round thin patch)",
+        "opt4": "Pronounced bald spot, scalp clearly visible",
+        "opt5": "Large bald area at the back-top of the head"
+      },
+      "q3": {
+        "text": "How much scalp shows through on top (mid-scalp / front)?",
+        "opt1": "None — hair fully covers",
+        "opt2": "A little — only with wet hair or harsh light",
+        "opt3": "Moderate — visible in normal daylight",
+        "opt4": "Substantial — scalp dominates over hair",
+        "opt5": "Almost fully — barely any hair on top"
+      },
+      "q4": {
+        "text": "How does the hair band (sides and back) compare to the top?",
+        "opt1": "Evenly dense — no difference",
+        "opt2": "Sides slightly denser, top minimally thinner",
+        "opt3": "Clear contrast: sides full, top thin",
+        "opt4": "Only a narrow horseshoe band at sides/back remains",
+        "opt5": "Sparse band, top of head completely bald"
+      }
+    },
+    "stage_1_name": "Stage 1",
+    "stage_2_name": "Stage 2",
+    "stage_3_name": "Stage 3",
+    "stage_3v_name": "Stage 3 Vertex",
+    "stage_4_name": "Stage 4",
+    "stage_5_name": "Stage 5",
+    "stage_6_name": "Stage 6",
+    "stage_7_name": "Stage 7",
+    "stage_1_desc": "No visible hair loss — youthful hairline",
+    "stage_2_desc": "Mature hairline — slight temple recession, not clinically relevant",
+    "stage_3_desc": "First clinically significant stage — pronounced M-shaped temple recession",
+    "stage_3v_desc": "Frontal recession plus additional thinning at the vertex (crown)",
+    "stage_4_desc": "Advanced — deeper recession, distinct vertex bald spot, hair band between zones",
+    "stage_5_desc": "Frontal and vertex zones merging — narrow band of hair remains",
+    "stage_6_desc": "Hair band gone — larger contiguous bald area",
+    "stage_7_desc": "Most severe stage — only sparse hair on sides and back",
+    "advice_1": "No signs of androgenetic alopecia. If you still notice shedding, check stress, iron / vitamin D, and thyroid markers — they are common reversible causes.",
+    "advice_2": "Mature hairline — a normal age-related change almost every man experiences. No treatment needed, but a good moment to take a baseline photo for tracking.",
+    "advice_3": "Stage 3 — the point where many men start treatment. Early intervention with topical minoxidil 5 % or oral finasteride is most effective here. Talk to your GP or dermatologist.",
+    "advice_3v": "Frontal recession plus vertex thinning — androgenetic alopecia is clearly manifest. Combination therapy (minoxidil + finasteride) is worth discussing with a doctor.",
+    "advice_4": "Advanced androgenetic alopecia. Medical therapy can slow progression but rarely regrows lost hair. Hair transplantation is increasingly considered from stage 4–5.",
+    "advice_5": "Stages 5–7 typically respond poorly to minoxidil/finasteride alone. Hair transplantation or cosmetic options (scalp micropigmentation, hair systems) are realistic alternatives.",
+    "advice_6": "Very advanced — donor area may still suffice for a transplant, but realistic expectations matter. Scalp micropigmentation is an established alternative.",
+    "advice_7": "Final Norwood stage. Acceptance, scalp micropigmentation, or partial transplantation from the donor area are options. Dermatology consult recommended.",
+    "refTitle": "Norwood-Hamilton stages",
+    "refStage": "Stage",
+    "refDescription": "Description",
+    "howItWorks": "How it works",
+    "howItWorksText": "The Norwood-Hamilton scale was developed by Hamilton (1951) and extended by O'Tar Norwood in 1975. It is the international clinical standard for classifying male androgenetic alopecia (MAGA). The 8 stages (1, 2, 3, 3-vertex, 4, 5, 6, 7) describe the typical course from a youthful hairline to complete loss of the top-of-scalp hair. In this self-assessment you answer 4 questions about temple recession, vertex (crown) thinning, scalp visibility and the hair band — your stage is then computed (score 4–20). The scale's reproducibility has been validated in multiple studies (kappa 0.77–0.82 between self- and clinician-rating).",
+    "disclaimer": "This assessment does not replace a medical diagnosis. Male androgenetic alopecia is the most common form, but other causes (iron deficiency, thyroid disorders, alopecia areata, stress, medications) are possible and should be ruled out for sudden or unusual loss. For diagnosis and treatment decisions, please see a dermatologist.",
+    "faq": [
+      {
+        "q": "What is the Norwood-Hamilton scale?",
+        "a": "The Norwood-Hamilton scale is the internationally recognised classification of male pattern baldness. Hamilton described the stages in 1951; Norwood extended them in 1975 with intermediate stages. It comprises 8 levels (1, 2, 3, 3-vertex, 4, 5, 6, 7) and is the standard in clinical practice, research and hair transplantation."
+      },
+      {
+        "q": "At which stage should I start treatment?",
+        "a": "Stage 3 is the typical entry point for medical therapy. Topical minoxidil 5 % and oral finasteride 1 mg are the only FDA-approved drugs. Both work best in early stages — lost hair is hard to recover, but progression can be stopped."
+      },
+      {
+        "q": "What's the difference between stage 3 and 3-vertex?",
+        "a": "Stage 3 shows only frontal temple recession (M-shape). Stage 3-vertex adds early thinning at the crown. The two zones typically progress independently, which is why Norwood added this distinction."
+      },
+      {
+        "q": "Are my answers private?",
+        "a": "Yes — the calculator runs entirely in your browser. Nothing is sent to a server, nothing is stored, nothing is shared. Just close the tab and your answers are gone."
+      },
+      {
+        "q": "How important is genetics?",
+        "a": "Male pattern baldness is roughly 80 % heritable. The main mechanism is increased follicle sensitivity to dihydrotestosterone (DHT). If your father or maternal grandfather went bald early, your risk is higher — but progression is individual."
+      },
+      {
+        "q": "Does a hair transplant work?",
+        "a": "Yes — from stage 3–4 onwards a transplant is an established option. Requirements: a sufficiently dense donor area at the back of the head and stabilised loss (ideally on finasteride). Methods: FUE (Follicular Unit Extraction) and FUT (strip technique). Realistic outcome: not a full teenage head of hair, but an aesthetically dense hairline."
+      }
+    ]
+  }
+}

--- a/src/pages/MalePatternCalculator.vue
+++ b/src/pages/MalePatternCalculator.vue
@@ -1,0 +1,168 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcMalePatternResult, NORWOOD_STAGES } from '../utils/malePattern.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('malePattern.faq') || [])
+
+useHead(() => ({
+  title: t('malePattern.meta.title'),
+  description: t('malePattern.meta.description'),
+  routeKey: 'malePattern',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Male Pattern Baldness Calculator',
+    url: 'https://healthcalculator.app/male-pattern-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const questionKeys = ['q1', 'q2', 'q3', 'q4']
+const answers = ref([null, null, null, null])
+
+const result = computed(() => calcMalePatternResult(answers.value))
+
+const stageColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.stage) {
+    case '1': return 'text-green-600'
+    case '2': return 'text-green-500'
+    case '3': return 'text-yellow-600'
+    case '3v': return 'text-yellow-700'
+    case '4': return 'text-orange-500'
+    case '5': return 'text-orange-600'
+    case '6': return 'text-red-600'
+    case '7': return 'text-red-700'
+    default: return 'text-stone-600'
+  }
+})
+
+const stageBg = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.stage) {
+    case '1': return 'bg-green-50 border-green-200 text-green-900'
+    case '2': return 'bg-green-50 border-green-200 text-green-900'
+    case '3': return 'bg-yellow-50 border-yellow-200 text-yellow-900'
+    case '3v': return 'bg-yellow-50 border-yellow-300 text-yellow-900'
+    case '4': return 'bg-orange-50 border-orange-200 text-orange-900'
+    case '5': return 'bg-orange-50 border-orange-300 text-orange-900'
+    case '6': return 'bg-red-50 border-red-200 text-red-900'
+    case '7': return 'bg-red-100 border-red-300 text-red-900'
+    default: return 'bg-stone-50 border-stone-200 text-stone-900'
+  }
+})
+
+function reset() {
+  answers.value = [null, null, null, null]
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('malePattern.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('malePattern.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('malePattern.instructionsLabel') }}</p>
+    <p class="text-sm text-stone-600 leading-relaxed mb-6">{{ t('malePattern.instructions') }}</p>
+
+    <div v-for="(qKey, qIdx) in questionKeys" :key="qKey" class="mb-6 pb-6 border-b border-stone-100 last:border-b-0 last:pb-0 last:mb-0">
+      <p class="text-sm font-semibold text-stone-900 mb-3">
+        <span class="text-stone-400">{{ qIdx + 1 }}.</span>
+        {{ t('malePattern.questions.' + qKey + '.text') }}
+      </p>
+      <div class="grid grid-cols-1 md:grid-cols-5 gap-2">
+        <button
+          v-for="opt in 5"
+          :key="opt"
+          @click="answers[qIdx] = opt"
+          :data-testid="qKey + '-option-' + opt"
+          :class="answers[qIdx] === opt ? 'bg-stone-900 text-white border-stone-900' : 'bg-white text-stone-600 border-stone-200 hover:bg-stone-50'"
+          class="text-left text-sm px-4 py-3 rounded-lg border transition-colors duration-150"
+        >
+          <span class="font-semibold mr-1">{{ opt }}.</span>
+          <span>{{ t('malePattern.questions.' + qKey + '.opt' + opt) }}</span>
+        </button>
+      </div>
+    </div>
+
+    <button
+      @click="reset"
+      class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150"
+    >&times; {{ t('malePattern.reset') }}</button>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('malePattern.results') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="norwood-stage">{{ result.stage }}</span>
+      <span class="text-lg text-stone-400">/ 7</span>
+      <span :class="stageColor" class="text-lg font-semibold" data-testid="result-status">{{ t('malePattern.stage_' + result.stage + '_name') }}</span>
+    </div>
+
+    <p class="text-sm text-stone-500 mb-4" data-testid="norwood-score">{{ t('malePattern.scoreLabel') }}: {{ result.score }} / 20</p>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-yellow-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: ((result.score - 4) / 16 * 100) + '%' }"></div>
+    </div>
+
+    <div
+      class="rounded-lg p-4 text-sm font-medium border mb-4"
+      :class="stageBg"
+      data-testid="stage-message"
+    >
+      {{ t('malePattern.advice_' + result.stage) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('malePattern.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('malePattern.refStage') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('malePattern.refDescription') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr v-for="s in NORWOOD_STAGES" :key="s">
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('malePattern.stage_' + s + '_name') }}</td>
+          <td class="px-6 py-3 text-stone-600">{{ t('malePattern.stage_' + s + '_desc') }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('malePattern.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('malePattern.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('malePattern.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="malePattern" />
+</template>

--- a/src/pages/blog/HaarausfallNorwoodSkala.vue
+++ b/src/pages/blog/HaarausfallNorwoodSkala.vue
@@ -1,0 +1,181 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Haarausfall bei Männern: Norwood-Hamilton-Skala, Ursachen und Behandlung | Health Calculators',
+  description: 'Androgenetischen Haarausfall mit der Norwood-Hamilton-Skala einschätzen. Stadien, Ursachen, Minoxidil/Finasterid und Haartransplantation — evidenzbasiert und kostenlos.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Haarausfall bei Männern: Norwood-Hamilton-Skala, Ursachen und Behandlung',
+    description: 'Androgenetischen Haarausfall mit der Norwood-Hamilton-Skala einschätzen. Stadien, Ursachen, Minoxidil/Finasterid und Haartransplantation — evidenzbasiert und kostenlos.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-02',
+    dateModified: '2026-05-02',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/haarausfall-norwood-skala',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Haarausfall bei Männern: Norwood-Hamilton-Skala, Ursachen und Behandlung</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">2. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Etwa <strong>50 % der Männer haben mit 50 sichtbaren Haarausfall</strong> — bei den 70-Jährigen sind es 80 %. Die Ursache ist meistens dieselbe: <strong>androgenetische Alopezie</strong>, ein genetisch bedingter Verlust durch Empfindlichkeit der Haarfollikel gegenüber DHT (Dihydrotestosteron).
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die <strong>Norwood-Hamilton-Skala</strong> ist seit 1975 der klinische Standard, um das Stadium des Verlusts in 8 Stufen einzuordnen. Dieser Artikel erklärt die Skala, die häufigsten Ursachen und welche Therapie wann sinnvoll ist.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist die Norwood-Hamilton-Skala?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          James Hamilton beschrieb 1951 erstmals systematisch die typischen Muster des männlichen Haarausfalls. <strong>O'Tar Norwood</strong> erweiterte das Schema 1975 um Zwischenstadien — vor allem das wichtige <strong>Stadium 3-Vertex</strong>, in dem zusätzlich zur Stirn auch der Wirbel betroffen ist.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Heute wird die Skala weltweit in der dermatologischen Praxis, in klinischen Studien und in der Haartransplantation als Standard verwendet — die Reproduzierbarkeit zwischen Selbst- und Arzt-Bewertung liegt bei <strong>Kappa 0,77–0,82</strong> (sehr gut).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die 8 Stadien im Überblick</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Stadium</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Beschreibung</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfehlung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">1</td><td class="px-6 py-3 text-stone-600">Jugendliche Haarlinie</td><td class="px-6 py-3 text-stone-600">Beobachten</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">2</td><td class="px-6 py-3 text-stone-600">Reife Haarlinie, leichte Schläfendreiecke</td><td class="px-6 py-3 text-stone-600">Foto-Baseline</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">3</td><td class="px-6 py-3 text-stone-600">M-Form, klinisch relevant</td><td class="px-6 py-3 text-stone-600">Minoxidil / Finasterid</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">3-Vertex</td><td class="px-6 py-3 text-stone-600">M-Form plus Tonsur</td><td class="px-6 py-3 text-stone-600">Kombi-Therapie</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">4</td><td class="px-6 py-3 text-stone-600">Tiefe Geheimratsecken + Tonsur</td><td class="px-6 py-3 text-stone-600">Therapie + ggf. Transplantation</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">5</td><td class="px-6 py-3 text-stone-600">Bereiche verschmelzen</td><td class="px-6 py-3 text-stone-600">Transplantation evaluieren</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">6</td><td class="px-6 py-3 text-stone-600">Haarband verschwunden</td><td class="px-6 py-3 text-stone-600">Transplantation / Mikropigmentierung</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">7</td><td class="px-6 py-3 text-stone-600">Nur Seitenkranz</td><td class="px-6 py-3 text-stone-600">Mikropigmentierung / Akzeptanz</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum Männer Haare verlieren — die Biologie</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Im Zentrum steht <strong>DHT (Dihydrotestosteron)</strong> — ein potentes Androgen, das aus Testosteron durch das Enzym <em>5-alpha-Reduktase</em> entsteht. Bei genetisch empfindlichen Haarfollikeln (vor allem an Stirn und Wirbel) bindet DHT an Androgenrezeptoren und löst eine schrittweise <strong>Miniaturisierung</strong> aus: Der Haarzyklus verkürzt sich, neue Haare werden dünner und kürzer, bis der Follikel ganz aufhört zu produzieren.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wichtig: Die Haare an Hinterkopf und Seiten — der spätere <strong>Spenderbereich</strong> für Transplantationen — sind genetisch DHT-resistent und bleiben fast immer erhalten. Das ist die biologische Grundlage, warum Haartransplantationen überhaupt funktionieren.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-sm text-stone-600 leading-relaxed">
+            <strong>Vererbung:</strong> Androgenetischer Haarausfall ist zu rund 80 % genetisch bedingt. Nicht nur die mütterliche Linie spielt eine Rolle (das ist ein verbreitetes Missverständnis) — Studien zeigen Beiträge von beiden Elternteilen.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was wirklich hilft — evidenzbasiert</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Minoxidil 5 % (topisch)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              FDA- und EMA-zugelassen. Verlängert die Wachstumsphase und stimuliert die Durchblutung. Wirkung nach 3–6 Monaten sichtbar, lebenslang anzuwenden — beim Absetzen kommt der Verlust zurück. Erfolg: 60–70 % stoppen den Verlust, 30–40 % bekommen sichtbar dichteres Haar.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Finasterid 1 mg (oral)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Hemmt die 5-alpha-Reduktase und senkt DHT um etwa 70 %. In Studien stoppt es den Verlust bei 90 % und verbessert die Dichte bei 65 % der Männer. Verschreibungspflichtig. Nebenwirkungen (Libido, Stimmung) bei 1–3 %, meist reversibel — vorab gut mit dem Arzt besprechen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Haartransplantation (FUE / FUT)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Ab Stadium 3–4 sinnvoll, wenn der Verlust stabilisiert ist. <strong>FUE</strong> entnimmt einzelne Follikel-Einheiten — wenig Narben, längere OP-Zeit. <strong>FUT</strong> entnimmt einen Streifen und teilt ihn — dichteres Ergebnis, sichtbare Narbe. Realistisch: kein voller Schopf wie mit 18, aber eine ästhetisch dichte Linie.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Skalp-Mikropigmentierung (SMP)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Tätowierähnliche Punkte simulieren Stoppelhaar — vor allem bei Stadium 6–7 oder als Ergänzung zur Transplantation. Kein nachwachsendes Haar, aber visuell dichteres Erscheinungsbild bei Kurzhaarschnitten.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt dein Norwood-Stadium ermitteln</h3>
+        <p class="text-stone-300 text-sm mb-5">4 Fragen, sofortiges Stadium nach Norwood-Hamilton, anonym und ohne Anmeldung — direkt im Browser.</p>
+        <router-link
+          :to="localePath('malePattern')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos einschätzen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann zum Arzt?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Norwood-Stadien beschreiben nur den typischen androgenetischen Haarausfall. Bei <strong>plötzlichem, fleckigem oder schubweisem</strong> Verlust solltest du einen Dermatologen aufsuchen — andere Ursachen müssen ausgeschlossen werden:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Eisenmangel</strong> (vor allem bei Vegetariern oder Sportlern)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Schilddrüsenstörungen</strong> (Hyper- und Hypothyreose)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Alopecia areata</strong> (kreisrunder Haarausfall — autoimmun)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Telogenes Effluvium</strong> (Stress, Operation, hohes Fieber 2–3 Monate vorher)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Medikamente</strong> (Chemotherapie, Beta-Blocker, manche Antidepressiva)</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Männergesundheit hängt zusammen — neben dem Haarstatus lohnt sich ein Blick auf den
+          <router-link :to="localeBlogPath('testosteronwert-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Testosteron-Rechner</router-link>
+          (Hypogonadismus ausschließen), den
+          <router-link :to="localeBlogPath('erektile-dysfunktion-test')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">IIEF-5-Test</router-link>
+          für erektile Funktion und das
+          <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biologische Alter</router-link>
+          als Gesamt-Marker.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die Norwood-Hamilton-Skala gibt dir eine klare Sprache für ein Thema, das viele Männer schweigend erleben. Wer früh sein Stadium kennt (typischerweise Stadium 2–3), hat die besten Chancen, den Verlust mit Minoxidil oder Finasterid zu stoppen. Nutze unseren
+          <router-link :to="localePath('malePattern')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Norwood-Rechner</router-link>
+          für die anonyme Selbsteinschätzung — und sprich bei auffälligen Stadien mit einem Dermatologen.
+        </p>
+      </div>
+
+      <RelatedArticles slug="haarausfall-norwood-skala" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/MalePatternBaldnessNorwood.vue
+++ b/src/pages/blog/en/MalePatternBaldnessNorwood.vue
@@ -1,0 +1,181 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Male Pattern Baldness: Norwood-Hamilton Scale, Causes and Treatment | Health Calculators',
+  description: 'Assess male androgenetic alopecia with the Norwood-Hamilton scale. Stages, causes, minoxidil/finasteride and hair transplantation — evidence-based and free.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Male Pattern Baldness: Norwood-Hamilton Scale, Causes and Treatment',
+    description: 'Assess male androgenetic alopecia with the Norwood-Hamilton scale. Stages, causes, minoxidil/finasteride and hair transplantation — evidence-based and free.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-02',
+    dateModified: '2026-05-02',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/male-pattern-baldness-norwood',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Male Pattern Baldness: Norwood-Hamilton Scale, Causes and Treatment</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 2, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          By age 50, roughly <strong>half of all men have visible hair loss</strong> — by 70, about 80 % do. The cause is almost always the same: <strong>androgenetic alopecia</strong>, a genetically driven loss caused by follicle sensitivity to DHT (dihydrotestosterone).
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The <strong>Norwood-Hamilton scale</strong> has been the clinical standard since 1975 for grading the stage of loss across 8 levels. This article explains the scale, the most common causes, and which treatment makes sense at which stage.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is the Norwood-Hamilton scale?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          James Hamilton was the first to systematically describe the typical patterns of male hair loss in 1951. <strong>O'Tar Norwood</strong> extended the scheme in 1975, adding intermediate stages — most notably the important <strong>stage 3-vertex</strong>, where the crown is affected in addition to the frontal hairline.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Today the scale is used worldwide in dermatology, clinical research and hair transplantation. Reproducibility between self- and clinician-rating is <strong>kappa 0.77–0.82</strong> (very good).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The 8 stages at a glance</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Stage</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Description</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Action</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">1</td><td class="px-6 py-3 text-stone-600">Youthful hairline</td><td class="px-6 py-3 text-stone-600">Monitor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">2</td><td class="px-6 py-3 text-stone-600">Mature hairline, slight temple recession</td><td class="px-6 py-3 text-stone-600">Photo baseline</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">3</td><td class="px-6 py-3 text-stone-600">M-shape, clinically relevant</td><td class="px-6 py-3 text-stone-600">Minoxidil / finasteride</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">3-vertex</td><td class="px-6 py-3 text-stone-600">M-shape plus crown thinning</td><td class="px-6 py-3 text-stone-600">Combination therapy</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">4</td><td class="px-6 py-3 text-stone-600">Deep recession + vertex</td><td class="px-6 py-3 text-stone-600">Therapy ± transplant</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">5</td><td class="px-6 py-3 text-stone-600">Zones merging</td><td class="px-6 py-3 text-stone-600">Evaluate transplant</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">6</td><td class="px-6 py-3 text-stone-600">Hair band lost</td><td class="px-6 py-3 text-stone-600">Transplant / SMP</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">7</td><td class="px-6 py-3 text-stone-600">Horseshoe only</td><td class="px-6 py-3 text-stone-600">SMP / acceptance</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why men lose hair — the biology</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The central player is <strong>DHT (dihydrotestosterone)</strong> — a potent androgen produced from testosterone by the enzyme <em>5-alpha-reductase</em>. In genetically sensitive follicles (mainly at the front and crown), DHT binds to androgen receptors and triggers a stepwise <strong>miniaturisation</strong>: the hair cycle shortens, new hairs come in thinner and shorter until the follicle stops producing altogether.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Importantly, the hair at the back and sides — the future <strong>donor area</strong> for transplants — is genetically DHT-resistant and almost always preserved. That is the biological reason hair transplantation works at all.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-sm text-stone-600 leading-relaxed">
+            <strong>Heredity:</strong> Male pattern baldness is roughly 80 % genetic. The maternal line is not the only contributor (a common myth) — studies show meaningful contribution from both parents.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What actually works — evidence-based</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Topical minoxidil 5 %</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              FDA- and EMA-approved. Extends the growth phase and stimulates blood flow to the follicle. Visible effect after 3–6 months, lifelong use — when you stop, loss returns. Outcomes: 60–70 % halt the loss, 30–40 % see visibly denser hair.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Oral finasteride 1 mg</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Inhibits 5-alpha-reductase, lowering DHT by ~70 %. In trials it stops loss in 90 % and improves density in 65 % of men. Prescription-only. Side effects (libido, mood) in 1–3 %, mostly reversible — discuss with your doctor first.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Hair transplantation (FUE / FUT)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Reasonable from stage 3–4 once loss is stable. <strong>FUE</strong> harvests individual follicular units — minimal scarring, longer surgery. <strong>FUT</strong> takes a strip and divides it — denser yield, visible scar. Realistic outcome: not a teenage head of hair, but an aesthetically dense hairline.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Scalp micropigmentation (SMP)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Tattoo-like dots simulate stubble — especially useful for stages 6–7 or to complement a transplant. No regrowth, but a visually denser appearance with short hairstyles.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Find out your Norwood stage now</h3>
+        <p class="text-stone-300 text-sm mb-5">4 questions, instant Norwood-Hamilton stage, anonymous and no sign-up — runs entirely in your browser.</p>
+        <router-link
+          :to="localePath('malePattern')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Take the assessment for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">When to see a doctor</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Norwood stages describe typical androgenetic alopecia. For <strong>sudden, patchy or episodic</strong> loss, see a dermatologist — other causes need to be ruled out:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Iron deficiency</strong> (especially in vegetarians and athletes)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Thyroid disorders</strong> (hyper- and hypothyroidism)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Alopecia areata</strong> (autoimmune patchy loss)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Telogen effluvium</strong> (stress, surgery, high fever 2–3 months earlier)</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Medications</strong> (chemotherapy, beta-blockers, some antidepressants)</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Men's health is interconnected — beyond the hair status it's worth checking your
+          <router-link :to="localeBlogPath('testosterone-level-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">testosterone level</router-link>
+          (rule out hypogonadism), the
+          <router-link :to="localeBlogPath('erectile-dysfunction-iief-5')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">IIEF-5 erectile function test</router-link>
+          and your
+          <router-link :to="localeBlogPath('biological-age-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biological age</router-link>
+          as a holistic marker.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The Norwood-Hamilton scale gives you a clear language for a topic many men experience in silence. Knowing your stage early (typically 2–3) gives the best odds of stopping loss with minoxidil or finasteride. Use our
+          <router-link :to="localePath('malePattern')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Norwood calculator</router-link>
+          for an anonymous self-assessment — and bring concerning stages to a dermatologist.
+        </p>
+      </div>
+
+      <RelatedArticles slug="male-pattern-baldness-norwood" />
+    </div>
+  </article>
+</template>

--- a/src/pages/malePattern.meta.js
+++ b/src/pages/malePattern.meta.js
@@ -1,0 +1,16 @@
+import Component from './MalePatternCalculator.vue'
+import BlogDe from './blog/HaarausfallNorwoodSkala.vue'
+import BlogEn from './blog/en/MalePatternBaldnessNorwood.vue'
+
+export default {
+  key: 'malePattern',
+  component: Component,
+  slugs: { de: 'haarausfall-rechner-maenner', en: 'male-pattern-baldness-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 30,
+  blog: {
+    de: { slug: 'haarausfall-norwood-skala', component: BlogDe },
+    en: { slug: 'male-pattern-baldness-norwood', component: BlogEn },
+  },
+}

--- a/src/utils/malePattern.js
+++ b/src/utils/malePattern.js
@@ -1,0 +1,55 @@
+// Norwood-Hamilton classification of male pattern baldness (androgenetic alopecia).
+// Original scale: Hamilton (1951), modified by Norwood (1975).
+// Stages 1, 2, 3, 3v, 4, 5, 6, 7 — increasing severity.
+//
+// Self-assessment: 4 questions about hairline recession at temples, vertex/crown
+// thinning, scalp visibility on top, and density at sides/back. Each scored 1–5.
+// Total range: 4–20. Mapping to Norwood stages:
+//   4– 5  Stage 1 (no loss)
+//   6– 7  Stage 2 (mature hairline)
+//   8– 9  Stage 3 (frontal recession)
+//  10–11  Stage 3v (frontal + vertex)
+//  12–13  Stage 4 (advanced front + crown)
+//  14–15  Stage 5 (zones merging)
+//  16–17  Stage 6 (band lost)
+//  18–20  Stage 7 (sides/back only)
+
+const STAGES = ['1', '2', '3', '3v', '4', '5', '6', '7']
+
+function isValidAnswer(a) {
+  return Number.isInteger(a) && a >= 1 && a <= 5
+}
+
+export function calcNorwoodScore(answers) {
+  if (!Array.isArray(answers) || answers.length !== 4) return null
+  if (!answers.every(isValidAnswer)) return null
+  return answers.reduce((sum, a) => sum + a, 0)
+}
+
+export function classifyNorwood(score) {
+  if (!Number.isFinite(score) || score < 4 || score > 20) return null
+  if (score <= 5) return '1'
+  if (score <= 7) return '2'
+  if (score <= 9) return '3'
+  if (score <= 11) return '3v'
+  if (score <= 13) return '4'
+  if (score <= 15) return '5'
+  if (score <= 17) return '6'
+  return '7'
+}
+
+export function calcMalePatternResult(answers) {
+  const score = calcNorwoodScore(answers)
+  if (score === null) return null
+  const stage = classifyNorwood(score)
+  const stageIndex = STAGES.indexOf(stage)
+  return {
+    score,
+    stage,
+    stageIndex,
+    hasLoss: stage !== '1',
+    isAdvanced: stageIndex >= 4,
+  }
+}
+
+export const NORWOOD_STAGES = STAGES


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-147-male-pattern
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-147-male-pattern-20260502-120002`
**Cost:** $7.52058625

Closes jenslaufer/health-calculators#147

### Prompt
> Implement the Male Pattern Calculator as described in issue #147.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Norwood-Hamilton hair loss stage assessment
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/malePattern.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/malePattern.test.js` with 6+ test cases covering edge cases. Run `npm test -- malePattern` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/MalePatternCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/malePattern.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/malePattern.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'malePattern'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/malePattern.json` + `src/locales/calculators/en/malePattern.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/malePattern.js (or shared util — verify pattern in repo first)`
- `src/__tests__/malePattern.test.js`
- `src/pages/MalePatternCalculator.vue`
- `src/pages/malePattern.meta.js`
- `src/locales/calculators/de/malePattern.json`
- `src/locales/calculators/en/malePattern.json`
- `e2e/malePattern.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'malePattern',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks