### PR TITLE
hc-154-thyroid-function: Implement the Thyroid Function Calculator as described in is

### DIFF
--- a/e2e/thyroidFunction.spec.js
+++ b/e2e/thyroidFunction.spec.js
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/schilddruesen-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Schilddrüsen-Rechner/)
+})
+
+test('TSH 2.0, fT4 1.2, fT3 3.0 → euthyroid', async ({ page }) => {
+  await page.getByTestId('tsh').fill('2.0')
+  await page.getByTestId('t4').fill('1.2')
+  await page.getByTestId('t3').fill('3.0')
+
+  const status = page.getByTestId('result-status')
+  await expect(status).toBeVisible()
+  await expect(status).toHaveText(/Euthyreote/)
+})
+
+test('TSH 8.0 + low T4 → primary hypothyroidism', async ({ page }) => {
+  await page.getByTestId('tsh').fill('8.0')
+  await page.getByTestId('t4').fill('0.6')
+
+  const status = page.getByTestId('result-status')
+  await expect(status).toBeVisible()
+  await expect(status).toHaveText(/Primäre Hypothyreose/)
+})
+
+test('TSH 0.1 + high T4 → primary hyperthyroidism', async ({ page }) => {
+  await page.getByTestId('tsh').fill('0.1')
+  await page.getByTestId('t4').fill('2.5')
+
+  const status = page.getByTestId('result-status')
+  await expect(status).toBeVisible()
+  await expect(status).toHaveText(/Primäre Hyperthyreose/)
+})
+
+test('high TSH + normal T4 → subclinical hypothyroidism', async ({ page }) => {
+  await page.getByTestId('tsh').fill('6.0')
+  await page.getByTestId('t4').fill('1.2')
+
+  const status = page.getByTestId('result-status')
+  await expect(status).toHaveText(/Subklinische Hypothyreose/)
+})
+
+test('T4 unit toggle to pmol/L still produces result', async ({ page }) => {
+  await page.getByTestId('tsh').fill('2.0')
+  await page.getByTestId('t4-unit-pmol').click()
+  await page.getByTestId('t4').fill('15.4')
+
+  const status = page.getByTestId('result-status')
+  await expect(status).toBeVisible()
+})
+
+test('reset clears all inputs', async ({ page }) => {
+  await page.getByTestId('tsh').fill('2.0')
+  await page.getByTestId('t4').fill('1.2')
+
+  await page.getByRole('button', { name: /Zurücksetzen/ }).click()
+
+  await expect(page.getByTestId('tsh')).toHaveValue('')
+  await expect(page.getByTestId('t4')).toHaveValue('')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -22,7 +22,7 @@ const EXPECTED_KEYS = [
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
-  'heartFailureRisk', 'dehydrationRisk',
+  'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -81,6 +81,7 @@ const EXPECTED_ROUTE_MAP = {
   bloodAlcoholEstimator: { de: 'blutalkohol-schaetzer', en: 'blood-alcohol-estimator' },
   heartFailureRisk: { de: 'herzinsuffizienz-risiko-rechner', en: 'heart-failure-risk-calculator' },
   dehydrationRisk: { de: 'dehydrations-risiko-rechner', en: 'dehydration-risk-calculator' },
+  thyroidFunction: { de: 'schilddruesen-rechner', en: 'thyroid-function-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -127,6 +128,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'blutalkohol-schaetzen',
   'herzinsuffizienz-risiko-berechnen',
   'dehydrations-risiko-berechnen',
+  'schilddruesenfunktion-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -173,19 +175,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'blood-alcohol-estimator-guide',
   'heart-failure-risk-calculator',
   'dehydration-risk-calculator-guide',
+  'thyroid-function-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 57 calculators', () => {
-    expect(calculatorMetas).toHaveLength(57)
+  it('discovers all 58 calculators', () => {
+    expect(calculatorMetas).toHaveLength(58)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 57 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(57)
+  it('builds calculatorComponents map for all 58 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(58)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -208,15 +211,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 55 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(55)
+  it('discovers all 56 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(56)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 55 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(55)
+  it('discovers all 56 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(56)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -232,10 +235,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 57 calculators with no duplicates', () => {
+  it('groups contain all 58 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(57)
-    expect(new Set(allKeys).size).toBe(57)
+    expect(allKeys).toHaveLength(58)
+    expect(new Set(allKeys).size).toBe(58)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -256,7 +259,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction',
     ])
   })
 
@@ -304,8 +307,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 321 routes', () => {
-    expect(routes).toHaveLength(321)
+  it('generates exactly 326 routes', () => {
+    expect(routes).toHaveLength(326)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 224 links (57 calcs × 2 locales + 55 blogs × 2 locales)', () => {
+  it('generates 228 links (58 calcs × 2 locales + 56 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(224)
+    expect(links).toHaveLength(228)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -16,7 +16,7 @@ const EXPECTED_KEYS = [
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
-  'heartFailureRisk', 'dehydrationRisk',
+  'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -62,6 +62,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'blutalkohol-schaetzen',
   'herzinsuffizienz-risiko-berechnen',
   'dehydrations-risiko-berechnen',
+  'schilddruesenfunktion-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -107,12 +108,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'blood-alcohol-estimator-guide',
   'heart-failure-risk-calculator',
   'dehydration-risk-calculator-guide',
+  'thyroid-function-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 57 calculator meta files', () => {
+  it('discovers all 58 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(57)
+    expect(metas).toHaveLength(58)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -150,19 +152,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 55 DE blog slugs', () => {
+  it('returns all 56 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(55)
+    expect(de).toHaveLength(56)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 55 EN blog slugs', () => {
+  it('returns all 56 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(55)
+    expect(en).toHaveLength(56)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -230,9 +232,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 114 calcs + 2 blog index + 110 blog articles = 228)', () => {
+  it('generates correct total URL count (2 home + 116 calcs + 2 blog index + 112 blog articles = 232)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(228)
+    expect(urlCount).toBe(232)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/__tests__/thyroidFunction.test.js
+++ b/src/__tests__/thyroidFunction.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyTsh,
+  classifyT3,
+  classifyT4,
+  classifyThyroidFunction,
+  convertTsh,
+  convertT4,
+  convertT3,
+} from '../utils/thyroidFunction.js'
+
+// Thyroid panel interpretation — TSH (mIU/L), free T4 (ng/dL), free T3 (pg/mL).
+// Reference ranges from American Thyroid Association (ATA) adult guidelines.
+
+describe('TSH classification', () => {
+  it('classifies < 0.4 mIU/L as low (hyperthyroid pattern)', () => {
+    expect(classifyTsh(0.2)).toBe('low')
+    expect(classifyTsh(0.39)).toBe('low')
+  })
+
+  it('classifies 0.4–4.0 mIU/L as normal', () => {
+    expect(classifyTsh(0.4)).toBe('normal')
+    expect(classifyTsh(2.5)).toBe('normal')
+    expect(classifyTsh(4.0)).toBe('normal')
+  })
+
+  it('classifies > 4.0 mIU/L as high (hypothyroid pattern)', () => {
+    expect(classifyTsh(4.1)).toBe('high')
+    expect(classifyTsh(10)).toBe('high')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(classifyTsh(null)).toBeNull()
+    expect(classifyTsh(NaN)).toBeNull()
+    expect(classifyTsh(-1)).toBeNull()
+  })
+})
+
+describe('Free T4 classification (ng/dL)', () => {
+  it('classifies < 0.8 ng/dL as low', () => {
+    expect(classifyT4(0.5)).toBe('low')
+  })
+
+  it('classifies 0.8–1.8 ng/dL as normal', () => {
+    expect(classifyT4(0.8)).toBe('normal')
+    expect(classifyT4(1.2)).toBe('normal')
+    expect(classifyT4(1.8)).toBe('normal')
+  })
+
+  it('classifies > 1.8 ng/dL as high', () => {
+    expect(classifyT4(2.5)).toBe('high')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(classifyT4(null)).toBeNull()
+    expect(classifyT4(-1)).toBeNull()
+  })
+})
+
+describe('Free T3 classification (pg/mL)', () => {
+  it('classifies < 2.3 pg/mL as low', () => {
+    expect(classifyT3(1.8)).toBe('low')
+  })
+
+  it('classifies 2.3–4.2 pg/mL as normal', () => {
+    expect(classifyT3(2.3)).toBe('normal')
+    expect(classifyT3(3.2)).toBe('normal')
+    expect(classifyT3(4.2)).toBe('normal')
+  })
+
+  it('classifies > 4.2 pg/mL as high', () => {
+    expect(classifyT3(5)).toBe('high')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(classifyT3(null)).toBeNull()
+  })
+})
+
+describe('Unit conversions', () => {
+  it('TSH is unitless between mIU/L and µIU/mL (1:1)', () => {
+    expect(convertTsh(2.5, 'mIU/L', 'µIU/mL')).toBeCloseTo(2.5)
+    expect(convertTsh(2.5, 'µIU/mL', 'mIU/L')).toBeCloseTo(2.5)
+  })
+
+  it('Free T4 ng/dL → pmol/L (×12.87)', () => {
+    expect(convertT4(1.0, 'ng/dL', 'pmol/L')).toBeCloseTo(12.87, 1)
+    expect(convertT4(1.5, 'ng/dL', 'pmol/L')).toBeCloseTo(19.31, 1)
+  })
+
+  it('Free T4 pmol/L → ng/dL (÷12.87)', () => {
+    expect(convertT4(12.87, 'pmol/L', 'ng/dL')).toBeCloseTo(1.0, 1)
+  })
+
+  it('Free T3 pg/mL → pmol/L (×1.536)', () => {
+    expect(convertT3(3.0, 'pg/mL', 'pmol/L')).toBeCloseTo(4.61, 1)
+  })
+
+  it('Free T3 pmol/L → pg/mL (÷1.536)', () => {
+    expect(convertT3(4.61, 'pmol/L', 'pg/mL')).toBeCloseTo(3.0, 1)
+  })
+})
+
+describe('Overall thyroid function classification', () => {
+  it('all normal → euthyroid', () => {
+    const r = classifyThyroidFunction({ tsh: 2.0, freeT4: 1.2, freeT3: 3.0 })
+    expect(r.status).toBe('euthyroid')
+  })
+
+  it('high TSH + low free T4 → primary hypothyroidism', () => {
+    const r = classifyThyroidFunction({ tsh: 8.0, freeT4: 0.6, freeT3: 2.0 })
+    expect(r.status).toBe('primaryHypo')
+  })
+
+  it('high TSH + normal free T4 → subclinical hypothyroidism', () => {
+    const r = classifyThyroidFunction({ tsh: 6.0, freeT4: 1.2, freeT3: 3.0 })
+    expect(r.status).toBe('subclinicalHypo')
+  })
+
+  it('low TSH + high free T4 → primary hyperthyroidism', () => {
+    const r = classifyThyroidFunction({ tsh: 0.1, freeT4: 2.5, freeT3: 5.0 })
+    expect(r.status).toBe('primaryHyper')
+  })
+
+  it('low TSH + normal free T4 + normal free T3 → subclinical hyperthyroidism', () => {
+    const r = classifyThyroidFunction({ tsh: 0.2, freeT4: 1.2, freeT3: 3.0 })
+    expect(r.status).toBe('subclinicalHyper')
+  })
+
+  it('only TSH provided + TSH high → can still classify', () => {
+    const r = classifyThyroidFunction({ tsh: 8.0 })
+    expect(r.status).toBe('elevatedTsh')
+  })
+
+  it('returns null when no values provided', () => {
+    expect(classifyThyroidFunction({})).toBeNull()
+    expect(classifyThyroidFunction(null)).toBeNull()
+  })
+
+  it('returned object includes per-marker categories', () => {
+    const r = classifyThyroidFunction({ tsh: 8.0, freeT4: 0.6 })
+    expect(r.tshCategory).toBe('high')
+    expect(r.t4Category).toBe('low')
+  })
+})

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -494,6 +494,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'dehydrationRisk',
     related: ['calculate-water-intake', 'caffeine-calculator-sleep-guide', 'sodium-correction-calculator'],
   },
+  {
+    slug: 'thyroid-function-calculator',
+    title: 'Thyroid Function Calculator: Read TSH, T3 and T4 Like a Pro',
+    description: 'Interpret TSH, free T3 and free T4 values. Hypothyroidism, hyperthyroidism, subclinical patterns and what each marker really tells you.',
+    date: '2026-05-05',
+    readTime: '9 min',
+    calculatorKey: 'thyroidFunction',
+    related: ['calculate-bmr', 'calculate-tdee', 'diabetes-risk-score'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -494,6 +494,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'dehydrationRisk',
     related: ['wasserbedarf-berechnen', 'koffein-rechner-schlafen', 'natrium-korrektur-berechnen'],
   },
+  {
+    slug: 'schilddruesenfunktion-berechnen',
+    title: 'Schilddrüsenwerte verstehen: TSH, T3 und T4 richtig deuten',
+    description: 'TSH, freies T3 und freies T4 in einen Befund einordnen. Hypothyreose, Hyperthyreose, subklinische Formen und welche Werte was bedeuten.',
+    date: '2026-05-05',
+    readTime: '9 min',
+    calculatorKey: 'thyroidFunction',
+    related: ['grundumsatz-berechnen', 'tdee-berechnen', 'diabetes-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/thyroidFunction.json
+++ b/src/locales/calculators/de/thyroidFunction.json
@@ -1,0 +1,87 @@
+{
+  "home": {
+    "calculators": {
+      "thyroidFunction": {
+        "name": "Schilddrüsen-Rechner",
+        "description": "Werte TSH, freies T3 und T4 ein und erhalte eine Einordnung der Schilddrüsenfunktion."
+      }
+    }
+  },
+  "thyroidFunction": {
+    "meta": {
+      "title": "Schilddrüsen-Rechner — TSH, T3, T4 Werte interpretieren",
+      "description": "Schilddrüsenwerte verstehen: TSH, freies T3 und freies T4 in einen Befund einordnen. Hyperthyreose, Hypothyreose, subklinische Formen — kostenlos und sofort."
+    },
+    "title": "Schilddrüsen-Rechner",
+    "description": "TSH, freies T3 und freies T4 in einen Schilddrüsenbefund einordnen — basierend auf den ATA-Referenzbereichen.",
+    "tshLabel": "TSH (mIU/L)",
+    "tshRange": "Normalbereich: 0,4 – 4,0 mIU/L",
+    "t4Label": "Freies T4 (fT4)",
+    "t4RangeNgdl": "Normalbereich: 0,8 – 1,8 ng/dL",
+    "t4RangePmol": "Normalbereich: 10,3 – 23,2 pmol/L",
+    "t3Label": "Freies T3 (fT3)",
+    "t3RangePgml": "Normalbereich: 2,3 – 4,2 pg/mL",
+    "t3RangePmol": "Normalbereich: 3,5 – 6,5 pmol/L",
+    "reset": "Zurücksetzen",
+    "results": "Ergebnis",
+    "cat_low": "Niedrig",
+    "cat_normal": "Normal",
+    "cat_high": "Erhöht",
+    "status_euthyroid": "Euthyreote Funktion",
+    "status_primaryHypo": "Primäre Hypothyreose",
+    "status_subclinicalHypo": "Subklinische Hypothyreose",
+    "status_primaryHyper": "Primäre Hyperthyreose",
+    "status_subclinicalHyper": "Subklinische Hyperthyreose",
+    "status_elevatedTsh": "Erhöhter TSH-Wert",
+    "status_suppressedTsh": "Supprimierter TSH-Wert",
+    "status_indeterminate": "Befund nicht eindeutig",
+    "advice_euthyroid": "Deine Schilddrüsenwerte liegen im Normbereich. Eine routinemäßige Kontrolle reicht in der Regel aus.",
+    "advice_primaryHypo": "Hinweise auf eine manifeste Schilddrüsenunterfunktion. Sprich mit deinem Arzt — meist ist eine Behandlung mit Levothyroxin sinnvoll.",
+    "advice_subclinicalHypo": "Subklinische Unterfunktion: TSH erhöht, T4 noch normal. Kontrolle nach 4–8 Wochen empfohlen, ggf. Antikörper (TPO-Ak) bestimmen.",
+    "advice_primaryHyper": "Hinweise auf eine manifeste Schilddrüsenüberfunktion. Eine zeitnahe ärztliche Abklärung ist wichtig — Morbus Basedow oder Knoten möglich.",
+    "advice_subclinicalHyper": "Subklinische Überfunktion: TSH supprimiert, T4 und T3 normal. Kontrolle nach 4–8 Wochen, Risiko für Vorhofflimmern und Osteoporose beachten.",
+    "advice_elevatedTsh": "TSH ist erhöht. Eine Bestimmung von freiem T4 ist erforderlich, um zwischen subklinischer und manifester Unterfunktion zu unterscheiden.",
+    "advice_suppressedTsh": "TSH ist niedrig. Bestimmung von freiem T4 und freiem T3 zur weiteren Abklärung empfohlen.",
+    "advice_indeterminate": "Die Werte ergeben kein eindeutiges Muster. Eine Wiederholung in 4–6 Wochen kann sinnvoll sein.",
+    "refTitle": "Referenzbereiche (Erwachsene, ATA-Leitlinien)",
+    "refMarker": "Marker",
+    "refRange": "Normalbereich",
+    "refMeaning": "Bedeutung",
+    "refTshMeaning": "Hypophysensignal an die Schilddrüse",
+    "refT4Meaning": "Hauptspeicherhormon (Vorstufe)",
+    "refT3Meaning": "Aktive Form, wirkt auf Zellen",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner ordnet TSH, freies T4 und freies T3 anhand der ATA-Referenzbereiche in eines von acht Mustern ein. Das Verhältnis der drei Werte unterscheidet primäre und subklinische Formen von Hyper- und Hypothyreose. Die Hypophyse setzt TSH frei, das die Schilddrüse zur T4- und T3-Bildung anregt — bei Funktionsstörungen sind diese Werte typisch verschoben.",
+    "disclaimer": "Hinweis: Dieser Rechner ist ein Orientierungs-Tool. Eine Diagnose erfordert immer ärztliche Bewertung mit Anamnese, klinischem Befund und ggf. Antikörpern (TPO-Ak, TRAK) sowie Sonografie.",
+    "faq": [
+      {
+        "q": "Was sagt der TSH-Wert aus?",
+        "a": "TSH (Thyreoidea-stimulierendes Hormon) wird von der Hypophyse gebildet und steuert die Schilddrüse. Ein hoher TSH-Wert deutet auf eine Unterfunktion hin (die Hypophyse ‚ruft lauter‘), ein niedriger Wert auf eine Überfunktion. TSH ist der empfindlichste Einzelmarker."
+      },
+      {
+        "q": "Was ist der Unterschied zwischen T3 und T4?",
+        "a": "T4 (Thyroxin) ist die Hauptspeicherform — etwa 80 % der Schilddrüsenproduktion. T3 (Trijodthyronin) ist die biologisch aktive Form, die in Geweben aus T4 entsteht. Frei (‚fT4‘, ‚fT3‘) bezeichnet den ungebundenen, wirksamen Anteil."
+      },
+      {
+        "q": "Was ist eine subklinische Schilddrüsenstörung?",
+        "a": "Bei subklinischer Hypothyreose ist der TSH-Wert erhöht, das freie T4 aber noch normal. Subklinische Hyperthyreose: TSH supprimiert, T4 und T3 normal. Symptome können vorhanden oder fehlend sein."
+      },
+      {
+        "q": "Welche Symptome deuten auf Schilddrüsenstörungen hin?",
+        "a": "Unterfunktion: Müdigkeit, Gewichtszunahme, Kälteempfindlichkeit, Verstopfung, trockene Haut. Überfunktion: Herzrasen, Gewichtsverlust, Hitzewallungen, Nervosität, Schlafstörungen. Hashimoto und Morbus Basedow sind die häufigsten Autoimmun-Ursachen."
+      },
+      {
+        "q": "Wie oft sollten die Werte kontrolliert werden?",
+        "a": "Bei normaler Funktion alle 1–2 Jahre, bei Levothyroxin-Therapie alle 6–12 Monate, bei subklinischen Befunden nach 4–8 Wochen. Schwangere mit Hypothyreose: alle 4–6 Wochen."
+      },
+      {
+        "q": "Beeinflussen Medikamente die Schilddrüsenwerte?",
+        "a": "Ja. Biotin (Hochdosis), Lithium, Amiodaron, Östrogen und Glukokortikoide können die Werte verfälschen. Biotin sollte 48 Stunden vor dem Bluttest pausiert werden."
+      },
+      {
+        "q": "Was ist Hashimoto-Thyreoiditis?",
+        "a": "Die häufigste Ursache der Hypothyreose: eine Autoimmunerkrankung, bei der das Immunsystem die Schilddrüse angreift. Diagnose über TPO-Antikörper. Behandlung mit Levothyroxin, sobald TSH dauerhaft erhöht ist."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/thyroidFunction.json
+++ b/src/locales/calculators/en/thyroidFunction.json
@@ -1,0 +1,87 @@
+{
+  "home": {
+    "calculators": {
+      "thyroidFunction": {
+        "name": "Thyroid Function Calculator",
+        "description": "Enter TSH, free T3 and T4 to interpret thyroid function with ATA reference ranges."
+      }
+    }
+  },
+  "thyroidFunction": {
+    "meta": {
+      "title": "Thyroid Function Calculator — Interpret TSH, T3, T4",
+      "description": "Understand your thyroid panel: TSH, free T3 and free T4 mapped to a clear pattern. Hyperthyroid, hypothyroid, subclinical forms — free, instant, no sign-up."
+    },
+    "title": "Thyroid Function Calculator",
+    "description": "Map TSH, free T3 and free T4 to a thyroid function pattern using ATA adult reference ranges.",
+    "tshLabel": "TSH (mIU/L)",
+    "tshRange": "Reference range: 0.4 – 4.0 mIU/L",
+    "t4Label": "Free T4 (fT4)",
+    "t4RangeNgdl": "Reference range: 0.8 – 1.8 ng/dL",
+    "t4RangePmol": "Reference range: 10.3 – 23.2 pmol/L",
+    "t3Label": "Free T3 (fT3)",
+    "t3RangePgml": "Reference range: 2.3 – 4.2 pg/mL",
+    "t3RangePmol": "Reference range: 3.5 – 6.5 pmol/L",
+    "reset": "Reset",
+    "results": "Result",
+    "cat_low": "Low",
+    "cat_normal": "Normal",
+    "cat_high": "High",
+    "status_euthyroid": "Euthyroid",
+    "status_primaryHypo": "Primary hypothyroidism",
+    "status_subclinicalHypo": "Subclinical hypothyroidism",
+    "status_primaryHyper": "Primary hyperthyroidism",
+    "status_subclinicalHyper": "Subclinical hyperthyroidism",
+    "status_elevatedTsh": "Elevated TSH",
+    "status_suppressedTsh": "Suppressed TSH",
+    "status_indeterminate": "Indeterminate pattern",
+    "advice_euthyroid": "Your thyroid markers are within the reference range. Routine monitoring is usually sufficient.",
+    "advice_primaryHypo": "Pattern suggests overt hypothyroidism. Discuss with your doctor — levothyroxine therapy is often indicated.",
+    "advice_subclinicalHypo": "Subclinical hypothyroidism: TSH elevated, free T4 still normal. Recheck in 4–8 weeks; consider TPO antibodies.",
+    "advice_primaryHyper": "Pattern suggests overt hyperthyroidism. Prompt medical evaluation is important — Graves' disease or autonomous nodules are possible.",
+    "advice_subclinicalHyper": "Subclinical hyperthyroidism: TSH suppressed, free T4 and T3 normal. Recheck in 4–8 weeks; watch for atrial fibrillation and bone loss risk.",
+    "advice_elevatedTsh": "TSH is elevated. Free T4 testing is needed to distinguish subclinical from overt hypothyroidism.",
+    "advice_suppressedTsh": "TSH is suppressed. Test free T4 and free T3 to clarify the picture.",
+    "advice_indeterminate": "The values do not fit a single pattern. A repeat panel in 4–6 weeks is reasonable.",
+    "refTitle": "Reference ranges (adults, ATA guidelines)",
+    "refMarker": "Marker",
+    "refRange": "Reference range",
+    "refMeaning": "Meaning",
+    "refTshMeaning": "Pituitary signal to the thyroid",
+    "refT4Meaning": "Main storage hormone (precursor)",
+    "refT3Meaning": "Active form, acts on cells",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator maps TSH, free T4 and free T3 against ATA reference ranges and matches the pattern to one of eight categories. The relationship between the three values distinguishes primary from subclinical forms of hyper- and hypothyroidism. The pituitary releases TSH to drive thyroid hormone production — when the gland under- or over-produces, the values shift in characteristic ways.",
+    "disclaimer": "Note: This is an educational tool, not a diagnosis. A clinical assessment requires history, physical exam, and often antibodies (TPO, TRAb) plus ultrasound.",
+    "faq": [
+      {
+        "q": "What does TSH measure?",
+        "a": "TSH (thyroid-stimulating hormone) is released by the pituitary gland and tells the thyroid to make T4 and T3. High TSH suggests an underactive thyroid (the pituitary is 'shouting louder'); low TSH suggests an overactive thyroid. TSH is the most sensitive single marker."
+      },
+      {
+        "q": "What's the difference between T3 and T4?",
+        "a": "T4 (thyroxine) is the main storage form — about 80 % of thyroid output. T3 (triiodothyronine) is the biologically active form, converted from T4 in tissues. 'Free' (fT4, fT3) refers to the unbound, active fraction."
+      },
+      {
+        "q": "What is subclinical thyroid disease?",
+        "a": "Subclinical hypothyroidism: TSH elevated, free T4 still normal. Subclinical hyperthyroidism: TSH suppressed, free T4 and T3 normal. Symptoms may be subtle or absent."
+      },
+      {
+        "q": "What symptoms suggest a thyroid problem?",
+        "a": "Hypothyroidism: fatigue, weight gain, cold intolerance, constipation, dry skin. Hyperthyroidism: palpitations, weight loss, heat intolerance, anxiety, insomnia. Hashimoto's and Graves' are the leading autoimmune causes."
+      },
+      {
+        "q": "How often should thyroid values be checked?",
+        "a": "Normal function: every 1–2 years. On levothyroxine: every 6–12 months. Subclinical findings: recheck in 4–8 weeks. In pregnancy with hypothyroidism: every 4–6 weeks."
+      },
+      {
+        "q": "Do medications affect thyroid values?",
+        "a": "Yes. High-dose biotin, lithium, amiodarone, estrogen, and glucocorticoids can shift the values. Hold biotin for 48 hours before testing."
+      },
+      {
+        "q": "What is Hashimoto's thyroiditis?",
+        "a": "The most common cause of hypothyroidism — an autoimmune disease where the immune system attacks the thyroid. Diagnosed via TPO antibodies. Treated with levothyroxine once TSH is persistently elevated."
+      }
+    ]
+  }
+}

--- a/src/pages/ThyroidFunctionCalculator.vue
+++ b/src/pages/ThyroidFunctionCalculator.vue
@@ -1,0 +1,223 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  classifyThyroidFunction,
+  convertT4,
+  convertT3,
+} from '../utils/thyroidFunction.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('thyroidFunction.faq') || [])
+
+useHead(() => ({
+  title: t('thyroidFunction.meta.title'),
+  description: t('thyroidFunction.meta.description'),
+  routeKey: 'thyroidFunction',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Thyroid Function Calculator',
+    url: 'https://healthcalculator.app/thyroid-function-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const tsh = ref(null)
+const freeT4 = ref(null)
+const freeT3 = ref(null)
+const t4Unit = ref('ng/dL')
+const t3Unit = ref('pg/mL')
+
+const tshNormalized = computed(() => (Number.isFinite(tsh.value) ? tsh.value : null))
+
+const t4Normalized = computed(() => {
+  if (!Number.isFinite(freeT4.value)) return null
+  return t4Unit.value === 'ng/dL' ? freeT4.value : convertT4(freeT4.value, 'pmol/L', 'ng/dL')
+})
+
+const t3Normalized = computed(() => {
+  if (!Number.isFinite(freeT3.value)) return null
+  return t3Unit.value === 'pg/mL' ? freeT3.value : convertT3(freeT3.value, 'pmol/L', 'pg/mL')
+})
+
+const result = computed(() => classifyThyroidFunction({
+  tsh: tshNormalized.value,
+  freeT4: t4Normalized.value,
+  freeT3: t3Normalized.value,
+}))
+
+const statusColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.status) {
+    case 'euthyroid': return 'text-green-600'
+    case 'subclinicalHypo':
+    case 'subclinicalHyper':
+    case 'elevatedTsh':
+    case 'suppressedTsh': return 'text-yellow-600'
+    case 'primaryHypo':
+    case 'primaryHyper': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+
+function categoryColor(cat) {
+  if (cat === 'normal') return 'text-green-600'
+  if (cat === 'low' || cat === 'high') return 'text-red-600'
+  return 'text-stone-400'
+}
+
+function reset() {
+  tsh.value = null
+  freeT4.value = null
+  freeT3.value = null
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('thyroidFunction.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('thyroidFunction.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <!-- TSH -->
+    <div class="mb-6">
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+        {{ t('thyroidFunction.tshLabel') }}
+      </label>
+      <input v-model.number="tsh" type="number" step="0.01" placeholder="2.5" data-testid="tsh"
+        class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      <p class="text-xs text-stone-400 mt-1">{{ t('thyroidFunction.tshRange') }}</p>
+    </div>
+
+    <!-- Free T4 -->
+    <div class="mb-6">
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+        {{ t('thyroidFunction.t4Label') }}
+      </label>
+      <div class="flex gap-2">
+        <input v-model.number="freeT4" type="number" step="0.01" :placeholder="t4Unit === 'ng/dL' ? '1.2' : '15.4'" data-testid="t4"
+          class="flex-1 border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        <div class="flex gap-1">
+          <button @click="t4Unit = 'ng/dL'" data-testid="t4-unit-ngdl"
+            :class="t4Unit === 'ng/dL' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-3 py-2 rounded-lg text-xs font-medium transition-colors duration-150"
+          >ng/dL</button>
+          <button @click="t4Unit = 'pmol/L'" data-testid="t4-unit-pmol"
+            :class="t4Unit === 'pmol/L' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-3 py-2 rounded-lg text-xs font-medium transition-colors duration-150"
+          >pmol/L</button>
+        </div>
+      </div>
+      <p class="text-xs text-stone-400 mt-1">{{ t4Unit === 'ng/dL' ? t('thyroidFunction.t4RangeNgdl') : t('thyroidFunction.t4RangePmol') }}</p>
+    </div>
+
+    <!-- Free T3 -->
+    <div class="mb-6">
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+        {{ t('thyroidFunction.t3Label') }}
+      </label>
+      <div class="flex gap-2">
+        <input v-model.number="freeT3" type="number" step="0.01" :placeholder="t3Unit === 'pg/mL' ? '3.2' : '4.9'" data-testid="t3"
+          class="flex-1 border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        <div class="flex gap-1">
+          <button @click="t3Unit = 'pg/mL'" data-testid="t3-unit-pgml"
+            :class="t3Unit === 'pg/mL' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-3 py-2 rounded-lg text-xs font-medium transition-colors duration-150"
+          >pg/mL</button>
+          <button @click="t3Unit = 'pmol/L'" data-testid="t3-unit-pmol"
+            :class="t3Unit === 'pmol/L' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-3 py-2 rounded-lg text-xs font-medium transition-colors duration-150"
+          >pmol/L</button>
+        </div>
+      </div>
+      <p class="text-xs text-stone-400 mt-1">{{ t3Unit === 'pg/mL' ? t('thyroidFunction.t3RangePgml') : t('thyroidFunction.t3RangePmol') }}</p>
+    </div>
+
+    <button @click="reset"
+      class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150"
+    >&times; {{ t('thyroidFunction.reset') }}</button>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('thyroidFunction.results') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-6">
+      <span :class="statusColor" class="text-3xl font-bold tracking-tight" data-testid="result-status">
+        {{ t('thyroidFunction.status_' + result.status) }}
+      </span>
+    </div>
+
+    <div class="grid grid-cols-3 gap-4 mb-6">
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="tsh-marker">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">TSH</p>
+        <p class="text-base font-semibold tabular-nums" :class="categoryColor(result.tshCategory)">
+          {{ result.tshCategory ? t('thyroidFunction.cat_' + result.tshCategory) : '—' }}
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="t4-marker">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">Free T4</p>
+        <p class="text-base font-semibold tabular-nums" :class="categoryColor(result.t4Category)">
+          {{ result.t4Category ? t('thyroidFunction.cat_' + result.t4Category) : '—' }}
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="t3-marker">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">Free T3</p>
+        <p class="text-base font-semibold tabular-nums" :class="categoryColor(result.t3Category)">
+          {{ result.t3Category ? t('thyroidFunction.cat_' + result.t3Category) : '—' }}
+        </p>
+      </div>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 text-sm text-stone-600 leading-relaxed" data-testid="advice">
+      {{ t('thyroidFunction.advice_' + result.status) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('thyroidFunction.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('thyroidFunction.refMarker') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('thyroidFunction.refRange') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('thyroidFunction.refMeaning') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">TSH</td><td class="px-6 py-3 text-stone-600">0.4 – 4.0 mIU/L</td><td class="px-6 py-3 text-stone-600">{{ t('thyroidFunction.refTshMeaning') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">Free T4</td><td class="px-6 py-3 text-stone-600">0.8 – 1.8 ng/dL (10.3 – 23.2 pmol/L)</td><td class="px-6 py-3 text-stone-600">{{ t('thyroidFunction.refT4Meaning') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">Free T3</td><td class="px-6 py-3 text-stone-600">2.3 – 4.2 pg/mL (3.5 – 6.5 pmol/L)</td><td class="px-6 py-3 text-stone-600">{{ t('thyroidFunction.refT3Meaning') }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('thyroidFunction.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('thyroidFunction.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('thyroidFunction.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="thyroidFunction" />
+</template>

--- a/src/pages/blog/SchilddruesenfunktionBerechnen.vue
+++ b/src/pages/blog/SchilddruesenfunktionBerechnen.vue
@@ -1,0 +1,169 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Schilddrüsenwerte verstehen: TSH, T3 und T4 richtig deuten | Health Calculators',
+  description: 'TSH, freies T3 und freies T4 in einen Befund einordnen. Hypothyreose, Hyperthyreose, subklinische Formen und welche Werte was bedeuten.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Schilddrüsenwerte verstehen: TSH, T3 und T4 richtig deuten',
+    description: 'TSH, freies T3 und freies T4 in einen Befund einordnen. Hypothyreose, Hyperthyreose, subklinische Formen und welche Werte was bedeuten.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-05',
+    dateModified: '2026-05-05',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/schilddruesenfunktion-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Schilddrüsenwerte verstehen: TSH, T3 und T4 richtig deuten</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">5. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Laborbefund nennt drei Werte: <strong>TSH</strong>, <strong>freies T4</strong> und <strong>freies T3</strong>. Was bedeutet erhöht? Wann ist eine Behandlung nötig — und wann nur eine Kontrolle?
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt das Hormon-Zusammenspiel von Hypophyse und Schilddrüse, die Referenzbereiche der ATA und die acht typischen Befundmuster.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wie die Schilddrüse gesteuert wird</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Schilddrüse produziert <strong>T4 (Thyroxin, ~80 %)</strong> und <strong>T3 (Trijodthyronin, ~20 %)</strong>. T3 ist die biologisch aktive Form — sie wirkt direkt auf die Zellen und steuert Stoffwechsel, Herzfrequenz und Körpertemperatur. T4 ist die Speicherform und wird in den Geweben bei Bedarf in T3 umgewandelt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Hypophyse („Hirnanhangsdrüse") regelt die Produktion über <strong>TSH (Thyreoidea-stimulierendes Hormon)</strong>. Das Prinzip: negative Rückkopplung. Sind die Schilddrüsenhormone zu niedrig, schüttet die Hypophyse mehr TSH aus — und umgekehrt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Daraus folgt das Grundprinzip der Diagnostik: <strong>TSH spiegelt die Funktion umgekehrt wider</strong>. Hohe TSH-Werte sprechen für eine Unterfunktion, niedrige Werte für eine Überfunktion.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Referenzbereiche</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Marker</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Normalbereich</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Alternative Einheit</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">TSH</td>
+                <td class="px-6 py-3 text-stone-600">0,4 – 4,0 mIU/L</td>
+                <td class="px-6 py-3 text-stone-600">= µIU/mL</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Freies T4</td>
+                <td class="px-6 py-3 text-stone-600">0,8 – 1,8 ng/dL</td>
+                <td class="px-6 py-3 text-stone-600">10,3 – 23,2 pmol/L</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Freies T3</td>
+                <td class="px-6 py-3 text-stone-600">2,3 – 4,2 pg/mL</td>
+                <td class="px-6 py-3 text-stone-600">3,5 – 6,5 pmol/L</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed">
+          Quelle: American Thyroid Association (ATA). Schwangerschaft, Alter und Labormethode können die Bereiche verschieben.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die acht typischen Befundmuster</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">TSH</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">fT4</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Befund</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-green-600 font-semibold">Euthyreote Funktion</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">Hoch</td><td class="px-6 py-3 text-stone-900">Niedrig</td><td class="px-6 py-3 text-red-600 font-semibold">Primäre Hypothyreose</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">Hoch</td><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-yellow-600 font-semibold">Subklinische Hypothyreose</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">Niedrig</td><td class="px-6 py-3 text-stone-900">Hoch</td><td class="px-6 py-3 text-red-600 font-semibold">Primäre Hyperthyreose</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">Niedrig</td><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-yellow-600 font-semibold">Subklinische Hyperthyreose</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hypothyreose — wenn die Schilddrüse zu wenig produziert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Häufigste Ursache: <strong>Hashimoto-Thyreoiditis</strong>. Das Immunsystem zerstört langsam Schilddrüsengewebe. Folge: T4 sinkt, TSH steigt. Typische Symptome: Müdigkeit, Gewichtszunahme, Frieren, Verstopfung, trockene Haut, depressive Verstimmung.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Behandlung: Levothyroxin als Tablette nüchtern. Ziel: TSH zwischen 0,5 und 2,5 mIU/L. Subklinische Formen (TSH erhöht, T4 normal) werden oft erst bei TSH &gt; 10 mIU/L oder Symptomen behandelt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hyperthyreose — wenn die Schilddrüse zu viel produziert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hauptursachen: <strong>Morbus Basedow</strong> (Autoimmunerkrankung mit TRAK-Antikörpern), autonome Adenome, Schilddrüsenentzündungen. Symptome: Herzrasen, Gewichtsverlust trotz Appetit, Schwitzen, Nervosität, Schlafstörungen, Tremor.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Behandlung je nach Ursache: Thyreostatika (Carbimazol), Radiojodtherapie oder Operation. Subklinische Formen erfordern Verlaufskontrolle wegen Risiken für Vorhofflimmern und Knochendichte.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Deine Schilddrüsenwerte einordnen</h3>
+        <p class="text-stone-300 text-sm mb-5">TSH, freies T3 und freies T4 eintragen — sofortige Einordnung in eines der acht Muster nach ATA-Leitlinien.</p>
+        <router-link
+          :to="localePath('thyroidFunction')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Schilddrüsenhormone steuern den <router-link :to="localeBlogPath('grundumsatz-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Grundumsatz</router-link> direkt — eine Unterfunktion senkt ihn um bis zu 15 %. Auch dein <router-link :to="localeBlogPath('tdee-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Gesamtenergiebedarf</router-link> hängt davon ab. Bei begleitenden Stoffwechselstörungen lohnt sich ein Blick auf das <router-link :to="localeBlogPath('diabetes-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Diabetes-Risiko</router-link>, da Hashimoto und Typ-1-Diabetes häufig gemeinsam auftreten.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          TSH ist der empfindlichste Marker — bei Auffälligkeiten ergänzen freies T4 und freies T3 das Bild. Subklinische Formen sind häufig und brauchen oft nur Kontrolle, manifeste Formen eine Behandlung. Nutze unseren <router-link :to="localePath('thyroidFunction')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Schilddrüsen-Rechner</router-link> als Orientierung, nicht als Diagnose-Ersatz.
+        </p>
+      </div>
+
+      <RelatedArticles slug="schilddruesenfunktion-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/ThyroidFunctionCalculator.vue
+++ b/src/pages/blog/en/ThyroidFunctionCalculator.vue
@@ -1,0 +1,166 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+
+useHead({
+  title: 'Thyroid Function Calculator: Read TSH, T3 and T4 Like a Pro | Health Calculators',
+  description: 'Interpret TSH, free T3 and free T4 values. Hypothyroidism, hyperthyroidism, subclinical patterns and what each marker really tells you.',
+  path: '/en/blog/thyroid-function-calculator',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Thyroid Function Calculator: Read TSH, T3 and T4 Like a Pro',
+    description: 'Interpret TSH, free T3 and free T4 values. Hypothyroidism, hyperthyroidism, subclinical patterns and what each marker really tells you.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-05',
+    dateModified: '2026-05-05',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/thyroid-function-calculator',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link to="/en/blog" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Thyroid Function Calculator: Read TSH, T3 and T4 Like a Pro</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 5, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Your lab report shows three values: <strong>TSH</strong>, <strong>free T4</strong>, and <strong>free T3</strong>. What does "elevated" actually mean? When does treatment matter — and when is it just monitoring?
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains the pituitary–thyroid feedback loop, the ATA reference ranges, and the eight clinical patterns you'll see on a thyroid panel.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How the thyroid is regulated</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The thyroid produces <strong>T4 (thyroxine, ~80 %)</strong> and <strong>T3 (triiodothyronine, ~20 %)</strong>. T3 is the biologically active form — it acts on cells and controls metabolism, heart rate, and body temperature. T4 is the storage form, converted to T3 in tissues as needed.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The pituitary regulates output via <strong>TSH (thyroid-stimulating hormone)</strong> in a negative feedback loop: when thyroid hormones drop, the pituitary releases more TSH; when they rise, TSH is suppressed.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The diagnostic principle that follows: <strong>TSH moves opposite to thyroid function</strong>. High TSH points to underactivity, low TSH to overactivity.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Reference ranges</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Marker</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Reference range</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Alternative units</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">TSH</td>
+                <td class="px-6 py-3 text-stone-600">0.4 – 4.0 mIU/L</td>
+                <td class="px-6 py-3 text-stone-600">= µIU/mL</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Free T4</td>
+                <td class="px-6 py-3 text-stone-600">0.8 – 1.8 ng/dL</td>
+                <td class="px-6 py-3 text-stone-600">10.3 – 23.2 pmol/L</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Free T3</td>
+                <td class="px-6 py-3 text-stone-600">2.3 – 4.2 pg/mL</td>
+                <td class="px-6 py-3 text-stone-600">3.5 – 6.5 pmol/L</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500 leading-relaxed">
+          Source: American Thyroid Association (ATA). Pregnancy, age, and lab method can shift the ranges.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The eight clinical patterns</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">TSH</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">fT4</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Pattern</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-green-600 font-semibold">Euthyroid</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">High</td><td class="px-6 py-3 text-stone-900">Low</td><td class="px-6 py-3 text-red-600 font-semibold">Primary hypothyroidism</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">High</td><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-yellow-600 font-semibold">Subclinical hypothyroidism</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">Low</td><td class="px-6 py-3 text-stone-900">High</td><td class="px-6 py-3 text-red-600 font-semibold">Primary hyperthyroidism</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900">Low</td><td class="px-6 py-3 text-stone-900">Normal</td><td class="px-6 py-3 text-yellow-600 font-semibold">Subclinical hyperthyroidism</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hypothyroidism — when output is too low</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Most common cause: <strong>Hashimoto's thyroiditis</strong>, an autoimmune attack on the thyroid that gradually destroys tissue. T4 falls, TSH climbs. Symptoms: fatigue, weight gain, cold intolerance, constipation, dry skin, low mood.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Treatment: levothyroxine, taken on an empty stomach. Target TSH 0.5–2.5 mIU/L. Subclinical disease (TSH high, T4 normal) is often watched until TSH exceeds 10 mIU/L or symptoms appear.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hyperthyroidism — when output is too high</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Main causes: <strong>Graves' disease</strong> (autoimmune, TRAb antibodies), autonomous nodules, thyroiditis. Symptoms: palpitations, weight loss with normal appetite, heat intolerance, anxiety, insomnia, tremor.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Treatment depends on cause: anti-thyroid drugs (methimazole), radioactive iodine, or surgery. Subclinical hyperthyroidism needs monitoring because of atrial fibrillation and bone density risks.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Interpret your thyroid panel</h3>
+        <p class="text-stone-300 text-sm mb-5">Enter TSH, free T3 and free T4 — instant pattern matching against ATA reference ranges.</p>
+        <router-link
+          to="/en/thyroid-function-calculator"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Thyroid hormones drive your <router-link to="/en/blog/calculate-bmr" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">basal metabolic rate</router-link> directly — hypothyroidism can cut it by up to 15 %. Your <router-link to="/en/blog/calculate-tdee" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">total daily energy expenditure</router-link> follows. If metabolic markers are off, also check your <router-link to="/en/blog/diabetes-risk-score" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">diabetes risk</router-link>, since Hashimoto's and type 1 diabetes commonly cluster together.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          TSH is the most sensitive marker; free T4 and free T3 fill in the picture when something looks off. Subclinical patterns are common and often need only follow-up. Use our <router-link to="/en/thyroid-function-calculator" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Thyroid Function Calculator</router-link> as orientation — not as a substitute for clinical evaluation.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="thyroid-function-calculator" />
+    </div>
+  </article>
+</template>

--- a/src/pages/thyroidFunction.meta.js
+++ b/src/pages/thyroidFunction.meta.js
@@ -1,0 +1,16 @@
+import Component from './ThyroidFunctionCalculator.vue'
+import BlogDe from './blog/SchilddruesenfunktionBerechnen.vue'
+import BlogEn from './blog/en/ThyroidFunctionCalculator.vue'
+
+export default {
+  key: 'thyroidFunction',
+  component: Component,
+  slugs: { de: 'schilddruesen-rechner', en: 'thyroid-function-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 35,
+  blog: {
+    de: { slug: 'schilddruesenfunktion-berechnen', component: BlogDe },
+    en: { slug: 'thyroid-function-calculator', component: BlogEn },
+  },
+}

--- a/src/utils/thyroidFunction.js
+++ b/src/utils/thyroidFunction.js
@@ -1,0 +1,105 @@
+// Thyroid panel interpretation. Reference ranges follow the American Thyroid
+// Association (ATA) guidelines for non-pregnant adults:
+//   TSH        0.4 – 4.0  mIU/L  (= µIU/mL)
+//   Free T4    0.8 – 1.8  ng/dL  (10.3 – 23.2 pmol/L)
+//   Free T3    2.3 – 4.2  pg/mL  (3.5  –  6.5 pmol/L)
+//
+// Pattern interpretation (ATA / AACE):
+//   high TSH + low  fT4   → primary hypothyroidism
+//   high TSH + normal fT4 → subclinical hypothyroidism
+//   low  TSH + high fT4 (or fT3) → primary hyperthyroidism
+//   low  TSH + normal fT4 + normal fT3 → subclinical hyperthyroidism
+//
+// References:
+//  - Garber JR et al. Clinical practice guidelines for hypothyroidism in adults
+//    (AACE / ATA), Thyroid 2012;22(12):1200-1235.
+//  - Ross DS et al. 2016 ATA Guidelines for Diagnosis and Management of
+//    Hyperthyroidism, Thyroid 2016;26(10):1343-1421.
+
+const TSH_LOW = 0.4
+const TSH_HIGH = 4.0
+const T4_LOW = 0.8
+const T4_HIGH = 1.8
+const T3_LOW = 2.3
+const T3_HIGH = 4.2
+
+const T4_NG_DL_TO_PMOL_L = 12.87
+const T3_PG_ML_TO_PMOL_L = 1.536
+
+function isValid(n) {
+  return Number.isFinite(n) && n >= 0
+}
+
+export function classifyTsh(value) {
+  if (!isValid(value)) return null
+  if (value < TSH_LOW) return 'low'
+  if (value > TSH_HIGH) return 'high'
+  return 'normal'
+}
+
+export function classifyT4(value) {
+  if (!isValid(value)) return null
+  if (value < T4_LOW) return 'low'
+  if (value > T4_HIGH) return 'high'
+  return 'normal'
+}
+
+export function classifyT3(value) {
+  if (!isValid(value)) return null
+  if (value < T3_LOW) return 'low'
+  if (value > T3_HIGH) return 'high'
+  return 'normal'
+}
+
+export function convertTsh(value, from, to) {
+  if (!isValid(value)) return null
+  // mIU/L and µIU/mL are numerically identical
+  return value
+}
+
+export function convertT4(value, from, to) {
+  if (!isValid(value)) return null
+  if (from === to) return value
+  if (from === 'ng/dL' && to === 'pmol/L') return value * T4_NG_DL_TO_PMOL_L
+  if (from === 'pmol/L' && to === 'ng/dL') return value / T4_NG_DL_TO_PMOL_L
+  return null
+}
+
+export function convertT3(value, from, to) {
+  if (!isValid(value)) return null
+  if (from === to) return value
+  if (from === 'pg/mL' && to === 'pmol/L') return value * T3_PG_ML_TO_PMOL_L
+  if (from === 'pmol/L' && to === 'pg/mL') return value / T3_PG_ML_TO_PMOL_L
+  return null
+}
+
+export function classifyThyroidFunction(input) {
+  if (!input || typeof input !== 'object') return null
+  const { tsh, freeT4, freeT3 } = input
+
+  const tshCategory = classifyTsh(tsh)
+  const t4Category = classifyT4(freeT4)
+  const t3Category = classifyT3(freeT3)
+
+  if (!tshCategory && !t4Category && !t3Category) return null
+
+  let status = 'indeterminate'
+
+  if (tshCategory === 'normal' && (t4Category === 'normal' || !t4Category) && (t3Category === 'normal' || !t3Category)) {
+    status = 'euthyroid'
+  } else if (tshCategory === 'high' && t4Category === 'low') {
+    status = 'primaryHypo'
+  } else if (tshCategory === 'high' && t4Category === 'normal') {
+    status = 'subclinicalHypo'
+  } else if (tshCategory === 'low' && (t4Category === 'high' || t3Category === 'high')) {
+    status = 'primaryHyper'
+  } else if (tshCategory === 'low' && (t4Category === 'normal' || !t4Category) && (t3Category === 'normal' || !t3Category)) {
+    status = 'subclinicalHyper'
+  } else if (tshCategory === 'high' && !t4Category) {
+    status = 'elevatedTsh'
+  } else if (tshCategory === 'low' && !t4Category && !t3Category) {
+    status = 'suppressedTsh'
+  }
+
+  return { status, tshCategory, t4Category, t3Category }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-154-thyroid-function
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-154-thyroid-function-20260505-220031`
**Cost:** $8.917173250000001

Closes jenslaufer/health-calculators#154

### Prompt
> Implement the Thyroid Function Calculator as described in issue #154.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- TSH, T3, T4 interpretation
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/thyroidFunction.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/thyroidFunction.test.js` with 6+ test cases covering edge cases. Run `npm test -- thyroidFunction` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/ThyroidFunctionCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/thyroidFunction.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/thyroidFunction.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'thyroidFunction'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/thyroidFunction.json` + `src/locales/calculators/en/thyroidFunction.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/thyroidFunction.js (or shared util — verify pattern in repo first)`
- `src/__tests__/thyroidFunction.test.js`
- `src/pages/ThyroidFunctionCalculator.vue`
- `src/pages/thyroidFunction.meta.js`
- `src/locales/calculators/de/thyroidFunction.json`
- `src/locales/calculators/en/thyroidFunction.json`
- `e2e/thyroidFunction.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'thyroidFunction',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks