### PR TITLE
hc-127-apgar-score: Implement the Apgar Score Calculator as described in issue #

### DIFF
--- a/e2e/apgarScore.spec.js
+++ b/e2e/apgarScore.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/apgar-score-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/APGAR-Score-Rechner/)
+})
+
+test('healthy newborn (all 2s at 1min and 5min) → reassuring', async ({ page }) => {
+  for (const c of ['appearance', 'pulse', 'grimace', 'activity', 'respiration']) {
+    await page.getByTestId(`oneMinute-${c}`).selectOption('2')
+    await page.getByTestId(`fiveMinute-${c}`).selectOption('2')
+  }
+  await expect(page.getByTestId('one-minute-total')).toHaveText('10')
+  await expect(page.getByTestId('five-minute-total')).toHaveText('10')
+  await expect(page.getByTestId('five-minute-category')).toHaveText('Unauffällig')
+})
+
+test('moderately depressed newborn (5min=5) → moderate, extended needed', async ({ page }) => {
+  for (const c of ['appearance', 'pulse', 'grimace', 'activity', 'respiration']) {
+    await page.getByTestId(`oneMinute-${c}`).selectOption('1')
+    await page.getByTestId(`fiveMinute-${c}`).selectOption('1')
+  }
+  await expect(page.getByTestId('five-minute-total')).toHaveText('5')
+  await expect(page.getByTestId('five-minute-category')).toHaveText('Moderat eingeschränkt')
+  await expect(page.getByTestId('extended-warning')).toBeVisible()
+})
+
+test('critical newborn (all 0s at 5min) → critical', async ({ page }) => {
+  for (const c of ['appearance', 'pulse', 'grimace', 'activity', 'respiration']) {
+    await page.getByTestId(`oneMinute-${c}`).selectOption('0')
+    await page.getByTestId(`fiveMinute-${c}`).selectOption('0')
+  }
+  await expect(page.getByTestId('five-minute-total')).toHaveText('0')
+  await expect(page.getByTestId('five-minute-category')).toHaveText('Kritisch')
+  await expect(page.getByTestId('extended-warning')).toBeVisible()
+})
+
+test('boundary: 5-minute score of 7 → reassuring, no extended warning', async ({ page }) => {
+  await page.getByTestId('fiveMinute-appearance').selectOption('1')
+  await page.getByTestId('fiveMinute-pulse').selectOption('2')
+  await page.getByTestId('fiveMinute-grimace').selectOption('1')
+  await page.getByTestId('fiveMinute-activity').selectOption('1')
+  await page.getByTestId('fiveMinute-respiration').selectOption('2')
+  await expect(page.getByTestId('five-minute-total')).toHaveText('7')
+  await expect(page.getByTestId('five-minute-category')).toHaveText('Unauffällig')
+  await expect(page.getByTestId('extended-warning')).toHaveCount(0)
+})
+
+test('partial input shows dash placeholder until complete', async ({ page }) => {
+  await page.getByTestId('oneMinute-appearance').selectOption('2')
+  await page.getByTestId('oneMinute-pulse').selectOption('2')
+  await expect(page.getByTestId('one-minute-result')).toContainText('—')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/apgarScore.test.js
+++ b/src/__tests__/apgarScore.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcApgarScore,
+  classifyApgar,
+  evaluateApgar,
+  APGAR_COMPONENTS,
+} from '../utils/apgarScore.js'
+
+// APGAR (Apgar V, 1953) — newborn assessment scoring 5 components 0/1/2 each:
+//   appearance, pulse, grimace, activity, respiration → total 0–10
+// Categories:
+//   7–10  reassuring (normal)
+//   4–6   moderate (intervention often needed)
+//   0–3   critical (immediate resuscitation)
+
+const ALL_TWOS = {
+  appearance: 2, pulse: 2, grimace: 2, activity: 2, respiration: 2,
+}
+const ALL_ZEROS = {
+  appearance: 0, pulse: 0, grimace: 0, activity: 0, respiration: 0,
+}
+const MIXED_FIVE = {
+  appearance: 1, pulse: 1, grimace: 1, activity: 1, respiration: 1,
+}
+
+describe('APGAR_COMPONENTS', () => {
+  it('exposes the 5 component names in standard order', () => {
+    expect(APGAR_COMPONENTS).toEqual(['appearance', 'pulse', 'grimace', 'activity', 'respiration'])
+  })
+})
+
+describe('calcApgarScore', () => {
+  it('all 2s → 10', () => {
+    expect(calcApgarScore(ALL_TWOS)).toBe(10)
+  })
+
+  it('all 0s → 0', () => {
+    expect(calcApgarScore(ALL_ZEROS)).toBe(0)
+  })
+
+  it('all 1s → 5', () => {
+    expect(calcApgarScore(MIXED_FIVE)).toBe(5)
+  })
+
+  it('mixed values sum correctly', () => {
+    expect(calcApgarScore({ appearance: 2, pulse: 2, grimace: 1, activity: 2, respiration: 1 })).toBe(8)
+  })
+
+  it('returns null when a component is missing', () => {
+    expect(calcApgarScore({ appearance: 2, pulse: 2, grimace: 2, activity: 2 })).toBeNull()
+  })
+
+  it('returns null when a component is out of range', () => {
+    expect(calcApgarScore({ ...ALL_TWOS, pulse: 3 })).toBeNull()
+    expect(calcApgarScore({ ...ALL_TWOS, pulse: -1 })).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(calcApgarScore(null)).toBeNull()
+    expect(calcApgarScore(undefined)).toBeNull()
+  })
+})
+
+describe('classifyApgar', () => {
+  it('10 → reassuring', () => {
+    expect(classifyApgar(10)).toBe('reassuring')
+  })
+
+  it('7 → reassuring (boundary)', () => {
+    expect(classifyApgar(7)).toBe('reassuring')
+  })
+
+  it('6 → moderate', () => {
+    expect(classifyApgar(6)).toBe('moderate')
+  })
+
+  it('4 → moderate (boundary)', () => {
+    expect(classifyApgar(4)).toBe('moderate')
+  })
+
+  it('3 → critical', () => {
+    expect(classifyApgar(3)).toBe('critical')
+  })
+
+  it('0 → critical', () => {
+    expect(classifyApgar(0)).toBe('critical')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(classifyApgar(null)).toBeNull()
+    expect(classifyApgar(-1)).toBeNull()
+    expect(classifyApgar(11)).toBeNull()
+    expect(classifyApgar('5')).toBeNull()
+  })
+})
+
+describe('evaluateApgar', () => {
+  it('healthy newborn (1min=9, 5min=10) → reassuring + reassuring, no extended', () => {
+    const r = evaluateApgar({
+      oneMinute: { ...ALL_TWOS, appearance: 1 },
+      fiveMinute: ALL_TWOS,
+    })
+    expect(r.oneMinute.total).toBe(9)
+    expect(r.oneMinute.category).toBe('reassuring')
+    expect(r.fiveMinute.total).toBe(10)
+    expect(r.fiveMinute.category).toBe('reassuring')
+    expect(r.needsExtended).toBe(false)
+  })
+
+  it('depressed newborn (1min=4, 5min=6) → moderate + moderate, needs extended', () => {
+    const r = evaluateApgar({
+      oneMinute: { appearance: 1, pulse: 1, grimace: 0, activity: 1, respiration: 1 },
+      fiveMinute: { appearance: 2, pulse: 1, grimace: 1, activity: 1, respiration: 1 },
+    })
+    expect(r.oneMinute.total).toBe(4)
+    expect(r.oneMinute.category).toBe('moderate')
+    expect(r.fiveMinute.total).toBe(6)
+    expect(r.fiveMinute.category).toBe('moderate')
+    expect(r.needsExtended).toBe(true)
+  })
+
+  it('critical newborn (1min=2, 5min=3) → both critical, needs extended', () => {
+    const r = evaluateApgar({
+      oneMinute: { appearance: 1, pulse: 1, grimace: 0, activity: 0, respiration: 0 },
+      fiveMinute: { appearance: 1, pulse: 1, grimace: 1, activity: 0, respiration: 0 },
+    })
+    expect(r.oneMinute.category).toBe('critical')
+    expect(r.fiveMinute.category).toBe('critical')
+    expect(r.needsExtended).toBe(true)
+  })
+
+  it('5-minute score of 7 → reassuring, no extended needed', () => {
+    const r = evaluateApgar({
+      oneMinute: { ...ALL_TWOS, appearance: 1 },
+      fiveMinute: { appearance: 1, pulse: 2, grimace: 1, activity: 1, respiration: 2 },
+    })
+    expect(r.fiveMinute.total).toBe(7)
+    expect(r.fiveMinute.category).toBe('reassuring')
+    expect(r.needsExtended).toBe(false)
+  })
+
+  it('returns nulls when scores incomplete', () => {
+    const r = evaluateApgar({ oneMinute: {}, fiveMinute: {} })
+    expect(r.oneMinute.total).toBeNull()
+    expect(r.oneMinute.category).toBeNull()
+    expect(r.fiveMinute.total).toBeNull()
+    expect(r.needsExtended).toBe(false)
+  })
+
+  it('handles partial input (only 1-min scored)', () => {
+    const r = evaluateApgar({
+      oneMinute: ALL_TWOS,
+      fiveMinute: { appearance: 2 },
+    })
+    expect(r.oneMinute.total).toBe(10)
+    expect(r.fiveMinute.total).toBeNull()
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -23,6 +23,7 @@ const EXPECTED_KEYS = [
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
+  'apgarScore',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -83,6 +84,7 @@ const EXPECTED_ROUTE_MAP = {
   dehydrationRisk: { de: 'dehydrations-risiko-rechner', en: 'dehydration-risk-calculator' },
   thyroidFunction: { de: 'schilddruesen-rechner', en: 'thyroid-function-calculator' },
   anemiaRisk: { de: 'anaemie-risiko-rechner', en: 'anemia-risk-calculator' },
+  apgarScore: { de: 'apgar-score-rechner', en: 'apgar-score-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -131,6 +133,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'dehydrations-risiko-berechnen',
   'schilddruesenfunktion-berechnen',
   'anaemie-risiko-berechnen',
+  'apgar-score-bewerten',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -179,19 +182,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'dehydration-risk-calculator-guide',
   'thyroid-function-calculator',
   'anemia-risk-calculator-guide',
+  'apgar-score-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 59 calculators', () => {
-    expect(calculatorMetas).toHaveLength(59)
+  it('discovers all 60 calculators', () => {
+    expect(calculatorMetas).toHaveLength(60)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 59 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(59)
+  it('builds calculatorComponents map for all 60 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(60)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -214,15 +218,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 57 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(57)
+  it('discovers all 58 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(58)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 57 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(57)
+  it('discovers all 58 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(58)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -238,10 +242,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 59 calculators with no duplicates', () => {
+  it('groups contain all 60 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(59)
-    expect(new Set(allKeys).size).toBe(59)
+    expect(allKeys).toHaveLength(60)
+    expect(new Set(allKeys).size).toBe(60)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -268,7 +272,7 @@ describe('calculator groups', () => {
 
   it('pregnancy group has correct calculators in order', () => {
     expect(calculatorGroups[3].calculators).toEqual([
-      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'period', 'dueDate', 'pcosSymptoms',
+      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
     ])
   })
 })
@@ -310,8 +314,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 331 routes', () => {
-    expect(routes).toHaveLength(331)
+  it('generates exactly 336 routes', () => {
+    expect(routes).toHaveLength(336)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 232 links (59 calcs × 2 locales + 57 blogs × 2 locales)', () => {
+  it('generates 236 links (60 calcs × 2 locales + 58 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(232)
+    expect(links).toHaveLength(236)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -17,6 +17,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
+  'apgarScore',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -64,6 +65,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'dehydrations-risiko-berechnen',
   'schilddruesenfunktion-berechnen',
   'anaemie-risiko-berechnen',
+  'apgar-score-bewerten',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -111,12 +113,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'dehydration-risk-calculator-guide',
   'thyroid-function-calculator',
   'anemia-risk-calculator-guide',
+  'apgar-score-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 59 calculator meta files', () => {
+  it('discovers all 60 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(59)
+    expect(metas).toHaveLength(60)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -154,19 +157,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 57 DE blog slugs', () => {
+  it('returns all 58 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(57)
+    expect(de).toHaveLength(58)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 57 EN blog slugs', () => {
+  it('returns all 58 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(57)
+    expect(en).toHaveLength(58)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -234,9 +237,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 118 calcs + 2 blog index + 114 blog articles = 236)', () => {
+  it('generates correct total URL count (2 home + 120 calcs + 2 blog index + 116 blog articles = 240)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(236)
+    expect(urlCount).toBe(240)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -512,6 +512,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'anemiaRisk',
     related: ['cardiovascular-risk-framingham', 'calculate-bmr', 'thyroid-function-calculator'],
   },
+  {
+    slug: 'apgar-score-calculator-guide',
+    title: 'APGAR Score: How to Read 1- and 5-Minute Newborn Assessments',
+    description: 'What the APGAR score at 1 and 5 minutes tells you about your newborn. The five criteria, scoring scale, normal vs. critical values — explained clearly.',
+    date: '2026-05-06',
+    readTime: '7 min',
+    calculatorKey: 'apgarScore',
+    related: ['due-date-calculator', 'child-growth-percentile-chart', 'child-dosage-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -512,6 +512,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'anemiaRisk',
     related: ['herz-kreislauf-risiko-berechnen', 'grundumsatz-berechnen', 'schilddruesenfunktion-berechnen'],
   },
+  {
+    slug: 'apgar-score-bewerten',
+    title: 'APGAR-Score: Neugeborene in 1 und 5 Minuten richtig bewerten',
+    description: 'Was der APGAR-Score nach 1 und 5 Minuten über dein Neugeborenes aussagt. Die fünf Kriterien, Punktebewertung, normale und kritische Werte — kompakt erklärt.',
+    date: '2026-05-06',
+    readTime: '7 min',
+    calculatorKey: 'apgarScore',
+    related: ['geburtsterminrechner', 'wachstumsperzentile-kinder', 'kinder-dosierung-rechner'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/apgarScore.json
+++ b/src/locales/calculators/de/apgarScore.json
@@ -1,0 +1,82 @@
+{
+  "home": {
+    "calculators": {
+      "apgarScore": {
+        "name": "APGAR-Score-Rechner",
+        "description": "Bewerte den Zustand eines Neugeborenen nach 1 und 5 Minuten anhand der fünf APGAR-Kriterien."
+      }
+    }
+  },
+  "apgarScore": {
+    "meta": {
+      "title": "APGAR-Score-Rechner — Neugeborenen-Bewertung 1 & 5 Minuten",
+      "description": "Berechne den APGAR-Score deines Neugeborenen aus Hautfarbe, Puls, Reflexen, Muskeltonus und Atmung. Sofortige Auswertung für 1- und 5-Minuten-Werte. Kostenlos, ohne Anmeldung."
+    },
+    "title": "APGAR-Score-Rechner",
+    "description": "Bewerte den klinischen Zustand eines Neugeborenen nach Virginia Apgar — fünf Kriterien je 0–2 Punkte, ausgewertet 1 und 5 Minuten nach der Geburt.",
+    "oneMinuteTitle": "1 Minute nach der Geburt",
+    "fiveMinuteTitle": "5 Minuten nach der Geburt",
+    "oneMinuteScore": "1-Minuten-Score",
+    "fiveMinuteScore": "5-Minuten-Score",
+    "selectPlaceholder": "Bitte wählen…",
+    "component_appearance": "Hautfarbe (Appearance)",
+    "component_pulse": "Puls (Pulse)",
+    "component_grimace": "Reflexe (Grimace)",
+    "component_activity": "Muskeltonus (Activity)",
+    "component_respiration": "Atmung (Respiration)",
+    "appearance_0": "Blau / blass am ganzen Körper",
+    "appearance_1": "Körper rosig, Extremitäten bläulich",
+    "appearance_2": "Komplett rosig",
+    "pulse_0": "Kein Puls tastbar",
+    "pulse_1": "Unter 100 Schläge/min",
+    "pulse_2": "Über 100 Schläge/min",
+    "grimace_0": "Keine Reaktion",
+    "grimace_1": "Grimassieren",
+    "grimace_2": "Schreien, Husten, Niesen",
+    "activity_0": "Schlaff",
+    "activity_1": "Geringe Beugung der Extremitäten",
+    "activity_2": "Aktive Bewegung",
+    "respiration_0": "Keine Atmung",
+    "respiration_1": "Langsam / unregelmäßig",
+    "respiration_2": "Kräftiges Schreien",
+    "resultsLabel": "APGAR-Auswertung",
+    "category_reassuring": "Unauffällig",
+    "category_moderate": "Moderat eingeschränkt",
+    "category_critical": "Kritisch",
+    "advice_reassuring": "Der 5-Minuten-Score von ≥ 7 spricht für eine gute postnatale Anpassung. Reguläre Routinemaßnahmen (Bonding, Erstuntersuchung U1/U2) reichen aus.",
+    "advice_moderate": "Score zwischen 4 und 6 — das Neugeborene benötigt häufig Atemunterstützung, Absaugen oder Sauerstoffgabe. Hebamme oder Arzt sollten eng überwachen, ggf. Reanimationsteam alarmieren.",
+    "advice_critical": "Score ≤ 3 — das Neugeborene ist in einem lebensbedrohlichen Zustand. Sofortige kardiopulmonale Reanimation und neonatologische Versorgung erforderlich.",
+    "extendedNote": "5-Minuten-Score unter 7: leitliniengerecht weitere Bewertungen alle 5 Minuten bis zum Score ≥ 7 oder bis zur Übergabe an die Neonatologie.",
+    "refTitle": "APGAR-Bewertungsschema",
+    "refSign": "Kriterium",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der APGAR-Score wurde 1953 von der Anästhesistin Virginia Apgar entwickelt. Er bewertet fünf Vitalkriterien — Hautfarbe (Appearance), Puls (Pulse), Reflexe (Grimace), Muskeltonus (Activity) und Atmung (Respiration) — mit jeweils 0 bis 2 Punkten. Die Summe (0–10) wird üblicherweise nach 1 und 5 Minuten erhoben. Werte ≥ 7 gelten als unauffällig, 4–6 als moderat eingeschränkt, ≤ 3 als kritisch und reanimationspflichtig.",
+    "disclaimer": "Dieser Rechner unterstützt die strukturierte Erfassung des APGAR-Scores und ersetzt keine fachärztliche Einschätzung. Die Bewertung eines Neugeborenen erfordert klinische Erfahrung. Bei jedem Verdacht auf eingeschränkte Vitalwerte sofort Hebamme, Geburtshelfer oder Neonatologie hinzuziehen.",
+    "faq": [
+      {
+        "q": "Was ist der APGAR-Score?",
+        "a": "Der APGAR-Score ist ein 1953 von Virginia Apgar entwickeltes Schema zur schnellen Beurteilung des Zustands Neugeborener. Er bewertet fünf Kriterien (Hautfarbe, Puls, Reflexe, Muskeltonus, Atmung) mit je 0 bis 2 Punkten — die Summe liegt zwischen 0 und 10."
+      },
+      {
+        "q": "Wann wird der APGAR-Score erhoben?",
+        "a": "Standardmäßig nach 1 und 5 Minuten nach der Geburt. Liegt der 5-Minuten-Wert unter 7, werden zusätzliche Messungen alle 5 Minuten bis zur Stabilisierung empfohlen — typischerweise auch nach 10, 15 und 20 Minuten."
+      },
+      {
+        "q": "Welche APGAR-Werte gelten als normal?",
+        "a": "Werte zwischen 7 und 10 nach 5 Minuten gelten als unauffällig. 4–6 weisen auf eine moderate Anpassungsstörung hin, ≤ 3 ist eine schwere Beeinträchtigung mit unmittelbarem Reanimationsbedarf."
+      },
+      {
+        "q": "Sagt der APGAR-Score etwas über die spätere Entwicklung?",
+        "a": "Der 1-Minuten-Wert beschreibt nur den unmittelbaren Anpassungsstatus und ist kein Prognoseinstrument. Erst sehr niedrige 5-Minuten-Werte (≤ 3) und insbesondere persistierend niedrige Werte über 10–20 Minuten korrelieren mit erhöhtem neurologischem Risiko."
+      },
+      {
+        "q": "Wer erhebt den APGAR-Score?",
+        "a": "In der Regel die Hebamme oder der Geburtshelfer, häufig gemeinsam mit einem Neonatologen oder Kinderarzt. Wichtig ist eine standardisierte und unabhängige Bewertung jedes Kriteriums."
+      },
+      {
+        "q": "Was bedeutet APGAR konkret?",
+        "a": "APGAR ist sowohl Eigenname (nach Virginia Apgar) als auch Akronym für Appearance (Hautfarbe), Pulse (Puls), Grimace (Reflexe), Activity (Muskeltonus) und Respiration (Atmung)."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/apgarScore.json
+++ b/src/locales/calculators/en/apgarScore.json
@@ -1,0 +1,82 @@
+{
+  "home": {
+    "calculators": {
+      "apgarScore": {
+        "name": "APGAR Score Calculator",
+        "description": "Score a newborn's condition at 1 and 5 minutes using the five APGAR criteria."
+      }
+    }
+  },
+  "apgarScore": {
+    "meta": {
+      "title": "APGAR Score Calculator — Newborn Assessment at 1 & 5 Minutes",
+      "description": "Calculate your newborn's APGAR score from skin color, pulse, reflexes, muscle tone, and breathing. Instant 1- and 5-minute results. Free, no sign-up."
+    },
+    "title": "APGAR Score Calculator",
+    "description": "Score a newborn's clinical condition using Virginia Apgar's five-criterion system — each rated 0–2 points, evaluated at 1 and 5 minutes after birth.",
+    "oneMinuteTitle": "1 minute after birth",
+    "fiveMinuteTitle": "5 minutes after birth",
+    "oneMinuteScore": "1-minute score",
+    "fiveMinuteScore": "5-minute score",
+    "selectPlaceholder": "Please select…",
+    "component_appearance": "Appearance (skin color)",
+    "component_pulse": "Pulse (heart rate)",
+    "component_grimace": "Grimace (reflex irritability)",
+    "component_activity": "Activity (muscle tone)",
+    "component_respiration": "Respiration (breathing effort)",
+    "appearance_0": "Blue / pale all over",
+    "appearance_1": "Body pink, extremities blue",
+    "appearance_2": "Pink all over",
+    "pulse_0": "No pulse detectable",
+    "pulse_1": "Below 100 bpm",
+    "pulse_2": "Above 100 bpm",
+    "grimace_0": "No response",
+    "grimace_1": "Grimace",
+    "grimace_2": "Cry, cough, or sneeze",
+    "activity_0": "Limp",
+    "activity_1": "Some flexion of extremities",
+    "activity_2": "Active motion",
+    "respiration_0": "Absent",
+    "respiration_1": "Slow / irregular",
+    "respiration_2": "Strong cry",
+    "resultsLabel": "APGAR result",
+    "category_reassuring": "Reassuring",
+    "category_moderate": "Moderately depressed",
+    "category_critical": "Critical",
+    "advice_reassuring": "A 5-minute score of ≥ 7 indicates good neonatal adaptation. Routine post-delivery care (bonding, newborn examination) is sufficient.",
+    "advice_moderate": "A score of 4–6 typically requires supportive measures: airway clearing, oxygen, or stimulation. Continued close observation by midwife or paediatrician — alert the resuscitation team if values do not improve.",
+    "advice_critical": "A score of ≤ 3 reflects a life-threatening condition. Immediate cardiopulmonary resuscitation and neonatal intensive care are required.",
+    "extendedNote": "5-minute score below 7: per guidelines, repeat the assessment every 5 minutes until ≥ 7 or until the newborn is handed over to neonatology.",
+    "refTitle": "APGAR scoring chart",
+    "refSign": "Sign",
+    "howItWorks": "How it works",
+    "howItWorksText": "The APGAR score was developed in 1953 by anaesthesiologist Virginia Apgar. It rates five vital signs — Appearance, Pulse, Grimace, Activity, and Respiration — with 0 to 2 points each. The total (0–10) is conventionally measured at 1 and 5 minutes after birth. Scores ≥ 7 are reassuring, 4–6 indicate moderate depression, and ≤ 3 are critical and require resuscitation.",
+    "disclaimer": "This calculator helps structure the APGAR assessment and does not replace expert clinical judgement. Newborn evaluation requires hands-on experience. If any vital sign is impaired, immediately involve a midwife, obstetrician, or neonatologist.",
+    "faq": [
+      {
+        "q": "What is the APGAR score?",
+        "a": "The APGAR score is a quick newborn-assessment tool created in 1953 by Virginia Apgar. It rates five clinical signs (skin color, pulse, reflexes, muscle tone, breathing) with 0 to 2 points each, summing to a total between 0 and 10."
+      },
+      {
+        "q": "When is the APGAR score taken?",
+        "a": "Routinely at 1 and 5 minutes after birth. If the 5-minute score is below 7, the assessment is repeated every 5 minutes until it reaches 7 or higher — typically also at 10, 15, and 20 minutes."
+      },
+      {
+        "q": "What APGAR values are normal?",
+        "a": "Scores between 7 and 10 at 5 minutes are considered reassuring. 4–6 indicates moderate adaptation difficulty, while ≤ 3 reflects a severely depressed newborn requiring immediate resuscitation."
+      },
+      {
+        "q": "Does the APGAR score predict long-term outcome?",
+        "a": "The 1-minute score only describes immediate adaptation status and is not a prognostic tool. Persistently low 5-minute scores (≤ 3 over 10–20 minutes) correlate with elevated neurologic risk, but most low APGAR babies develop normally."
+      },
+      {
+        "q": "Who performs the APGAR scoring?",
+        "a": "Usually the midwife or obstetrician, often together with a neonatologist or paediatrician. Standardized, independent evaluation of each sign is essential."
+      },
+      {
+        "q": "What does APGAR stand for?",
+        "a": "APGAR is both the inventor's name (Virginia Apgar) and an acronym: Appearance (skin color), Pulse (heart rate), Grimace (reflex irritability), Activity (muscle tone), and Respiration (breathing effort)."
+      }
+    ]
+  }
+}

--- a/src/pages/ApgarScoreCalculator.vue
+++ b/src/pages/ApgarScoreCalculator.vue
@@ -1,0 +1,174 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { evaluateApgar, APGAR_COMPONENTS } from '../utils/apgarScore.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('apgarScore.faq') || [])
+
+useHead(() => ({
+  title: t('apgarScore.meta.title'),
+  description: t('apgarScore.meta.description'),
+  routeKey: 'apgarScore',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'APGAR Score Calculator',
+    url: 'https://healthcalculator.app/apgar-score-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const emptyScores = () => ({
+  appearance: null, pulse: null, grimace: null, activity: null, respiration: null,
+})
+
+const oneMinute = ref(emptyScores())
+const fiveMinute = ref(emptyScores())
+
+const result = computed(() => evaluateApgar({
+  oneMinute: oneMinute.value,
+  fiveMinute: fiveMinute.value,
+}))
+
+function categoryStyle(cat) {
+  switch (cat) {
+    case 'reassuring': return { color: 'text-green-600', bg: 'bg-green-50 border-green-200 text-green-900' }
+    case 'moderate': return { color: 'text-orange-500', bg: 'bg-orange-50 border-orange-200 text-orange-900' }
+    case 'critical': return { color: 'text-red-700', bg: 'bg-red-100 border-red-300 text-red-900' }
+    default: return { color: 'text-stone-400', bg: '' }
+  }
+}
+
+function categoryLevel(cat) {
+  return { critical: 0, moderate: 1, reassuring: 2 }[cat] ?? 0
+}
+
+const componentList = APGAR_COMPONENTS
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('apgarScore.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('apgarScore.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid md:grid-cols-2 gap-8">
+      <div v-for="(timing, key) in { oneMinute, fiveMinute }" :key="key">
+        <h2 class="text-base font-semibold text-stone-900 mb-4">
+          {{ t('apgarScore.' + (key === 'oneMinute' ? 'oneMinuteTitle' : 'fiveMinuteTitle')) }}
+        </h2>
+        <div class="space-y-3">
+          <div v-for="c in componentList" :key="c">
+            <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">
+              {{ t('apgarScore.component_' + c) }}
+            </label>
+            <select
+              v-model.number="(key === 'oneMinute' ? oneMinute : fiveMinute)[c]"
+              :data-testid="key + '-' + c"
+              class="w-full border border-stone-300 rounded-lg px-3 py-2.5 text-stone-900 text-sm font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+            >
+              <option :value="null">{{ t('apgarScore.selectPlaceholder') }}</option>
+              <option :value="0">0 — {{ t('apgarScore.' + c + '_0') }}</option>
+              <option :value="1">1 — {{ t('apgarScore.' + c + '_1') }}</option>
+              <option :value="2">2 — {{ t('apgarScore.' + c + '_2') }}</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('apgarScore.resultsLabel') }}</p>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div class="bg-stone-50 rounded-lg p-5" data-testid="one-minute-result">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('apgarScore.oneMinuteScore') }}</p>
+        <div v-if="result.oneMinute.total !== null" class="flex items-baseline gap-2">
+          <span class="text-4xl font-bold text-stone-900 tabular-nums leading-none" data-testid="one-minute-total">{{ result.oneMinute.total }}</span>
+          <span class="text-base text-stone-400 font-medium">/ 10</span>
+        </div>
+        <span v-else class="text-3xl font-bold text-stone-300 tabular-nums">—</span>
+        <p v-if="result.oneMinute.category" class="text-sm font-semibold mt-2" :class="categoryStyle(result.oneMinute.category).color" data-testid="one-minute-category">
+          {{ t('apgarScore.category_' + result.oneMinute.category) }}
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-5" data-testid="five-minute-result">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('apgarScore.fiveMinuteScore') }}</p>
+        <div v-if="result.fiveMinute.total !== null" class="flex items-baseline gap-2">
+          <span class="text-4xl font-bold text-stone-900 tabular-nums leading-none" data-testid="five-minute-total">{{ result.fiveMinute.total }}</span>
+          <span class="text-base text-stone-400 font-medium">/ 10</span>
+        </div>
+        <span v-else class="text-3xl font-bold text-stone-300 tabular-nums">—</span>
+        <p v-if="result.fiveMinute.category" class="text-sm font-semibold mt-2" :class="categoryStyle(result.fiveMinute.category).color" data-testid="five-minute-category">
+          {{ t('apgarScore.category_' + result.fiveMinute.category) }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="result.fiveMinute.category" class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-red-700 via-orange-500 to-green-500 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (categoryLevel(result.fiveMinute.category) / 2 * 100) + '%' }"></div>
+    </div>
+
+    <div v-if="result.fiveMinute.category" class="rounded-lg p-4 text-sm font-medium border" :class="categoryStyle(result.fiveMinute.category).bg" data-testid="advice">
+      {{ t('apgarScore.advice_' + result.fiveMinute.category) }}
+    </div>
+
+    <div v-if="result.needsExtended" class="mt-4 bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-900 leading-relaxed" data-testid="extended-warning">
+      {{ t('apgarScore.extendedNote') }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('apgarScore.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('apgarScore.refSign') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">0</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">1</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">2</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr v-for="c in componentList" :key="c">
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('apgarScore.component_' + c) }}</td>
+          <td class="px-6 py-3 text-stone-600">{{ t('apgarScore.' + c + '_0') }}</td>
+          <td class="px-6 py-3 text-stone-600">{{ t('apgarScore.' + c + '_1') }}</td>
+          <td class="px-6 py-3 text-stone-600">{{ t('apgarScore.' + c + '_2') }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('apgarScore.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('apgarScore.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('apgarScore.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="apgarScore" />
+</template>

--- a/src/pages/apgarScore.meta.js
+++ b/src/pages/apgarScore.meta.js
@@ -1,0 +1,16 @@
+import Component from './ApgarScoreCalculator.vue'
+import BlogDe from './blog/ApgarScoreBewerten.vue'
+import BlogEn from './blog/en/ApgarScoreCalculatorGuide.vue'
+
+export default {
+  key: 'apgarScore',
+  component: Component,
+  slugs: { de: 'apgar-score-rechner', en: 'apgar-score-calculator' },
+  group: 'pregnancy',
+  groupOrder: 3,
+  order: 7,
+  blog: {
+    de: { slug: 'apgar-score-bewerten', component: BlogDe },
+    en: { slug: 'apgar-score-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/pages/blog/ApgarScoreBewerten.vue
+++ b/src/pages/blog/ApgarScoreBewerten.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'APGAR-Score: Neugeborene in 1 und 5 Minuten richtig bewerten | Health Calculators',
+  description: 'Was der APGAR-Score nach 1 und 5 Minuten über dein Neugeborenes aussagt. Die fünf Kriterien, Punktebewertung, normale und kritische Werte — kompakt erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'APGAR-Score: Neugeborene in 1 und 5 Minuten richtig bewerten',
+    description: 'Was der APGAR-Score nach 1 und 5 Minuten über dein Neugeborenes aussagt. Die fünf Kriterien, Punktebewertung, normale und kritische Werte — kompakt erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-06',
+    dateModified: '2026-05-06',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/apgar-score-bewerten',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">APGAR-Score: Neugeborene in 1 und 5 Minuten richtig bewerten</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">6. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wenige Sekunden nach der Geburt schauen Hebamme und Geburtshelfer auf <strong>fünf Vitalzeichen</strong>. Sie addieren sie zu einer Zahl zwischen 0 und 10 — dem APGAR-Score. Diese Zahl zeigt, wie gut sich dein Baby an das Leben außerhalb der Gebärmutter angepasst hat.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Was bedeuten die einzelnen Punkte? Wann ist Eingreifen nötig? Und warum sagt ein 1-Minuten-Wert von 5 noch nichts Schlimmes aus? Dieser Ratgeber erklärt es Schritt für Schritt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Geschichte: Von Virginia Apgar 1953 bis heute</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die amerikanische Anästhesistin <strong>Virginia Apgar</strong> stellte 1953 fest, dass Neugeborene oft sterben, weil ihr Zustand direkt nach der Geburt nicht systematisch erfasst wurde. Sie entwickelte einen Score aus fünf Kriterien — schnell zu erheben, ohne Gerät, von jeder Fachperson reproduzierbar.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ihr Akronym war doppelt clever gewählt: APGAR steht sowohl für ihren Namen als auch für die fünf Kriterien — Appearance, Pulse, Grimace, Activity, Respiration. Bis heute ist der Score weltweit Standard und in jeder Geburtsleitlinie verankert.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die fünf APGAR-Kriterien im Detail</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kriterium</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">0 Punkte</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">1 Punkt</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">2 Punkte</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hautfarbe (Appearance)</td><td class="px-6 py-3 text-stone-600">Blau / blass</td><td class="px-6 py-3 text-stone-600">Körper rosig, Extremitäten blau</td><td class="px-6 py-3 text-stone-600">Komplett rosig</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Puls (Pulse)</td><td class="px-6 py-3 text-stone-600">Nicht tastbar</td><td class="px-6 py-3 text-stone-600">&lt; 100/min</td><td class="px-6 py-3 text-stone-600">≥ 100/min</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Reflexe (Grimace)</td><td class="px-6 py-3 text-stone-600">Keine Reaktion</td><td class="px-6 py-3 text-stone-600">Grimassieren</td><td class="px-6 py-3 text-stone-600">Schreien, Husten, Niesen</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Muskeltonus (Activity)</td><td class="px-6 py-3 text-stone-600">Schlaff</td><td class="px-6 py-3 text-stone-600">Geringe Beugung</td><td class="px-6 py-3 text-stone-600">Aktive Bewegung</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Atmung (Respiration)</td><td class="px-6 py-3 text-stone-600">Keine Atmung</td><td class="px-6 py-3 text-stone-600">Langsam / unregelmäßig</td><td class="px-6 py-3 text-stone-600">Kräftiges Schreien</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bewertung: Was die Gesamtsumme bedeutet</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Punkte aller fünf Kriterien werden addiert. Das Ergebnis liegt zwischen 0 (schwerste Beeinträchtigung) und 10 (optimale Anpassung):
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>7 bis 10 Punkte — unauffällig:</strong> Das Neugeborene hat sich gut angepasst. Routine reicht.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>4 bis 6 Punkte — moderat eingeschränkt:</strong> Atemunterstützung, Sauerstoffgabe oder Stimulation häufig nötig. Engmaschige Kontrolle.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>0 bis 3 Punkte — kritisch:</strong> Sofortige Reanimation. Neonatologisches Team alarmieren.</li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">APGAR-Score jetzt berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Strukturiere die Bewertung deines Neugeborenen — fünf Kriterien für 1 und 5 Minuten, sofortiges Ergebnis mit klinischer Einordnung. Kostenlos, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('apgarScore')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum 1 und 5 Minuten?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <strong>1-Minuten-Wert</strong> beschreibt die unmittelbare Anpassung — wie gut das Kind den Geburtsstress überwunden hat. Niedrige Werte hier sind häufig (z. B. nach langer Geburt) und sagen wenig über die Prognose.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <strong>5-Minuten-Wert</strong> ist klinisch deutlich aussagekräftiger. Er zeigt, ob das Neugeborene auf Maßnahmen anspricht oder sich von selbst stabilisiert. Liegt er unter 7, werden weitere Messungen nach 10, 15 und 20 Minuten empfohlen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Erst <strong>persistierend niedrige Werte</strong> über 10–20 Minuten korrelieren mit erhöhtem neurologischem Risiko. Die meisten Babys mit niedrigem 1-Minuten-Wert entwickeln sich völlig normal.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Faktoren, die den Score beeinflussen</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Frühgeburtlichkeit:</strong> Frühgeborene haben physiologisch oft niedrigere Werte (Muskeltonus, Hautfarbe). Das ist nicht zwingend pathologisch.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mütterliche Anästhesie:</strong> Periduralanästhesie oder Vollnarkose kann initial die Reflexe und Atmung dämpfen.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Geburtsstress:</strong> Lange oder traumatische Geburten senken zunächst Puls und Atmung.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Mekoniumaspiration:</strong> Eingeatmetes Mekonium kann Atemnot und niedrige Sauerstoffsättigung verursachen.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Konstitutionell rosige vs. dunkelhäutige Babys:</strong> Hautfarbe ist beim APGAR-Score umstritten — kritischer ist die Sauerstoffsättigung an Mund- und Nagelschleimhaut.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Rund um die Geburt gibt es weitere klinisch wichtige Berechnungen. Der
+          <router-link :to="localeBlogPath('geburtsterminrechner')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Geburtsterminrechner</router-link>
+          hilft, das voraussichtliche Geburtsdatum nach Naegele zu bestimmen. Nach der Entbindung dokumentiert die
+          <router-link :to="localeBlogPath('wachstumsperzentile-kinder')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Wachstumsperzentile</router-link>
+          die kindliche Entwicklung. Bei medikamentöser Versorgung im Kindesalter ist die
+          <router-link :to="localeBlogPath('kinder-dosierung-rechner')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Kinder-Dosierungsberechnung</router-link>
+          unverzichtbar.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der APGAR-Score ist seit über 70 Jahren das Standardinstrument zur ersten Einschätzung Neugeborener. Mit unserem
+          <router-link :to="localePath('apgarScore')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">APGAR-Score-Rechner</router-link>
+          erfasst du die fünf Kriterien strukturiert für 1- und 5-Minuten-Werte. Werte unter 7 nach 5 Minuten erfordern weitere Maßnahmen, ≤ 3 sind ein Notfall. Die meisten Babys liegen zwischen 7 und 10 — ein guter Start ins Leben.
+        </p>
+      </div>
+
+      <RelatedArticles slug="apgar-score-bewerten" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/ApgarScoreCalculatorGuide.vue
+++ b/src/pages/blog/en/ApgarScoreCalculatorGuide.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'APGAR Score: How to Read 1- and 5-Minute Newborn Assessments | Health Calculators',
+  description: 'What the APGAR score at 1 and 5 minutes tells you about your newborn. The five criteria, scoring scale, normal vs. critical values — explained clearly.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'APGAR Score: How to Read 1- and 5-Minute Newborn Assessments',
+    description: 'What the APGAR score at 1 and 5 minutes tells you about your newborn. The five criteria, scoring scale, normal vs. critical values — explained clearly.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-06',
+    dateModified: '2026-05-06',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/apgar-score-calculator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">APGAR Score: How to Read 1- and 5-Minute Newborn Assessments</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 6, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Within seconds of birth, the midwife or obstetrician scans <strong>five vital signs</strong> and adds them up. The result — a number between 0 and 10 — is the APGAR score, an instant snapshot of how well a newborn is adapting to life outside the womb.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          What does each point mean? When does the team need to step in? And why is a 1-minute score of 5 usually nothing to panic about? This guide walks you through the score one criterion at a time.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The history: From Virginia Apgar in 1953 to today</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          American anaesthesiologist <strong>Virginia Apgar</strong> noticed in 1953 that newborns often died because no one systematically checked their condition right after birth. She designed a fast, equipment-free score using five clinical criteria — reproducible by any trained clinician.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The acronym was doubly clever: APGAR is both her surname and a mnemonic for the five signs — Appearance, Pulse, Grimace, Activity, Respiration. The score is now embedded in every delivery guideline worldwide.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The five APGAR criteria in detail</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Sign</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">0 points</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">1 point</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">2 points</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Appearance (skin color)</td><td class="px-6 py-3 text-stone-600">Blue / pale</td><td class="px-6 py-3 text-stone-600">Body pink, extremities blue</td><td class="px-6 py-3 text-stone-600">Pink all over</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Pulse (heart rate)</td><td class="px-6 py-3 text-stone-600">Absent</td><td class="px-6 py-3 text-stone-600">&lt; 100 bpm</td><td class="px-6 py-3 text-stone-600">≥ 100 bpm</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Grimace (reflex irritability)</td><td class="px-6 py-3 text-stone-600">No response</td><td class="px-6 py-3 text-stone-600">Grimace</td><td class="px-6 py-3 text-stone-600">Cry, cough, sneeze</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Activity (muscle tone)</td><td class="px-6 py-3 text-stone-600">Limp</td><td class="px-6 py-3 text-stone-600">Some flexion</td><td class="px-6 py-3 text-stone-600">Active motion</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Respiration (breathing)</td><td class="px-6 py-3 text-stone-600">Absent</td><td class="px-6 py-3 text-stone-600">Slow / irregular</td><td class="px-6 py-3 text-stone-600">Strong cry</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Reading the total score</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Add the five points together. The total ranges from 0 (most depressed) to 10 (optimal adaptation):
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>7 to 10 — reassuring:</strong> The newborn has adapted well. Routine post-delivery care is sufficient.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>4 to 6 — moderately depressed:</strong> Airway clearing, oxygen, or stimulation often needed. Continued close monitoring.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>0 to 3 — critical:</strong> Immediate resuscitation. Alert the neonatal team.</li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate the APGAR score now</h3>
+        <p class="text-stone-300 text-sm mb-5">Structure the assessment of your newborn — five criteria for 1- and 5-minute scores, instant clinical interpretation. Free, no sign-up required.</p>
+        <router-link
+          :to="localePath('apgarScore')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Score it now &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why 1 and 5 minutes?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>1-minute score</strong> captures immediate adaptation — how well the newborn coped with the stress of birth. Low scores here are common (e.g. after a long labour) and rarely have prognostic value.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>5-minute score</strong> is clinically far more meaningful. It reflects whether the baby responds to interventions or stabilises spontaneously. If it is below 7, the score is repeated at 10, 15, and 20 minutes.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Only <strong>persistently low scores</strong> over 10–20 minutes correlate with elevated neurologic risk. Most babies with low 1-minute scores develop completely normally.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Factors that commonly affect the score</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Prematurity:</strong> Preterm infants physiologically score lower (muscle tone, color). Not necessarily pathological.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Maternal anaesthesia:</strong> Epidural or general anaesthesia can initially blunt reflexes and breathing.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Birth stress:</strong> Long or traumatic deliveries depress pulse and respiration in the first minute.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Meconium aspiration:</strong> Inhaled meconium can cause respiratory distress and low oxygen saturation.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Skin color in darker-skinned babies:</strong> Appearance is the most criticised criterion — oxygen saturation at the lips and nail beds is more reliable.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Several calculators support clinical decisions around birth and the newborn period. The
+          <router-link :to="localeBlogPath('due-date-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Due Date Calculator</router-link>
+          predicts the expected date of delivery. After birth, the
+          <router-link :to="localeBlogPath('child-growth-percentile-chart')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Child Growth Percentile Chart</router-link>
+          documents healthy infant development. For paediatric medication dosing, the
+          <router-link :to="localeBlogPath('child-dosage-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Child Dosage Calculator</router-link>
+          is essential.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The APGAR score has been the standard newborn screen for over seven decades. Use our
+          <router-link :to="localePath('apgarScore')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">APGAR Score Calculator</router-link>
+          to record the five criteria for 1- and 5-minute assessments in a structured way. Values below 7 at 5 minutes call for further measures, and ≤ 3 is an emergency. Most babies score between 7 and 10 — a good start to life.
+        </p>
+      </div>
+
+      <RelatedArticles slug="apgar-score-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/utils/apgarScore.js
+++ b/src/utils/apgarScore.js
@@ -1,0 +1,61 @@
+// APGAR score for newborn assessment.
+//
+// Apgar V (1953) — five clinical signs scored 0/1/2 each, summed (0–10):
+//   A — Appearance     : skin color
+//                        0 = blue/pale all over, 1 = body pink + extremities blue, 2 = pink all over
+//   P — Pulse          : heart rate
+//                        0 = absent, 1 = < 100 bpm, 2 = ≥ 100 bpm
+//   G — Grimace        : reflex irritability
+//                        0 = no response, 1 = grimace, 2 = cry / cough / sneeze
+//   A — Activity       : muscle tone
+//                        0 = limp, 1 = some flexion, 2 = active motion
+//   R — Respiration    : breathing effort
+//                        0 = absent, 1 = slow / irregular, 2 = good crying
+//
+// Total score classification (per AAP / WHO):
+//   7–10 : reassuring     (normal)
+//   4–6  : moderate       (some assistance / oxygen typically needed)
+//   0–3  : critical       (immediate resuscitation)
+//
+// Apgar is taken at 1 and 5 minutes; a 5-minute score < 7 typically
+// triggers further measurements at 10, 15, 20 minutes.
+
+export const APGAR_COMPONENTS = ['appearance', 'pulse', 'grimace', 'activity', 'respiration']
+
+function isValidComponent(v) {
+  return v === 0 || v === 1 || v === 2
+}
+
+export function calcApgarScore(scores) {
+  if (!scores || typeof scores !== 'object') return null
+  let total = 0
+  for (const c of APGAR_COMPONENTS) {
+    if (!isValidComponent(scores[c])) return null
+    total += scores[c]
+  }
+  return total
+}
+
+export function classifyApgar(total) {
+  if (typeof total !== 'number' || !Number.isFinite(total)) return null
+  if (total < 0 || total > 10) return null
+  if (total >= 7) return 'reassuring'
+  if (total >= 4) return 'moderate'
+  return 'critical'
+}
+
+export function evaluateApgar({ oneMinute, fiveMinute } = {}) {
+  const oneMinuteTotal = calcApgarScore(oneMinute)
+  const fiveMinuteTotal = calcApgarScore(fiveMinute)
+  return {
+    oneMinute: {
+      total: oneMinuteTotal,
+      category: oneMinuteTotal !== null ? classifyApgar(oneMinuteTotal) : null,
+    },
+    fiveMinute: {
+      total: fiveMinuteTotal,
+      category: fiveMinuteTotal !== null ? classifyApgar(fiveMinuteTotal) : null,
+    },
+    needsExtended: fiveMinuteTotal !== null && fiveMinuteTotal < 7,
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-127-apgar-score
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-127-apgar-score-20260506-120031`
**Cost:** $9.65634

Closes jenslaufer/health-calculators#127

### Prompt
> Implement the Apgar Score Calculator as described in issue #127.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Newborn APGAR scoring (1min, 5min)
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/apgarScore.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/apgarScore.test.js` with 6+ test cases covering edge cases. Run `npm test -- apgarScore` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/ApgarScoreCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/apgarScore.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/apgarScore.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'apgarScore'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/apgarScore.json` + `src/locales/calculators/en/apgarScore.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/apgarScore.js (or shared util — verify pattern in repo first)`
- `src/__tests__/apgarScore.test.js`
- `src/pages/ApgarScoreCalculator.vue`
- `src/pages/apgarScore.meta.js`
- `src/locales/calculators/de/apgarScore.json`
- `src/locales/calculators/en/apgarScore.json`
- `e2e/apgarScore.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'apgarScore',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks