### PR TITLE
hc-151-blood-alcohol-estimator: Implement the Blood Alcohol Estimator Calculator as describe

### DIFF
--- a/e2e/bloodAlcoholEstimator.spec.js
+++ b/e2e/bloodAlcoholEstimator.spec.js
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/blutalkohol-schaetzer')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Blutalkohol-Schätzer/)
+})
+
+test('male 80kg, 1 drink, 0 hours → ~0.026 %', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('drinks').fill('1')
+  await page.getByTestId('hours').fill('0')
+
+  const result = page.getByTestId('bac-result')
+  await expect(result).toBeVisible()
+  const bac = parseFloat(await result.textContent())
+  expect(bac).toBeGreaterThanOrEqual(0.020)
+  expect(bac).toBeLessThanOrEqual(0.035)
+})
+
+test('female 60kg, 3 drinks, 0 hours → ~0.127 %', async ({ page }) => {
+  await page.getByTestId('sex-female').click()
+  await page.getByTestId('weight').fill('60')
+  await page.getByTestId('drinks').fill('3')
+  await page.getByTestId('hours').fill('0')
+
+  const result = page.getByTestId('bac-result')
+  await expect(result).toBeVisible()
+  const bac = parseFloat(await result.textContent())
+  expect(bac).toBeGreaterThanOrEqual(0.115)
+  expect(bac).toBeLessThanOrEqual(0.140)
+})
+
+test('imperial unit toggle converts weight correctly', async ({ page }) => {
+  await page.getByTestId('unit-imperial').click()
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('176')
+  await page.getByTestId('drinks').fill('4')
+  await page.getByTestId('hours').fill('1')
+
+  const result = page.getByTestId('bac-result')
+  await expect(result).toBeVisible()
+  const bac = parseFloat(await result.textContent())
+  // 176 lb ≈ 79.8 kg → ~0.088 %
+  expect(bac).toBeGreaterThanOrEqual(0.075)
+  expect(bac).toBeLessThanOrEqual(0.100)
+})
+
+test('shows time until sober', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('drinks').fill('4')
+  await page.getByTestId('hours').fill('0')
+
+  const soberTime = page.getByTestId('time-until-sober')
+  await expect(soberTime).toBeVisible()
+})
+
+test('shows legal limit comparison block', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('drinks').fill('4')
+  await page.getByTestId('hours').fill('0')
+
+  await expect(page.getByTestId('legal-limit')).toBeVisible()
+})
+
+test('shows promille alongside BAC', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('drinks').fill('4')
+  await page.getByTestId('hours').fill('0')
+
+  const promille = page.getByTestId('promille-result')
+  await expect(promille).toBeVisible()
+  const value = parseFloat(await promille.textContent())
+  expect(value).toBeGreaterThan(0.5)
+})
+
+test('after enough hours BAC is 0', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('drinks').fill('1')
+  await page.getByTestId('hours').fill('10')
+
+  const result = page.getByTestId('bac-result')
+  await expect(result).toBeVisible()
+  const bac = parseFloat(await result.textContent())
+  expect(bac).toBe(0)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -21,7 +21,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
-  'malePattern', 'cardiovascularRisk', 'strokeRisk',
+  'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -77,6 +77,7 @@ const EXPECTED_ROUTE_MAP = {
   malePattern: { de: 'haarausfall-rechner-maenner', en: 'male-pattern-baldness-calculator' },
   cardiovascularRisk: { de: 'herz-kreislauf-risiko-rechner', en: 'cardiovascular-risk-calculator' },
   strokeRisk: { de: 'schlaganfall-risiko-rechner', en: 'stroke-risk-calculator' },
+  bloodAlcoholEstimator: { de: 'blutalkohol-schaetzer', en: 'blood-alcohol-estimator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -120,6 +121,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'haarausfall-norwood-skala',
   'herz-kreislauf-risiko-berechnen',
   'schlaganfall-risiko-berechnen',
+  'blutalkohol-schaetzen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -163,19 +165,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'male-pattern-baldness-norwood',
   'cardiovascular-risk-framingham',
   'stroke-risk-calculator-cha2ds2-vasc',
+  'blood-alcohol-estimator-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 54 calculators', () => {
-    expect(calculatorMetas).toHaveLength(54)
+  it('discovers all 55 calculators', () => {
+    expect(calculatorMetas).toHaveLength(55)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 54 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(54)
+  it('builds calculatorComponents map for all 55 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(55)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -198,15 +201,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 52 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(52)
+  it('discovers all 53 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(53)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 52 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(52)
+  it('discovers all 53 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(53)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -224,8 +227,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 54 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(54)
-    expect(new Set(allKeys).size).toBe(54)
+    expect(allKeys).toHaveLength(55)
+    expect(new Set(allKeys).size).toBe(55)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -246,7 +249,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
     ])
   })
 
@@ -294,8 +297,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 306 routes', () => {
-    expect(routes).toHaveLength(306)
+  it('generates exactly 311 routes', () => {
+    expect(routes).toHaveLength(311)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/bloodAlcoholEstimator.test.js
+++ b/src/__tests__/bloodAlcoholEstimator.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { estimateBac, timeUntilSober, classifyImpairment } from '../utils/bloodAlcoholEstimator.js'
+
+// Quick BAC estimator using US standard drinks (14 g pure alcohol per drink)
+// and the Widmark formula. Output is in % BAC (g/dL) — US convention.
+//
+//   BAC (%) = (drinks × 14 g) / (weight × r) × 100 / 1000 − 0.015 × hours
+//   r = 0.68 for male, 0.55 for female (Widmark constants)
+//   Elimination ~ 0.015 % per hour
+//
+// Inputs:
+//   standardDrinks: number of US standard drinks
+//   weightKg: body weight in kg
+//   sex: 'male' | 'female'
+//   hours: hours since first drink
+
+describe('estimateBac', () => {
+  it('returns 0 for zero drinks', () => {
+    expect(estimateBac({ standardDrinks: 0, weightKg: 80, sex: 'male', hours: 0 })).toBe(0)
+  })
+
+  it('1 drink, 80 kg male, 0 hours → ~0.026 %', () => {
+    // 14 / (80 * 0.68) = 0.2574 g/kg → /10 → 0.02574 %
+    const bac = estimateBac({ standardDrinks: 1, weightKg: 80, sex: 'male', hours: 0 })
+    expect(bac).toBeCloseTo(0.0257, 3)
+  })
+
+  it('4 drinks, 80 kg male, 1 hour → ~0.088 %', () => {
+    // 56 / (80 * 0.68) / 10 = 0.1029 → 0.1029 - 0.015 = 0.0879
+    const bac = estimateBac({ standardDrinks: 4, weightKg: 80, sex: 'male', hours: 1 })
+    expect(bac).toBeCloseTo(0.0879, 3)
+  })
+
+  it('3 drinks, 60 kg female, 0 hours → ~0.127 %', () => {
+    // 42 / (60 * 0.55) / 10 = 0.1273
+    const bac = estimateBac({ standardDrinks: 3, weightKg: 60, sex: 'female', hours: 0 })
+    expect(bac).toBeCloseTo(0.1273, 3)
+  })
+
+  it('clamps to 0 once enough hours have passed', () => {
+    const bac = estimateBac({ standardDrinks: 1, weightKg: 80, sex: 'male', hours: 10 })
+    expect(bac).toBe(0)
+  })
+
+  it('returns null for invalid weight', () => {
+    expect(estimateBac({ standardDrinks: 2, weightKg: 0, sex: 'male', hours: 0 })).toBeNull()
+    expect(estimateBac({ standardDrinks: 2, weightKg: -10, sex: 'male', hours: 0 })).toBeNull()
+    expect(estimateBac({ standardDrinks: 2, weightKg: null, sex: 'male', hours: 0 })).toBeNull()
+  })
+
+  it('returns null for invalid sex', () => {
+    expect(estimateBac({ standardDrinks: 2, weightKg: 80, sex: 'other', hours: 0 })).toBeNull()
+  })
+
+  it('returns null for negative drinks', () => {
+    expect(estimateBac({ standardDrinks: -1, weightKg: 80, sex: 'male', hours: 0 })).toBeNull()
+  })
+
+  it('treats missing hours as 0', () => {
+    const bac = estimateBac({ standardDrinks: 2, weightKg: 80, sex: 'male' })
+    // 28 / (80 * 0.68) / 10 = 0.0515
+    expect(bac).toBeCloseTo(0.0515, 3)
+  })
+})
+
+describe('timeUntilSober', () => {
+  it('0.08 % BAC → ~5.33 hours to fully sober', () => {
+    expect(timeUntilSober(0.08)).toBeCloseTo(5.333, 2)
+  })
+
+  it('0.03 % BAC → 2 hours', () => {
+    expect(timeUntilSober(0.03)).toBeCloseTo(2, 2)
+  })
+
+  it('returns 0 for zero BAC', () => {
+    expect(timeUntilSober(0)).toBe(0)
+  })
+
+  it('returns 0 for negative or null BAC', () => {
+    expect(timeUntilSober(-0.05)).toBe(0)
+    expect(timeUntilSober(null)).toBe(0)
+  })
+})
+
+describe('classifyImpairment', () => {
+  it('0 → sober', () => {
+    expect(classifyImpairment(0)).toBe('sober')
+  })
+
+  it('0.02 → minimal', () => {
+    expect(classifyImpairment(0.02)).toBe('minimal')
+  })
+
+  it('0.05 → mild (below US legal limit)', () => {
+    expect(classifyImpairment(0.05)).toBe('mild')
+  })
+
+  it('0.08 → legal limit reached', () => {
+    expect(classifyImpairment(0.08)).toBe('legal')
+  })
+
+  it('0.15 → significant', () => {
+    expect(classifyImpairment(0.15)).toBe('significant')
+  })
+
+  it('0.30 → dangerous', () => {
+    expect(classifyImpairment(0.30)).toBe('dangerous')
+  })
+
+  it('returns null for null input', () => {
+    expect(classifyImpairment(null)).toBeNull()
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 212 links (54 calcs × 2 locales + 52 blogs × 2 locales)', () => {
+  it('generates 216 links (55 calcs × 2 locales + 53 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(212)
+    expect(links).toHaveLength(216)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -15,7 +15,7 @@ const EXPECTED_KEYS = [
   'leanBodyMass', 'pregnancyWeightGain', 'hba1c', 'bloodSugar', 'bsa', 'gfr',
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
-  'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk',
+  'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -58,6 +58,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'haarausfall-norwood-skala',
   'herz-kreislauf-risiko-berechnen',
   'schlaganfall-risiko-berechnen',
+  'blutalkohol-schaetzen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -100,12 +101,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'male-pattern-baldness-norwood',
   'cardiovascular-risk-framingham',
   'stroke-risk-calculator-cha2ds2-vasc',
+  'blood-alcohol-estimator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 54 calculator meta files', () => {
+  it('discovers all 55 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(54)
+    expect(metas).toHaveLength(55)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -143,19 +145,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 52 DE blog slugs', () => {
+  it('returns all 53 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(52)
+    expect(de).toHaveLength(53)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 52 EN blog slugs', () => {
+  it('returns all 53 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(52)
+    expect(en).toHaveLength(53)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -223,9 +225,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 108 calcs + 2 blog index + 104 blog articles = 216)', () => {
+  it('generates correct total URL count (2 home + 110 calcs + 2 blog index + 106 blog articles = 220)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(216)
+    expect(urlCount).toBe(220)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -467,6 +467,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'strokeRisk',
     related: ['measure-blood-pressure', 'diabetes-risk-score', 'cholesterol-ratio'],
   },
+  {
+    slug: 'blood-alcohol-estimator-guide',
+    title: 'Blood Alcohol Estimator: Standard Drinks, BAC and Driving Limits',
+    description: 'Estimate your blood alcohol concentration (BAC) fast using US standard drinks and body weight. Widmark formula, US/EU driving limits and hourly elimination — explained.',
+    date: '2026-05-04',
+    readTime: '8 min',
+    calculatorKey: 'bloodAlcoholEstimator',
+    related: ['blood-alcohol-calculator', 'alcohol-unit-calculator', 'life-expectancy-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -467,6 +467,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'strokeRisk',
     related: ['blutdruck-richtig-messen', 'diabetes-risiko-berechnen', 'cholesterol-verhaeltnis-rechner'],
   },
+  {
+    slug: 'blutalkohol-schaetzen',
+    title: 'Blutalkohol schätzen: BAC, Promille und der schnelle Standardgetränk-Rechner',
+    description: 'Blutalkohol (BAC) schnell schätzen mit Standardgetränken und Körpergewicht. Widmark-Formel, US- und DE-Grenzwerte, Abbau pro Stunde — kompakt erklärt.',
+    date: '2026-05-04',
+    readTime: '8 min',
+    calculatorKey: 'bloodAlcoholEstimator',
+    related: ['promille-berechnen', 'alkohol-einheiten-berechnen', 'lebenserwartung-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/bloodAlcoholEstimator.json
+++ b/src/locales/calculators/de/bloodAlcoholEstimator.json
@@ -1,0 +1,85 @@
+{
+  "home": {
+    "calculators": {
+      "bloodAlcoholEstimator": {
+        "name": "Blutalkohol-Schätzer",
+        "description": "Schnell-Schätzung des Blutalkohols (BAC) mit Standardgetränken, Gewicht und Zeit."
+      }
+    }
+  },
+  "bloodAlcoholEstimator": {
+    "meta": {
+      "title": "Blutalkohol-Schätzer — Schneller BAC-Rechner mit Standardgetränken",
+      "description": "Schätze deinen Blutalkohol (BAC) in % schnell mit Standardgetränken, Körpergewicht und Zeit. Widmark-Formel, Abbau-Prognose und Grenzwerte. Kostenlos, sofort, ohne Anmeldung."
+    },
+    "title": "Blutalkohol-Schätzer",
+    "description": "Schnelle BAC-Schätzung mit Standardgetränken (14 g reiner Alkohol pro Drink), Gewicht und Zeit — ideal für eine schnelle Einschätzung.",
+    "instructionsLabel": "Anleitung",
+    "instructions": "Wähle Geschlecht und Maßeinheit, gib Körpergewicht, Anzahl der Standardgetränke und Stunden seit dem ersten Drink ein. Ein Standardgetränk entspricht 14 g reinem Alkohol (= ein 0,33-l-Bier mit ~5 %, 150 ml Wein mit ~12 % oder 44 ml Spirituose mit ~40 %).",
+    "sexLabel": "Geschlecht",
+    "weightLabel": "Körpergewicht ({unit})",
+    "weightPlaceholder": "80",
+    "drinksLabel": "Anzahl Standardgetränke",
+    "drinksPlaceholder": "3",
+    "drinksHelp": "1 Standardgetränk = 14 g reiner Alkohol",
+    "hoursLabel": "Stunden seit dem ersten Getränk",
+    "hoursPlaceholder": "1",
+    "results": "Geschätzter Blutalkohol",
+    "bacLabel": "BAC",
+    "promilleLabel": "Promille",
+    "timeUntilSoberLabel": "Zeit bis nüchtern (BAC = 0)",
+    "alreadySober": "Bereits nüchtern",
+    "hoursMinutes": "{hours} Std. {minutes} Min.",
+    "alcoholGramsLabel": "Reiner Alkohol",
+    "legalLimitLabel": "Gesetzlicher Grenzwert",
+    "belowUsLimit": "Unter US-Grenzwert (0,08 %).",
+    "aboveUsLimit": "Über US-Grenzwert (0,08 %). Nicht fahren!",
+    "belowDeLimit": "Unter DE-Grenzwert (0,5 ‰).",
+    "aboveDeLimit": "Über DE-Grenzwert (0,5 ‰). Nicht fahren!",
+    "impairment_sober": "Nüchtern",
+    "impairment_minimal": "Minimale Beeinträchtigung",
+    "impairment_mild": "Leichte Beeinträchtigung",
+    "impairment_legal": "Gesetzlicher Grenzwert erreicht",
+    "impairment_significant": "Erhebliche Beeinträchtigung",
+    "impairment_dangerous": "Gefährlicher Bereich",
+    "scaleLabel": "BAC-Skala (%)",
+    "effectsTableTitle": "BAC-Bereich und Wirkung",
+    "bacRangeHeader": "BAC (%)",
+    "effectHeader": "Wirkung",
+    "effect_sober": "Keine Beeinträchtigung",
+    "effect_minimal": "Wärmegefühl, leichte Enthemmung",
+    "effect_mild": "Reduzierte Reaktionszeit, Stimmung gehoben",
+    "effect_legal": "Deutlich verlangsamte Reaktion, Koordinationsstörungen — US-Fahrgrenze",
+    "effect_significant": "Sprache, Sehen und Gleichgewicht stark gestört",
+    "effect_dangerous": "Bewusstseinsstörungen, Erbrechen, Lebensgefahr",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Diese Schätzung verwendet US-Standardgetränke (14 g reiner Alkohol) und die Widmark-Formel. BAC (%) = (Drinks × 14 g) / (Gewicht × r) × 0,1 − 0,015 × Stunden, mit r = 0,68 (Mann) bzw. 0,55 (Frau). Die Abbaurate beträgt ca. 0,015 % pro Stunde. Die Schätzung kann individuell um ±20–30 % abweichen — Magenfüllung, Lebergesundheit, Medikamente und genetische Unterschiede beeinflussen den Wert.",
+    "disclaimer": "Diese Schätzung ersetzt keinen Atem- oder Bluttest. Wenn du getrunken hast: Nicht fahren.",
+    "faq": [
+      {
+        "q": "Was ist ein Standardgetränk?",
+        "a": "Ein US-Standardgetränk enthält 14 g reinen Alkohol. Das entspricht ungefähr 350 ml Bier (5 %), 150 ml Wein (12 %) oder 44 ml Spirituose (40 %). In Deutschland werden meist 10–12 g pro Einheit verwendet — der Rechner verwendet die US-Konvention."
+      },
+      {
+        "q": "Wie unterscheidet sich BAC von Promille?",
+        "a": "BAC in % (USA) und Promille (DE/EU) messen dasselbe, nur in unterschiedlichen Einheiten. 0,08 % BAC = 0,8 ‰. Der Rechner zeigt beide Werte parallel an."
+      },
+      {
+        "q": "Wie schnell baut der Körper Alkohol ab?",
+        "a": "Im Mittel etwa 0,015 % pro Stunde (≈ 0,15 ‰). Diese Rate ist nahezu konstant und kann nicht durch Kaffee, Wasser oder Bewegung beschleunigt werden."
+      },
+      {
+        "q": "Welche Grenzwerte gelten beim Fahren?",
+        "a": "USA: meist 0,08 % BAC (0,04 % für Berufsfahrer, 0,00 % für unter 21). Deutschland: 0,5 ‰ (0,3 ‰ bei Auffälligkeiten, 0,0 ‰ Fahranfänger). EU-Länder variieren — meist 0,02–0,05 %."
+      },
+      {
+        "q": "Warum ist die Schätzung ungenau?",
+        "a": "Magenfüllung, Lebergesundheit, Medikamente, Hormonzyklus und genetische Unterschiede beeinflussen den realen Wert. Frauen haben außerdem im Mittel weniger Wasseranteil im Körper. Im Zweifel immer das niedrigere Risiko annehmen."
+      },
+      {
+        "q": "Was unterscheidet diesen Rechner vom Promillerechner?",
+        "a": "Der Promillerechner nimmt einzelne Getränke (Volumen × Vol.-%) an — präzise, aber langsam. Dieser Schätzer arbeitet mit Standardgetränken — schneller, aber weniger fein justiert. Beide Rechner verwenden die gleiche Widmark-Formel."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/bloodAlcoholEstimator.json
+++ b/src/locales/calculators/en/bloodAlcoholEstimator.json
@@ -1,0 +1,85 @@
+{
+  "home": {
+    "calculators": {
+      "bloodAlcoholEstimator": {
+        "name": "Blood Alcohol Estimator",
+        "description": "Quick BAC estimate from standard drinks, weight and time."
+      }
+    }
+  },
+  "bloodAlcoholEstimator": {
+    "meta": {
+      "title": "Blood Alcohol Estimator — Quick BAC Calculator with Standard Drinks",
+      "description": "Estimate your blood alcohol concentration (BAC) fast using standard drinks, body weight and time. Widmark formula, sobriety prognosis and legal limits. Free, instant, no sign-up."
+    },
+    "title": "Blood Alcohol Estimator",
+    "description": "Quick BAC estimate using US standard drinks (14 g pure alcohol per drink), body weight and time — for a fast read on your level.",
+    "instructionsLabel": "How to use",
+    "instructions": "Pick sex and unit, enter your body weight, the number of standard drinks you've had and the hours since your first drink. One US standard drink = 14 g pure alcohol (≈ 12 oz beer at 5%, 5 oz wine at 12%, or 1.5 oz spirits at 40%).",
+    "sexLabel": "Sex",
+    "weightLabel": "Body weight ({unit})",
+    "weightPlaceholder": "180",
+    "drinksLabel": "Number of standard drinks",
+    "drinksPlaceholder": "3",
+    "drinksHelp": "1 standard drink = 14 g pure alcohol",
+    "hoursLabel": "Hours since first drink",
+    "hoursPlaceholder": "1",
+    "results": "Estimated BAC",
+    "bacLabel": "BAC",
+    "promilleLabel": "Promille",
+    "timeUntilSoberLabel": "Time until sober (BAC = 0)",
+    "alreadySober": "Already sober",
+    "hoursMinutes": "{hours} hr {minutes} min",
+    "alcoholGramsLabel": "Pure alcohol",
+    "legalLimitLabel": "Legal limit",
+    "belowUsLimit": "Below US legal limit (0.08%).",
+    "aboveUsLimit": "Above US legal limit (0.08%). Do not drive!",
+    "belowDeLimit": "Below German legal limit (0.05%).",
+    "aboveDeLimit": "Above German legal limit (0.05%). Do not drive!",
+    "impairment_sober": "Sober",
+    "impairment_minimal": "Minimal impairment",
+    "impairment_mild": "Mild impairment",
+    "impairment_legal": "Legal limit reached",
+    "impairment_significant": "Significant impairment",
+    "impairment_dangerous": "Dangerous range",
+    "scaleLabel": "BAC scale (%)",
+    "effectsTableTitle": "BAC range and effect",
+    "bacRangeHeader": "BAC (%)",
+    "effectHeader": "Effect",
+    "effect_sober": "No impairment",
+    "effect_minimal": "Feeling of warmth, slight disinhibition",
+    "effect_mild": "Reduced reaction time, elevated mood",
+    "effect_legal": "Notably slowed reaction, coordination loss — US driving limit",
+    "effect_significant": "Slurred speech, blurred vision, severe balance issues",
+    "effect_dangerous": "Impaired consciousness, vomiting, life-threatening",
+    "howItWorks": "How it works",
+    "howItWorksText": "This estimator uses US standard drinks (14 g pure alcohol) and the Widmark formula. BAC (%) = (drinks × 14 g) / (weight × r) × 0.1 − 0.015 × hours, where r = 0.68 (male) or 0.55 (female). Elimination is approximately 0.015% per hour. Individual values can shift ±20–30% — stomach contents, liver health, medications and genetics all matter.",
+    "disclaimer": "This estimate is no substitute for a breath or blood test. If you've been drinking: do not drive.",
+    "faq": [
+      {
+        "q": "What is a standard drink?",
+        "a": "A US standard drink contains 14 g of pure alcohol. That's roughly 12 oz of beer (5%), 5 oz of wine (12%) or 1.5 oz of spirits (40%). UK units are smaller (8 g) — this calculator uses the US convention."
+      },
+      {
+        "q": "What's the difference between BAC and promille?",
+        "a": "BAC in % (US) and promille (Europe) measure the same thing in different units. 0.08% BAC = 0.8‰. The result panel shows both side by side."
+      },
+      {
+        "q": "How fast does the body process alcohol?",
+        "a": "On average about 0.015% BAC per hour (≈ 0.15‰). The rate is roughly constant and cannot be sped up by coffee, water or exercise — only time."
+      },
+      {
+        "q": "What are the driving limits?",
+        "a": "US: 0.08% BAC in most states (0.04% for commercial drivers, 0.00% under 21). Germany: 0.05% / 0.5‰ (0.03% with signs of impairment, 0.00% for new drivers). Most EU countries: 0.02–0.05%."
+      },
+      {
+        "q": "Why is the estimate imprecise?",
+        "a": "Stomach contents, liver function, medications, hormonal cycle and genetics all shift real BAC. Women on average have less body water. When in doubt, assume the more conservative reading."
+      },
+      {
+        "q": "How is this different from the Blood Alcohol Calculator?",
+        "a": "The full Blood Alcohol Calculator takes individual drinks (volume × ABV) — precise but slower. This estimator uses standard drinks — faster but less fine-grained. Both use the Widmark formula."
+      }
+    ]
+  }
+}

--- a/src/pages/BloodAlcoholEstimatorCalculator.vue
+++ b/src/pages/BloodAlcoholEstimatorCalculator.vue
@@ -1,0 +1,271 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { estimateBac, timeUntilSober, classifyImpairment } from '../utils/bloodAlcoholEstimator.js'
+
+const { t, tm, locale } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('bloodAlcoholEstimator.faq') || [])
+
+useHead(() => ({
+  title: t('bloodAlcoholEstimator.meta.title'),
+  description: t('bloodAlcoholEstimator.meta.description'),
+  routeKey: 'bloodAlcoholEstimator',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Blood Alcohol Estimator',
+    url: 'https://healthcalculator.app/blood-alcohol-estimator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const sex = ref('male')
+const unit = ref('metric')
+const weight = ref(null)
+const drinks = ref(null)
+const hours = ref(null)
+
+const weightKg = computed(() => {
+  if (weight.value == null) return null
+  return unit.value === 'imperial' ? weight.value * 0.453592 : weight.value
+})
+
+const result = computed(() => {
+  if (drinks.value == null || weightKg.value == null) return null
+  const bac = estimateBac({
+    standardDrinks: drinks.value,
+    weightKg: weightKg.value,
+    sex: sex.value,
+    hours: hours.value || 0,
+  })
+  if (bac === null) return null
+  return {
+    bac,
+    promille: bac * 10,
+    alcoholGrams: drinks.value * 14,
+    timeHours: timeUntilSober(bac),
+    impairment: classifyImpairment(bac),
+  }
+})
+
+const timeFormatted = computed(() => {
+  if (!result.value) return null
+  const totalMin = Math.ceil(result.value.timeHours * 60)
+  return { hours: Math.floor(totalMin / 60), minutes: totalMin % 60 }
+})
+
+const impairmentColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.impairment) {
+    case 'sober': return 'text-green-600'
+    case 'minimal': return 'text-green-500'
+    case 'mild': return 'text-yellow-500'
+    case 'legal': return 'text-orange-500'
+    case 'significant': return 'text-red-500'
+    case 'dangerous': return 'text-red-700'
+    default: return 'text-stone-500'
+  }
+})
+
+const scalePosition = computed(() => {
+  if (!result.value) return 0
+  return Math.min(result.value.bac / 0.4 * 100, 100)
+})
+
+const effectsRows = [
+  { range: '0.00', key: 'sober' },
+  { range: '0.01–0.029', key: 'minimal' },
+  { range: '0.03–0.079', key: 'mild' },
+  { range: '0.08–0.149', key: 'legal' },
+  { range: '0.15–0.299', key: 'significant' },
+  { range: '> 0.30', key: 'dangerous' },
+]
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('bloodAlcoholEstimator.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('bloodAlcoholEstimator.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('bloodAlcoholEstimator.instructionsLabel') }}</p>
+    <p class="text-sm text-stone-600 leading-relaxed mb-6">{{ t('bloodAlcoholEstimator.instructions') }}</p>
+
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="unit = 'metric'"
+        data-testid="unit-metric"
+        :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.metric') }}</button>
+      <button
+        @click="unit = 'imperial'"
+        data-testid="unit-imperial"
+        :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.imperial') }}</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('bloodAlcoholEstimator.sexLabel') }}</label>
+        <div class="flex gap-2">
+          <button
+            @click="sex = 'male'"
+            data-testid="sex-male"
+            :class="sex === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('common.male') }}</button>
+          <button
+            @click="sex = 'female'"
+            data-testid="sex-female"
+            :class="sex === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('common.female') }}</button>
+        </div>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('bloodAlcoholEstimator.weightLabel', { unit: t('common.' + (unit === 'metric' ? 'kg' : 'lbs')) }) }}
+        </label>
+        <input
+          v-model.number="weight"
+          type="number"
+          :placeholder="unit === 'metric' ? '80' : '180'"
+          data-testid="weight"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('bloodAlcoholEstimator.drinksLabel') }}</label>
+        <input
+          v-model.number="drinks"
+          type="number"
+          step="0.5"
+          min="0"
+          :placeholder="t('bloodAlcoholEstimator.drinksPlaceholder')"
+          data-testid="drinks"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+        <p class="text-xs text-stone-400 mt-1.5">{{ t('bloodAlcoholEstimator.drinksHelp') }}</p>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('bloodAlcoholEstimator.hoursLabel') }}</label>
+        <input
+          v-model.number="hours"
+          type="number"
+          step="0.5"
+          min="0"
+          :placeholder="t('bloodAlcoholEstimator.hoursPlaceholder')"
+          data-testid="hours"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('bloodAlcoholEstimator.results') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="bac-result">{{ result.bac.toFixed(3) }}</span>
+      <span class="text-lg text-stone-400">% {{ t('bloodAlcoholEstimator.bacLabel') }}</span>
+      <span :class="impairmentColor" class="text-base font-semibold ml-auto" data-testid="result-status">{{ t('bloodAlcoholEstimator.impairment_' + result.impairment) }}</span>
+    </div>
+
+    <div class="text-sm text-stone-500 mb-6 tabular-nums">
+      <span data-testid="promille-result">{{ result.promille.toFixed(2) }}</span> ‰ {{ t('bloodAlcoholEstimator.promilleLabel') }}
+    </div>
+
+    <div class="mb-2">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('bloodAlcoholEstimator.scaleLabel') }}</p>
+      <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden">
+        <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-yellow-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+        <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: scalePosition + '%' }"></div>
+      </div>
+      <div class="flex justify-between text-[10px] text-stone-400 tabular-nums mt-1">
+        <span>0.00</span>
+        <span>0.08</span>
+        <span>0.20</span>
+        <span>≥ 0.40</span>
+      </div>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 mt-6 mb-3" data-testid="legal-limit">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('bloodAlcoholEstimator.legalLimitLabel') }}</p>
+      <p class="text-sm font-medium leading-relaxed">
+        <span :class="result.bac < 0.08 ? 'text-green-600' : 'text-red-600'">
+          {{ result.bac < 0.08 ? t('bloodAlcoholEstimator.belowUsLimit') : t('bloodAlcoholEstimator.aboveUsLimit') }}
+        </span>
+        <br />
+        <span :class="result.bac < 0.05 ? 'text-green-600' : 'text-red-600'">
+          {{ result.bac < 0.05 ? t('bloodAlcoholEstimator.belowDeLimit') : t('bloodAlcoholEstimator.aboveDeLimit') }}
+        </span>
+      </p>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3">
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="time-until-sober">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('bloodAlcoholEstimator.timeUntilSoberLabel') }}</p>
+        <p class="text-xl font-bold text-stone-900 tabular-nums leading-tight">
+          <span v-if="result.timeHours === 0">{{ t('bloodAlcoholEstimator.alreadySober') }}</span>
+          <span v-else>{{ t('bloodAlcoholEstimator.hoursMinutes', { hours: timeFormatted.hours, minutes: timeFormatted.minutes }) }}</span>
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="alcohol-grams">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('bloodAlcoholEstimator.alcoholGramsLabel') }}</p>
+        <p class="text-xl font-bold text-stone-900 tabular-nums leading-tight">{{ result.alcoholGrams.toFixed(0) }} g</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('bloodAlcoholEstimator.effectsTableTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('bloodAlcoholEstimator.bacRangeHeader') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('bloodAlcoholEstimator.effectHeader') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr v-for="row in effectsRows" :key="row.key">
+          <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">{{ row.range }}</td>
+          <td class="px-6 py-3 text-stone-600">{{ t('bloodAlcoholEstimator.effect_' + row.key) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('bloodAlcoholEstimator.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('bloodAlcoholEstimator.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('bloodAlcoholEstimator.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="bloodAlcoholEstimator" />
+</template>

--- a/src/pages/blog/BlutalkoholSchaetzen.vue
+++ b/src/pages/blog/BlutalkoholSchaetzen.vue
@@ -1,0 +1,251 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Blutalkohol schätzen: BAC, Promille und der schnelle Standardgetränk-Rechner | Health Calculators',
+  description: 'Blutalkohol (BAC) schnell schätzen mit Standardgetränken und Körpergewicht. Widmark-Formel, US- und DE-Grenzwerte, Abbau pro Stunde — kompakt erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Blutalkohol schätzen: BAC, Promille und der schnelle Standardgetränk-Rechner',
+    description: 'Blutalkohol (BAC) schnell schätzen mit Standardgetränken und Körpergewicht. Widmark-Formel, US- und DE-Grenzwerte, Abbau pro Stunde — kompakt erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-04',
+    dateModified: '2026-05-04',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/blutalkohol-schaetzen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Blutalkohol schätzen: BAC, Promille und der schnelle Standardgetränk-Rechner</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">4. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wie viel Promille hat man nach drei Bier? Reicht das schon für den US-Grenzwert? Und wann darf man wieder Auto fahren? Statt jedes Glas einzeln in Volumen und Vol.-% einzugeben, reicht für eine schnelle Einschätzung die <strong>Standardgetränk-Methode</strong>.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt, wie der <strong>Blutalkohol-Schätzer</strong> mit der Widmark-Formel arbeitet, was BAC und Promille unterscheidet, und welche Grenzwerte in den USA und Deutschland gelten.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist ein Standardgetränk?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein <strong>US-Standardgetränk</strong> enthält genau 14 Gramm reinen Alkohol — unabhängig davon, was im Glas ist. Diese Konvention macht die Rechnung im Kopf möglich.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Getränk</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Menge</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Alkohol</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Bier</td>
+                <td class="px-6 py-3 text-stone-600">350 ml (12 oz)</td>
+                <td class="px-6 py-3 text-stone-600">~ 5 %</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Wein</td>
+                <td class="px-6 py-3 text-stone-600">150 ml (5 oz)</td>
+                <td class="px-6 py-3 text-stone-600">~ 12 %</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Spirituose</td>
+                <td class="px-6 py-3 text-stone-600">44 ml (1.5 oz)</td>
+                <td class="px-6 py-3 text-stone-600">~ 40 %</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Achtung: ein 0,5-l-Bier sind <strong>~ 1,4 Standardgetränke</strong>, ein großes Glas Wein (250 ml) sind <strong>~ 1,7</strong>. Die UK-Einheit ist mit 8 g kleiner — siehe <router-link :to="localeBlogPath('alkohol-einheiten-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Alkoholeinheiten</router-link>.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Schätzformel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Schätzer setzt die Standardgetränke direkt in die <strong>Widmark-Formel</strong> ein:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p class="mb-2"><strong>BAC (%)</strong> = (Drinks &times; 14 g) / (Gewicht &times; r) &times; 0,1 &minus; 0,015 &times; Stunden</p>
+          <p>r = 0,68 (Männer) | r = 0,55 (Frauen)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der Reduktionsfaktor <strong>r</strong> spiegelt den Wasseranteil im Körper wider. Frauen haben im Durchschnitt weniger Körperwasser, weshalb derselbe Alkohol einen höheren BAC ergibt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Rechenbeispiel</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Schritt</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Berechnung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Eingabe</td>
+                <td class="px-6 py-3 text-stone-600">Mann, 80 kg, 4 Drinks, 1 h</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Alkohol (g)</td>
+                <td class="px-6 py-3 text-stone-600">4 &times; 14 = 56 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Roher BAC</td>
+                <td class="px-6 py-3 text-stone-600">56 / (80 &times; 0,68) &times; 0,1 = 0,103 %</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Nach 1 h</td>
+                <td class="px-6 py-3 text-stone-600">0,103 &minus; 0,015 = <strong>0,088 %</strong> (≈ 0,88 ‰)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Zeit bis nüchtern</td>
+                <td class="px-6 py-3 text-stone-600">0,088 / 0,015 = ~ 5,9 Stunden</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BAC vs. Promille</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          BAC in % (USA) und Promille (Deutschland, EU) messen dasselbe — nur in unterschiedlichen Einheiten:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p>0,08 % BAC = 0,8 ‰ &nbsp; | &nbsp; 0,05 % BAC = 0,5 ‰ &nbsp; | &nbsp; 0,02 % BAC = 0,2 ‰</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Faustregel: <strong>BAC &times; 10 = Promille</strong>. Der Rechner zeigt beide Werte parallel an.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Grenzwerte beim Fahren</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Land</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Grenzwert</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Anmerkung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">USA (meiste Bundesstaaten)</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0,08 %</td>
+                <td class="px-6 py-3 text-stone-600">0,04 % für Berufsfahrer, 0,00 % unter 21</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Deutschland</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0,5 ‰ (0,05 %)</td>
+                <td class="px-6 py-3 text-stone-600">0,3 ‰ bei Auffälligkeiten, 0,0 ‰ Fahranfänger</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Schweden, Norwegen</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0,2 ‰</td>
+                <td class="px-6 py-3 text-stone-600">Praktisch ein Drink ist schon zu viel</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Österreich, Schweiz</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0,5 ‰</td>
+                <td class="px-6 py-3 text-stone-600">Probefahrer 0,1 ‰</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Alkoholabbau pro Stunde</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Körper baut Alkohol mit etwa <strong>0,015 % BAC pro Stunde</strong> (~ 0,15 ‰) ab. Diese Rate ist nahezu konstant — Kaffee, kalte Duschen oder Bewegung beschleunigen sie <strong>nicht</strong>. Was hilft, ist nur Zeit.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Praktische Konsequenz: nach einer durchzechten Nacht mit BAC 0,15 % beim Schlafengehen ist man morgens nach 8 Stunden Schlaf erst bei <strong>0,03 %</strong> — Restalkohol ist Realität.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Schnell BAC schätzen</h3>
+        <p class="text-stone-300 text-sm mb-5">Geschlecht, Gewicht, Drinks, Stunden — fertig. BAC, Promille und Restzeit auf einen Blick.</p>
+        <router-link
+          :to="localePath('bloodAlcoholEstimator')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos schätzen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann ist eine Schätzung ungenau?</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Magenfüllung</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Auf nüchternen Magen wird Alkohol schneller resorbiert — der Spitzenwert liegt höher. Eine deftige Mahlzeit kann den Peak um 20–30 % senken.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Medikamente</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Schmerzmittel, Antibiotika und einige Antidepressiva interagieren mit Alkohol und verstärken die Wirkung. Im Zweifel den Beipackzettel prüfen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Genetik & Lebergesundheit</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Alkoholdehydrogenase-Varianten (besonders bei Menschen ostasiatischer Herkunft) und Lebervorerkrankungen verlangsamen den Abbau deutlich.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Brauchst du eine genaue Eingabe pro Glas (Volumen × Vol.-%)? Nutze den ausführlicheren <router-link :to="localePath('bac')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Promillerechner</router-link>. Für die wöchentliche Konsumübersicht in UK-Einheiten siehe den <router-link :to="localePath('alcoholUnits')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Alkoholeinheiten-Rechner</router-link>. Und wer wissen will, wie sich Lebensstil-Entscheidungen langfristig auswirken: <router-link :to="localePath('lifeExpectancy')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Lebenserwartung berechnen</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die Standardgetränk-Methode liefert in 30 Sekunden eine brauchbare BAC-Schätzung — gut genug, um die Frage „darf ich noch Auto fahren?" mit einem klaren <em>Nein</em> zu beantworten. Im Zweifel: einen Drink weniger, eine Stunde länger warten. Probiere den <router-link :to="localePath('bloodAlcoholEstimator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Blutalkohol-Schätzer</router-link> für deine persönliche Situation.
+        </p>
+      </div>
+
+      <RelatedArticles slug="blutalkohol-schaetzen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/BloodAlcoholEstimatorGuide.vue
+++ b/src/pages/blog/en/BloodAlcoholEstimatorGuide.vue
@@ -1,0 +1,251 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Blood Alcohol Estimator: Standard Drinks, BAC and Driving Limits | Health Calculators',
+  description: 'Estimate your blood alcohol concentration (BAC) fast using US standard drinks and body weight. Widmark formula, US/EU driving limits and hourly elimination — explained.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Blood Alcohol Estimator: Standard Drinks, BAC and Driving Limits',
+    description: 'Estimate your blood alcohol concentration (BAC) fast using US standard drinks and body weight. Widmark formula, US/EU driving limits and hourly elimination — explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-04',
+    dateModified: '2026-05-04',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/blood-alcohol-estimator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Blood Alcohol Estimator: Standard Drinks, BAC and Driving Limits</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 4, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          How drunk are you really after three beers? Are you over the legal limit? When can you drive again? Instead of typing in every glass's volume and ABV, the <strong>standard-drink method</strong> gives you a usable BAC estimate in 30 seconds.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how the <strong>Blood Alcohol Estimator</strong> uses the Widmark formula, what BAC and promille really measure, and which legal limits apply in the US, UK and EU.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is a standard drink?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A <strong>US standard drink</strong> contains exactly 14 grams of pure alcohol — regardless of what's in the glass. That convention makes the math doable in your head.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Drink</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Serving</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">ABV</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Beer</td>
+                <td class="px-6 py-3 text-stone-600">12 oz (350 ml)</td>
+                <td class="px-6 py-3 text-stone-600">~ 5%</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Wine</td>
+                <td class="px-6 py-3 text-stone-600">5 oz (150 ml)</td>
+                <td class="px-6 py-3 text-stone-600">~ 12%</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Spirits</td>
+                <td class="px-6 py-3 text-stone-600">1.5 oz (44 ml)</td>
+                <td class="px-6 py-3 text-stone-600">~ 40%</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Watch out: a 16 oz craft IPA at 7% is closer to <strong>2 standard drinks</strong>, and a generous wine pour easily counts as 1.5. UK units are smaller (8 g of alcohol) — see the <router-link :to="localeBlogPath('alcohol-unit-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Alcohol Unit Calculator</router-link>.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The estimation formula</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The estimator plugs your standard drinks into the <strong>Widmark formula</strong> directly:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p class="mb-2"><strong>BAC (%)</strong> = (drinks &times; 14 g) / (weight &times; r) &times; 0.1 &minus; 0.015 &times; hours</p>
+          <p>r = 0.68 (male) | r = 0.55 (female)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The <strong>r</strong> factor reflects body water content. Women on average have less body water, so the same alcohol load yields a higher BAC.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Worked example</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Step</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Calculation</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Input</td>
+                <td class="px-6 py-3 text-stone-600">Male, 80 kg (176 lb), 4 drinks, 1 hour</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Alcohol (g)</td>
+                <td class="px-6 py-3 text-stone-600">4 &times; 14 = 56 g</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Raw BAC</td>
+                <td class="px-6 py-3 text-stone-600">56 / (80 &times; 0.68) &times; 0.1 = 0.103%</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">After 1 h</td>
+                <td class="px-6 py-3 text-stone-600">0.103 &minus; 0.015 = <strong>0.088%</strong> (≈ 0.88‰)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Time to sober</td>
+                <td class="px-6 py-3 text-stone-600">0.088 / 0.015 = ~ 5.9 hours</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BAC vs. promille</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          BAC in % (US) and promille (Europe) measure the same thing in different units:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm text-stone-700">
+          <p>0.08% BAC = 0.8‰ &nbsp; | &nbsp; 0.05% BAC = 0.5‰ &nbsp; | &nbsp; 0.02% BAC = 0.2‰</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Rule of thumb: <strong>BAC &times; 10 = promille</strong>. The result panel shows both values.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Driving limits around the world</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Country</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Limit</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Notes</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">USA (most states)</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0.08%</td>
+                <td class="px-6 py-3 text-stone-600">0.04% commercial, 0.00% under 21; Utah: 0.05%</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">UK (England, Wales, NI)</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0.08%</td>
+                <td class="px-6 py-3 text-stone-600">Scotland: 0.05%</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Germany / Austria</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0.05% (0.5‰)</td>
+                <td class="px-6 py-3 text-stone-600">0.03% with signs of impairment, 0.00% new drivers</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Sweden, Norway, Poland</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0.02%</td>
+                <td class="px-6 py-3 text-stone-600">A single drink may put you over</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hourly elimination</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The body clears alcohol at roughly <strong>0.015% BAC per hour</strong> (~ 0.15‰). The rate is essentially constant — coffee, cold showers and exercise do <strong>not</strong> speed it up. Only time does.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Practical takeaway: if you go to bed at BAC 0.15%, after eight hours of sleep you're still at <strong>0.03%</strong> — morning-after residual is real.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Estimate your BAC now</h3>
+        <p class="text-stone-300 text-sm mb-5">Sex, weight, drinks, hours — done. BAC, promille and time-to-sober at a glance.</p>
+        <router-link
+          :to="localePath('bloodAlcoholEstimator')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Run the free estimate &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Where the estimate gets fuzzy</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Empty stomach</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              On an empty stomach alcohol absorbs faster — peak BAC is higher. A heavy meal can reduce the peak by 20–30%.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Medications</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Pain relievers, antibiotics and several antidepressants interact with alcohol and amplify its effects. Check the label.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Genetics &amp; liver health</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              ADH gene variants (common in East Asian populations) and liver disease slow elimination significantly.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Need precise per-drink input (volume × ABV)? Use the more detailed <router-link :to="localePath('bac')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Blood Alcohol Calculator</router-link>. For weekly consumption tracking in UK units, see the <router-link :to="localePath('alcoholUnits')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Alcohol Unit Calculator</router-link>. And for the long-term picture: <router-link :to="localePath('lifeExpectancy')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Life Expectancy Calculator</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The standard-drink method is precise enough to answer the only question that matters in the moment: "can I drive?" If the estimator returns anything above your local limit, the answer is no. When in doubt — one drink fewer, one hour more. Try the <router-link :to="localePath('bloodAlcoholEstimator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Blood Alcohol Estimator</router-link> for your situation.
+        </p>
+      </div>
+
+      <RelatedArticles slug="blood-alcohol-estimator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/bloodAlcoholEstimator.meta.js
+++ b/src/pages/bloodAlcoholEstimator.meta.js
@@ -1,0 +1,16 @@
+import Component from './BloodAlcoholEstimatorCalculator.vue'
+import BlogDe from './blog/BlutalkoholSchaetzen.vue'
+import BlogEn from './blog/en/BloodAlcoholEstimatorGuide.vue'
+
+export default {
+  key: 'bloodAlcoholEstimator',
+  component: Component,
+  slugs: { de: 'blutalkohol-schaetzer', en: 'blood-alcohol-estimator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 33,
+  blog: {
+    de: { slug: 'blutalkohol-schaetzen', component: BlogDe },
+    en: { slug: 'blood-alcohol-estimator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/bloodAlcoholEstimator.js
+++ b/src/utils/bloodAlcoholEstimator.js
@@ -1,0 +1,54 @@
+// Quick Blood Alcohol Estimator using US standard drinks (14 g pure alcohol per drink)
+// and the Widmark formula. Output is in % BAC (g/dL) — US convention.
+//
+//   alcoholGrams = drinks × 14
+//   BAC (%) = alcoholGrams / (weightKg × r) × 0.1 − 0.015 × hours
+//   r = 0.68 (male), 0.55 (female)  — Widmark distribution ratios
+//   Elimination ~ 0.015 % per hour (≈ 0.15 g/L per hour)
+
+const STD_DRINK_GRAMS = 14
+const ELIMINATION_PCT_PER_HOUR = 0.015
+const WIDMARK_R = { male: 0.68, female: 0.55 }
+
+function isValidSex(sex) {
+  return sex === 'male' || sex === 'female'
+}
+
+function rawBac({ standardDrinks, weightKg, sex }) {
+  const grams = standardDrinks * STD_DRINK_GRAMS
+  return (grams / (weightKg * WIDMARK_R[sex])) * 0.1
+}
+
+export function estimateBac({ standardDrinks, weightKg, sex, hours = 0 } = {}) {
+  if (standardDrinks == null || standardDrinks < 0) return null
+  if (weightKg == null || weightKg <= 0) return null
+  if (!isValidSex(sex)) return null
+  const peak = rawBac({ standardDrinks, weightKg, sex })
+  const elapsed = hours > 0 ? hours : 0
+  return Math.max(0, peak - ELIMINATION_PCT_PER_HOUR * elapsed)
+}
+
+export function timeUntilSober(bac) {
+  if (bac == null || bac <= 0) return 0
+  return bac / ELIMINATION_PCT_PER_HOUR
+}
+
+export function classifyImpairment(bac) {
+  if (bac == null) return null
+  if (bac <= 0) return 'sober'
+  if (bac < 0.03) return 'minimal'
+  if (bac < 0.08) return 'mild'
+  if (bac < 0.15) return 'legal'
+  if (bac < 0.30) return 'significant'
+  return 'dangerous'
+}
+
+export function estimate(input) {
+  const bac = estimateBac(input)
+  if (bac === null) return null
+  return {
+    bac,
+    timeUntilSober: timeUntilSober(bac),
+    impairment: classifyImpairment(bac),
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-151-blood-alcohol-estimator
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-151-blood-alcohol-estimator-20260504-120031`
**Cost:** $10.701055

Closes jenslaufer/health-calculators#151

### Prompt
> Implement the Blood Alcohol Estimator Calculator as described in issue #151.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Blood alcohol level from drinks, weight, time
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/bloodAlcoholEstimator.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/bloodAlcoholEstimator.test.js` with 6+ test cases covering edge cases. Run `npm test -- bloodAlcoholEstimator` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/BloodAlcoholEstimatorCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/bloodAlcoholEstimator.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/bloodAlcoholEstimator.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'bloodAlcoholEstimator'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/bloodAlcoholEstimator.json` + `src/locales/calculators/en/bloodAlcoholEstimator.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/bloodAlcoholEstimator.js (or shared util — verify pattern in repo first)`
- `src/__tests__/bloodAlcoholEstimator.test.js`
- `src/pages/BloodAlcoholEstimatorCalculator.vue`
- `src/pages/bloodAlcoholEstimator.meta.js`
- `src/locales/calculators/de/bloodAlcoholEstimator.json`
- `src/locales/calculators/en/bloodAlcoholEstimator.json`
- `e2e/bloodAlcoholEstimator.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'bloodAlcoholEstimator',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks