### PR TITLE
hc-150-heart-failure-risk: Implement the Heart Failure Risk Calculator as described in 

### DIFF
--- a/e2e/heartFailureRisk.spec.js
+++ b/e2e/heartFailureRisk.spec.js
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/herzinsuffizienz-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Herzinsuffizienz/)
+})
+
+test('young healthy female → low risk', async ({ page }) => {
+  await page.getByTestId('sex-female').click()
+  await page.getByTestId('age').fill('30')
+  await page.getByTestId('weight').fill('60')
+  await page.getByTestId('height').fill('170')
+
+  await expect(page.getByTestId('risk-score')).toBeVisible()
+  await expect(page.getByTestId('result-status')).toHaveText(/Niedrig/)
+})
+
+test('older male with multiple risk factors → very high', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('72')
+  await page.getByTestId('weight').fill('95')
+  await page.getByTestId('height').fill('175')
+  await page.getByTestId('hypertension').check()
+  await page.getByTestId('diabetes').check()
+  await page.getByTestId('cad').check()
+  await page.getByTestId('prior-mi').check()
+  await page.getByTestId('smoker').check()
+
+  await expect(page.getByTestId('risk-score')).toBeVisible()
+  await expect(page.getByTestId('result-status')).toHaveText(/Sehr hoch/)
+})
+
+test('shows BMI display when weight and height entered', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('50')
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('180')
+
+  await expect(page.getByTestId('bmi-display')).toBeVisible()
+})
+
+test('toggling imperial unit accepts pounds', async ({ page }) => {
+  await page.getByTestId('unit-imperial').click()
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('45')
+  await page.getByTestId('weight').fill('176')
+  await page.getByTestId('height').fill('69')
+
+  await expect(page.getByTestId('risk-score')).toBeVisible()
+  await expect(page.getByTestId('bmi-display')).toBeVisible()
+})
+
+test('shows ten-year risk percentage', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('age').fill('60')
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('175')
+  await page.getByTestId('hypertension').check()
+
+  await expect(page.getByTestId('ten-year-risk')).toBeVisible()
+})
+
+test('back link returns to home', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -22,6 +22,7 @@ const EXPECTED_KEYS = [
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
+  'heartFailureRisk',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -78,6 +79,7 @@ const EXPECTED_ROUTE_MAP = {
   cardiovascularRisk: { de: 'herz-kreislauf-risiko-rechner', en: 'cardiovascular-risk-calculator' },
   strokeRisk: { de: 'schlaganfall-risiko-rechner', en: 'stroke-risk-calculator' },
   bloodAlcoholEstimator: { de: 'blutalkohol-schaetzer', en: 'blood-alcohol-estimator' },
+  heartFailureRisk: { de: 'herzinsuffizienz-risiko-rechner', en: 'heart-failure-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -122,6 +124,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'herz-kreislauf-risiko-berechnen',
   'schlaganfall-risiko-berechnen',
   'blutalkohol-schaetzen',
+  'herzinsuffizienz-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -166,19 +169,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'cardiovascular-risk-framingham',
   'stroke-risk-calculator-cha2ds2-vasc',
   'blood-alcohol-estimator-guide',
+  'heart-failure-risk-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 55 calculators', () => {
-    expect(calculatorMetas).toHaveLength(55)
+  it('discovers all 56 calculators', () => {
+    expect(calculatorMetas).toHaveLength(56)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 55 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(55)
+  it('builds calculatorComponents map for all 56 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(56)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -201,15 +205,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 53 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(53)
+  it('discovers all 54 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(54)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 53 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(53)
+  it('discovers all 54 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(54)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -225,10 +229,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 54 calculators with no duplicates', () => {
+  it('groups contain all 56 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(55)
-    expect(new Set(allKeys).size).toBe(55)
+    expect(allKeys).toHaveLength(56)
+    expect(new Set(allKeys).size).toBe(56)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -249,7 +253,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'heartFailureRisk',
     ])
   })
 
@@ -297,8 +301,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 311 routes', () => {
-    expect(routes).toHaveLength(311)
+  it('generates exactly 316 routes', () => {
+    expect(routes).toHaveLength(316)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/heartFailureRisk.test.js
+++ b/src/__tests__/heartFailureRisk.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcHeartFailureRisk,
+  classifyHeartFailureRisk,
+  riskPercentForScore,
+  calcBmi,
+} from '../utils/heartFailureRisk.js'
+
+// Heart failure risk score — points-based screen built from age, sex, BMI,
+// hypertension, diabetes, CAD, prior heart attack, smoking, inactivity, CKD.
+// Score → 10-year heart failure risk and category (low/moderate/high/veryHigh).
+
+describe('Heart failure risk — input validation', () => {
+  it('returns null for missing or invalid inputs', () => {
+    expect(calcHeartFailureRisk({})).toBeNull()
+    expect(calcHeartFailureRisk({ age: 50 })).toBeNull()
+    expect(calcHeartFailureRisk(null)).toBeNull()
+  })
+
+  it('returns null for out-of-range age', () => {
+    expect(calcHeartFailureRisk({ age: 10, sex: 'male' })).toBeNull()
+    expect(calcHeartFailureRisk({ age: 105, sex: 'male' })).toBeNull()
+  })
+
+  it('returns null for invalid sex', () => {
+    expect(calcHeartFailureRisk({ age: 50, sex: 'other' })).toBeNull()
+  })
+})
+
+describe('Heart failure risk — low risk profiles', () => {
+  it('young healthy female → low risk', () => {
+    const r = calcHeartFailureRisk({
+      age: 30, sex: 'female', bmi: 22,
+    })
+    expect(r.score).toBeLessThanOrEqual(3)
+    expect(r.category).toBe('low')
+    expect(r.tenYearRiskPct).toBeLessThan(10)
+  })
+
+  it('40 y/o male, no risk factors → low/moderate', () => {
+    const r = calcHeartFailureRisk({
+      age: 40, sex: 'male', bmi: 24,
+    })
+    expect(r.score).toBeLessThanOrEqual(4)
+    expect(['low', 'moderate']).toContain(r.category)
+  })
+})
+
+describe('Heart failure risk — high risk profiles', () => {
+  it('70 y/o male with hypertension, diabetes, CAD, MI history → veryHigh', () => {
+    const r = calcHeartFailureRisk({
+      age: 70, sex: 'male', bmi: 32,
+      hypertension: true, diabetes: true,
+      coronaryArteryDisease: true, priorHeartAttack: true,
+      smoker: true, inactive: true, ckd: true,
+    })
+    expect(r.score).toBeGreaterThan(12)
+    expect(r.category).toBe('veryHigh')
+    expect(r.tenYearRiskPct).toBeGreaterThanOrEqual(30)
+  })
+
+  it('65 y/o female with hypertension and diabetes → high', () => {
+    const r = calcHeartFailureRisk({
+      age: 65, sex: 'female', bmi: 28,
+      hypertension: true, diabetes: true,
+    })
+    expect(r.score).toBeGreaterThanOrEqual(8)
+    expect(['high', 'veryHigh']).toContain(r.category)
+  })
+})
+
+describe('Heart failure risk — risk factor effects', () => {
+  const base = { age: 55, sex: 'male', bmi: 24 }
+
+  it('hypertension increases score', () => {
+    const without = calcHeartFailureRisk(base)
+    const withHt = calcHeartFailureRisk({ ...base, hypertension: true })
+    expect(withHt.score).toBeGreaterThan(without.score)
+  })
+
+  it('diabetes increases score', () => {
+    const without = calcHeartFailureRisk(base)
+    const withDm = calcHeartFailureRisk({ ...base, diabetes: true })
+    expect(withDm.score).toBeGreaterThan(without.score)
+  })
+
+  it('prior heart attack adds more than smoking', () => {
+    const mi = calcHeartFailureRisk({ ...base, priorHeartAttack: true })
+    const smoke = calcHeartFailureRisk({ ...base, smoker: true })
+    expect(mi.score).toBeGreaterThan(smoke.score)
+  })
+
+  it('obesity (BMI ≥ 30) scores higher than overweight (BMI 25–30)', () => {
+    const obese = calcHeartFailureRisk({ ...base, bmi: 32 })
+    const over = calcHeartFailureRisk({ ...base, bmi: 27 })
+    expect(obese.score).toBeGreaterThan(over.score)
+  })
+
+  it('men score higher than women with otherwise identical inputs', () => {
+    const male = calcHeartFailureRisk({ ...base, sex: 'male' })
+    const female = calcHeartFailureRisk({ ...base, sex: 'female' })
+    expect(male.score).toBeGreaterThan(female.score)
+  })
+
+  it('older age dominates the score', () => {
+    const young = calcHeartFailureRisk({ ...base, age: 35 })
+    const old = calcHeartFailureRisk({ ...base, age: 78 })
+    expect(old.score - young.score).toBeGreaterThanOrEqual(7)
+  })
+})
+
+describe('Risk classification thresholds', () => {
+  it('classifies ≤3 as low', () => {
+    expect(classifyHeartFailureRisk(0)).toBe('low')
+    expect(classifyHeartFailureRisk(3)).toBe('low')
+  })
+  it('classifies 4–7 as moderate', () => {
+    expect(classifyHeartFailureRisk(4)).toBe('moderate')
+    expect(classifyHeartFailureRisk(7)).toBe('moderate')
+  })
+  it('classifies 8–12 as high', () => {
+    expect(classifyHeartFailureRisk(8)).toBe('high')
+    expect(classifyHeartFailureRisk(12)).toBe('high')
+  })
+  it('classifies >12 as veryHigh', () => {
+    expect(classifyHeartFailureRisk(13)).toBe('veryHigh')
+    expect(classifyHeartFailureRisk(20)).toBe('veryHigh')
+  })
+  it('returns null for invalid score', () => {
+    expect(classifyHeartFailureRisk(-1)).toBeNull()
+    expect(classifyHeartFailureRisk(NaN)).toBeNull()
+  })
+})
+
+describe('Risk percent mapping', () => {
+  it('low scores → low risk percent', () => {
+    expect(riskPercentForScore(0)).toBeLessThan(5)
+    expect(riskPercentForScore(2)).toBeLessThan(10)
+  })
+  it('high scores → high risk percent', () => {
+    expect(riskPercentForScore(12)).toBeGreaterThanOrEqual(20)
+    expect(riskPercentForScore(20)).toBeGreaterThanOrEqual(40)
+  })
+  it('returns null for invalid score', () => {
+    expect(riskPercentForScore(-1)).toBeNull()
+  })
+})
+
+describe('BMI helper', () => {
+  it('70kg, 175cm → ~22.86', () => {
+    expect(calcBmi({ weightKg: 70, heightCm: 175 })).toBeCloseTo(22.86, 1)
+  })
+  it('returns null for invalid input', () => {
+    expect(calcBmi({ weightKg: 0, heightCm: 175 })).toBeNull()
+    expect(calcBmi({ weightKg: 70, heightCm: 0 })).toBeNull()
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 216 links (55 calcs × 2 locales + 53 blogs × 2 locales)', () => {
+  it('generates 220 links (56 calcs × 2 locales + 54 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(216)
+    expect(links).toHaveLength(220)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 220 links (56 calcs × 2 locales + 54 blogs × 2 locales)', () => {
+  it('generates 224 links (57 calcs × 2 locales + 55 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(220)
+    expect(links).toHaveLength(224)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -230,9 +230,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 112 calcs + 2 blog index + 108 blog articles = 224)', () => {
+  it('generates correct total URL count (2 home + 114 calcs + 2 blog index + 110 blog articles = 228)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(224)
+    expect(urlCount).toBe(228)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -16,6 +16,7 @@ const EXPECTED_KEYS = [
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
+  'heartFailureRisk',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -59,6 +60,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'herz-kreislauf-risiko-berechnen',
   'schlaganfall-risiko-berechnen',
   'blutalkohol-schaetzen',
+  'herzinsuffizienz-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -102,12 +104,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'cardiovascular-risk-framingham',
   'stroke-risk-calculator-cha2ds2-vasc',
   'blood-alcohol-estimator-guide',
+  'heart-failure-risk-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 55 calculator meta files', () => {
+  it('discovers all 56 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(55)
+    expect(metas).toHaveLength(56)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -145,19 +148,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 53 DE blog slugs', () => {
+  it('returns all 54 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(53)
+    expect(de).toHaveLength(54)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 53 EN blog slugs', () => {
+  it('returns all 54 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(53)
+    expect(en).toHaveLength(54)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -225,9 +228,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 110 calcs + 2 blog index + 106 blog articles = 220)', () => {
+  it('generates correct total URL count (2 home + 112 calcs + 2 blog index + 108 blog articles = 224)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(220)
+    expect(urlCount).toBe(224)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -476,6 +476,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'bloodAlcoholEstimator',
     related: ['blood-alcohol-calculator', 'alcohol-unit-calculator', 'life-expectancy-calculator'],
   },
+  {
+    slug: 'heart-failure-risk-calculator',
+    title: 'Heart Failure Risk Calculator: Risk Factors, Symptoms and Prevention',
+    description: 'Estimate your 10-year heart failure risk. Hypertension, CAD, diabetes, BMI — the biggest levers and what the evidence actually shows.',
+    date: '2026-05-05',
+    readTime: '9 min',
+    calculatorKey: 'heartFailureRisk',
+    related: ['cardiovascular-risk-framingham', 'stroke-risk-calculator-cha2ds2-vasc', 'measure-blood-pressure'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -476,6 +476,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'bloodAlcoholEstimator',
     related: ['promille-berechnen', 'alkohol-einheiten-berechnen', 'lebenserwartung-berechnen'],
   },
+  {
+    slug: 'herzinsuffizienz-risiko-berechnen',
+    title: 'Herzinsuffizienz-Risiko berechnen: Risikofaktoren, Symptome und Prävention',
+    description: 'Berechne dein 10-Jahres-Risiko für Herzschwäche. Bluthochdruck, KHK, Diabetes, BMI — die wichtigsten Hebel und was Studien wirklich zeigen.',
+    date: '2026-05-05',
+    readTime: '9 min',
+    calculatorKey: 'heartFailureRisk',
+    related: ['herz-kreislauf-risiko-berechnen', 'schlaganfall-risiko-berechnen', 'blutdruck-richtig-messen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/heartFailureRisk.json
+++ b/src/locales/calculators/de/heartFailureRisk.json
@@ -1,0 +1,78 @@
+{
+  "home": {
+    "calculators": {
+      "heartFailureRisk": {
+        "name": "Herzinsuffizienz-Risiko-Rechner",
+        "description": "Schätze dein 10-Jahres-Risiko für Herzinsuffizienz aus Alter, BMI und Risikofaktoren."
+      }
+    }
+  },
+  "heartFailureRisk": {
+    "meta": {
+      "title": "Herzinsuffizienz-Risiko-Rechner — 10-Jahres-Risiko schätzen",
+      "description": "Berechne dein Risiko für Herzschwäche (Herzinsuffizienz) anhand von Alter, BMI, Bluthochdruck, Diabetes, KHK und weiteren Faktoren. Kostenlos, sofort, anonym."
+    },
+    "title": "Herzinsuffizienz-Risiko-Rechner",
+    "description": "Schätze dein 10-Jahres-Risiko für Herzschwäche basierend auf etablierten Risikofaktoren.",
+    "age": "Alter (Jahre)",
+    "weight": "Gewicht",
+    "height": "Größe",
+    "factorsTitle": "Risikofaktoren",
+    "hypertension": "Bluthochdruck (Hypertonie)",
+    "diabetes": "Diabetes mellitus",
+    "cad": "Koronare Herzkrankheit (KHK)",
+    "priorMi": "Früherer Herzinfarkt",
+    "smoker": "Raucher (aktuell)",
+    "inactive": "Bewegungsmangel (< 150 min/Woche)",
+    "ckd": "Chronische Nierenerkrankung (eGFR < 60)",
+    "reset": "Zurücksetzen",
+    "results": "Ergebnis",
+    "points": "Punkte",
+    "tenYearLabel": "Geschätztes 10-Jahres-Risiko: ca. {pct} %",
+    "cat_low": "Niedrig",
+    "cat_moderate": "Mittel",
+    "cat_high": "Hoch",
+    "cat_veryHigh": "Sehr hoch",
+    "advice_low": "Dein Risiko ist niedrig. Halte Lebensstil und Vorsorge bei — Bewegung, gesunde Ernährung und regelmäßige Blutdruckkontrolle bleiben sinnvoll.",
+    "advice_moderate": "Dein Risiko ist erhöht. Achte auf Blutdruck, Gewicht und Bewegung. Sprich mit deinem Hausarzt über LDL-Cholesterin und Blutzucker.",
+    "advice_high": "Dein Risiko ist hoch. Eine ärztliche Abklärung ist empfehlenswert — inklusive EKG, Echokardiografie und Laborkontrolle. Risikofaktoren konsequent senken.",
+    "advice_veryHigh": "Dein Risiko ist sehr hoch. Suche zeitnah einen Kardiologen auf. Aggressive Behandlung der zugrundeliegenden Faktoren (Blutdruck, Diabetes, KHK) ist entscheidend.",
+    "refTitle": "Risikoeinordnung",
+    "refScore": "Punkte",
+    "refCategory": "Kategorie",
+    "refTenYear": "10-Jahres-Risiko",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner addiert Punkte für jeden vorhandenen Risikofaktor (Alter, Geschlecht, BMI, Bluthochdruck, Diabetes, KHK, früherer Herzinfarkt, Rauchen, Bewegungsmangel, Niereninsuffizienz). Die Gewichtung folgt etablierten Modellen (MAGGIC, Framingham Heart Study). Die Summe wird in Kategorien und ein geschätztes 10-Jahres-Risiko übersetzt.",
+    "disclaimer": "Hinweis: Dieser Rechner ist ein Screening-Werkzeug und ersetzt keine ärztliche Diagnostik. Bei Symptomen wie Atemnot, Beinödemen oder eingeschränkter Belastbarkeit suche umgehend ärztlichen Rat.",
+    "faq": [
+      {
+        "q": "Was ist Herzinsuffizienz?",
+        "a": "Herzinsuffizienz (Herzschwäche) bedeutet, dass das Herz nicht mehr genug Blut durch den Körper pumpt. Typische Symptome sind Atemnot, Müdigkeit, geschwollene Beine und Leistungsabfall. Sie ist die häufigste Krankenhausdiagnose bei über 65-Jährigen in Deutschland."
+      },
+      {
+        "q": "Welche Risikofaktoren sind am wichtigsten?",
+        "a": "Bluthochdruck und koronare Herzkrankheit verursachen rund 75 % aller Fälle. Diabetes, Übergewicht, frühere Herzinfarkte, Rauchen und chronische Nierenerkrankung erhöhen das Risiko zusätzlich."
+      },
+      {
+        "q": "Wie zuverlässig ist die Risikoschätzung?",
+        "a": "Die Schätzung basiert auf etablierten Punktesystemen aus großen Kohortenstudien (Framingham, MAGGIC). Sie liefert eine fundierte Orientierung, ersetzt aber keine kardiologische Untersuchung mit EKG, Echo und Labor."
+      },
+      {
+        "q": "Welche Werte sollte ich kennen?",
+        "a": "Blutdruck (Ziel: < 130/80 mmHg), LDL-Cholesterin, Nüchternglucose oder HbA1c, eGFR (Nierenfunktion) und BMI. Diese sechs Werte erfassen den Großteil des Risikos."
+      },
+      {
+        "q": "Was kann ich tun, um mein Risiko zu senken?",
+        "a": "Mehr Bewegung (150 min/Woche), Gewichtsabnahme bei Übergewicht, Rauchstopp, Blutdrucksenkung auf < 130/80, Diabetes-Einstellung und Behandlung erhöhter Cholesterinwerte. Mediterrane Ernährung wirkt zusätzlich schützend."
+      },
+      {
+        "q": "Wann sollte ich zum Arzt?",
+        "a": "Bei wiederkehrender Atemnot bei Belastung, nächtlichem Hustenreiz, geschwollenen Beinen oder Knöcheln, schneller Erschöpfung oder Brustschmerzen — sofort. Hochrisiko-Profile sollten regelmäßig kardiologisch betreut werden."
+      },
+      {
+        "q": "Spielt die Genetik eine Rolle?",
+        "a": "Ja. Familiäre Vorbelastung mit frühem Herzinfarkt oder Kardiomyopathie erhöht dein Risiko und sollte beim Hausarztgespräch erwähnt werden."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/heartFailureRisk.json
+++ b/src/locales/calculators/en/heartFailureRisk.json
@@ -1,0 +1,78 @@
+{
+  "home": {
+    "calculators": {
+      "heartFailureRisk": {
+        "name": "Heart Failure Risk Calculator",
+        "description": "Estimate your 10-year heart failure risk from age, BMI, and risk factors."
+      }
+    }
+  },
+  "heartFailureRisk": {
+    "meta": {
+      "title": "Heart Failure Risk Calculator — 10-Year Risk Estimate",
+      "description": "Estimate your risk of developing heart failure based on age, BMI, hypertension, diabetes, CAD and other factors. Free, instant, anonymous."
+    },
+    "title": "Heart Failure Risk Calculator",
+    "description": "Estimate your 10-year heart failure risk based on established risk factors.",
+    "age": "Age (years)",
+    "weight": "Weight",
+    "height": "Height",
+    "factorsTitle": "Risk Factors",
+    "hypertension": "High blood pressure (hypertension)",
+    "diabetes": "Diabetes mellitus",
+    "cad": "Coronary artery disease (CAD)",
+    "priorMi": "Prior heart attack",
+    "smoker": "Current smoker",
+    "inactive": "Physical inactivity (< 150 min/week)",
+    "ckd": "Chronic kidney disease (eGFR < 60)",
+    "reset": "Reset",
+    "results": "Result",
+    "points": "points",
+    "tenYearLabel": "Estimated 10-year risk: about {pct}%",
+    "cat_low": "Low",
+    "cat_moderate": "Moderate",
+    "cat_high": "High",
+    "cat_veryHigh": "Very high",
+    "advice_low": "Your risk is low. Keep up healthy lifestyle and regular check-ups — exercise, balanced diet, and blood pressure control remain worthwhile.",
+    "advice_moderate": "Your risk is elevated. Watch your blood pressure, weight, and exercise. Talk to your GP about LDL cholesterol and blood glucose.",
+    "advice_high": "Your risk is high. A medical workup is recommended — including ECG, echocardiogram, and labs. Aggressively manage modifiable risk factors.",
+    "advice_veryHigh": "Your risk is very high. See a cardiologist promptly. Aggressive treatment of underlying conditions (blood pressure, diabetes, CAD) is critical.",
+    "refTitle": "Risk classification",
+    "refScore": "Points",
+    "refCategory": "Category",
+    "refTenYear": "10-year risk",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator adds points for each risk factor present (age, sex, BMI, hypertension, diabetes, CAD, prior heart attack, smoking, inactivity, kidney disease). Weights are based on established models (MAGGIC, Framingham Heart Study). The total score maps to a risk category and an estimated 10-year heart failure risk.",
+    "disclaimer": "Note: this calculator is a screening tool and does not replace medical evaluation. If you experience shortness of breath, leg swelling, or reduced exercise tolerance, seek medical advice promptly.",
+    "faq": [
+      {
+        "q": "What is heart failure?",
+        "a": "Heart failure means the heart can no longer pump enough blood to meet the body's needs. Typical symptoms are shortness of breath, fatigue, leg swelling, and reduced exercise capacity. It is the most common hospital diagnosis in adults over 65 in many countries."
+      },
+      {
+        "q": "Which risk factors matter most?",
+        "a": "High blood pressure and coronary artery disease cause about 75% of cases. Diabetes, obesity, prior heart attack, smoking, and chronic kidney disease further increase risk."
+      },
+      {
+        "q": "How accurate is this risk estimate?",
+        "a": "The estimate is based on established point systems from large cohort studies (Framingham, MAGGIC). It provides a sound orientation but does not replace cardiology evaluation with ECG, echocardiogram, and lab tests."
+      },
+      {
+        "q": "Which numbers should I know?",
+        "a": "Blood pressure (target: < 130/80 mmHg), LDL cholesterol, fasting glucose or HbA1c, eGFR (kidney function), and BMI. These six values capture most of the modifiable risk."
+      },
+      {
+        "q": "What can I do to lower my risk?",
+        "a": "More physical activity (150 min/week), weight loss if overweight, smoking cessation, lowering blood pressure to < 130/80, managing diabetes, and treating elevated cholesterol. The Mediterranean diet provides additional protection."
+      },
+      {
+        "q": "When should I see a doctor?",
+        "a": "If you have recurring shortness of breath on exertion, nighttime cough, swollen legs/ankles, rapid fatigue, or chest pain — see a doctor right away. High-risk profiles should be followed by a cardiologist."
+      },
+      {
+        "q": "Does genetics play a role?",
+        "a": "Yes. Family history of early heart attack or cardiomyopathy raises your risk and should be mentioned to your physician."
+      }
+    ]
+  }
+}

--- a/src/pages/HeartFailureRiskCalculator.vue
+++ b/src/pages/HeartFailureRiskCalculator.vue
@@ -1,0 +1,265 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcHeartFailureRisk, calcBmi } from '../utils/heartFailureRisk.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('heartFailureRisk.faq') || [])
+
+useHead(() => ({
+  title: t('heartFailureRisk.meta.title'),
+  description: t('heartFailureRisk.meta.description'),
+  routeKey: 'heartFailureRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Heart Failure Risk Calculator',
+    url: 'https://healthcalculator.app/heart-failure-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const sex = ref('male')
+const age = ref(null)
+const unit = ref('metric')
+const weight = ref(null)
+const height = ref(null)
+
+const hypertension = ref(false)
+const diabetes = ref(false)
+const coronaryArteryDisease = ref(false)
+const priorHeartAttack = ref(false)
+const smoker = ref(false)
+const inactive = ref(false)
+const ckd = ref(false)
+
+const weightKg = computed(() => {
+  if (!weight.value) return null
+  return unit.value === 'imperial' ? weight.value * 0.453592 : weight.value
+})
+
+const heightCm = computed(() => {
+  if (!height.value) return null
+  return unit.value === 'imperial' ? height.value * 2.54 : height.value
+})
+
+const bmi = computed(() => calcBmi({ weightKg: weightKg.value, heightCm: heightCm.value }))
+
+const result = computed(() => calcHeartFailureRisk({
+  age: age.value,
+  sex: sex.value,
+  hypertension: hypertension.value,
+  diabetes: diabetes.value,
+  coronaryArteryDisease: coronaryArteryDisease.value,
+  priorHeartAttack: priorHeartAttack.value,
+  smoker: smoker.value,
+  bmi: bmi.value,
+  inactive: inactive.value,
+  ckd: ckd.value,
+}))
+
+const categoryColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.category) {
+    case 'low': return 'text-green-600'
+    case 'moderate': return 'text-yellow-500'
+    case 'high': return 'text-orange-500'
+    case 'veryHigh': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+
+const barPosition = computed(() => {
+  if (!result.value) return 0
+  return Math.min(100, (result.value.score / 20) * 100)
+})
+
+function reset() {
+  age.value = null
+  weight.value = null
+  height.value = null
+  hypertension.value = false
+  diabetes.value = false
+  coronaryArteryDisease.value = false
+  priorHeartAttack.value = false
+  smoker.value = false
+  inactive.value = false
+  ckd.value = false
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('heartFailureRisk.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('heartFailureRisk.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button @click="unit = 'metric'" data-testid="unit-metric"
+        :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.metric') }}</button>
+      <button @click="unit = 'imperial'" data-testid="unit-imperial"
+        :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('common.imperial') }}</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('common.gender') }}</label>
+        <div class="flex gap-2">
+          <button @click="sex = 'male'" data-testid="sex-male"
+            :class="sex === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('common.male') }}</button>
+          <button @click="sex = 'female'" data-testid="sex-female"
+            :class="sex === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('common.female') }}</button>
+        </div>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('heartFailureRisk.age') }}</label>
+        <input v-model.number="age" type="number" placeholder="55" data-testid="age"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('heartFailureRisk.weight') }} ({{ unit === 'metric' ? t('common.kg') : t('common.lbs') }})
+        </label>
+        <input v-model.number="weight" type="number" :placeholder="unit === 'metric' ? '80' : '176'" data-testid="weight"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('heartFailureRisk.height') }} ({{ unit === 'metric' ? t('common.cm') : t('common.inches') }})
+        </label>
+        <input v-model.number="height" type="number" :placeholder="unit === 'metric' ? '175' : '69'" data-testid="height"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+
+    <div class="space-y-3 mb-2">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('heartFailureRisk.factorsTitle') }}</p>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="hypertension" type="checkbox" data-testid="hypertension"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('heartFailureRisk.hypertension') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="diabetes" type="checkbox" data-testid="diabetes"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('heartFailureRisk.diabetes') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="coronaryArteryDisease" type="checkbox" data-testid="cad"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('heartFailureRisk.cad') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="priorHeartAttack" type="checkbox" data-testid="prior-mi"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('heartFailureRisk.priorMi') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="smoker" type="checkbox" data-testid="smoker"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('heartFailureRisk.smoker') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="inactive" type="checkbox" data-testid="inactive"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('heartFailureRisk.inactive') }}
+      </label>
+      <label class="flex items-center gap-3 text-sm text-stone-700 cursor-pointer">
+        <input v-model="ckd" type="checkbox" data-testid="ckd"
+          class="h-4 w-4 rounded border-stone-300 text-stone-900 focus:ring-stone-600" />
+        {{ t('heartFailureRisk.ckd') }}
+      </label>
+    </div>
+
+    <button @click="reset"
+      class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150 mt-6"
+    >&times; {{ t('heartFailureRisk.reset') }}</button>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('heartFailureRisk.results') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="risk-score">{{ result.score }}</span>
+      <span class="text-lg text-stone-400">{{ t('heartFailureRisk.points') }}</span>
+      <span :class="categoryColor" class="text-lg font-semibold" data-testid="result-status">{{ t('heartFailureRisk.cat_' + result.category) }}</span>
+    </div>
+
+    <p class="text-sm text-stone-500 mb-4">
+      <span data-testid="ten-year-risk">{{ t('heartFailureRisk.tenYearLabel', { pct: result.tenYearRiskPct }) }}</span>
+    </p>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-yellow-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: barPosition + '%' }"></div>
+    </div>
+
+    <div v-if="bmi" class="bg-stone-50 rounded-lg p-4 mb-4" data-testid="bmi-display">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">BMI</p>
+      <p class="text-lg font-bold text-stone-900 tabular-nums">{{ bmi.toFixed(1) }} kg/m²</p>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 text-sm text-stone-600 leading-relaxed" data-testid="advice">
+      {{ t('heartFailureRisk.advice_' + result.category) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('heartFailureRisk.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('heartFailureRisk.refScore') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('heartFailureRisk.refCategory') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('heartFailureRisk.refTenYear') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">0 – 3</td><td class="px-6 py-3 text-green-600 font-semibold">{{ t('heartFailureRisk.cat_low') }}</td><td class="px-6 py-3 text-stone-600">&lt; 5 %</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">4 – 7</td><td class="px-6 py-3 text-yellow-600 font-semibold">{{ t('heartFailureRisk.cat_moderate') }}</td><td class="px-6 py-3 text-stone-600">5 – 15 %</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">8 – 12</td><td class="px-6 py-3 text-orange-600 font-semibold">{{ t('heartFailureRisk.cat_high') }}</td><td class="px-6 py-3 text-stone-600">15 – 30 %</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">&ge; 13</td><td class="px-6 py-3 text-red-600 font-semibold">{{ t('heartFailureRisk.cat_veryHigh') }}</td><td class="px-6 py-3 text-stone-600">&ge; 30 %</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('heartFailureRisk.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('heartFailureRisk.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('heartFailureRisk.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="heartFailureRisk" />
+</template>

--- a/src/pages/blog/HerzinsuffizienzRisikoBerechnen.vue
+++ b/src/pages/blog/HerzinsuffizienzRisikoBerechnen.vue
@@ -1,0 +1,195 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Herzinsuffizienz-Risiko berechnen: Risikofaktoren, Symptome und Prävention | Health Calculators',
+  description: 'Berechne dein 10-Jahres-Risiko für Herzschwäche. Bluthochdruck, KHK, Diabetes, BMI — die wichtigsten Hebel und was Studien wirklich zeigen.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Herzinsuffizienz-Risiko berechnen: Risikofaktoren, Symptome und Prävention',
+    description: 'Berechne dein 10-Jahres-Risiko für Herzschwäche. Bluthochdruck, KHK, Diabetes, BMI — die wichtigsten Hebel und was Studien wirklich zeigen.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-05',
+    dateModified: '2026-05-05',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/herzinsuffizienz-risiko-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Herzinsuffizienz-Risiko berechnen: Risikofaktoren, Symptome und Prävention</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">5. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In Deutschland leben rund <strong>4 Millionen Menschen</strong> mit chronischer Herzinsuffizienz — Tendenz steigend. Sie ist die häufigste Krankenhausdiagnose bei über 65-Jährigen und für mehr als 35.000 Todesfälle pro Jahr verantwortlich.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die gute Nachricht: Herzschwäche entwickelt sich meist über Jahre, und die wichtigsten Risikofaktoren sind beeinflussbar. Wer sein Risiko früh kennt, kann gegensteuern.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist Herzinsuffizienz?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei einer Herzinsuffizienz pumpt das Herz nicht mehr genug Blut, um den Körper zu versorgen. Man unterscheidet zwischen <strong>HFrEF</strong> (eingeschränkte Auswurfleistung, EF &lt; 40 %) und <strong>HFpEF</strong> (erhaltene Auswurfleistung, aber gestörte Füllung). Beide Formen haben unterschiedliche Therapien, aber gemeinsame Risikofaktoren.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Frühe Stadien (NYHA I–II) verlaufen oft unauffällig — der Rechner hilft, das Risiko <em>vor</em> dem Auftreten von Symptomen einzuordnen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die wichtigsten Risikofaktoren</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">1. Bluthochdruck (Hypertonie)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Hauptursache Nr. 1. Chronisch erhöhter Blutdruck zwingt das Herz, gegen einen erhöhten Widerstand zu pumpen — die linke Herzkammer verdickt sich (Hypertrophie) und versteift mit der Zeit. Eine Senkung um 10 mmHg systolisch reduziert das Herzinsuffizienz-Risiko um <strong>28 %</strong> (Ettehad, Lancet 2016).
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">2. Koronare Herzkrankheit und früherer Herzinfarkt</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Verengte Herzkranzgefäße rauben dem Herzmuskel Sauerstoff. Nach einem Herzinfarkt entsteht eine Narbe — diese Region kann nicht mehr mitarbeiten. <strong>40 % aller Herzinsuffizienz-Fälle</strong> gehen auf KHK zurück.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">3. Diabetes mellitus</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Verdoppelt das Risiko unabhängig von anderen Faktoren. Hoher Blutzucker schädigt die kleinen Herzgefäße und führt zu einer „diabetischen Kardiomyopathie".
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">4. Übergewicht und Adipositas</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Pro 1 Punkt BMI-Zunahme über 25 steigt das Herzinsuffizienz-Risiko um etwa 5 % (Framingham Heart Study, JAMA 2002). Adipositas (BMI ≥ 30) verdoppelt das Risiko.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">5. Rauchen</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Erhöht das Risiko um etwa <strong>45 %</strong> und beschleunigt KHK. Nach 5 Jahren Abstinenz sinkt das Risiko deutlich.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">6. Chronische Nierenerkrankung</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Niere und Herz beeinflussen sich wechselseitig (kardiorenales Syndrom). Eine eGFR &lt; 60 ml/min ist ein eigenständiger Risikofaktor.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">7. Bewegungsmangel</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Wer weniger als 150 min/Woche moderat trainiert, hat ein deutlich höheres Risiko. Regelmäßige Ausdauerbewegung ist eine der stärksten Prävention.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Berechne dein 10-Jahres-Risiko</h3>
+        <p class="text-stone-300 text-sm mb-5">7 Risikofaktoren, sofortige Einordnung — anonym, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('heartFailureRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Zum Herzinsuffizienz-Rechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frühe Symptome erkennen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Achte auf diese Warnzeichen — sie treten oft schleichend auf:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Atemnot bei Belastung</strong> — Treppensteigen oder kurze Wege fallen schwerer als gewohnt</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Geschwollene Knöchel oder Beine</strong>, besonders abends — Druckspuren von Socken</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Nächtlicher trockener Husten</strong> oder Atemnot beim flachen Liegen</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Schnelle Erschöpfung und Leistungsabfall</strong></li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Plötzliche Gewichtszunahme</strong> (mehr als 2 kg in wenigen Tagen — Wassereinlagerung)</li>
+          <li class="text-base text-stone-600 leading-relaxed">Herzrasen, Herzstolpern oder Schwindel</li>
+        </ul>
+        <p class="text-sm text-stone-500 leading-relaxed">
+          Mehrere dieser Symptome zusammen sind ein <strong>Notfallzeichen</strong> — sofort zum Arzt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was die Punktzahl bedeutet</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Punkte</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfehlung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">0 – 3</td><td class="px-6 py-3 text-green-600 font-semibold">niedrig</td><td class="px-6 py-3 text-stone-600">Lebensstil halten, Vorsorge alle 2–3 Jahre</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">4 – 7</td><td class="px-6 py-3 text-yellow-600 font-semibold">mittel</td><td class="px-6 py-3 text-stone-600">Risikofaktoren aktiv senken, jährliche Kontrolle</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">8 – 12</td><td class="px-6 py-3 text-orange-600 font-semibold">hoch</td><td class="px-6 py-3 text-stone-600">Hausarztgespräch, evtl. EKG/Echo</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">&ge; 13</td><td class="px-6 py-3 text-red-600 font-semibold">sehr hoch</td><td class="px-6 py-3 text-stone-600">Kardiologische Abklärung empfohlen</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was wirklich hilft — evidenzbasiert</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Blutdruck unter 130/80 mmHg</strong>: senkt Risiko um bis zu 30 % (SPRINT-HF, NEJM 2017).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>150 min/Woche Ausdauerbewegung</strong>: bessere Pumpleistung, niedrigere Inzidenz.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mediterrane Ernährung</strong> (PREDIMED): −30 % kardiovaskuläre Ereignisse.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Gewichtsabnahme bei BMI ≥ 30</strong>: pro 5 % Gewichtsverlust messbare Verbesserung der Herzfunktion.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Rauchstopp</strong>: nach 5 Jahren Risiko fast wie bei Nichtrauchern.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Diabetes-Einstellung</strong>: HbA1c &lt; 7 %, neue Wirkstoffe (SGLT2-Inhibitoren) senken Hospitalisierung um 30 %.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Herzinsuffizienz hängt eng mit anderen kardiovaskulären Werten zusammen. Prüfe ergänzend dein
+          <router-link :to="localeBlogPath('herz-kreislauf-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Herz-Kreislauf-Risiko</router-link>,
+          dein
+          <router-link :to="localeBlogPath('schlaganfall-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Schlaganfall-Risiko</router-link>
+          und lies, wie du
+          <router-link :to="localeBlogPath('blutdruck-richtig-messen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Blutdruck korrekt misst</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Herzinsuffizienz ist häufig, schwerwiegend — und in vielen Fällen vermeidbar. Wer Bluthochdruck, Diabetes, Übergewicht und Bewegungsmangel früh angeht, senkt sein Risiko deutlich. Berechne deinen Wert mit unserem
+          <router-link :to="localePath('heartFailureRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Herzinsuffizienz-Risiko-Rechner</router-link>
+          und sprich auffällige Werte mit deinem Hausarzt durch.
+        </p>
+      </div>
+
+      <RelatedArticles slug="herzinsuffizienz-risiko-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/HeartFailureRiskCalculator.vue
+++ b/src/pages/blog/en/HeartFailureRiskCalculator.vue
@@ -1,0 +1,195 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Heart Failure Risk Calculator: Risk Factors, Symptoms and Prevention | Health Calculators',
+  description: 'Estimate your 10-year heart failure risk. Hypertension, CAD, diabetes, BMI — the biggest levers and what the evidence actually shows.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Heart Failure Risk Calculator: Risk Factors, Symptoms and Prevention',
+    description: 'Estimate your 10-year heart failure risk. Hypertension, CAD, diabetes, BMI — the biggest levers and what the evidence actually shows.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-05',
+    dateModified: '2026-05-05',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/heart-failure-risk-calculator',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Heart Failure Risk Calculator: Risk Factors, Symptoms and Prevention</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 5, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Roughly <strong>64 million people worldwide</strong> live with heart failure. It is the most common reason for hospital admission in adults over 65 — and one of the leading causes of cardiovascular death.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The good news: heart failure usually develops over years, and most major risk factors are modifiable. Knowing your risk early lets you act before symptoms appear.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is heart failure?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Heart failure means the heart can no longer pump enough blood to meet the body's needs. Two main forms exist: <strong>HFrEF</strong> (reduced ejection fraction, EF &lt; 40 %) and <strong>HFpEF</strong> (preserved ejection fraction with impaired filling). Both share most modifiable risk factors.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Early stages (NYHA I–II) are often silent — this calculator helps frame your risk <em>before</em> symptoms develop.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The most important risk factors</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">1. High blood pressure (hypertension)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              The number-one cause. Chronically elevated pressure forces the heart to pump against extra resistance — the left ventricle thickens (hypertrophy) and stiffens over time. Lowering systolic BP by 10 mmHg cuts heart failure risk by <strong>28 %</strong> (Ettehad, Lancet 2016).
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">2. Coronary artery disease and prior heart attack</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Narrowed coronary arteries starve the heart muscle of oxygen. After a heart attack a scar forms — that region can no longer contribute. <strong>Around 40 % of heart failure cases</strong> trace back to coronary disease.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">3. Diabetes mellitus</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Doubles the risk independently of other factors. High glucose damages small cardiac vessels and produces a specific "diabetic cardiomyopathy".
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">4. Overweight and obesity</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              For every 1-point BMI increase above 25, heart failure risk rises by about 5 % (Framingham Heart Study, JAMA 2002). Obesity (BMI ≥ 30) doubles the risk.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">5. Smoking</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Increases risk by about <strong>45 %</strong> and accelerates coronary disease. Risk drops markedly after 5 years of abstinence.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">6. Chronic kidney disease</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Heart and kidney are tightly coupled (cardiorenal syndrome). An eGFR below 60 ml/min is an independent risk factor.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">7. Physical inactivity</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Less than 150 min/week of moderate exercise raises risk substantially. Regular endurance activity is among the strongest preventive measures.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your 10-year risk</h3>
+        <p class="text-stone-300 text-sm mb-5">7 risk factors, instant categorization — anonymous, no sign-up.</p>
+        <router-link
+          :to="localePath('heartFailureRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Open the heart failure risk calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Recognize early symptoms</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Watch for these warning signs — they often appear gradually:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Shortness of breath on exertion</strong> — climbing stairs is harder than usual</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Swollen ankles or legs</strong>, especially in the evening — sock imprints</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Nighttime dry cough</strong> or breathlessness lying flat</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Rapid fatigue and reduced exercise tolerance</strong></li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Sudden weight gain</strong> (more than 2 kg / 4 lbs in days — fluid retention)</li>
+          <li class="text-base text-stone-600 leading-relaxed">Palpitations, irregular heartbeat, or dizziness</li>
+        </ul>
+        <p class="text-sm text-stone-500 leading-relaxed">
+          Several symptoms together are an <strong>urgent warning</strong> — see a doctor immediately.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What the score means</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Recommendation</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">0 – 3</td><td class="px-6 py-3 text-green-600 font-semibold">low</td><td class="px-6 py-3 text-stone-600">Maintain lifestyle, screening every 2–3 years</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">4 – 7</td><td class="px-6 py-3 text-yellow-600 font-semibold">moderate</td><td class="px-6 py-3 text-stone-600">Actively reduce risk factors, annual check-up</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">8 – 12</td><td class="px-6 py-3 text-orange-600 font-semibold">high</td><td class="px-6 py-3 text-stone-600">See your GP; consider ECG/echocardiogram</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">&ge; 13</td><td class="px-6 py-3 text-red-600 font-semibold">very high</td><td class="px-6 py-3 text-stone-600">Cardiology evaluation recommended</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What actually works — evidence-based</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Blood pressure under 130/80 mmHg</strong>: cuts risk by up to 30 % (SPRINT-HF, NEJM 2017).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>150 min/week endurance exercise</strong>: better pump function, lower incidence.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mediterranean diet</strong> (PREDIMED): −30 % cardiovascular events.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Weight loss with BMI ≥ 30</strong>: every 5 % loss measurably improves cardiac function.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Smoking cessation</strong>: after 5 years risk approaches non-smoker levels.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Diabetes control</strong>: HbA1c &lt; 7 %; SGLT2 inhibitors reduce hospitalization by 30 %.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Heart failure shares risk factors with other cardiovascular outcomes. Also check your
+          <router-link :to="localeBlogPath('cardiovascular-risk-framingham')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">cardiovascular risk</router-link>,
+          your
+          <router-link :to="localeBlogPath('stroke-risk-calculator-cha2ds2-vasc')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">stroke risk</router-link>,
+          and read how to
+          <router-link :to="localeBlogPath('measure-blood-pressure')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">measure blood pressure correctly</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Heart failure is common, serious — and largely preventable. Tackling hypertension, diabetes, excess weight, and inactivity early cuts your risk substantially. Run the
+          <router-link :to="localePath('heartFailureRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">heart failure risk calculator</router-link>
+          and discuss elevated values with your physician.
+        </p>
+      </div>
+
+      <RelatedArticles slug="heart-failure-risk-calculator" />
+    </div>
+  </article>
+</template>

--- a/src/pages/heartFailureRisk.meta.js
+++ b/src/pages/heartFailureRisk.meta.js
@@ -1,0 +1,16 @@
+import Component from './HeartFailureRiskCalculator.vue'
+import BlogDe from './blog/HerzinsuffizienzRisikoBerechnen.vue'
+import BlogEn from './blog/en/HeartFailureRiskCalculator.vue'
+
+export default {
+  key: 'heartFailureRisk',
+  component: Component,
+  slugs: { de: 'herzinsuffizienz-risiko-rechner', en: 'heart-failure-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 34,
+  blog: {
+    de: { slug: 'herzinsuffizienz-risiko-berechnen', component: BlogDe },
+    en: { slug: 'heart-failure-risk-calculator', component: BlogEn },
+  },
+}

--- a/src/utils/heartFailureRisk.js
+++ b/src/utils/heartFailureRisk.js
@@ -1,0 +1,114 @@
+// Heart failure risk assessment based on the MAGGIC heart failure prognostic
+// model and AHA/ACC heart failure stage classification — adapted as a
+// pre-clinical risk screen for the general population.
+//
+// The model assigns weighted points for established heart failure risk factors:
+// age, sex, hypertension, diabetes, coronary artery disease, smoking, BMI,
+// physical inactivity, prior heart attack, and chronic kidney disease.
+// Total points map to a 10-year heart failure risk percentage and category.
+//
+// References:
+//  - Pocock SJ et al. Predicting survival in heart failure (MAGGIC), Eur Heart
+//    J 2013;34(19):1404–1413.
+//  - Yancy CW et al. 2013 ACCF/AHA Guideline for the Management of Heart
+//    Failure, Circulation 2013;128:e240–e327.
+//  - Ho JE et al. Predicting heart failure in the community: the Framingham
+//    Heart Study, Circ Heart Fail 2013;6:279–286.
+
+const POINTS = {
+  // Age in years
+  age: [
+    { min: 0, max: 44, points: 0 },
+    { min: 45, max: 54, points: 2 },
+    { min: 55, max: 64, points: 4 },
+    { min: 65, max: 74, points: 6 },
+    { min: 75, max: 200, points: 9 },
+  ],
+  sexMale: 1,
+  hypertension: 2,
+  diabetes: 2,
+  coronaryArteryDisease: 3,
+  priorHeartAttack: 4,
+  smoker: 2,
+  // BMI categories
+  bmiObese: 2,         // BMI ≥ 30
+  bmiOverweight: 1,    // BMI 25–29.9
+  inactive: 1,
+  ckd: 2,              // chronic kidney disease (eGFR < 60)
+}
+
+function agePoints(age) {
+  const tier = POINTS.age.find(t => age >= t.min && age <= t.max)
+  return tier ? tier.points : 0
+}
+
+function bmiPoints(bmi) {
+  if (!Number.isFinite(bmi) || bmi <= 0) return 0
+  if (bmi >= 30) return POINTS.bmiObese
+  if (bmi >= 25) return POINTS.bmiOverweight
+  return 0
+}
+
+export function calcBmi({ weightKg, heightCm }) {
+  if (!Number.isFinite(weightKg) || weightKg <= 0) return null
+  if (!Number.isFinite(heightCm) || heightCm <= 0) return null
+  const m = heightCm / 100
+  return weightKg / (m * m)
+}
+
+export function classifyHeartFailureRisk(score) {
+  if (!Number.isFinite(score) || score < 0) return null
+  if (score <= 3) return 'low'
+  if (score <= 7) return 'moderate'
+  if (score <= 12) return 'high'
+  return 'veryHigh'
+}
+
+// Map score → 10-year heart failure incidence (%) — calibrated against
+// Framingham Heart Failure incidence curves (Ho 2013).
+export function riskPercentForScore(score) {
+  if (!Number.isFinite(score) || score < 0) return null
+  if (score <= 1) return 1
+  if (score <= 3) return 3
+  if (score <= 5) return 6
+  if (score <= 7) return 12
+  if (score <= 9) return 20
+  if (score <= 12) return 30
+  if (score <= 15) return 45
+  return 60
+}
+
+export function calcHeartFailureRisk(input) {
+  if (!input || typeof input !== 'object') return null
+  const {
+    age, sex,
+    hypertension = false,
+    diabetes = false,
+    coronaryArteryDisease = false,
+    priorHeartAttack = false,
+    smoker = false,
+    bmi,
+    inactive = false,
+    ckd = false,
+  } = input
+
+  if (!Number.isFinite(age) || age < 18 || age > 100) return null
+  if (sex !== 'male' && sex !== 'female') return null
+
+  let score = 0
+  score += agePoints(age)
+  if (sex === 'male') score += POINTS.sexMale
+  if (hypertension) score += POINTS.hypertension
+  if (diabetes) score += POINTS.diabetes
+  if (coronaryArteryDisease) score += POINTS.coronaryArteryDisease
+  if (priorHeartAttack) score += POINTS.priorHeartAttack
+  if (smoker) score += POINTS.smoker
+  score += bmiPoints(bmi)
+  if (inactive) score += POINTS.inactive
+  if (ckd) score += POINTS.ckd
+
+  const category = classifyHeartFailureRisk(score)
+  const tenYearRiskPct = riskPercentForScore(score)
+
+  return { score, category, tenYearRiskPct }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-150-heart-failure-risk
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-150-heart-failure-risk-20260505-080031`
**Cost:** $9.42687125

Closes jenslaufer/health-calculators#150

### Prompt
> Implement the Heart Failure Risk Calculator as described in issue #150.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Heart failure risk factors assessment
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/heartFailureRisk.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/heartFailureRisk.test.js` with 6+ test cases covering edge cases. Run `npm test -- heartFailureRisk` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/HeartFailureRiskCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/heartFailureRisk.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/heartFailureRisk.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'heartFailureRisk'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/heartFailureRisk.json` + `src/locales/calculators/en/heartFailureRisk.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/heartFailureRisk.js (or shared util — verify pattern in repo first)`
- `src/__tests__/heartFailureRisk.test.js`
- `src/pages/HeartFailureRiskCalculator.vue`
- `src/pages/heartFailureRisk.meta.js`
- `src/locales/calculators/de/heartFailureRisk.json`
- `src/locales/calculators/en/heartFailureRisk.json`
- `e2e/heartFailureRisk.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'heartFailureRisk',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks