### PR TITLE
hc-148-cardiovascular-risk: Implement the Cardiovascular Risk Calculator as described in

### DIFF
--- a/e2e/cardiovascularRisk.spec.js
+++ b/e2e/cardiovascularRisk.spec.js
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/herz-kreislauf-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Herz-Kreislauf-Risiko/)
+})
+
+test('low-risk profile (40, healthy) → low band', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('40')
+  await page.getByTestId('total-chol').fill('180')
+  await page.getByTestId('hdl').fill('60')
+  await page.getByTestId('sbp').fill('110')
+
+  const result = page.getByTestId('risk-result')
+  await expect(result).toBeVisible()
+  const risk = parseFloat(await result.textContent())
+  expect(risk).toBeGreaterThan(0)
+  expect(risk).toBeLessThan(5)
+
+  await expect(page.getByTestId('result-status')).toHaveText('Niedrig')
+})
+
+test('high-risk profile (65 male, smoker, diabetic, hypertensive) → high band', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('65')
+  await page.getByTestId('total-chol').fill('260')
+  await page.getByTestId('hdl').fill('35')
+  await page.getByTestId('sbp').fill('160')
+  await page.getByTestId('treated').check()
+  await page.getByTestId('smoker').check()
+  await page.getByTestId('diabetic').check()
+
+  const result = page.getByTestId('risk-result')
+  await expect(result).toBeVisible()
+  const risk = parseFloat(await result.textContent())
+  expect(risk).toBeGreaterThan(20)
+
+  await expect(page.getByTestId('result-status')).toHaveText('Hoch')
+})
+
+test('shows heart age', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('50')
+  await page.getByTestId('total-chol').fill('220')
+  await page.getByTestId('hdl').fill('45')
+  await page.getByTestId('sbp').fill('140')
+
+  await expect(page.getByTestId('heart-age')).toBeVisible()
+})
+
+test('shows advice block', async ({ page }) => {
+  await page.getByTestId('sex-female').click()
+  await page.getByTestId('age').fill('55')
+  await page.getByTestId('total-chol').fill('210')
+  await page.getByTestId('hdl').fill('55')
+  await page.getByTestId('sbp').fill('125')
+
+  await expect(page.getByTestId('advice')).toBeVisible()
+})
+
+test('mmol/L unit toggle works', async ({ page }) => {
+  await page.getByTestId('unit-mmol').click()
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('50')
+  await page.getByTestId('total-chol').fill('5.2')
+  await page.getByTestId('hdl').fill('1.3')
+  await page.getByTestId('sbp').fill('120')
+
+  const result = page.getByTestId('risk-result')
+  await expect(result).toBeVisible()
+  const risk = parseFloat(await result.textContent())
+  expect(risk).toBeGreaterThan(0)
+  expect(risk).toBeLessThan(15)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -21,7 +21,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
-  'malePattern',
+  'malePattern', 'cardiovascularRisk',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -75,6 +75,7 @@ const EXPECTED_ROUTE_MAP = {
   testosteroneLevel: { de: 'testosteron-rechner', en: 'testosterone-level-calculator' },
   erectileDysfunction: { de: 'erektile-dysfunktion-rechner', en: 'erectile-dysfunction-calculator' },
   malePattern: { de: 'haarausfall-rechner-maenner', en: 'male-pattern-baldness-calculator' },
+  cardiovascularRisk: { de: 'herz-kreislauf-risiko-rechner', en: 'cardiovascular-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -116,6 +117,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'testosteronwert-berechnen',
   'erektile-dysfunktion-test',
   'haarausfall-norwood-skala',
+  'herz-kreislauf-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -157,19 +159,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'testosterone-level-calculator',
   'erectile-dysfunction-iief-5',
   'male-pattern-baldness-norwood',
+  'cardiovascular-risk-framingham',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 52 calculators', () => {
-    expect(calculatorMetas).toHaveLength(52)
+  it('discovers all 53 calculators', () => {
+    expect(calculatorMetas).toHaveLength(53)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 52 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(52)
+  it('builds calculatorComponents map for all 53 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(53)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -192,15 +195,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 50 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(50)
+  it('discovers all 51 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(51)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 50 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(50)
+  it('discovers all 51 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(51)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -216,10 +219,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 51 calculators with no duplicates', () => {
+  it('groups contain all 53 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(52)
-    expect(new Set(allKeys).size).toBe(52)
+    expect(allKeys).toHaveLength(53)
+    expect(new Set(allKeys).size).toBe(53)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -240,7 +243,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk',
     ])
   })
 
@@ -288,8 +291,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 296 routes', () => {
-    expect(routes).toHaveLength(296)
+  it('generates exactly 301 routes', () => {
+    expect(routes).toHaveLength(301)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/cardiovascularRisk.test.js
+++ b/src/__tests__/cardiovascularRisk.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { calcCardiovascularRisk, classifyRisk } from '../utils/cardiovascularRisk.js'
+
+// 10-year cardiovascular risk based on D'Agostino's Framingham general CVD model
+// (Circulation 2008). Inputs: age, sex, total cholesterol, HDL, systolic BP,
+// BP treatment, smoking, diabetes. Output: percentage risk + category.
+
+describe('Framingham CVD risk — input validation', () => {
+  it('returns null for missing required inputs', () => {
+    expect(calcCardiovascularRisk({})).toBeNull()
+    expect(calcCardiovascularRisk({ age: 50, sex: 'male' })).toBeNull()
+  })
+
+  it('returns null for out-of-range age (model validated 30-79)', () => {
+    const base = {
+      sex: 'male', totalChol: 200, hdl: 50,
+      systolicBP: 120, treated: false, smoker: false, diabetic: false,
+    }
+    expect(calcCardiovascularRisk({ ...base, age: 25 })).toBeNull()
+    expect(calcCardiovascularRisk({ ...base, age: 85 })).toBeNull()
+  })
+
+  it('returns null for non-positive cholesterol or BP', () => {
+    const base = {
+      age: 50, sex: 'male', totalChol: 200, hdl: 50,
+      systolicBP: 120, treated: false, smoker: false, diabetic: false,
+    }
+    expect(calcCardiovascularRisk({ ...base, totalChol: 0 })).toBeNull()
+    expect(calcCardiovascularRisk({ ...base, hdl: -1 })).toBeNull()
+    expect(calcCardiovascularRisk({ ...base, systolicBP: 0 })).toBeNull()
+  })
+})
+
+describe('Framingham CVD risk — male profiles', () => {
+  it('low risk: 40 y/o male, healthy values → <5 %', () => {
+    const r = calcCardiovascularRisk({
+      age: 40, sex: 'male', totalChol: 180, hdl: 60,
+      systolicBP: 110, treated: false, smoker: false, diabetic: false,
+    })
+    expect(r.risk).toBeGreaterThan(0)
+    expect(r.risk).toBeLessThan(5)
+    expect(r.category).toBe('low')
+  })
+
+  it('high risk: 65 y/o male smoker, hypertension, diabetes → >20 %', () => {
+    const r = calcCardiovascularRisk({
+      age: 65, sex: 'male', totalChol: 260, hdl: 35,
+      systolicBP: 160, treated: true, smoker: true, diabetic: true,
+    })
+    expect(r.risk).toBeGreaterThan(20)
+    expect(r.category).toBe('high')
+  })
+
+  it('intermediate risk: 55 y/o male moderate values', () => {
+    const r = calcCardiovascularRisk({
+      age: 55, sex: 'male', totalChol: 220, hdl: 45,
+      systolicBP: 135, treated: false, smoker: false, diabetic: false,
+    })
+    expect(r.risk).toBeGreaterThan(7.5)
+    expect(r.risk).toBeLessThan(20)
+    expect(r.category).toBe('intermediate')
+  })
+})
+
+describe('Framingham CVD risk — female profiles', () => {
+  it('low risk: 40 y/o female, healthy values → <5 %', () => {
+    const r = calcCardiovascularRisk({
+      age: 40, sex: 'female', totalChol: 180, hdl: 65,
+      systolicBP: 110, treated: false, smoker: false, diabetic: false,
+    })
+    expect(r.risk).toBeLessThan(5)
+    expect(r.category).toBe('low')
+  })
+
+  it('high risk: 70 y/o female smoker with hypertension and diabetes', () => {
+    const r = calcCardiovascularRisk({
+      age: 70, sex: 'female', totalChol: 260, hdl: 35,
+      systolicBP: 165, treated: true, smoker: true, diabetic: true,
+    })
+    expect(r.risk).toBeGreaterThan(20)
+    expect(r.category).toBe('high')
+  })
+
+  it('women have lower risk than men with identical inputs', () => {
+    const base = {
+      age: 55, totalChol: 220, hdl: 45,
+      systolicBP: 140, treated: false, smoker: true, diabetic: false,
+    }
+    const male = calcCardiovascularRisk({ ...base, sex: 'male' })
+    const female = calcCardiovascularRisk({ ...base, sex: 'female' })
+    expect(female.risk).toBeLessThan(male.risk)
+  })
+})
+
+describe('Framingham CVD risk — risk factor effects', () => {
+  const base = {
+    age: 55, sex: 'male', totalChol: 200, hdl: 50,
+    systolicBP: 130, treated: false, smoker: false, diabetic: false,
+  }
+
+  it('smoking increases risk', () => {
+    const noSmoke = calcCardiovascularRisk(base)
+    const smoke = calcCardiovascularRisk({ ...base, smoker: true })
+    expect(smoke.risk).toBeGreaterThan(noSmoke.risk)
+  })
+
+  it('diabetes increases risk', () => {
+    const noDm = calcCardiovascularRisk(base)
+    const dm = calcCardiovascularRisk({ ...base, diabetic: true })
+    expect(dm.risk).toBeGreaterThan(noDm.risk)
+  })
+
+  it('higher SBP increases risk', () => {
+    const lowBp = calcCardiovascularRisk({ ...base, systolicBP: 110 })
+    const highBp = calcCardiovascularRisk({ ...base, systolicBP: 170 })
+    expect(highBp.risk).toBeGreaterThan(lowBp.risk)
+  })
+
+  it('higher HDL decreases risk', () => {
+    const lowHdl = calcCardiovascularRisk({ ...base, hdl: 30 })
+    const highHdl = calcCardiovascularRisk({ ...base, hdl: 75 })
+    expect(highHdl.risk).toBeLessThan(lowHdl.risk)
+  })
+
+  it('treated BP at the same SBP is slightly higher risk than untreated', () => {
+    const untreated = calcCardiovascularRisk({ ...base, systolicBP: 150, treated: false })
+    const treated = calcCardiovascularRisk({ ...base, systolicBP: 150, treated: true })
+    expect(treated.risk).toBeGreaterThan(untreated.risk)
+  })
+})
+
+describe('Cholesterol unit conversion', () => {
+  it('mmol/L input gives same result as equivalent mg/dL input', () => {
+    // 200 mg/dL ≈ 5.17 mmol/L  (factor 38.67)
+    const mg = calcCardiovascularRisk({
+      age: 50, sex: 'male', totalChol: 200, hdl: 50,
+      systolicBP: 120, treated: false, smoker: false, diabetic: false,
+      cholUnit: 'mgdl',
+    })
+    const mmol = calcCardiovascularRisk({
+      age: 50, sex: 'male', totalChol: 5.17, hdl: 1.29,
+      systolicBP: 120, treated: false, smoker: false, diabetic: false,
+      cholUnit: 'mmol',
+    })
+    expect(Math.abs(mg.risk - mmol.risk)).toBeLessThan(0.5)
+  })
+})
+
+describe('Risk categorisation thresholds', () => {
+  it('classifies <5 % as low', () => {
+    expect(classifyRisk(2)).toBe('low')
+    expect(classifyRisk(4.9)).toBe('low')
+  })
+  it('classifies 5-7.5 % as borderline', () => {
+    expect(classifyRisk(5)).toBe('borderline')
+    expect(classifyRisk(7.4)).toBe('borderline')
+  })
+  it('classifies 7.5-20 % as intermediate', () => {
+    expect(classifyRisk(7.5)).toBe('intermediate')
+    expect(classifyRisk(19.9)).toBe('intermediate')
+  })
+  it('classifies ≥20 % as high', () => {
+    expect(classifyRisk(20)).toBe('high')
+    expect(classifyRisk(35)).toBe('high')
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 204 links (52 calcs × 2 locales + 50 blogs × 2 locales)', () => {
+  it('generates 208 links (53 calcs × 2 locales + 51 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(204)
+    expect(links).toHaveLength(208)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -99,9 +99,9 @@ const EXPECTED_BLOG_SLUGS_EN = [
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 52 calculator meta files', () => {
+  it('discovers all 53 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(52)
+    expect(metas).toHaveLength(53)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -139,19 +139,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 50 DE blog slugs', () => {
+  it('returns all 51 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(50)
+    expect(de).toHaveLength(51)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 50 EN blog slugs', () => {
+  it('returns all 51 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(50)
+    expect(en).toHaveLength(51)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -219,9 +219,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 104 calcs + 2 blog index + 100 blog articles = 208)', () => {
+  it('generates correct total URL count (2 home + 106 calcs + 2 blog index + 102 blog articles = 212)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(208)
+    expect(urlCount).toBe(212)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -449,6 +449,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'malePattern',
     related: ['testosterone-level-calculator', 'erectile-dysfunction-iief-5', 'biological-age-calculator'],
   },
+  {
+    slug: 'cardiovascular-risk-framingham',
+    title: 'Cardiovascular Risk Calculator: Framingham, SCORE2 and What the Numbers Mean',
+    description: 'Estimate your 10-year risk of heart attack and stroke with Framingham/SCORE2. Cholesterol, blood pressure, lifestyle — and what actually moves the needle.',
+    date: '2026-05-02',
+    readTime: '9 min',
+    calculatorKey: 'cardiovascularRisk',
+    related: ['cholesterol-ratio', 'diabetes-risk-score', 'measure-blood-pressure'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -449,6 +449,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'malePattern',
     related: ['testosteronwert-berechnen', 'erektile-dysfunktion-test', 'biologisches-alter-berechnen'],
   },
+  {
+    slug: 'herz-kreislauf-risiko-berechnen',
+    title: 'Herz-Kreislauf-Risiko berechnen: Framingham, SCORE2 und was die Werte bedeuten',
+    description: 'Berechne dein 10-Jahres-Risiko für Herzinfarkt und Schlaganfall mit Framingham/SCORE2. Cholesterin, Blutdruck, Lebensstil — und was wirklich hilft.',
+    date: '2026-05-02',
+    readTime: '9 min',
+    calculatorKey: 'cardiovascularRisk',
+    related: ['cholesterol-verhaeltnis-rechner', 'diabetes-risiko-berechnen', 'blutdruck-richtig-messen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/cardiovascularRisk.json
+++ b/src/locales/calculators/de/cardiovascularRisk.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "cardiovascularRisk": {
+        "name": "Herz-Kreislauf-Risiko-Rechner",
+        "description": "Berechne dein 10-Jahres-Risiko für Herzinfarkt oder Schlaganfall (Framingham)."
+      }
+    }
+  },
+  "cardiovascularRisk": {
+    "meta": {
+      "title": "Herz-Kreislauf-Risiko berechnen — Framingham 10-Jahres-Risiko",
+      "description": "Berechne dein 10-Jahres-Risiko für Herzinfarkt und Schlaganfall mit dem Framingham-Score. Inkl. Herzalter, Risikoeinordnung und Empfehlungen — kostenlos, anonym."
+    },
+    "title": "Herz-Kreislauf-Risiko-Rechner",
+    "description": "Schätze dein 10-Jahres-Risiko für eine Herz-Kreislauf-Erkrankung mit der Framingham-Formel.",
+    "age": "Alter",
+    "totalChol": "Gesamtcholesterin",
+    "hdl": "HDL-Cholesterin",
+    "sbp": "Systolischer Blutdruck",
+    "treated": "Blutdruckmedikamente",
+    "smoker": "Aktueller Raucher",
+    "diabetic": "Diabetes mellitus",
+    "reset": "Zurücksetzen",
+    "results": "Ergebnis",
+    "tenYearLabel": "Geschätztes 10-Jahres-Risiko für Herzinfarkt oder Schlaganfall.",
+    "heartAge": "Herzalter",
+    "years": "Jahre",
+    "heartAgeOlder": "Dein Herz ist {years} Jahre älter als dein tatsächliches Alter.",
+    "heartAgeYounger": "Dein Herz ist {years} Jahre jünger als dein tatsächliches Alter.",
+    "cat_low": "Niedrig",
+    "cat_borderline": "Grenzwertig",
+    "cat_intermediate": "Mittel",
+    "cat_high": "Hoch",
+    "advice_low": "Geringes 10-Jahres-Risiko. Beibehalten: nicht rauchen, regelmäßige Bewegung, mediterrane Ernährung. Routinekontrolle alle 4–6 Jahre.",
+    "advice_borderline": "Grenzwertiges Risiko. Lebensstil intensivieren: 150 min/Woche Ausdauersport, Gewichtsoptimierung, Cholesterin- und Blutdruckkontrolle alle 1–2 Jahre.",
+    "advice_intermediate": "Mittleres Risiko. Mit Hausarzt besprechen: ggf. Statin-Indikation prüfen, Blutdruck optimieren, Diabetes-Screening, Bewegung intensivieren.",
+    "advice_high": "Hohes Risiko. Ärztliche Abklärung empfohlen — Statin-Therapie, Blutdrucksenkung und Lebensstiländerung sind in der Regel indiziert. ESC-Leitlinie 2021.",
+    "refTitle": "Risikokategorien (AHA/ACC)",
+    "refRange": "10-Jahres-Risiko",
+    "refCategory": "Kategorie",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Dieser Rechner verwendet das D'Agostino-Modell (General CVD Framingham, Circulation 2008). Berücksichtigt: Alter, Geschlecht, Gesamt- und HDL-Cholesterin, systolischer Blutdruck (mit/ohne Therapie), Rauchen, Diabetes. Validiert für 30–79 Jahre. Ergebnis: 10-Jahres-Wahrscheinlichkeit für Herzinfarkt, Schlaganfall, Herzinsuffizienz oder peripheren Gefäßverschluss.",
+    "disclaimer": "Hinweis: Dieser Rechner ersetzt keine ärztliche Diagnose. Bei erhöhtem Risiko, Brustschmerzen, Kurzatmigkeit oder familiärer Vorbelastung suche zeitnah deinen Hausarzt oder Kardiologen auf.",
+    "faq": [
+      {
+        "q": "Was bedeutet das 10-Jahres-Risiko?",
+        "a": "Es schätzt die Wahrscheinlichkeit, in den nächsten 10 Jahren eine Herz-Kreislauf-Erkrankung (Infarkt, Schlaganfall, Herzinsuffizienz, periphere Verschlusskrankheit) zu erleiden. Der Wert basiert auf statistischen Modellen großer Kohortenstudien."
+      },
+      {
+        "q": "Was unterscheidet Framingham von SCORE2?",
+        "a": "Framingham (USA) misst tödliche und nicht-tödliche Ereignisse, validiert für 30–79 Jahre. SCORE2 (Europa, ESC 2021) wurde an europäische Kohorten neu kalibriert und ist offizielle Empfehlung der ESC für 40–69 Jahre. Beide liefern ähnliche Risikoabschätzungen."
+      },
+      {
+        "q": "Was ist das Herzalter?",
+        "a": "Das Herzalter beschreibt das biologische Alter eines Menschen mit optimalen Risikofaktoren, der das gleiche kardiovaskuläre Risiko wie du hat. Ein Herzalter über deinem realen Alter signalisiert vermeidbares Risiko durch Lebensstil oder Therapie."
+      },
+      {
+        "q": "Welche Cholesterinwerte sind ideal?",
+        "a": "Gesamt-Cholesterin: < 190 mg/dL (4,9 mmol/L). LDL: < 116 mg/dL (3,0 mmol/L) — bei Risikopatienten deutlich tiefer. HDL: Männer > 40 mg/dL, Frauen > 48 mg/dL. Triglyceride: < 150 mg/dL. Quelle: ESC/EAS-Leitlinie 2019."
+      },
+      {
+        "q": "Ab welchem Risiko ist eine Statin-Therapie sinnvoll?",
+        "a": "Nach AHA/ACC- und ESC-Leitlinien wird bei einem 10-Jahres-Risiko ≥ 7,5 % (intermediär) eine Statin-Therapie diskutiert, ab ≥ 20 % in der Regel empfohlen. Die endgültige Entscheidung fällt im Arztgespräch unter Berücksichtigung individueller Faktoren."
+      },
+      {
+        "q": "Wie kann ich mein Risiko senken?",
+        "a": "Nicht rauchen senkt das Risiko innerhalb von 5 Jahren um 50 %. 150 min/Woche moderate Bewegung halbiert das Infarktrisiko. Mediterrane Ernährung (PREDIMED-Studie): –30 %. Blutdrucksenkung um 10 mmHg: –20 %. LDL-Senkung um 1 mmol/L: –22 % Ereignisse."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/cardiovascularRisk.json
+++ b/src/locales/calculators/en/cardiovascularRisk.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "cardiovascularRisk": {
+        "name": "Cardiovascular Risk Calculator",
+        "description": "Estimate your 10-year risk of heart attack or stroke (Framingham)."
+      }
+    }
+  },
+  "cardiovascularRisk": {
+    "meta": {
+      "title": "Cardiovascular Risk Calculator — Framingham 10-Year Risk",
+      "description": "Estimate your 10-year risk of heart attack and stroke with the Framingham general CVD score. Includes heart age, risk band and recommendations — free, anonymous."
+    },
+    "title": "Cardiovascular Risk Calculator",
+    "description": "Estimate your 10-year risk of cardiovascular disease using the Framingham general CVD model.",
+    "age": "Age",
+    "totalChol": "Total cholesterol",
+    "hdl": "HDL cholesterol",
+    "sbp": "Systolic blood pressure",
+    "treated": "On blood pressure medication",
+    "smoker": "Current smoker",
+    "diabetic": "Diabetes mellitus",
+    "reset": "Reset",
+    "results": "Result",
+    "tenYearLabel": "Estimated 10-year risk of heart attack, stroke or cardiovascular event.",
+    "heartAge": "Heart age",
+    "years": "years",
+    "heartAgeOlder": "Your heart is {years} years older than your actual age.",
+    "heartAgeYounger": "Your heart is {years} years younger than your actual age.",
+    "cat_low": "Low",
+    "cat_borderline": "Borderline",
+    "cat_intermediate": "Intermediate",
+    "cat_high": "High",
+    "advice_low": "Low 10-year risk. Maintain: don't smoke, exercise regularly, follow a Mediterranean diet. Routine check-up every 4–6 years.",
+    "advice_borderline": "Borderline risk. Intensify lifestyle: 150 min/week aerobic exercise, weight management, cholesterol and blood pressure check every 1–2 years.",
+    "advice_intermediate": "Intermediate risk. Discuss with your physician: consider statin eligibility, optimize blood pressure, screen for diabetes, increase activity.",
+    "advice_high": "High risk. Medical evaluation recommended — statin therapy, blood pressure control and lifestyle changes are usually indicated. ESC Guidelines 2021.",
+    "refTitle": "Risk categories (AHA/ACC)",
+    "refRange": "10-year risk",
+    "refCategory": "Category",
+    "howItWorks": "How it works",
+    "howItWorksText": "This calculator uses the D'Agostino general CVD Framingham model (Circulation 2008). Inputs: age, sex, total and HDL cholesterol, systolic blood pressure (treated/untreated), smoking, diabetes. Validated for ages 30–79. Output: 10-year probability of myocardial infarction, stroke, heart failure or peripheral artery disease.",
+    "disclaimer": "This calculator does not replace medical diagnosis. If your risk is elevated, or you have chest pain, shortness of breath or a strong family history, see your physician or cardiologist promptly.",
+    "faq": [
+      {
+        "q": "What does 10-year risk mean?",
+        "a": "It estimates the probability of a cardiovascular event (heart attack, stroke, heart failure, peripheral artery disease) within the next 10 years. The figure is based on statistical models from large prospective cohort studies."
+      },
+      {
+        "q": "How does Framingham differ from SCORE2?",
+        "a": "Framingham (US, 2008) covers fatal and non-fatal events for ages 30–79. SCORE2 (Europe, ESC 2021) was recalibrated for European populations and is the official ESC recommendation for ages 40–69. Both produce comparable risk estimates."
+      },
+      {
+        "q": "What is heart age?",
+        "a": "Heart age is the chronological age of someone with optimal risk factors who has the same cardiovascular risk as you. A heart age above your real age signals avoidable risk through lifestyle or therapy."
+      },
+      {
+        "q": "What are ideal cholesterol values?",
+        "a": "Total cholesterol: < 190 mg/dL (4.9 mmol/L). LDL: < 116 mg/dL (3.0 mmol/L) — much lower in high-risk patients. HDL: men > 40 mg/dL, women > 48 mg/dL. Triglycerides: < 150 mg/dL. Source: ESC/EAS Guidelines 2019."
+      },
+      {
+        "q": "When is statin therapy recommended?",
+        "a": "AHA/ACC and ESC guidelines discuss statin therapy at a 10-year risk ≥ 7.5 % (intermediate) and generally recommend it at ≥ 20 %. The final decision is shared with the physician based on individual factors."
+      },
+      {
+        "q": "How can I lower my risk?",
+        "a": "Quitting smoking halves cardiovascular risk within 5 years. 150 min/week of moderate exercise halves heart attack risk. Mediterranean diet (PREDIMED): –30 %. Lowering systolic BP by 10 mmHg: –20 %. Lowering LDL by 1 mmol/L: –22 % events."
+      }
+    ]
+  }
+}

--- a/src/pages/CardiovascularRiskCalculator.vue
+++ b/src/pages/CardiovascularRiskCalculator.vue
@@ -1,0 +1,235 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcCardiovascularRisk } from '../utils/cardiovascularRisk.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('cardiovascularRisk.faq') || [])
+
+useHead(() => ({
+  title: t('cardiovascularRisk.meta.title'),
+  description: t('cardiovascularRisk.meta.description'),
+  routeKey: 'cardiovascularRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Cardiovascular Risk Calculator',
+    url: 'https://healthcalculator.app/cardiovascular-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const sex = ref('male')
+const age = ref(null)
+const totalChol = ref(null)
+const hdl = ref(null)
+const systolicBP = ref(null)
+const treated = ref(false)
+const smoker = ref(false)
+const diabetic = ref(false)
+const cholUnit = ref('mgdl')
+
+const result = computed(() => calcCardiovascularRisk({
+  age: age.value,
+  sex: sex.value,
+  totalChol: totalChol.value,
+  hdl: hdl.value,
+  systolicBP: systolicBP.value,
+  treated: treated.value,
+  smoker: smoker.value,
+  diabetic: diabetic.value,
+  cholUnit: cholUnit.value,
+}))
+
+const categoryColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.category) {
+    case 'low': return 'text-green-600'
+    case 'borderline': return 'text-yellow-500'
+    case 'intermediate': return 'text-orange-500'
+    case 'high': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+
+const barPosition = computed(() => {
+  if (!result.value) return 0
+  return Math.min(100, (result.value.risk / 30) * 100)
+})
+
+function reset() {
+  age.value = null
+  totalChol.value = null
+  hdl.value = null
+  systolicBP.value = null
+  treated.value = false
+  smoker.value = false
+  diabetic.value = false
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('cardiovascularRisk.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('cardiovascularRisk.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button @click="cholUnit = 'mgdl'" data-testid="unit-mgdl"
+        :class="cholUnit === 'mgdl' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >mg/dL</button>
+      <button @click="cholUnit = 'mmol'" data-testid="unit-mmol"
+        :class="cholUnit === 'mmol' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >mmol/L</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('common.gender') }}</label>
+        <div class="flex gap-2">
+          <button @click="sex = 'male'" data-testid="sex-male"
+            :class="sex === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('common.male') }}</button>
+          <button @click="sex = 'female'" data-testid="sex-female"
+            :class="sex === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('common.female') }}</button>
+        </div>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('cardiovascularRisk.age') }}</label>
+        <input v-model.number="age" type="number" placeholder="50" data-testid="age"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('cardiovascularRisk.totalChol') }} ({{ cholUnit === 'mgdl' ? 'mg/dL' : 'mmol/L' }})
+        </label>
+        <input v-model.number="totalChol" type="number" step="0.01"
+          :placeholder="cholUnit === 'mgdl' ? '200' : '5.2'" data-testid="total-chol"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('cardiovascularRisk.hdl') }} ({{ cholUnit === 'mgdl' ? 'mg/dL' : 'mmol/L' }})
+        </label>
+        <input v-model.number="hdl" type="number" step="0.01"
+          :placeholder="cholUnit === 'mgdl' ? '50' : '1.3'" data-testid="hdl"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+
+    <div class="mb-6">
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('cardiovascularRisk.sbp') }} (mmHg)</label>
+      <input v-model.number="systolicBP" type="number" placeholder="120" data-testid="sbp"
+        class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+    </div>
+
+    <div class="space-y-3 mb-2">
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="treated" type="checkbox" data-testid="treated"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('cardiovascularRisk.treated') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="smoker" type="checkbox" data-testid="smoker"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('cardiovascularRisk.smoker') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="diabetic" type="checkbox" data-testid="diabetic"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('cardiovascularRisk.diabetic') }}
+      </label>
+    </div>
+
+    <button @click="reset"
+      class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150 mt-6"
+    >&times; {{ t('cardiovascularRisk.reset') }}</button>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('cardiovascularRisk.results') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="risk-result">{{ result.risk.toFixed(1) }}</span>
+      <span class="text-lg text-stone-400">%</span>
+      <span :class="categoryColor" class="text-lg font-semibold" data-testid="result-status">{{ t('cardiovascularRisk.cat_' + result.category) }}</span>
+    </div>
+
+    <p class="text-sm text-stone-500 mb-4">{{ t('cardiovascularRisk.tenYearLabel') }}</p>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-yellow-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: barPosition + '%' }"></div>
+    </div>
+
+    <div v-if="result.heartAge" class="bg-stone-50 rounded-lg p-4 mb-4" data-testid="heart-age">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('cardiovascularRisk.heartAge') }}</p>
+      <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.heartAge }} {{ t('cardiovascularRisk.years') }}</p>
+      <p v-if="age && result.heartAge > age" class="text-xs text-red-600 mt-1">
+        {{ t('cardiovascularRisk.heartAgeOlder', { years: result.heartAge - age }) }}
+      </p>
+      <p v-else-if="age && result.heartAge < age" class="text-xs text-green-600 mt-1">
+        {{ t('cardiovascularRisk.heartAgeYounger', { years: age - result.heartAge }) }}
+      </p>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 text-sm text-stone-600 leading-relaxed" data-testid="advice">
+      {{ t('cardiovascularRisk.advice_' + result.category) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('cardiovascularRisk.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('cardiovascularRisk.refRange') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('cardiovascularRisk.refCategory') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">&lt; 5 %</td><td class="px-6 py-3 text-green-600 font-semibold">{{ t('cardiovascularRisk.cat_low') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">5 – 7.5 %</td><td class="px-6 py-3 text-yellow-600 font-semibold">{{ t('cardiovascularRisk.cat_borderline') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">7.5 – 20 %</td><td class="px-6 py-3 text-orange-600 font-semibold">{{ t('cardiovascularRisk.cat_intermediate') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">&ge; 20 %</td><td class="px-6 py-3 text-red-600 font-semibold">{{ t('cardiovascularRisk.cat_high') }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('cardiovascularRisk.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('cardiovascularRisk.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('cardiovascularRisk.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="cardiovascularRisk" />
+</template>

--- a/src/pages/blog/HerzInfarktRisikoBerechnen.vue
+++ b/src/pages/blog/HerzInfarktRisikoBerechnen.vue
@@ -1,0 +1,212 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Herz-Kreislauf-Risiko berechnen: Framingham, SCORE2 und was die Werte bedeuten | Health Calculators',
+  description: 'Berechne dein 10-Jahres-Risiko für Herzinfarkt und Schlaganfall mit Framingham/SCORE2. Cholesterin, Blutdruck, Lebensstil — und was wirklich hilft.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Herz-Kreislauf-Risiko berechnen: Framingham, SCORE2 und was die Werte bedeuten',
+    description: 'Berechne dein 10-Jahres-Risiko für Herzinfarkt und Schlaganfall mit Framingham/SCORE2. Cholesterin, Blutdruck, Lebensstil — und was wirklich hilft.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-02',
+    dateModified: '2026-05-02',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/herz-kreislauf-risiko-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Herz-Kreislauf-Risiko berechnen: Framingham, SCORE2 und was die Werte bedeuten</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">2. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Herz-Kreislauf-Erkrankungen sind in Deutschland mit <strong>rund 340.000 Todesfällen pro Jahr</strong> die häufigste Todesursache. Die gute Nachricht: bis zu 80 % davon sind durch frühzeitige Erkennung und einfache Maßnahmen vermeidbar.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt die etablierten Risiko-Scores (<strong>Framingham</strong> und <strong>SCORE2</strong>), wie du dein 10-Jahres-Risiko realistisch einschätzt — und welche Hebel den größten Effekt haben.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum überhaupt rechnen?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein einzelner Wert wie der Blutdruck oder das LDL sagt wenig über das tatsächliche Risiko aus. Erst die Kombination aller Risikofaktoren — Alter, Geschlecht, Cholesterin, Blutdruck, Rauchen, Diabetes — ergibt ein belastbares Bild. Genau das leisten die <strong>Risiko-Scores</strong>: sie übersetzen mehrere Werte in <em>eine</em> Zahl: dein 10-Jahres-Risiko in Prozent.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Beispiel: Ein 55-jähriger Mann mit einem LDL von 160 mg/dL kann je nach restlichen Werten ein Risiko von 5 % oder 25 % haben. Das hat direkte Konsequenzen für die Therapieentscheidung.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die wichtigsten Scores im Vergleich</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Region</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Alter</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Endpunkt</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Framingham</td><td class="px-6 py-3 text-stone-600">USA</td><td class="px-6 py-3 text-stone-600">30–79</td><td class="px-6 py-3 text-stone-600">tödlich + nicht-tödlich</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SCORE2</td><td class="px-6 py-3 text-stone-600">Europa</td><td class="px-6 py-3 text-stone-600">40–69</td><td class="px-6 py-3 text-stone-600">tödlich + nicht-tödlich</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SCORE2-OP</td><td class="px-6 py-3 text-stone-600">Europa</td><td class="px-6 py-3 text-stone-600">≥ 70</td><td class="px-6 py-3 text-stone-600">tödlich + nicht-tödlich</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">ASCVD</td><td class="px-6 py-3 text-stone-600">USA (AHA/ACC)</td><td class="px-6 py-3 text-stone-600">40–79</td><td class="px-6 py-3 text-stone-600">Infarkt + Schlaganfall</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed">
+          Unser Rechner verwendet das <strong>Framingham General CVD-Modell</strong> nach D'Agostino (Circulation 2008). Es liefert für deutsche Patienten realistische Werte und ist gut validiert.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die 6 Risikofaktoren, die zählen</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">1. Alter und Geschlecht</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Männer haben im Schnitt <strong>10 Jahre früher</strong> ein vergleichbares Risiko wie Frauen. Nach der Menopause gleicht sich das Risiko an — Östrogene wirken bis dahin schützend.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">2. Cholesterin (Total und HDL)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Nicht das LDL allein, sondern das <strong>Verhältnis zu HDL</strong> ist entscheidend. Eine LDL-Senkung um 1 mmol/L (≈ 39 mg/dL) reduziert kardiovaskuläre Ereignisse um 22 % (CTT-Metaanalyse, Lancet 2010).
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">3. Blutdruck</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Ab <strong>140/90 mmHg</strong> Hypertonie. Eine Senkung des systolischen Werts um 10 mmHg verringert Herzinfarkt-Risiko um 17 % und Schlaganfall-Risiko um 27 % (Ettehad, Lancet 2016).
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">4. Rauchen</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Aktive Raucher haben ein <strong>2-3-fach erhöhtes Risiko</strong>. Nach 5 Jahren Abstinenz halbiert sich das Risiko, nach 15 Jahren ist es nahezu wie bei Nichtrauchern.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">5. Diabetes mellitus</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Diabetes verdoppelt das Herz-Kreislauf-Risiko unabhängig von anderen Faktoren. Schon Prädiabetes (HbA1c 5,7–6,4 %) erhöht das Risiko deutlich.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">6. Familienanamnese</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Frühe Herzerkrankung (Männer &lt; 55 J., Frauen &lt; 65 J.) bei Eltern oder Geschwistern erhöht das Risiko um 50 % — wird in den Standard-Scores nicht erfasst, aber separat berücksichtigt.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Berechne dein 10-Jahres-Risiko jetzt</h3>
+        <p class="text-stone-300 text-sm mb-5">7 Eingaben, sofortige Risikoeinordnung inklusive Herzalter — anonym und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('cardiovascularRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Zum Risiko-Rechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">So liest du dein Ergebnis</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">10-Jahres-Risiko</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfehlung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">&lt; 5 %</td><td class="px-6 py-3 text-green-600 font-semibold">niedrig</td><td class="px-6 py-3 text-stone-600">Lebensstil halten, Kontrolle alle 4–6 Jahre</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">5 – 7,5 %</td><td class="px-6 py-3 text-yellow-600 font-semibold">grenzwertig</td><td class="px-6 py-3 text-stone-600">Lebensstil intensivieren, jährliche Kontrolle</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">7,5 – 20 %</td><td class="px-6 py-3 text-orange-600 font-semibold">mittel</td><td class="px-6 py-3 text-stone-600">Statin-Indikation prüfen, Hausarztgespräch</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">≥ 20 %</td><td class="px-6 py-3 text-red-600 font-semibold">hoch</td><td class="px-6 py-3 text-stone-600">Statin + Blutdrucksenkung in der Regel indiziert</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was wirklich hilft — evidenzbasiert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Lebensstil-Maßnahmen wirken nachweisbar — und oft stärker als Medikamente:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mediterrane Ernährung</strong> (PREDIMED, NEJM 2018): Olivenöl, Nüsse, Fisch, viel Gemüse — senkt Risiko um 30 %.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>150 min/Woche moderate Bewegung</strong>: halbiert das Infarktrisiko (WHO, Lancet 2020).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Rauchstopp</strong>: nach 5 Jahren Risikoreduktion um 50 %.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Statine</strong> bei intermediärem/hohem Risiko: −22 % Ereignisse pro mmol/L LDL-Senkung.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Blutdrucksenkung</strong> auf &lt; 130/80 mmHg: −20 % Schlaganfälle.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Gewichtsabnahme</strong> 5–10 % bei Adipositas: verbessert alle Risikofaktoren gleichzeitig.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann zum Arzt?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Dein Hausarzt sollte dein Risiko spätestens ab dem <strong>40. Lebensjahr</strong> regelmäßig erfassen. Sofort zum Arzt bei:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed">Brustenge oder Druck hinter dem Brustbein, ggf. mit Ausstrahlung in Arm/Kiefer</li>
+          <li class="text-base text-stone-600 leading-relaxed">Plötzlicher Atemnot oder unerklärlicher Erschöpfung bei Belastung</li>
+          <li class="text-base text-stone-600 leading-relaxed">Schwindel, Herzrasen oder unregelmäßigem Puls</li>
+          <li class="text-base text-stone-600 leading-relaxed">Familiärer Belastung (Herzinfarkt vor 55/65 Jahren)</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das Herz-Kreislauf-Risiko hängt mit vielen Werten zusammen. Prüfe ergänzend dein
+          <router-link :to="localeBlogPath('cholesterol-verhaeltnis-rechner')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Cholesterin-Verhältnis</router-link>,
+          dein
+          <router-link :to="localeBlogPath('diabetes-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko</router-link>
+          und lies, wie du
+          <router-link :to="localeBlogPath('blutdruck-richtig-messen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Blutdruck korrekt misst</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das 10-Jahres-Risiko ist eine der mächtigsten Zahlen in der Präventivmedizin: sie macht Lebensstil-Entscheidungen mess- und vergleichbar. Berechne deinen Wert mit unserem
+          <router-link :to="localePath('cardiovascularRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Herz-Kreislauf-Risiko-Rechner</router-link>
+          — und sprich auffällige Werte mit deinem Hausarzt durch.
+        </p>
+      </div>
+
+      <RelatedArticles slug="herz-kreislauf-risiko-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/CardiovascularRiskCalculator.vue
+++ b/src/pages/blog/en/CardiovascularRiskCalculator.vue
@@ -1,0 +1,212 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Cardiovascular Risk Calculator: Framingham, SCORE2 and What the Numbers Mean | Health Calculators',
+  description: 'Estimate your 10-year risk of heart attack and stroke with Framingham/SCORE2. Cholesterol, blood pressure, lifestyle — and what actually moves the needle.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Cardiovascular Risk Calculator: Framingham, SCORE2 and What the Numbers Mean',
+    description: 'Estimate your 10-year risk of heart attack and stroke with Framingham/SCORE2. Cholesterol, blood pressure, lifestyle — and what actually moves the needle.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-02',
+    dateModified: '2026-05-02',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/cardiovascular-risk-framingham',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Cardiovascular Risk Calculator: Framingham, SCORE2 and What the Numbers Mean</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 2, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Cardiovascular disease is the leading cause of death worldwide — over <strong>17 million people per year</strong>. The good news: up to 80 % of these events are preventable through early detection and a few well-known interventions.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article explains the established risk scores (<strong>Framingham</strong> and <strong>SCORE2</strong>), how to read your 10-year risk realistically, and which levers move the needle the most.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why calculate at all?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A single value like blood pressure or LDL says little about actual risk. Only the <em>combination</em> of all factors — age, sex, cholesterol, blood pressure, smoking, diabetes — gives a reliable picture. That's exactly what <strong>risk scores</strong> do: they translate several values into a single percentage, your 10-year risk.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Example: a 55-year-old man with an LDL of 160 mg/dL might have a 5 % or a 25 % risk depending on the rest of his profile. That has direct consequences for treatment decisions.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The major scores at a glance</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Region</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Age</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Endpoint</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Framingham</td><td class="px-6 py-3 text-stone-600">USA</td><td class="px-6 py-3 text-stone-600">30–79</td><td class="px-6 py-3 text-stone-600">fatal + non-fatal</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SCORE2</td><td class="px-6 py-3 text-stone-600">Europe (ESC)</td><td class="px-6 py-3 text-stone-600">40–69</td><td class="px-6 py-3 text-stone-600">fatal + non-fatal</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">SCORE2-OP</td><td class="px-6 py-3 text-stone-600">Europe</td><td class="px-6 py-3 text-stone-600">≥ 70</td><td class="px-6 py-3 text-stone-600">fatal + non-fatal</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">ASCVD (PCE)</td><td class="px-6 py-3 text-stone-600">USA (AHA/ACC)</td><td class="px-6 py-3 text-stone-600">40–79</td><td class="px-6 py-3 text-stone-600">infarction + stroke</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed">
+          Our calculator implements the <strong>Framingham General CVD model</strong> by D'Agostino (Circulation 2008). It gives well-validated, intuitive results across both US and European populations.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The 6 risk factors that count</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">1. Age and sex</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Men reach a comparable risk roughly <strong>10 years earlier</strong> than women. After menopause the gap closes — estrogen is protective until then.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">2. Cholesterol (total and HDL)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Not LDL alone, but the <strong>ratio with HDL</strong> matters. A 1 mmol/L (≈ 39 mg/dL) reduction in LDL lowers cardiovascular events by 22 % (CTT meta-analysis, Lancet 2010).
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">3. Blood pressure</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Hypertension from <strong>140/90 mmHg</strong>. A 10 mmHg reduction in systolic BP lowers heart attacks by 17 % and strokes by 27 % (Ettehad, Lancet 2016).
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">4. Smoking</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Current smokers have <strong>2-3× the risk</strong>. After 5 years of abstinence the risk halves; after 15 years it approaches that of non-smokers.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">5. Diabetes mellitus</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Diabetes doubles cardiovascular risk independent of other factors. Even prediabetes (HbA1c 5.7–6.4 %) raises risk meaningfully.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">6. Family history</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Premature coronary disease in a parent or sibling (men &lt; 55 y, women &lt; 65 y) raises risk by 50 %. Not captured by standard scores — discuss with your physician.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your 10-year risk now</h3>
+        <p class="text-stone-300 text-sm mb-5">7 inputs, instant risk band including heart age — anonymous, no sign-up.</p>
+        <router-link
+          :to="localePath('cardiovascularRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Open the calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How to read your result</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">10-year risk</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Action</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">&lt; 5 %</td><td class="px-6 py-3 text-green-600 font-semibold">low</td><td class="px-6 py-3 text-stone-600">Maintain lifestyle, check every 4–6 years</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">5 – 7.5 %</td><td class="px-6 py-3 text-yellow-600 font-semibold">borderline</td><td class="px-6 py-3 text-stone-600">Intensify lifestyle, annual check</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">7.5 – 20 %</td><td class="px-6 py-3 text-orange-600 font-semibold">intermediate</td><td class="px-6 py-3 text-stone-600">Discuss statin eligibility with physician</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">≥ 20 %</td><td class="px-6 py-3 text-red-600 font-semibold">high</td><td class="px-6 py-3 text-stone-600">Statin + BP control usually indicated</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What actually works — evidence-based</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Lifestyle interventions are well documented — and often more effective than medication:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mediterranean diet</strong> (PREDIMED, NEJM 2018): olive oil, nuts, fish, lots of vegetables — lowers risk by 30 %.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>150 min/week of moderate exercise</strong>: halves heart attack risk (WHO, Lancet 2020).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Smoking cessation</strong>: 50 % risk reduction within 5 years.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Statins</strong> at intermediate/high risk: −22 % events per mmol/L LDL reduction.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>BP reduction</strong> to &lt; 130/80 mmHg: −20 % strokes.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>5–10 % weight loss</strong> in obesity: improves all risk factors simultaneously.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">When to see a doctor</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Have your physician check your risk regularly from <strong>age 40</strong>. Seek immediate care for:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed">Chest tightness or pressure, possibly radiating into arm/jaw</li>
+          <li class="text-base text-stone-600 leading-relaxed">Sudden shortness of breath or unexplained fatigue on exertion</li>
+          <li class="text-base text-stone-600 leading-relaxed">Dizziness, palpitations or irregular pulse</li>
+          <li class="text-base text-stone-600 leading-relaxed">Strong family history (heart attack &lt; 55/65 years)</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Cardiovascular risk is connected to many markers. Also check your
+          <router-link :to="localeBlogPath('cholesterol-ratio')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">cholesterol ratio</router-link>,
+          your
+          <router-link :to="localeBlogPath('diabetes-risk-score')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">diabetes risk</router-link>
+          and how to
+          <router-link :to="localeBlogPath('measure-blood-pressure')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">measure blood pressure correctly</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The 10-year risk is one of the most powerful numbers in preventive medicine: it makes lifestyle decisions measurable and comparable. Calculate yours with our
+          <router-link :to="localePath('cardiovascularRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">cardiovascular risk calculator</router-link>
+          — and discuss elevated values with your physician.
+        </p>
+      </div>
+
+      <RelatedArticles slug="cardiovascular-risk-framingham" />
+    </div>
+  </article>
+</template>

--- a/src/pages/cardiovascularRisk.meta.js
+++ b/src/pages/cardiovascularRisk.meta.js
@@ -1,0 +1,16 @@
+import Component from './CardiovascularRiskCalculator.vue'
+import BlogDe from './blog/HerzInfarktRisikoBerechnen.vue'
+import BlogEn from './blog/en/CardiovascularRiskCalculator.vue'
+
+export default {
+  key: 'cardiovascularRisk',
+  component: Component,
+  slugs: { de: 'herz-kreislauf-risiko-rechner', en: 'cardiovascular-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 31,
+  blog: {
+    de: { slug: 'herz-kreislauf-risiko-berechnen', component: BlogDe },
+    en: { slug: 'cardiovascular-risk-framingham', component: BlogEn },
+  },
+}

--- a/src/utils/cardiovascularRisk.js
+++ b/src/utils/cardiovascularRisk.js
@@ -1,0 +1,108 @@
+// 10-year cardiovascular disease risk based on the D'Agostino general CVD
+// Framingham model (Circulation 2008;117:743-753). Inputs: age, sex,
+// total cholesterol, HDL, systolic blood pressure (treated/untreated),
+// smoking, diabetes. Output: percentage 10-year risk + category.
+//
+// Coefficients (β) and survival baseline S0(10) reproduced from the original
+// paper, Tables 2-3.
+
+const COEFFS = {
+  male: {
+    lnAge: 3.06117,
+    lnTotChol: 1.12370,
+    lnHdl: -0.93263,
+    lnSbpUntreated: 1.93303,
+    lnSbpTreated: 1.99881,
+    smoker: 0.65451,
+    diabetic: 0.57367,
+    meanLP: 23.9802,
+    s0: 0.88936,
+  },
+  female: {
+    lnAge: 2.32888,
+    lnTotChol: 1.20904,
+    lnHdl: -0.70833,
+    lnSbpUntreated: 2.76157,
+    lnSbpTreated: 2.82263,
+    smoker: 0.52873,
+    diabetic: 0.69154,
+    meanLP: 26.1931,
+    s0: 0.95012,
+  },
+}
+
+// 1 mmol/L cholesterol = 38.67 mg/dL
+const MMOL_TO_MGDL = 38.67
+
+export function classifyRisk(percent) {
+  if (percent == null || !Number.isFinite(percent)) return null
+  if (percent < 5) return 'low'
+  if (percent < 7.5) return 'borderline'
+  if (percent < 20) return 'intermediate'
+  return 'high'
+}
+
+export function calcCardiovascularRisk(input) {
+  if (!input || typeof input !== 'object') return null
+  const {
+    age, sex, totalChol, hdl, systolicBP,
+    treated = false, smoker = false, diabetic = false,
+    cholUnit = 'mgdl',
+  } = input
+
+  if (!Number.isFinite(age) || age < 30 || age > 79) return null
+  if (sex !== 'male' && sex !== 'female') return null
+  if (!Number.isFinite(totalChol) || totalChol <= 0) return null
+  if (!Number.isFinite(hdl) || hdl <= 0) return null
+  if (!Number.isFinite(systolicBP) || systolicBP <= 0) return null
+
+  const tc = cholUnit === 'mmol' ? totalChol * MMOL_TO_MGDL : totalChol
+  const hd = cholUnit === 'mmol' ? hdl * MMOL_TO_MGDL : hdl
+
+  const c = COEFFS[sex]
+  const lp =
+    c.lnAge * Math.log(age) +
+    c.lnTotChol * Math.log(tc) +
+    c.lnHdl * Math.log(hd) +
+    (treated ? c.lnSbpTreated : c.lnSbpUntreated) * Math.log(systolicBP) +
+    (smoker ? c.smoker : 0) +
+    (diabetic ? c.diabetic : 0)
+
+  const risk = (1 - Math.pow(c.s0, Math.exp(lp - c.meanLP))) * 100
+  const clamped = Math.max(0, Math.min(99, risk))
+
+  return {
+    risk: Number(clamped.toFixed(1)),
+    category: classifyRisk(clamped),
+    heartAge: estimateHeartAge(clamped, sex),
+  }
+}
+
+// Heart age = age of someone with optimal risk factors who has the same risk.
+// Reverse-solved against a reference profile (TC 180, HDL 50, SBP 110, no
+// smoke/diabetes/treatment) to give an intuitive comparator.
+function estimateHeartAge(percentRisk, sex) {
+  if (percentRisk == null) return null
+  const c = COEFFS[sex]
+  const tc = 180
+  const hd = 50
+  const sbp = 110
+  const baseline =
+    c.lnTotChol * Math.log(tc) +
+    c.lnHdl * Math.log(hd) +
+    c.lnSbpUntreated * Math.log(sbp)
+
+  // Solve: risk = 1 - s0^exp(lnAge*β + baseline - meanLP)
+  // → ln(1 - r) = exp(...) * ln(s0)
+  // → exp(...) = ln(1 - r) / ln(s0)
+  // → lnAge*β + baseline - meanLP = ln(ln(1 - r) / ln(s0))
+  // → age = exp((ln(...) - baseline + meanLP) / β)
+  const r = percentRisk / 100
+  if (r <= 0 || r >= 1) return null
+  const inner = Math.log(1 - r) / Math.log(c.s0)
+  if (inner <= 0) return null
+  const lnAge = (Math.log(inner) - baseline + c.meanLP) / c.lnAge
+  const age = Math.round(Math.exp(lnAge))
+  if (!Number.isFinite(age) || age < 30 || age > 95) return null
+  return age
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-148-cardiovascular-risk
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-148-cardiovascular-risk-20260502-220024`
**Cost:** $8.366914000000003

Closes jenslaufer/health-calculators#148

### Prompt
> Implement the Cardiovascular Risk Calculator as described in issue #148.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- SCORE2/Framingham cardiovascular risk
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/cardiovascularRisk.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/cardiovascularRisk.test.js` with 6+ test cases covering edge cases. Run `npm test -- cardiovascularRisk` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/CardiovascularRiskCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/cardiovascularRisk.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/cardiovascularRisk.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'cardiovascularRisk'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/cardiovascularRisk.json` + `src/locales/calculators/en/cardiovascularRisk.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/cardiovascularRisk.js (or shared util — verify pattern in repo first)`
- `src/__tests__/cardiovascularRisk.test.js`
- `src/pages/CardiovascularRiskCalculator.vue`
- `src/pages/cardiovascularRisk.meta.js`
- `src/locales/calculators/de/cardiovascularRisk.json`
- `src/locales/calculators/en/cardiovascularRisk.json`
- `e2e/cardiovascularRisk.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'cardiovascularRisk',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks