### PR TITLE
hc-153-anemia-risk: Implement the Anemia Risk Calculator as described in issue #

### DIFF
--- a/e2e/anemiaRisk.spec.js
+++ b/e2e/anemiaRisk.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/anaemie-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Anämie-Risiko-Rechner/)
+})
+
+test('woman with Hb 13.5 and no symptoms → no risk', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('hemoglobin').fill('13.5')
+  await expect(page.getByTestId('result-status')).toHaveText('Kein Risiko')
+})
+
+test('woman with Hb 11.5 (mild) → mild', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('hemoglobin').fill('11.5')
+  await expect(page.getByTestId('result-status')).toHaveText('Leicht')
+})
+
+test('woman with Hb 9.5 (moderate) → moderate', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('hemoglobin').fill('9.5')
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+})
+
+test('woman with Hb 7 (severe) → severe', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('hemoglobin').fill('7')
+  await expect(page.getByTestId('result-status')).toHaveText('Schwer')
+})
+
+test('symptom-only screening: 4 symptoms (fatigue+pallor+SOB) → moderate', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('hemoglobin').fill('13')
+  await page.getByTestId('checkbox-fatigue').check()
+  await page.getByTestId('checkbox-pallor').check()
+  await page.getByTestId('checkbox-shortnessOfBreath').check()
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+})
+
+test('imperial unit toggle (g/L) works', async ({ page }) => {
+  await page.getByRole('button', { name: 'g/L', exact: true }).click()
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('hemoglobin').fill('135') // 13.5 g/dL
+  await expect(page.getByTestId('result-status')).toHaveText('Kein Risiko')
+})
+
+test('symptom score reflects checked symptoms', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('hemoglobin').fill('13')
+  await page.getByTestId('checkbox-fatigue').check()
+  await page.getByTestId('checkbox-shortnessOfBreath').check()
+  await expect(page.getByTestId('symptom-score')).toContainText('3')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/anemiaRisk.test.js
+++ b/src/__tests__/anemiaRisk.test.js
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyHemoglobin,
+  calcSymptomScore,
+  classifyAnemia,
+  calcAnemiaRisk,
+} from '../utils/anemiaRisk.js'
+
+// Anemia risk screening combines:
+// 1) Hemoglobin (g/dL) measured against WHO sex-specific cutoffs:
+//    Women  : <12.0 anemia, <11.0 moderate, <8.0 severe
+//    Men    : <13.0 anemia, <11.0 moderate, <8.0 severe
+//    None when Hb is at or above the sex-specific normal cutoff.
+// 2) Clinical symptom score (additive points):
+//    fatigue (1), pallor (1), shortnessOfBreath (2), dizziness (1),
+//    coldHandsFeet (1), headache (1), rapidHeartbeat (2),
+//    brittleNails (1), restlessLegs (1), pica (2)
+// 3) Final risk = max(Hb category, symptom-band):
+//    score 0    → none
+//    score 1–3  → mild
+//    score 4–6  → moderate
+//    score ≥ 7  → severe
+
+describe('Hemoglobin classification', () => {
+  it('woman with Hb 13.5 g/dL → none', () => {
+    expect(classifyHemoglobin(13.5, 'female')).toBe('none')
+  })
+
+  it('woman with Hb 11.5 g/dL → mild', () => {
+    expect(classifyHemoglobin(11.5, 'female')).toBe('mild')
+  })
+
+  it('woman with Hb 9.0 g/dL → moderate', () => {
+    expect(classifyHemoglobin(9.0, 'female')).toBe('moderate')
+  })
+
+  it('woman with Hb 7.0 g/dL → severe', () => {
+    expect(classifyHemoglobin(7.0, 'female')).toBe('severe')
+  })
+
+  it('man with Hb 14.0 g/dL → none', () => {
+    expect(classifyHemoglobin(14.0, 'male')).toBe('none')
+  })
+
+  it('man with Hb 12.5 g/dL → mild (below 13.0 male cutoff)', () => {
+    expect(classifyHemoglobin(12.5, 'male')).toBe('mild')
+  })
+
+  it('returns null for invalid hb', () => {
+    expect(classifyHemoglobin(null, 'female')).toBeNull()
+    expect(classifyHemoglobin(-1, 'female')).toBeNull()
+    expect(classifyHemoglobin(0, 'female')).toBeNull()
+  })
+
+  it('returns null for unknown sex', () => {
+    expect(classifyHemoglobin(12, 'other')).toBeNull()
+  })
+})
+
+describe('Symptom score', () => {
+  it('no symptoms → 0', () => {
+    expect(calcSymptomScore({})).toBe(0)
+  })
+
+  it('fatigue alone → 1', () => {
+    expect(calcSymptomScore({ fatigue: true })).toBe(1)
+  })
+
+  it('shortnessOfBreath alone → 2', () => {
+    expect(calcSymptomScore({ shortnessOfBreath: true })).toBe(2)
+  })
+
+  it('pica alone → 2', () => {
+    expect(calcSymptomScore({ pica: true })).toBe(2)
+  })
+
+  it('all symptoms → 13', () => {
+    expect(
+      calcSymptomScore({
+        fatigue: true,
+        pallor: true,
+        shortnessOfBreath: true,
+        dizziness: true,
+        coldHandsFeet: true,
+        headache: true,
+        rapidHeartbeat: true,
+        brittleNails: true,
+        restlessLegs: true,
+        pica: true,
+      }),
+    ).toBe(13)
+  })
+
+  it('ignores unknown flags', () => {
+    expect(calcSymptomScore({ fatigue: true, foo: true })).toBe(1)
+  })
+})
+
+describe('Anemia classification', () => {
+  it('Hb none + score 0 → none', () => {
+    expect(classifyAnemia('none', 0)).toBe('none')
+  })
+
+  it('Hb none + score 2 → mild', () => {
+    expect(classifyAnemia('none', 2)).toBe('mild')
+  })
+
+  it('Hb mild + score 0 → mild', () => {
+    expect(classifyAnemia('mild', 0)).toBe('mild')
+  })
+
+  it('Hb none + score 5 → moderate', () => {
+    expect(classifyAnemia('none', 5)).toBe('moderate')
+  })
+
+  it('Hb moderate + score 1 → moderate', () => {
+    expect(classifyAnemia('moderate', 1)).toBe('moderate')
+  })
+
+  it('Hb none + score 7 → severe', () => {
+    expect(classifyAnemia('none', 7)).toBe('severe')
+  })
+
+  it('Hb severe overrides low score → severe', () => {
+    expect(classifyAnemia('severe', 0)).toBe('severe')
+  })
+
+  it('takes the higher of two estimates', () => {
+    expect(classifyAnemia('mild', 5)).toBe('moderate')
+  })
+})
+
+describe('calcAnemiaRisk integration', () => {
+  it('returns null without sex', () => {
+    expect(calcAnemiaRisk({ hemoglobin: 13, sex: null, symptoms: {} })).toBeNull()
+  })
+
+  it('healthy man: Hb 14.5, no symptoms → none', () => {
+    const r = calcAnemiaRisk({ hemoglobin: 14.5, sex: 'male', symptoms: {} })
+    expect(r.category).toBe('none')
+    expect(r.symptomScore).toBe(0)
+    expect(r.hbCategory).toBe('none')
+  })
+
+  it('woman with normal Hb but 3 symptoms → mild via symptoms', () => {
+    const r = calcAnemiaRisk({
+      hemoglobin: 13,
+      sex: 'female',
+      symptoms: { fatigue: true, pallor: true, dizziness: true },
+    })
+    expect(r.category).toBe('mild')
+    expect(r.symptomScore).toBe(3)
+    expect(r.hbCategory).toBe('none')
+  })
+
+  it('woman with Hb 9.5 (moderate) + mild symptoms → moderate', () => {
+    const r = calcAnemiaRisk({
+      hemoglobin: 9.5,
+      sex: 'female',
+      symptoms: { fatigue: true },
+    })
+    expect(r.category).toBe('moderate')
+    expect(r.hbCategory).toBe('moderate')
+  })
+
+  it('man with severe Hb 7 → severe regardless of symptoms', () => {
+    const r = calcAnemiaRisk({ hemoglobin: 7, sex: 'male', symptoms: {} })
+    expect(r.category).toBe('severe')
+    expect(r.hbCategory).toBe('severe')
+  })
+
+  it('symptom-only screening when Hb omitted', () => {
+    const r = calcAnemiaRisk({
+      hemoglobin: null,
+      sex: 'female',
+      symptoms: { fatigue: true, pallor: true, shortnessOfBreath: true, pica: true },
+    })
+    // 1 + 1 + 2 + 2 = 6 → moderate by symptom band
+    expect(r.symptomScore).toBe(6)
+    expect(r.category).toBe('moderate')
+    expect(r.hbCategory).toBeNull()
+  })
+
+  it('exposes WHO cutoff used for the given sex', () => {
+    expect(calcAnemiaRisk({ hemoglobin: 13.2, sex: 'female', symptoms: {} }).cutoff).toBe(12)
+    expect(calcAnemiaRisk({ hemoglobin: 14.2, sex: 'male', symptoms: {} }).cutoff).toBe(13)
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -22,7 +22,7 @@ const EXPECTED_KEYS = [
   'bmiFrauen', 'bmiMaenner', 'childDosage', 'cholesterolRatio',
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
-  'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction',
+  'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -82,6 +82,7 @@ const EXPECTED_ROUTE_MAP = {
   heartFailureRisk: { de: 'herzinsuffizienz-risiko-rechner', en: 'heart-failure-risk-calculator' },
   dehydrationRisk: { de: 'dehydrations-risiko-rechner', en: 'dehydration-risk-calculator' },
   thyroidFunction: { de: 'schilddruesen-rechner', en: 'thyroid-function-calculator' },
+  anemiaRisk: { de: 'anaemie-risiko-rechner', en: 'anemia-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -129,6 +130,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'herzinsuffizienz-risiko-berechnen',
   'dehydrations-risiko-berechnen',
   'schilddruesenfunktion-berechnen',
+  'anaemie-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -176,19 +178,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'heart-failure-risk-calculator',
   'dehydration-risk-calculator-guide',
   'thyroid-function-calculator',
+  'anemia-risk-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 58 calculators', () => {
-    expect(calculatorMetas).toHaveLength(58)
+  it('discovers all 59 calculators', () => {
+    expect(calculatorMetas).toHaveLength(59)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 58 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(58)
+  it('builds calculatorComponents map for all 59 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(59)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -211,15 +214,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 56 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(56)
+  it('discovers all 57 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(57)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 56 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(56)
+  it('discovers all 57 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(57)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -235,10 +238,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 58 calculators with no duplicates', () => {
+  it('groups contain all 59 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(58)
-    expect(new Set(allKeys).size).toBe(58)
+    expect(allKeys).toHaveLength(59)
+    expect(new Set(allKeys).size).toBe(59)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -259,7 +262,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk',
     ])
   })
 
@@ -307,8 +310,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 326 routes', () => {
-    expect(routes).toHaveLength(326)
+  it('generates exactly 331 routes', () => {
+    expect(routes).toHaveLength(331)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 228 links (58 calcs × 2 locales + 56 blogs × 2 locales)', () => {
+  it('generates 232 links (59 calcs × 2 locales + 57 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(228)
+    expect(links).toHaveLength(232)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -16,7 +16,7 @@ const EXPECTED_KEYS = [
   'dueDate', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk',
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
-  'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction',
+  'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -63,6 +63,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'herzinsuffizienz-risiko-berechnen',
   'dehydrations-risiko-berechnen',
   'schilddruesenfunktion-berechnen',
+  'anaemie-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -109,12 +110,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'heart-failure-risk-calculator',
   'dehydration-risk-calculator-guide',
   'thyroid-function-calculator',
+  'anemia-risk-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 58 calculator meta files', () => {
+  it('discovers all 59 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(58)
+    expect(metas).toHaveLength(59)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -152,19 +154,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 56 DE blog slugs', () => {
+  it('returns all 57 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(56)
+    expect(de).toHaveLength(57)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 56 EN blog slugs', () => {
+  it('returns all 57 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(56)
+    expect(en).toHaveLength(57)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -232,9 +234,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 116 calcs + 2 blog index + 112 blog articles = 232)', () => {
+  it('generates correct total URL count (2 home + 118 calcs + 2 blog index + 114 blog articles = 236)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(232)
+    expect(urlCount).toBe(236)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -503,6 +503,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'thyroidFunction',
     related: ['calculate-bmr', 'calculate-tdee', 'diabetes-risk-score'],
   },
+  {
+    slug: 'anemia-risk-calculator-guide',
+    title: 'Anemia Risk Calculator: Spot Iron Deficiency and Low Hemoglobin Early',
+    description: 'Screen for anemia from hemoglobin, sex, and 10 typical symptoms. WHO cutoffs, iron-deficiency clues, and treatment principles — explained.',
+    date: '2026-05-06',
+    readTime: '8 min',
+    calculatorKey: 'anemiaRisk',
+    related: ['cardiovascular-risk-framingham', 'calculate-bmr', 'thyroid-function-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -503,6 +503,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'thyroidFunction',
     related: ['grundumsatz-berechnen', 'tdee-berechnen', 'diabetes-risiko-berechnen'],
   },
+  {
+    slug: 'anaemie-risiko-berechnen',
+    title: 'Anämie berechnen: Eisenmangel und Blutarmut früh erkennen',
+    description: 'Anämie-Risiko aus Hämoglobin, Geschlecht und 10 typischen Symptomen einschätzen. WHO-Grenzwerte, Eisenmangel-Hinweise und Therapieprinzipien — kompakt erklärt.',
+    date: '2026-05-06',
+    readTime: '8 min',
+    calculatorKey: 'anemiaRisk',
+    related: ['herz-kreislauf-risiko-berechnen', 'grundumsatz-berechnen', 'schilddruesenfunktion-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/anemiaRisk.json
+++ b/src/locales/calculators/de/anemiaRisk.json
@@ -1,0 +1,89 @@
+{
+  "home": {
+    "calculators": {
+      "anemiaRisk": {
+        "name": "Anämie-Risiko-Rechner",
+        "description": "Schätze dein Anämie-Risiko aus Hämoglobinwert, Geschlecht und Symptomen ein."
+      }
+    }
+  },
+  "anemiaRisk": {
+    "meta": {
+      "title": "Anämie-Risiko-Rechner — Eisenmangel & Blutarmut erkennen",
+      "description": "Berechne dein Anämie-Risiko aus Hämoglobin, Geschlecht und klinischen Symptomen. WHO-Grenzwerte, Schweregrad-Einstufung und ärztliche Hinweise. Kostenlos, sofort, ohne Anmeldung."
+    },
+    "title": "Anämie-Risiko-Rechner",
+    "description": "Schätze deinen Schweregrad einer Blutarmut aus Hämoglobinwert und 10 klinischen Symptomen — basierend auf WHO-Referenzwerten und Leitlinien-Symptomkriterien.",
+    "sexLabel": "Geschlecht",
+    "sexFemale": "Weiblich",
+    "sexMale": "Männlich",
+    "hbLabel": "Hämoglobin ({unit})",
+    "symptomsLabel": "Symptome (alle zutreffenden ankreuzen)",
+    "symptom_fatigue": "Müdigkeit / Erschöpfung",
+    "symptom_fatigue_desc": "Anhaltende Schwäche, Antriebslosigkeit auch nach Schlaf",
+    "symptom_pallor": "Blasse Haut / Schleimhäute",
+    "symptom_pallor_desc": "Blasses Gesicht, Augenlider innen oder Nagelbett",
+    "symptom_shortnessOfBreath": "Atemnot bei Belastung",
+    "symptom_shortnessOfBreath_desc": "Kurzatmigkeit beim Treppensteigen oder leichter Anstrengung",
+    "symptom_dizziness": "Schwindel beim Aufstehen",
+    "symptom_dizziness_desc": "Benommenheit, Schwarzwerden vor den Augen",
+    "symptom_coldHandsFeet": "Kalte Hände und Füße",
+    "symptom_coldHandsFeet_desc": "Reduzierte periphere Durchblutung trotz warmer Umgebung",
+    "symptom_headache": "Kopfschmerzen",
+    "symptom_headache_desc": "Häufige dumpfe Kopfschmerzen, oft morgens",
+    "symptom_rapidHeartbeat": "Herzklopfen / schneller Puls",
+    "symptom_rapidHeartbeat_desc": "Tachykardie, spürbares Herzklopfen schon in Ruhe",
+    "symptom_brittleNails": "Brüchige Nägel / Haarausfall",
+    "symptom_brittleNails_desc": "Trockene Haut, Längsrillen oder Löffelnägel",
+    "symptom_restlessLegs": "Restless-Legs / Kribbeln in Beinen",
+    "symptom_restlessLegs_desc": "Unruhige Beine besonders abends — typisch bei Eisenmangel",
+    "symptom_pica": "Pica / ungewöhnliches Verlangen",
+    "symptom_pica_desc": "Drang, Eis, Erde oder Stärke zu essen — alarmierendes Eisenmangel-Zeichen",
+    "resultsLabel": "Dein Anämie-Risiko",
+    "hbCategoryLabel": "Hb-Bewertung",
+    "symptomScoreLabel": "Symptom-Score",
+    "cutoffLabel": "WHO-Grenzwert",
+    "cutoffValue": "{value} {unit}",
+    "category_none": "Kein Risiko",
+    "category_mild": "Leicht",
+    "category_moderate": "Moderat",
+    "category_severe": "Schwer",
+    "advice_none": "Dein Hämoglobinwert und deine Symptome sprechen aktuell nicht für eine Anämie. Bei anhaltender Müdigkeit dennoch Blutbild kontrollieren lassen.",
+    "advice_mild": "Leichte Anämie wahrscheinlich. Lass ein großes Blutbild und Eisenparameter (Ferritin, Transferrin-Sättigung) bei deinem Hausarzt bestimmen.",
+    "advice_moderate": "Moderate Anämie — ärztliche Abklärung in den nächsten Tagen empfohlen. Ursache klären (Eisen-, B12-, Folatmangel oder chronische Erkrankung) und gezielt therapieren.",
+    "advice_severe": "Schwere Anämie — kann lebensbedrohlich sein. Bei Atemnot in Ruhe, Brustschmerz oder Synkope sofort Notarzt rufen. Sonst zeitnahe internistische Vorstellung mit Hb-Kontrolle und ggf. Transfusion.",
+    "refTitle": "WHO-Grenzwerte für Hämoglobin (g/dL)",
+    "refCategory": "Schweregrad",
+    "refWomen": "Frauen (nicht schwanger)",
+    "refMen": "Männer",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner kombiniert zwei Verfahren: (1) Hämoglobin — der eingegebene Wert wird gegen die WHO-Grenzwerte abgeglichen (Frauen 12,0 g/dL, Männer 13,0 g/dL für 'keine Anämie'). (2) Symptom-Score — zehn typische Anämie-Zeichen werden gewichtet aufaddiert (max. 13 Punkte). Maßgeblich ist der höhere der beiden Schweregrade. Pica und Restless-Legs gelten als spezifische Hinweise auf Eisenmangel und sollten ärztlich abgeklärt werden.",
+    "disclaimer": "Dieser Rechner dient zur Selbsteinschätzung gesunder Erwachsener und ersetzt keine ärztliche Untersuchung. Schwangere, Kinder, Menschen mit chronischen Erkrankungen oder Tumorleiden benötigen abweichende Grenzwerte. Bei Atemnot, Brustschmerz, Synkope oder schwarzem Stuhl sofort medizinische Hilfe in Anspruch nehmen.",
+    "faq": [
+      {
+        "q": "Was ist Anämie?",
+        "a": "Anämie (Blutarmut) bezeichnet einen verminderten Hämoglobingehalt im Blut. Damit kann weniger Sauerstoff zu den Geweben transportiert werden, was Müdigkeit, Atemnot und Leistungsabfall erklärt. Die häufigste Ursache weltweit ist Eisenmangel."
+      },
+      {
+        "q": "Welche Hb-Werte gelten als anämisch?",
+        "a": "Die WHO definiert Anämie ab Hb < 12,0 g/dL bei nicht-schwangeren Frauen und < 13,0 g/dL bei Männern. Bei Schwangeren liegt die Grenze bei 11,0 g/dL. Werte unter 8,0 g/dL gelten als schwer."
+      },
+      {
+        "q": "Welche Symptome treten typischerweise auf?",
+        "a": "Müdigkeit, blasse Haut, Atemnot bei Belastung, schneller Puls, Kopfschmerzen, kalte Extremitäten, brüchige Nägel, Haarausfall, Restless-Legs sowie ungewöhnliches Verlangen nach Eis oder Erde (Pica)."
+      },
+      {
+        "q": "Was sind häufige Ursachen?",
+        "a": "Eisenmangel (z. B. starke Menstruation, vegane Ernährung, Magengeschwüre), Vitamin-B12- oder Folsäuremangel, chronische Entzündungen, Nierenerkrankungen und Blutverluste. Eine Diagnose erfordert immer ein Blutbild plus Eisen- bzw. Vitaminparameter."
+      },
+      {
+        "q": "Wie wird Anämie behandelt?",
+        "a": "Je nach Ursache: orale Eisenpräparate (60–120 mg/Tag), Vitamin-B12- oder Folsäure-Substitution, Behandlung der Grunderkrankung. Bei schwerer oder symptomatischer Anämie ggf. intravenöse Eisengabe oder Bluttransfusion."
+      },
+      {
+        "q": "Welche Ernährung beugt Eisenmangel vor?",
+        "a": "Hämeisen aus rotem Fleisch, Fisch und Geflügel wird besser aufgenommen als pflanzliches Nicht-Hämeisen. Hülsenfrüchte, Vollkorn, dunkles Blattgemüse und Nüsse plus Vitamin C (z. B. Paprika) zur Aufnahmesteigerung. Kaffee, Tee und Calcium hemmen die Eisenaufnahme."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/anemiaRisk.json
+++ b/src/locales/calculators/en/anemiaRisk.json
@@ -1,0 +1,89 @@
+{
+  "home": {
+    "calculators": {
+      "anemiaRisk": {
+        "name": "Anemia Risk Calculator",
+        "description": "Estimate your anemia risk from hemoglobin level, sex, and clinical symptoms."
+      }
+    }
+  },
+  "anemiaRisk": {
+    "meta": {
+      "title": "Anemia Risk Calculator — Iron Deficiency & Low Hemoglobin Screen",
+      "description": "Screen for anemia from hemoglobin, sex, and clinical symptoms. WHO cutoffs, severity grading, and clinical guidance. Free, instant, no sign-up."
+    },
+    "title": "Anemia Risk Calculator",
+    "description": "Grade your anemia risk from hemoglobin and 10 clinical symptoms — based on WHO reference values and guideline-derived symptom criteria.",
+    "sexLabel": "Sex",
+    "sexFemale": "Female",
+    "sexMale": "Male",
+    "hbLabel": "Hemoglobin ({unit})",
+    "symptomsLabel": "Symptoms (check all that apply)",
+    "symptom_fatigue": "Fatigue / low energy",
+    "symptom_fatigue_desc": "Persistent tiredness, low drive even after sleep",
+    "symptom_pallor": "Pale skin / mucous membranes",
+    "symptom_pallor_desc": "Pale face, inner eyelids, or nail beds",
+    "symptom_shortnessOfBreath": "Shortness of breath on exertion",
+    "symptom_shortnessOfBreath_desc": "Breathlessness climbing stairs or with light effort",
+    "symptom_dizziness": "Lightheaded on standing",
+    "symptom_dizziness_desc": "Dizziness, vision blackouts when getting up",
+    "symptom_coldHandsFeet": "Cold hands and feet",
+    "symptom_coldHandsFeet_desc": "Reduced peripheral perfusion in a warm room",
+    "symptom_headache": "Headache",
+    "symptom_headache_desc": "Frequent dull headaches, often in the morning",
+    "symptom_rapidHeartbeat": "Palpitations / rapid heartbeat",
+    "symptom_rapidHeartbeat_desc": "Resting tachycardia or noticeable heart pounding",
+    "symptom_brittleNails": "Brittle nails / hair loss",
+    "symptom_brittleNails_desc": "Dry skin, ridged nails, or spoon-shaped nails",
+    "symptom_restlessLegs": "Restless legs / leg tingling",
+    "symptom_restlessLegs_desc": "Urge to move legs in the evening — typical for iron deficiency",
+    "symptom_pica": "Pica / unusual cravings",
+    "symptom_pica_desc": "Craving ice, dirt, or starch — red-flag iron-deficiency sign",
+    "resultsLabel": "Your anemia risk",
+    "hbCategoryLabel": "Hb assessment",
+    "symptomScoreLabel": "Symptom score",
+    "cutoffLabel": "WHO cutoff",
+    "cutoffValue": "{value} {unit}",
+    "category_none": "No risk",
+    "category_mild": "Mild",
+    "category_moderate": "Moderate",
+    "category_severe": "Severe",
+    "advice_none": "Your hemoglobin and symptoms do not currently suggest anemia. If fatigue persists, ask your GP for a complete blood count anyway.",
+    "advice_mild": "Mild anemia is likely. Have your GP order a full blood count and iron panel (ferritin, transferrin saturation).",
+    "advice_moderate": "Moderate anemia — see a clinician within the next few days. Identify the cause (iron, B12, folate deficiency, or chronic disease) and treat accordingly.",
+    "advice_severe": "Severe anemia — possibly life-threatening. With breathlessness at rest, chest pain, or fainting, call emergency services. Otherwise seek same-day medical care for repeat Hb testing and possible transfusion.",
+    "refTitle": "WHO hemoglobin cutoffs (g/dL)",
+    "refCategory": "Severity",
+    "refWomen": "Women (non-pregnant)",
+    "refMen": "Men",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator combines two methods: (1) Hemoglobin — your value is compared to WHO cutoffs (women < 12.0 g/dL, men < 13.0 g/dL define anemia). (2) Symptom score — ten typical anemia signs are weighted and summed (max. 13 points). The higher of the two estimates determines the final severity. Pica and restless legs are considered specific signs of iron deficiency and warrant clinical evaluation.",
+    "disclaimer": "This calculator is intended for self-assessment in healthy adults and does not replace clinical evaluation. Pregnant women, children, and people with chronic disease or cancer have different cutoffs. With breathlessness at rest, chest pain, syncope, or black stools seek medical care immediately.",
+    "faq": [
+      {
+        "q": "What is anemia?",
+        "a": "Anemia means a reduced hemoglobin level in the blood, lowering the oxygen-carrying capacity. That explains fatigue, breathlessness, and reduced performance. Iron deficiency is the leading cause worldwide."
+      },
+      {
+        "q": "Which hemoglobin values count as anemic?",
+        "a": "WHO defines anemia as Hb < 12.0 g/dL in non-pregnant women and < 13.0 g/dL in men. The cutoff in pregnancy is 11.0 g/dL. Values below 8.0 g/dL are considered severe."
+      },
+      {
+        "q": "What are typical symptoms?",
+        "a": "Fatigue, pale skin, breathlessness on exertion, palpitations, headaches, cold hands and feet, brittle nails, hair loss, restless legs, and unusual cravings for ice or dirt (pica)."
+      },
+      {
+        "q": "What are common causes?",
+        "a": "Iron deficiency (heavy menstruation, vegan diet, peptic ulcer), vitamin B12 or folate deficiency, chronic inflammation, kidney disease, and blood loss. Diagnosis always requires a complete blood count plus iron and vitamin parameters."
+      },
+      {
+        "q": "How is anemia treated?",
+        "a": "Treatment depends on the cause: oral iron supplements (60–120 mg/day), B12 or folate replacement, treating the underlying disease. Severe or symptomatic cases may require IV iron or blood transfusion."
+      },
+      {
+        "q": "Which foods help prevent iron deficiency?",
+        "a": "Heme iron from red meat, fish, and poultry is absorbed better than non-heme iron. Legumes, whole grains, dark leafy greens, and nuts combined with vitamin C (e.g. peppers) improve absorption. Coffee, tea, and calcium reduce it."
+      }
+    ]
+  }
+}

--- a/src/pages/AnemiaRiskCalculator.vue
+++ b/src/pages/AnemiaRiskCalculator.vue
@@ -1,0 +1,240 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcAnemiaRisk } from '../utils/anemiaRisk.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('anemiaRisk.faq') || [])
+
+useHead(() => ({
+  title: t('anemiaRisk.meta.title'),
+  description: t('anemiaRisk.meta.description'),
+  routeKey: 'anemiaRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Anemia Risk Calculator',
+    url: 'https://healthcalculator.app/anemia-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const unit = ref('metric') // metric = g/dL, imperial-ish = g/L
+const sex = ref('female')
+const hemoglobin = ref(null)
+
+const symptoms = ref({
+  fatigue: false,
+  pallor: false,
+  shortnessOfBreath: false,
+  dizziness: false,
+  coldHandsFeet: false,
+  headache: false,
+  rapidHeartbeat: false,
+  brittleNails: false,
+  restlessLegs: false,
+  pica: false,
+})
+
+const symptomList = [
+  { key: 'fatigue', points: 1 },
+  { key: 'pallor', points: 1 },
+  { key: 'shortnessOfBreath', points: 2 },
+  { key: 'dizziness', points: 1 },
+  { key: 'coldHandsFeet', points: 1 },
+  { key: 'headache', points: 1 },
+  { key: 'rapidHeartbeat', points: 2 },
+  { key: 'brittleNails', points: 1 },
+  { key: 'restlessLegs', points: 1 },
+  { key: 'pica', points: 2 },
+]
+
+// hemoglobin is g/dL in metric; in g/L (SI) for imperial toggle. Convert to g/dL.
+const hemoglobinGdL = computed(() => {
+  if (hemoglobin.value == null) return null
+  return unit.value === 'imperial' ? hemoglobin.value / 10 : hemoglobin.value
+})
+
+const result = computed(() => calcAnemiaRisk({
+  hemoglobin: hemoglobinGdL.value,
+  sex: sex.value,
+  symptoms: symptoms.value,
+}))
+
+const categoryStyle = computed(() => {
+  if (!result.value) return { color: '', bg: '' }
+  switch (result.value.category) {
+    case 'none': return { color: 'text-green-600', bg: 'bg-green-50 border-green-200 text-green-900' }
+    case 'mild': return { color: 'text-yellow-600', bg: 'bg-yellow-50 border-yellow-200 text-yellow-900' }
+    case 'moderate': return { color: 'text-orange-500', bg: 'bg-orange-50 border-orange-200 text-orange-900' }
+    case 'severe': return { color: 'text-red-700', bg: 'bg-red-100 border-red-300 text-red-900' }
+    default: return { color: '', bg: '' }
+  }
+})
+
+const categoryLevel = computed(() => {
+  if (!result.value) return 0
+  return { none: 0, mild: 1, moderate: 2, severe: 3 }[result.value.category] ?? 0
+})
+
+const hbUnit = computed(() => unit.value === 'imperial' ? 'g/L' : 'g/dL')
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('anemiaRisk.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('anemiaRisk.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="unit = 'metric'"
+        :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >g/dL</button>
+      <button
+        @click="unit = 'imperial'"
+        :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >g/L</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('anemiaRisk.sexLabel') }}
+        </label>
+        <select
+          v-model="sex"
+          data-testid="sex"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        >
+          <option value="female">{{ t('anemiaRisk.sexFemale') }}</option>
+          <option value="male">{{ t('anemiaRisk.sexMale') }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('anemiaRisk.hbLabel', { unit: hbUnit }) }}
+        </label>
+        <input
+          v-model.number="hemoglobin"
+          type="number"
+          step="0.1"
+          :placeholder="unit === 'metric' ? '13.5' : '135'"
+          data-testid="hemoglobin"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('anemiaRisk.symptomsLabel') }}</p>
+    <div class="space-y-3">
+      <label
+        v-for="s in symptomList"
+        :key="s.key"
+        :data-testid="'symptom-' + s.key"
+        :class="symptoms[s.key] ? 'border-stone-900 bg-stone-50' : 'border-stone-200 hover:border-stone-300'"
+        class="flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-colors duration-150"
+      >
+        <input
+          v-model="symptoms[s.key]"
+          type="checkbox"
+          :data-testid="'checkbox-' + s.key"
+          class="mt-1 h-5 w-5 rounded border-stone-300 text-stone-900 focus:ring-stone-600"
+        />
+        <div class="flex-1 min-w-0">
+          <div class="flex items-baseline justify-between gap-3">
+            <p class="text-sm font-semibold text-stone-900">{{ t('anemiaRisk.symptom_' + s.key) }}</p>
+            <span class="text-xs font-semibold text-stone-400 tabular-nums">+{{ s.points }}</span>
+          </div>
+          <p class="text-xs text-stone-500 leading-relaxed mt-1">{{ t('anemiaRisk.symptom_' + s.key + '_desc') }}</p>
+        </div>
+      </label>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('anemiaRisk.resultsLabel') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold tabular-nums tracking-tight leading-none" :class="categoryStyle.color" data-testid="result-status">{{ t('anemiaRisk.category_' + result.category) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-yellow-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (categoryLevel / 3 * 100) + '%' }"></div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="hb-category">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('anemiaRisk.hbCategoryLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900">
+          <span v-if="result.hbCategory">{{ t('anemiaRisk.category_' + result.hbCategory) }}</span>
+          <span v-else class="text-stone-400 text-lg">—</span>
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="symptom-score">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('anemiaRisk.symptomScoreLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.symptomScore }}<span class="text-lg text-stone-400 font-medium"> / 13</span></p>
+      </div>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 mb-4" data-testid="cutoff">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('anemiaRisk.cutoffLabel') }}</p>
+      <p class="text-base font-semibold text-stone-900 tabular-nums">{{ t('anemiaRisk.cutoffValue', { value: result.cutoff, unit: 'g/dL' }) }}</p>
+    </div>
+
+    <div class="rounded-lg p-4 text-sm font-medium border" :class="categoryStyle.bg" data-testid="advice">
+      {{ t('anemiaRisk.advice_' + result.category) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('anemiaRisk.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('anemiaRisk.refCategory') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('anemiaRisk.refWomen') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('anemiaRisk.refMen') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('anemiaRisk.category_none') }}</td><td class="px-6 py-3 text-stone-600">≥ 12.0 g/dL</td><td class="px-6 py-3 text-stone-600">≥ 13.0 g/dL</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('anemiaRisk.category_mild') }}</td><td class="px-6 py-3 text-stone-600">11.0–11.9 g/dL</td><td class="px-6 py-3 text-stone-600">11.0–12.9 g/dL</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('anemiaRisk.category_moderate') }}</td><td class="px-6 py-3 text-stone-600">8.0–10.9 g/dL</td><td class="px-6 py-3 text-stone-600">8.0–10.9 g/dL</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('anemiaRisk.category_severe') }}</td><td class="px-6 py-3 text-stone-600">&lt; 8.0 g/dL</td><td class="px-6 py-3 text-stone-600">&lt; 8.0 g/dL</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('anemiaRisk.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('anemiaRisk.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('anemiaRisk.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="anemiaRisk" />
+</template>

--- a/src/pages/anemiaRisk.meta.js
+++ b/src/pages/anemiaRisk.meta.js
@@ -1,0 +1,16 @@
+import Component from './AnemiaRiskCalculator.vue'
+import BlogDe from './blog/AnaemieRisikoBerechnen.vue'
+import BlogEn from './blog/en/AnemiaRiskCalculatorGuide.vue'
+
+export default {
+  key: 'anemiaRisk',
+  component: Component,
+  slugs: { de: 'anaemie-risiko-rechner', en: 'anemia-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 36,
+  blog: {
+    de: { slug: 'anaemie-risiko-berechnen', component: BlogDe },
+    en: { slug: 'anemia-risk-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/pages/blog/AnaemieRisikoBerechnen.vue
+++ b/src/pages/blog/AnaemieRisikoBerechnen.vue
@@ -1,0 +1,178 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Anämie berechnen: Eisenmangel und Blutarmut früh erkennen | Health Calculators',
+  description: 'Anämie-Risiko aus Hämoglobin, Geschlecht und 10 typischen Symptomen einschätzen. WHO-Grenzwerte, Eisenmangel-Hinweise, Therapie und Notfallzeichen — kompakt erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Anämie berechnen: Eisenmangel und Blutarmut früh erkennen',
+    description: 'Anämie-Risiko aus Hämoglobin, Geschlecht und 10 typischen Symptomen einschätzen. WHO-Grenzwerte, Eisenmangel-Hinweise, Therapie und Notfallzeichen — kompakt erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-06',
+    dateModified: '2026-05-06',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/anaemie-risiko-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Anämie berechnen: Eisenmangel und Blutarmut früh erkennen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">6. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Etwa <strong>jede fünfte Frau im gebärfähigen Alter</strong> ist von Eisenmangelanämie betroffen — Männer trifft es seltener, dann aber oft mit ernsterer Ursache. Müdigkeit, blasse Haut und Atemnot sind die häufigsten Hinweise. Frühe Erkennung verhindert Komplikationen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Ratgeber zeigt, wie du dein Anämie-Risiko quantitativ einschätzen kannst — über deinen Hämoglobinwert verglichen mit WHO-Grenzwerten und einen klinischen Symptom-Score über 10 typische Anämie-Zeichen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist Anämie?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Anämie (umgangssprachlich Blutarmut) bedeutet einen <strong>verminderten Hämoglobingehalt im Blut</strong>. Das rote Eiweiß Hämoglobin transportiert Sauerstoff von der Lunge zu den Geweben — sinkt es ab, fehlt überall im Körper Sauerstoff. Daraus entstehen die typischen Beschwerden.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die Weltgesundheitsorganisation (WHO) schätzt, dass weltweit über 1,6 Milliarden Menschen anämisch sind. <strong>Eisenmangel ist mit Abstand die häufigste Ursache</strong>, gefolgt von Vitamin-B12- und Folatmangel sowie chronischen Erkrankungen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">WHO-Grenzwerte für Hämoglobin</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Schweregrad</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Frauen</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Männer</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Keine Anämie</td><td class="px-6 py-3 text-stone-600">≥ 12,0 g/dL</td><td class="px-6 py-3 text-stone-600">≥ 13,0 g/dL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Leicht</td><td class="px-6 py-3 text-stone-600">11,0–11,9 g/dL</td><td class="px-6 py-3 text-stone-600">11,0–12,9 g/dL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Moderat</td><td class="px-6 py-3 text-stone-600">8,0–10,9 g/dL</td><td class="px-6 py-3 text-stone-600">8,0–10,9 g/dL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Schwer</td><td class="px-6 py-3 text-stone-600">&lt; 8,0 g/dL</td><td class="px-6 py-3 text-stone-600">&lt; 8,0 g/dL</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei <strong>Schwangeren</strong> liegt die Grenze niedriger (11,0 g/dL), bei Kindern altersabhängig zwischen 11,0 und 12,0 g/dL. Werte unter 7 g/dL sind eine Indikation für Bluttransfusion und gelten als Notfall.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die 10 klinischen Symptome im Score</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Unser Rechner wertet zehn typische Zeichen mit unterschiedlicher Gewichtung aus — abgestützt auf S3-Leitlinien-Beschreibungen:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptom</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Punkte</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bedeutung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Müdigkeit</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Häufigstes, aber unspezifisches Zeichen</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Blasse Haut</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Augenlider innen, Nagelbett, Lippen</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Atemnot bei Belastung</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Reduzierte Sauerstoff-Transportkapazität</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Schwindel</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Orthostatisch oder bei Anstrengung</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Kalte Hände/Füße</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Periphere Vasokonstriktion zur Schonung zentraler Organe</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Kopfschmerzen</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Hypoxie der Hirnrinde</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Herzklopfen</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Tachykardie als Kompensation</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Brüchige Nägel / Haarausfall</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Spezifisch für Eisenmangel</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Restless-Legs</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Hochgradig spezifisch für Eisenmangel</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Pica (Eis-/Erde-Verlangen)</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Alarmzeichen — fast immer Eisenmangel</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Pica und Restless-Legs</strong> sind besonders aussagekräftig: Sie haben hohe Spezifität für einen Eisenmangel, auch wenn das Hämoglobin noch im Normbereich liegt (latenter Eisenmangel mit niedrigem Ferritin).
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt Anämie-Risiko berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Hämoglobin, Geschlecht und 10 klinische Symptome — sofortiges Ergebnis mit Schweregrad und ärztlicher Empfehlung. Anonym und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('anemiaRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Ursachen einer Anämie</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Eisenmangel (50–80 % aller Anämien):</strong> Starke Menstruation, vegane Ernährung, Magengeschwüre, Darmtumoren, häufige Blutspenden.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Vitamin-B12-Mangel:</strong> Veganer, Atrophische Gastritis, Magen-Operationen, Metformin-Langzeitgabe.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Folsäuremangel:</strong> Alkoholabusus, Schwangerschaft, bestimmte Antikonvulsiva.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Renale Anämie:</strong> Bei chronischer Niereninsuffizienz fehlt Erythropoetin.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anämie der chronischen Erkrankung:</strong> Tumoren, Autoimmunerkrankungen, chronische Infektionen.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">So wird Anämie behandelt</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Therapie richtet sich nach Ursache und Schweregrad:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Eisenmangel:</strong> Orale Eisenpräparate (60–120 mg elementares Eisen pro Tag) über mindestens 3 Monate, optimal nüchtern mit Vitamin C, ohne Kaffee/Tee. Bei Unverträglichkeit oder schwerem Mangel intravenöse Eisengabe.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>B12-Mangel:</strong> Intramuskuläre Injektionen oder hochdosiert oral.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Schwere symptomatische Anämie (Hb &lt; 7–8 g/dL):</strong> Bluttransfusion erwägen.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Grunderkrankung:</strong> Immer mitbehandeln — eine reine Eisengabe bei Tumoranämie oder Magenblutung ist nicht ausreichend.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Anämie geht oft mit Begleitsymptomen einher, die sich quantifizieren lassen. Bei Erschöpfung lohnt der
+          <router-link :to="localeBlogPath('herz-kreislauf-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Herz-Kreislauf-Risiko-Rechner</router-link>
+          zur Einschätzung der kardiovaskulären Belastbarkeit. Bei niedrigem Energieumsatz hilft der
+          <router-link :to="localeBlogPath('grundumsatz-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Grundumsatz-Rechner</router-link>
+          zur Trennung von ernährungs- und erkrankungsbedingter Müdigkeit. Wer auch eine
+          <router-link :to="localeBlogPath('schilddruesenfunktion-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Schilddrüsen-Diagnostik</router-link>
+          benötigt, findet dort eine kompakte TSH-Einordnung.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Anämie ist häufig, leicht zu screenen und sehr gut behandelbar — vorausgesetzt, sie wird erkannt. Mit unserem
+          <router-link :to="localePath('anemiaRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Anämie-Risiko-Rechner</router-link>
+          erkennst du in Sekunden, ob ein Verdacht besteht. Bei Hb-Werten unter den WHO-Grenzwerten oder mehreren passenden Symptomen sollte ein vollständiges Blutbild plus Eisen-, B12- und Folatparameter erfolgen.
+        </p>
+      </div>
+
+      <RelatedArticles slug="anaemie-risiko-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/AnemiaRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/AnemiaRiskCalculatorGuide.vue
@@ -1,0 +1,178 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Anemia Risk Calculator: Spot Iron Deficiency and Low Hemoglobin Early | Health Calculators',
+  description: 'Screen for anemia from hemoglobin, sex, and 10 typical symptoms. WHO cutoffs, iron-deficiency clues, treatment principles, and red-flag signs — explained.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Anemia Risk Calculator: Spot Iron Deficiency and Low Hemoglobin Early',
+    description: 'Screen for anemia from hemoglobin, sex, and 10 typical symptoms. WHO cutoffs, iron-deficiency clues, treatment principles, and red-flag signs — explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-06',
+    dateModified: '2026-05-06',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/anemia-risk-calculator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Anemia Risk Calculator: Spot Iron Deficiency and Low Hemoglobin Early</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 6, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Roughly <strong>one in five women of reproductive age</strong> has iron-deficiency anemia. Men are affected less often but, when they are, the cause is usually more serious. Fatigue, pale skin, and breathlessness are the leading clues — and early detection prevents complications.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide shows how to quantify your anemia risk — by checking your hemoglobin against WHO cutoffs and scoring 10 typical clinical signs.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is anemia?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Anemia means a <strong>reduced hemoglobin level in your blood</strong>. Hemoglobin is the red protein that carries oxygen from the lungs to every tissue. When it falls, oxygen delivery drops everywhere — and that is why the symptoms are so varied.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The WHO estimates that more than 1.6 billion people worldwide are anemic. <strong>Iron deficiency is by far the most common cause</strong>, followed by vitamin B12 and folate deficiency, chronic disease, and blood loss.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">WHO hemoglobin cutoffs</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Severity</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Women</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Men</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">No anemia</td><td class="px-6 py-3 text-stone-600">≥ 12.0 g/dL</td><td class="px-6 py-3 text-stone-600">≥ 13.0 g/dL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Mild</td><td class="px-6 py-3 text-stone-600">11.0–11.9 g/dL</td><td class="px-6 py-3 text-stone-600">11.0–12.9 g/dL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Moderate</td><td class="px-6 py-3 text-stone-600">8.0–10.9 g/dL</td><td class="px-6 py-3 text-stone-600">8.0–10.9 g/dL</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Severe</td><td class="px-6 py-3 text-stone-600">&lt; 8.0 g/dL</td><td class="px-6 py-3 text-stone-600">&lt; 8.0 g/dL</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Pregnancy</strong> uses a lower cutoff (11.0 g/dL); childhood values are age-specific (11.0–12.0 g/dL). Hemoglobin under 7 g/dL is a transfusion threshold and a medical emergency.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The 10 clinical symptoms in our score</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Our calculator weights ten typical signs based on guideline descriptions:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptom</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Points</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Meaning</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Fatigue</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Most common, but unspecific</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Pale skin</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Inner eyelids, nail beds, lips</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Shortness of breath</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Reduced oxygen-carrying capacity</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Lightheadedness</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Orthostatic or on exertion</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Cold hands/feet</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Peripheral vasoconstriction to protect core organs</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Headache</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Cortical hypoxia</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Palpitations</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Tachycardia as compensation</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Brittle nails / hair loss</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Specific for iron deficiency</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Restless legs</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Highly specific for iron deficiency</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Pica (ice/dirt cravings)</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Red flag — almost always iron deficiency</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Pica and restless legs</strong> are particularly informative: both are highly specific for iron deficiency, even when hemoglobin is still normal but ferritin is low (latent iron deficiency).
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your anemia risk now</h3>
+        <p class="text-stone-300 text-sm mb-5">Hemoglobin, sex, and 10 clinical symptoms — instant severity grading and clinical guidance. Anonymous, no sign-up.</p>
+        <router-link
+          :to="localePath('anemiaRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Run the free check &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Common causes of anemia</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Iron deficiency (50–80 % of all anemias):</strong> Heavy menstruation, vegan diet, peptic ulcer, colorectal tumors, frequent blood donation.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Vitamin B12 deficiency:</strong> Vegans, atrophic gastritis, gastric surgery, long-term metformin.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Folate deficiency:</strong> Alcohol overuse, pregnancy, certain anticonvulsants.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Renal anemia:</strong> Chronic kidney disease leads to low erythropoietin.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anemia of chronic disease:</strong> Cancer, autoimmune disease, chronic infection.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How anemia is treated</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Treatment depends on cause and severity:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Iron deficiency:</strong> Oral iron (60–120 mg elemental iron/day) for at least 3 months, ideally on an empty stomach with vitamin C, separated from coffee/tea. IV iron if oral therapy fails or deficiency is severe.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>B12 deficiency:</strong> Intramuscular injections or high-dose oral.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Severe symptomatic anemia (Hb &lt; 7–8 g/dL):</strong> Consider transfusion.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Underlying disease:</strong> Always treat alongside — iron alone will not fix anemia driven by GI bleeding or cancer.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Anemia often comes with quantifiable companion symptoms. For exertional fatigue, the
+          <router-link :to="localeBlogPath('cardiovascular-risk-framingham')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">cardiovascular risk calculator</router-link>
+          is helpful for assessing cardiac reserve. For low energy that may be diet-driven, see the
+          <router-link :to="localeBlogPath('calculate-bmr')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMR calculator</router-link>
+          to separate nutritional from disease-driven fatigue. If thyroid problems may be contributing, the
+          <router-link :to="localeBlogPath('thyroid-function-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">thyroid function calculator</router-link>
+          will help interpret TSH, T3, and T4.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Summary</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Anemia is common, easy to screen for, and very treatable — once recognized. With our
+          <router-link :to="localePath('anemiaRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">anemia risk calculator</router-link>
+          you can spot a likely problem in seconds. Hemoglobin below the WHO cutoff or several matching symptoms warrants a complete blood count plus iron, B12, and folate testing.
+        </p>
+      </div>
+
+      <RelatedArticles slug="anemia-risk-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/utils/anemiaRisk.js
+++ b/src/utils/anemiaRisk.js
@@ -1,0 +1,89 @@
+// Anemia risk screening.
+//
+// Combines a hemoglobin assessment against WHO sex-specific cutoffs with a
+// clinical symptom score. The final category is the higher of both estimates,
+// so a severe Hb deficit always overrides a low symptom score.
+//
+// WHO Hb cutoffs (g/dL) for non-pregnant adults:
+//   Women: < 12.0 anemia, < 11.0 moderate, < 8.0 severe
+//   Men:   < 13.0 anemia, < 11.0 moderate, < 8.0 severe
+//
+// Symptom point weights:
+//   fatigue (1), pallor (1), shortnessOfBreath (2), dizziness (1),
+//   coldHandsFeet (1), headache (1), rapidHeartbeat (2),
+//   brittleNails (1), restlessLegs (1), pica (2)
+//
+// Symptom bands:
+//   0      → none
+//   1–3    → mild
+//   4–6    → moderate
+//   ≥ 7    → severe
+
+const SYMPTOM_POINTS = {
+  fatigue: 1,
+  pallor: 1,
+  shortnessOfBreath: 2,
+  dizziness: 1,
+  coldHandsFeet: 1,
+  headache: 1,
+  rapidHeartbeat: 2,
+  brittleNails: 1,
+  restlessLegs: 1,
+  pica: 2,
+}
+
+const HB_CUTOFFS = {
+  female: { mild: 12.0, moderate: 11.0, severe: 8.0 },
+  male: { mild: 13.0, moderate: 11.0, severe: 8.0 },
+}
+
+const LEVELS = ['none', 'mild', 'moderate', 'severe']
+
+function isPositiveNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0
+}
+
+export function classifyHemoglobin(hb, sex) {
+  if (!isPositiveNumber(hb)) return null
+  const cutoffs = HB_CUTOFFS[sex]
+  if (!cutoffs) return null
+  if (hb < cutoffs.severe) return 'severe'
+  if (hb < cutoffs.moderate) return 'moderate'
+  if (hb < cutoffs.mild) return 'mild'
+  return 'none'
+}
+
+export function calcSymptomScore(symptoms) {
+  if (!symptoms || typeof symptoms !== 'object') return 0
+  let score = 0
+  for (const [key, points] of Object.entries(SYMPTOM_POINTS)) {
+    if (symptoms[key]) score += points
+  }
+  return score
+}
+
+export function symptomBand(score) {
+  if (score >= 7) return 'severe'
+  if (score >= 4) return 'moderate'
+  if (score >= 1) return 'mild'
+  return 'none'
+}
+
+export function classifyAnemia(hbCategory, symptomScore) {
+  const hbLevel = LEVELS.indexOf(hbCategory ?? 'none')
+  const symLevel = LEVELS.indexOf(symptomBand(symptomScore))
+  return LEVELS[Math.max(hbLevel < 0 ? 0 : hbLevel, symLevel)]
+}
+
+export function calcAnemiaRisk({ hemoglobin, sex, symptoms } = {}) {
+  if (sex !== 'male' && sex !== 'female') return null
+  const hbCategory = classifyHemoglobin(hemoglobin, sex)
+  const symptomScore = calcSymptomScore(symptoms)
+  const category = classifyAnemia(hbCategory, symptomScore)
+  return {
+    category,
+    hbCategory,
+    symptomScore,
+    cutoff: HB_CUTOFFS[sex].mild,
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-153-anemia-risk
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-153-anemia-risk-20260506-040030`
**Cost:** $7.395088499999999

Closes jenslaufer/health-calculators#153

### Prompt
> Implement the Anemia Risk Calculator as described in issue #153.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Anemia screening from symptoms + basic labs
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/anemiaRisk.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/anemiaRisk.test.js` with 6+ test cases covering edge cases. Run `npm test -- anemiaRisk` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/AnemiaRiskCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/anemiaRisk.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/anemiaRisk.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'anemiaRisk'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/anemiaRisk.json` + `src/locales/calculators/en/anemiaRisk.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/anemiaRisk.js (or shared util — verify pattern in repo first)`
- `src/__tests__/anemiaRisk.test.js`
- `src/pages/AnemiaRiskCalculator.vue`
- `src/pages/anemiaRisk.meta.js`
- `src/locales/calculators/de/anemiaRisk.json`
- `src/locales/calculators/en/anemiaRisk.json`
- `e2e/anemiaRisk.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'anemiaRisk',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks