### PR TITLE
hc-156-osteoporosis-risk: Implement the Osteoporosis Risk Calculator as described in i

### DIFF
--- a/e2e/osteoporosisRisk.spec.js
+++ b/e2e/osteoporosisRisk.spec.js
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/osteoporose-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Osteoporose-Risiko-Rechner/)
+})
+
+test('healthy 45-year-old man → low risk (score 0)', async ({ page }) => {
+  await page.getByTestId('age').fill('45')
+  await page.getByTestId('sex').selectOption('male')
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('180')
+  await expect(page.getByTestId('result-status')).toHaveText('Niedrig')
+  await expect(page.getByTestId('score')).toContainText('0')
+})
+
+test('70-year-old woman with normal BMI → moderate', async ({ page }) => {
+  await page.getByTestId('age').fill('70')
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('weight').fill('65')
+  await page.getByTestId('height').fill('168')
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+})
+
+test('high risk: elderly woman with previous fracture and low BMI', async ({ page }) => {
+  await page.getByTestId('age').fill('80')
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('weight').fill('45')
+  await page.getByTestId('height').fill('156')
+  await page.getByTestId('checkbox-previousFracture').check()
+  await expect(page.getByTestId('result-status')).toHaveText('Hoch')
+})
+
+test('imperial unit toggle converts weight and height', async ({ page }) => {
+  await page.getByRole('button', { name: 'imperial', exact: true }).click()
+  await page.getByTestId('age').fill('45')
+  await page.getByTestId('sex').selectOption('male')
+  await page.getByTestId('weight').fill('176') // ≈ 80 kg
+  await page.getByTestId('height').fill('71')  // ≈ 180 cm
+  await expect(page.getByTestId('result-status')).toHaveText('Niedrig')
+})
+
+test('checking risk factors increases score', async ({ page }) => {
+  await page.getByTestId('age').fill('60')
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('weight').fill('65')
+  await page.getByTestId('height').fill('168')
+  // age 60 = 1, female = 1 → 2
+  await expect(page.getByTestId('score')).toContainText('2')
+  await page.getByTestId('checkbox-previousFracture').check()
+  // +3 → 5
+  await expect(page.getByTestId('score')).toContainText('5')
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+})
+
+test('T-score osteoporosis adds 3 points', async ({ page }) => {
+  await page.getByTestId('age').fill('60')
+  await page.getByTestId('sex').selectOption('male')
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('180')
+  // baseline: 1
+  await expect(page.getByTestId('score')).toContainText('1')
+  await page.getByTestId('t-score').fill('-2.8')
+  // +3 → 4
+  await expect(page.getByTestId('score')).toContainText('4')
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -23,7 +23,7 @@ const EXPECTED_KEYS = [
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore',
+  'apgarScore', 'osteoporosisRisk',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -85,6 +85,7 @@ const EXPECTED_ROUTE_MAP = {
   thyroidFunction: { de: 'schilddruesen-rechner', en: 'thyroid-function-calculator' },
   anemiaRisk: { de: 'anaemie-risiko-rechner', en: 'anemia-risk-calculator' },
   apgarScore: { de: 'apgar-score-rechner', en: 'apgar-score-calculator' },
+  osteoporosisRisk: { de: 'osteoporose-risiko-rechner', en: 'osteoporosis-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -134,6 +135,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'schilddruesenfunktion-berechnen',
   'anaemie-risiko-berechnen',
   'apgar-score-bewerten',
+  'osteoporose-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -183,11 +185,12 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'thyroid-function-calculator',
   'anemia-risk-calculator-guide',
   'apgar-score-calculator-guide',
+  'osteoporosis-risk-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
   it('discovers all 60 calculators', () => {
-    expect(calculatorMetas).toHaveLength(60)
+    expect(calculatorMetas).toHaveLength(61)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
@@ -195,7 +198,7 @@ describe('calculator discovery', () => {
   })
 
   it('builds calculatorComponents map for all 60 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(60)
+    expect(Object.keys(calculatorComponents)).toHaveLength(61)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -219,14 +222,14 @@ describe('calculator discovery', () => {
 
 describe('blog component discovery', () => {
   it('discovers all 58 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(58)
+    expect(Object.keys(blogComponentsDe)).toHaveLength(59)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
   it('discovers all 58 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(58)
+    expect(Object.keys(blogComponentsEn)).toHaveLength(59)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -244,8 +247,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 60 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(60)
-    expect(new Set(allKeys).size).toBe(60)
+    expect(allKeys).toHaveLength(61)
+    expect(new Set(allKeys).size).toBe(61)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -266,7 +269,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk',
     ])
   })
 
@@ -315,7 +318,7 @@ describe('i18n completeness', () => {
 
 describe('SSG routes', () => {
   it('generates exactly 336 routes', () => {
-    expect(routes).toHaveLength(336)
+    expect(routes).toHaveLength(341)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 236 links (60 calcs × 2 locales + 58 blogs × 2 locales)', () => {
+  it('generates 240 links (61 calcs × 2 locales + 59 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(236)
+    expect(links).toHaveLength(240)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/osteoporosisRisk.test.js
+++ b/src/__tests__/osteoporosisRisk.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcBmi,
+  categorize,
+  calcOsteoporosisRisk,
+} from '../utils/osteoporosisRisk.js'
+
+// FRAX-inspired osteoporosis 10-year fracture risk model.
+// Score sums weighted clinical risk factors:
+//   Age:       <50=0, 50–64=1, 65–74=3, 75–84=5, ≥85=7
+//   Female:    +1
+//   BMI:       <19=2, 19–20=1, ≥20=0
+//   Previous fragility fracture: +3
+//   Parent hip fracture: +2
+//   Current smoking: +1
+//   Glucocorticoids ≥3 months: +2
+//   Rheumatoid arthritis: +1
+//   Secondary osteoporosis: +1
+//   Alcohol ≥3 units/day: +2
+//   T-score ≤ -2.5: +3, -1 to -2.5: +1
+// Categories: 0–3 low, 4–7 moderate, ≥8 high.
+
+describe('calcBmi', () => {
+  it('computes BMI from kg and cm', () => {
+    expect(calcBmi(60, 170)).toBeCloseTo(20.76, 2)
+  })
+
+  it('returns null for invalid input', () => {
+    expect(calcBmi(0, 170)).toBeNull()
+    expect(calcBmi(60, 0)).toBeNull()
+    expect(calcBmi(null, 170)).toBeNull()
+  })
+})
+
+describe('categorize', () => {
+  it('0–3 → low', () => {
+    expect(categorize(0)).toBe('low')
+    expect(categorize(3)).toBe('low')
+  })
+  it('4–7 → moderate', () => {
+    expect(categorize(4)).toBe('moderate')
+    expect(categorize(7)).toBe('moderate')
+  })
+  it('≥8 → high', () => {
+    expect(categorize(8)).toBe('high')
+    expect(categorize(15)).toBe('high')
+  })
+})
+
+describe('calcOsteoporosisRisk', () => {
+  it('returns null without sex', () => {
+    expect(calcOsteoporosisRisk({ age: 60, sex: null, weightKg: 60, heightCm: 170 })).toBeNull()
+  })
+
+  it('returns null without valid age', () => {
+    expect(calcOsteoporosisRisk({ age: null, sex: 'female', weightKg: 60, heightCm: 170 })).toBeNull()
+  })
+
+  it('healthy 45-year-old man → low (score 0)', () => {
+    const r = calcOsteoporosisRisk({
+      age: 45, sex: 'male', weightKg: 80, heightCm: 180,
+    })
+    expect(r.score).toBe(0)
+    expect(r.category).toBe('low')
+  })
+
+  it('healthy 45-year-old woman → low (score 1: female)', () => {
+    const r = calcOsteoporosisRisk({
+      age: 45, sex: 'female', weightKg: 65, heightCm: 168,
+    })
+    expect(r.score).toBe(1)
+    expect(r.category).toBe('low')
+  })
+
+  it('70-year-old woman, normal BMI, no risk factors → moderate (3+1=4)', () => {
+    const r = calcOsteoporosisRisk({
+      age: 70, sex: 'female', weightKg: 65, heightCm: 168,
+    })
+    expect(r.score).toBe(4)
+    expect(r.category).toBe('moderate')
+  })
+
+  it('80-year-old woman with prior fracture and low BMI → high', () => {
+    // age 80 = 5, female = 1, BMI 18.4 (45/156²) = 2, fracture = 3 → 11
+    const r = calcOsteoporosisRisk({
+      age: 80, sex: 'female', weightKg: 45, heightCm: 156,
+      previousFracture: true,
+    })
+    expect(r.score).toBe(11)
+    expect(r.category).toBe('high')
+  })
+
+  it('all risk factors stack', () => {
+    // age 70 = 3, female = 1, BMI 18.4 = 2, fracture = 3, parent hip = 2,
+    // smoking = 1, gluco = 2, RA = 1, sec = 1, alc = 2, T -3.0 = 3 → 21
+    const r = calcOsteoporosisRisk({
+      age: 70, sex: 'female', weightKg: 45, heightCm: 156,
+      previousFracture: true, parentHipFracture: true, smoking: true,
+      glucocorticoids: true, rheumatoidArthritis: true, secondaryOsteoporosis: true,
+      alcohol3Plus: true, tScore: -3.0,
+    })
+    expect(r.score).toBe(21)
+    expect(r.category).toBe('high')
+  })
+
+  it('T-score osteopenia adds 1 point', () => {
+    const r = calcOsteoporosisRisk({
+      age: 60, sex: 'male', weightKg: 80, heightCm: 180, tScore: -1.5,
+    })
+    // age 60 = 1, male = 0, BMI 24.7 = 0, T -1.5 = 1 → 2
+    expect(r.score).toBe(2)
+    expect(r.category).toBe('low')
+  })
+
+  it('T-score normal (−0.5) adds 0', () => {
+    const r = calcOsteoporosisRisk({
+      age: 60, sex: 'male', weightKg: 80, heightCm: 180, tScore: -0.5,
+    })
+    expect(r.score).toBe(1)
+  })
+
+  it('exposes BMI in result', () => {
+    const r = calcOsteoporosisRisk({
+      age: 60, sex: 'female', weightKg: 60, heightCm: 170,
+    })
+    expect(r.bmi).toBeCloseTo(20.76, 2)
+  })
+
+  it('boundary: 65 → age band 3', () => {
+    // age 65 = 3, male = 0, BMI 24.7 = 0 → 3 (still low)
+    const r = calcOsteoporosisRisk({ age: 65, sex: 'male', weightKg: 80, heightCm: 180 })
+    expect(r.score).toBe(3)
+    expect(r.category).toBe('low')
+  })
+
+  it('boundary: 50 → age band 1', () => {
+    const r = calcOsteoporosisRisk({ age: 50, sex: 'male', weightKg: 80, heightCm: 180 })
+    expect(r.score).toBe(1)
+  })
+
+  it('BMI <19 contributes 2, BMI 19.5 contributes 1', () => {
+    const lean = calcOsteoporosisRisk({ age: 40, sex: 'male', weightKg: 50, heightCm: 175 })
+    // BMI 50/1.75² = 16.3 → +2
+    expect(lean.score).toBe(2)
+
+    const r = calcOsteoporosisRisk({ age: 40, sex: 'male', weightKg: 60, heightCm: 175 })
+    // BMI 60/1.75² = 19.6 → +1
+    expect(r.score).toBe(1)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -17,7 +17,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore',
+  'apgarScore', 'osteoporosisRisk',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -66,6 +66,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'schilddruesenfunktion-berechnen',
   'anaemie-risiko-berechnen',
   'apgar-score-bewerten',
+  'osteoporose-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -114,12 +115,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'thyroid-function-calculator',
   'anemia-risk-calculator-guide',
   'apgar-score-calculator-guide',
+  'osteoporosis-risk-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
   it('discovers all 60 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(60)
+    expect(metas).toHaveLength(61)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -160,7 +162,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 58 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(58)
+    expect(de).toHaveLength(59)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
@@ -169,7 +171,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 58 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(58)
+    expect(en).toHaveLength(59)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -239,7 +241,7 @@ describe('generateSitemap', () => {
 
   it('generates correct total URL count (2 home + 120 calcs + 2 blog index + 116 blog articles = 240)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(240)
+    expect(urlCount).toBe(244)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -521,6 +521,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'apgarScore',
     related: ['due-date-calculator', 'child-growth-percentile-chart', 'child-dosage-calculator'],
   },
+  {
+    slug: 'osteoporosis-risk-calculator-guide',
+    title: 'Osteoporosis Risk Calculator: Understand Your 10-Year FRAX Fracture Risk',
+    description: 'FRAX-inspired estimate of your 10-year osteoporotic fracture risk. Risk factors, T-score, treatment thresholds, and prevention — clearly explained.',
+    date: '2026-05-06',
+    readTime: '9 min',
+    calculatorKey: 'osteoporosisRisk',
+    related: ['vitamin-d-calculator', 'biological-age-calculator', 'calculate-bmi'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -521,6 +521,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'apgarScore',
     related: ['geburtsterminrechner', 'wachstumsperzentile-kinder', 'kinder-dosierung-rechner'],
   },
+  {
+    slug: 'osteoporose-risiko-berechnen',
+    title: 'Osteoporose-Risiko berechnen: FRAX 10-Jahres-Frakturrisiko verstehen',
+    description: 'FRAX-basierte Einschätzung deines 10-Jahres-Frakturrisikos. Risikofaktoren, T-Score, DVO-Behandlungsschwelle und Prävention — verständlich erklärt.',
+    date: '2026-05-06',
+    readTime: '9 min',
+    calculatorKey: 'osteoporosisRisk',
+    related: ['vitamin-d-berechnen', 'biologisches-alter-berechnen', 'bmi-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/osteoporosisRisk.json
+++ b/src/locales/calculators/de/osteoporosisRisk.json
@@ -1,0 +1,86 @@
+{
+  "home": {
+    "calculators": {
+      "osteoporosisRisk": {
+        "name": "Osteoporose-Risiko-Rechner",
+        "description": "FRAX-basierte Einschätzung deines 10-Jahres-Frakturrisikos aus Alter, BMI und klinischen Risikofaktoren."
+      }
+    }
+  },
+  "osteoporosisRisk": {
+    "meta": {
+      "title": "Osteoporose-Risiko-Rechner — FRAX 10-Jahres-Frakturrisiko",
+      "description": "Berechne dein 10-Jahres-Risiko für osteoporotische Frakturen. FRAX-basiert mit Alter, BMI, Frakturhistorie, Glukokortikoiden und optionalem T-Score. Kostenlos, sofort, anonym."
+    },
+    "title": "Osteoporose-Risiko-Rechner",
+    "description": "FRAX-inspirierter Score für das 10-Jahres-Risiko einer osteoporotischen Fraktur — basierend auf Alter, Geschlecht, BMI und 8 etablierten klinischen Risikofaktoren.",
+    "unitMetric": "metrisch",
+    "unitImperial": "imperial",
+    "ageLabel": "Alter (Jahre)",
+    "sexLabel": "Geschlecht",
+    "sexFemale": "Weiblich",
+    "sexMale": "Männlich",
+    "weightLabel": "Gewicht ({unit})",
+    "heightLabel": "Größe ({unit})",
+    "tScoreLabel": "Femurhals T-Score (optional)",
+    "tScorePlaceholder": "z. B. -1.8 (DXA-Befund)",
+    "tScoreHelp": "Falls eine Knochendichtemessung (DXA) vorliegt, kann der T-Score präziser einstufen.",
+    "riskFactorsLabel": "Klinische Risikofaktoren",
+    "rf_previousFracture": "Frühere osteoporotische Fraktur",
+    "rf_previousFracture_desc": "Wirbel-, Hüft-, Handgelenks- oder Oberarmbruch nach Bagatelltrauma",
+    "rf_parentHipFracture": "Hüftfraktur eines Elternteils",
+    "rf_parentHipFracture_desc": "Familiäre Belastung — wichtigster genetischer Risikofaktor",
+    "rf_smoking": "Aktiver Tabakkonsum",
+    "rf_smoking_desc": "Rauchen verringert die Knochendichte und Frakturheilung",
+    "rf_glucocorticoids": "Glukokortikoide ≥ 3 Monate",
+    "rf_glucocorticoids_desc": "Prednisolon ≥ 5 mg/Tag oder vergleichbar — starkes Risiko",
+    "rf_rheumatoidArthritis": "Rheumatoide Arthritis",
+    "rf_rheumatoidArthritis_desc": "Gesicherte Diagnose (nicht Arthrose)",
+    "rf_secondaryOsteoporosis": "Sekundäre Osteoporose-Ursache",
+    "rf_secondaryOsteoporosis_desc": "Diabetes Typ 1, Hyperthyreose, frühe Menopause, Hypogonadismus, chronische Lebererkrankung",
+    "rf_alcohol3Plus": "Alkohol ≥ 3 Einheiten/Tag",
+    "rf_alcohol3Plus_desc": "Eine Einheit ≈ 10–12 g reiner Alkohol",
+    "resultsLabel": "Dein 10-Jahres-Frakturrisiko",
+    "scoreLabel": "Risiko-Score",
+    "bmiLabel": "BMI",
+    "category_low": "Niedrig",
+    "category_moderate": "Moderat",
+    "category_high": "Hoch",
+    "advice_low": "Niedriges 10-Jahres-Frakturrisiko (< 10 %). Kalzium- und Vitamin-D-reiche Ernährung, regelmäßige Belastungsübungen sowie Sturzprophylaxe genügen aktuell. Bei Frauen ab 65 / Männern ab 70 Routine-DXA empfohlen.",
+    "advice_moderate": "Moderates Risiko (10–20 %). DXA-Knochendichtemessung empfohlen. Optimierung von Vitamin D, Kalzium, Eiweißzufuhr und Krafttraining. Sturzrisiko-Assessment durch Hausarzt sinnvoll.",
+    "advice_high": "Hohes 10-Jahres-Frakturrisiko (> 20 %). Ärztliche Vorstellung mit DXA, Labordiagnostik (Vitamin D, Kalzium, TSH) und ggf. medikamentöse Osteoporose-Therapie (Bisphosphonate, Denosumab, Teriparatid). Sturzprophylaxe konsequent umsetzen.",
+    "refTitle": "FRAX-Score Kategorien",
+    "refCategory": "Kategorie",
+    "refScore": "Punkte",
+    "refRisk": "10-Jahres-Risiko (geschätzt)",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner kombiniert die wichtigsten FRAX-Risikofaktoren der WHO zu einem einfachen Punktescore: Alter (0–7 Punkte), weibliches Geschlecht (+1), niedriger BMI (+1 bis +2), frühere Fraktur (+3), Hüftfraktur eines Elternteils (+2), Rauchen (+1), Langzeit-Glukokortikoide (+2), rheumatoide Arthritis (+1), sekundäre Ursachen (+1) und schwerer Alkoholkonsum (+2). Liegt eine DXA vor, modifiziert der T-Score den Score (+1 bei Osteopenie, +3 bei Osteoporose). Score ≥ 8 entspricht der NOF/DVO-Behandlungsschwelle.",
+    "disclaimer": "Dieser Rechner liefert eine Risikoeinschätzung — er ersetzt keinen offiziellen FRAX-Befund noch eine DXA-Knochendichtemessung. Behandlungsentscheidungen treffen Ärzt:innen unter Berücksichtigung individueller Faktoren. Bei Verdacht auf Wirbelfraktur (akuter Rückenschmerz, Größenverlust > 4 cm) zeitnah Bildgebung veranlassen.",
+    "faq": [
+      {
+        "q": "Was ist Osteoporose?",
+        "a": "Osteoporose ist eine systemische Skeletterkrankung mit verminderter Knochenmasse und gestörter Mikroarchitektur. Folge: erhöhte Knochenbrüchigkeit, vor allem an Wirbeln, Hüfte, Handgelenk und Oberarm. In Deutschland sind etwa 6 Millionen Menschen betroffen, überwiegend Frauen nach der Menopause."
+      },
+      {
+        "q": "Was ist FRAX?",
+        "a": "FRAX (Fracture Risk Assessment Tool) ist ein von der WHO entwickelter Algorithmus zur Berechnung des 10-Jahres-Risikos für eine schwere osteoporotische Fraktur (Hüfte, Wirbel, Unterarm, Schulter). Er berücksichtigt 11 klinische Risikofaktoren und optional die Knochendichte (DXA T-Score)."
+      },
+      {
+        "q": "Ab wann ist eine Therapie nötig?",
+        "a": "Die DVO-Leitlinie empfiehlt eine medikamentöse Therapie ab einem 10-Jahres-Risiko von ≥ 20 % für Wirbel- und Hüftfrakturen — entspricht in unserem Score ≥ 8 Punkten. Bei stattgehabter Wirbelfraktur oder T-Score ≤ -2,5 wird in der Regel direkt therapiert."
+      },
+      {
+        "q": "Welche Medikamente kommen infrage?",
+        "a": "First-Line sind Bisphosphonate (Alendronat, Risedronat, Zoledronat) — gut wirksam und kostengünstig. Alternativen: Denosumab (Antikörper), Teriparatid (PTH-Analog für schwere Osteoporose) sowie Romosozumab. Immer in Kombination mit Vitamin D und Kalzium."
+      },
+      {
+        "q": "Wie kann ich vorbeugen?",
+        "a": "Tägliche Eiweißzufuhr von 1,0–1,2 g/kg, 1000 mg Kalzium und 800–1000 IE Vitamin D, regelmäßige Belastungs- und Krafttrainings, Rauchverzicht, moderater Alkoholkonsum sowie Sturzprophylaxe (Sehkraft, Schuhwerk, Wohnumfeld) reduzieren das Risiko nachweislich."
+      },
+      {
+        "q": "Was ist der Unterschied zwischen T-Score und Z-Score?",
+        "a": "Der T-Score vergleicht deine Knochendichte mit der eines jungen, gesunden Erwachsenen — relevant für Diagnose und Therapieentscheidung (≤ -2,5 = Osteoporose). Der Z-Score vergleicht mit Gleichaltrigen und wird vor allem bei jüngeren Patient:innen verwendet."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/osteoporosisRisk.json
+++ b/src/locales/calculators/en/osteoporosisRisk.json
@@ -1,0 +1,86 @@
+{
+  "home": {
+    "calculators": {
+      "osteoporosisRisk": {
+        "name": "Osteoporosis Risk Calculator",
+        "description": "FRAX-based 10-year fracture risk estimate from age, BMI, and clinical risk factors."
+      }
+    }
+  },
+  "osteoporosisRisk": {
+    "meta": {
+      "title": "Osteoporosis Risk Calculator — FRAX 10-Year Fracture Risk",
+      "description": "Estimate your 10-year osteoporotic fracture risk. FRAX-inspired with age, BMI, fracture history, glucocorticoids, and optional T-score. Free, instant, no sign-up."
+    },
+    "title": "Osteoporosis Risk Calculator",
+    "description": "FRAX-inspired score for 10-year major osteoporotic fracture risk — based on age, sex, BMI, and 8 established clinical risk factors.",
+    "unitMetric": "Metric",
+    "unitImperial": "Imperial",
+    "ageLabel": "Age (years)",
+    "sexLabel": "Sex",
+    "sexFemale": "Female",
+    "sexMale": "Male",
+    "weightLabel": "Weight ({unit})",
+    "heightLabel": "Height ({unit})",
+    "tScoreLabel": "Femoral neck T-score (optional)",
+    "tScorePlaceholder": "e.g. -1.8 (DXA result)",
+    "tScoreHelp": "If you have a bone density (DXA) result, the T-score refines the estimate.",
+    "riskFactorsLabel": "Clinical risk factors",
+    "rf_previousFracture": "Previous osteoporotic fracture",
+    "rf_previousFracture_desc": "Vertebral, hip, wrist, or humerus fracture from low-energy trauma",
+    "rf_parentHipFracture": "Parent had hip fracture",
+    "rf_parentHipFracture_desc": "Family history — strongest genetic risk factor",
+    "rf_smoking": "Current smoker",
+    "rf_smoking_desc": "Smoking reduces bone density and impairs fracture healing",
+    "rf_glucocorticoids": "Glucocorticoids ≥ 3 months",
+    "rf_glucocorticoids_desc": "Prednisolone ≥ 5 mg/day or equivalent — major risk factor",
+    "rf_rheumatoidArthritis": "Rheumatoid arthritis",
+    "rf_rheumatoidArthritis_desc": "Confirmed diagnosis (not osteoarthritis)",
+    "rf_secondaryOsteoporosis": "Secondary osteoporosis cause",
+    "rf_secondaryOsteoporosis_desc": "Type 1 diabetes, hyperthyroidism, early menopause, hypogonadism, chronic liver disease",
+    "rf_alcohol3Plus": "Alcohol ≥ 3 units/day",
+    "rf_alcohol3Plus_desc": "One unit ≈ 10–12 g of pure alcohol",
+    "resultsLabel": "Your 10-year fracture risk",
+    "scoreLabel": "Risk score",
+    "bmiLabel": "BMI",
+    "category_low": "Low",
+    "category_moderate": "Moderate",
+    "category_high": "High",
+    "advice_low": "Low 10-year fracture risk (< 10 %). Calcium- and vitamin-D-rich diet, regular weight-bearing exercise, and basic fall prevention are sufficient. Routine DXA recommended for women ≥ 65 and men ≥ 70.",
+    "advice_moderate": "Moderate risk (10–20 %). DXA bone density scan recommended. Optimize vitamin D, calcium, and protein intake; add resistance training. Ask your GP for a fall-risk assessment.",
+    "advice_high": "High 10-year fracture risk (> 20 %). See a clinician for DXA, lab workup (vitamin D, calcium, TSH), and likely pharmacologic osteoporosis therapy (bisphosphonates, denosumab, teriparatide). Implement strict fall prevention.",
+    "refTitle": "FRAX score categories",
+    "refCategory": "Category",
+    "refScore": "Points",
+    "refRisk": "10-year risk (estimated)",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator combines the main WHO FRAX risk factors into a simple point score: age (0–7 points), female sex (+1), low BMI (+1 to +2), previous fracture (+3), parent hip fracture (+2), smoking (+1), long-term glucocorticoids (+2), rheumatoid arthritis (+1), secondary osteoporosis (+1), and heavy alcohol use (+2). If a DXA result is available, the T-score adjusts the total (+1 for osteopenia, +3 for osteoporosis). A score ≥ 8 corresponds to the NOF/DVO treatment threshold.",
+    "disclaimer": "This calculator provides a risk estimate — it does not replace an official FRAX report or a DXA bone density scan. Treatment decisions require a clinician's individualized assessment. With sudden back pain or height loss > 4 cm, seek imaging to rule out vertebral fracture.",
+    "faq": [
+      {
+        "q": "What is osteoporosis?",
+        "a": "Osteoporosis is a systemic skeletal disease with reduced bone mass and disrupted micro-architecture, leading to fragile bones — especially at the spine, hip, wrist, and humerus. Worldwide, about 200 million people are affected, mostly post-menopausal women."
+      },
+      {
+        "q": "What is FRAX?",
+        "a": "FRAX (Fracture Risk Assessment Tool) is a WHO-developed algorithm that estimates the 10-year probability of major osteoporotic fracture (hip, spine, forearm, shoulder). It uses 11 clinical risk factors and optionally bone density (DXA T-score)."
+      },
+      {
+        "q": "When is treatment required?",
+        "a": "Most guidelines (NOF, DVO) recommend pharmacologic treatment when the 10-year major fracture risk exceeds 20 % — corresponding to a score of ≥ 8 in our calculator. A prior vertebral fracture or T-score ≤ -2.5 typically triggers immediate treatment."
+      },
+      {
+        "q": "Which medications are used?",
+        "a": "First-line: bisphosphonates (alendronate, risedronate, zoledronate) — effective and inexpensive. Alternatives: denosumab (antibody), teriparatide (PTH analog for severe cases), romosozumab. Always combined with vitamin D and calcium."
+      },
+      {
+        "q": "How can I prevent osteoporosis?",
+        "a": "Aim for 1.0–1.2 g/kg protein, 1000 mg calcium, and 800–1000 IU vitamin D daily; do regular weight-bearing and resistance exercise; avoid smoking; limit alcohol; address fall risk (vision, footwear, home environment). These steps demonstrably reduce fracture incidence."
+      },
+      {
+        "q": "What's the difference between T-score and Z-score?",
+        "a": "The T-score compares your bone density to that of a young healthy adult — it drives diagnosis and treatment decisions (≤ -2.5 = osteoporosis). The Z-score compares to age-matched peers and is mainly used in younger patients."
+      }
+    ]
+  }
+}

--- a/src/pages/OsteoporosisRiskCalculator.vue
+++ b/src/pages/OsteoporosisRiskCalculator.vue
@@ -1,0 +1,280 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcOsteoporosisRisk } from '../utils/osteoporosisRisk.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('osteoporosisRisk.faq') || [])
+
+useHead(() => ({
+  title: t('osteoporosisRisk.meta.title'),
+  description: t('osteoporosisRisk.meta.description'),
+  routeKey: 'osteoporosisRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Osteoporosis Risk Calculator',
+    url: 'https://healthcalculator.app/osteoporosis-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const unit = ref('metric')
+const sex = ref('female')
+const age = ref(null)
+const weight = ref(null)
+const height = ref(null)
+const tScore = ref(null)
+
+const factors = ref({
+  previousFracture: false,
+  parentHipFracture: false,
+  smoking: false,
+  glucocorticoids: false,
+  rheumatoidArthritis: false,
+  secondaryOsteoporosis: false,
+  alcohol3Plus: false,
+})
+
+const factorList = [
+  'previousFracture',
+  'parentHipFracture',
+  'smoking',
+  'glucocorticoids',
+  'rheumatoidArthritis',
+  'secondaryOsteoporosis',
+  'alcohol3Plus',
+]
+
+const weightKg = computed(() => {
+  if (weight.value == null) return null
+  return unit.value === 'imperial' ? weight.value * 0.453592 : weight.value
+})
+
+const heightCm = computed(() => {
+  if (height.value == null) return null
+  return unit.value === 'imperial' ? height.value * 2.54 : height.value
+})
+
+const result = computed(() => calcOsteoporosisRisk({
+  age: age.value,
+  sex: sex.value,
+  weightKg: weightKg.value,
+  heightCm: heightCm.value,
+  ...factors.value,
+  tScore: tScore.value,
+}))
+
+const categoryStyle = computed(() => {
+  if (!result.value) return { color: '', bg: '' }
+  switch (result.value.category) {
+    case 'low': return { color: 'text-green-600', bg: 'bg-green-50 border-green-200 text-green-900' }
+    case 'moderate': return { color: 'text-orange-500', bg: 'bg-orange-50 border-orange-200 text-orange-900' }
+    case 'high': return { color: 'text-red-700', bg: 'bg-red-100 border-red-300 text-red-900' }
+    default: return { color: '', bg: '' }
+  }
+})
+
+const categoryLevel = computed(() => {
+  if (!result.value) return 0
+  return { low: 0, moderate: 1, high: 2 }[result.value.category] ?? 0
+})
+
+const weightUnit = computed(() => unit.value === 'imperial' ? 'lbs' : 'kg')
+const heightUnit = computed(() => unit.value === 'imperial' ? 'in' : 'cm')
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('osteoporosisRisk.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('osteoporosisRisk.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="unit = 'metric'"
+        :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('osteoporosisRisk.unitMetric') }}</button>
+      <button
+        @click="unit = 'imperial'"
+        :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('osteoporosisRisk.unitImperial') }}</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('osteoporosisRisk.ageLabel') }}
+        </label>
+        <input
+          v-model.number="age"
+          type="number"
+          min="18"
+          max="120"
+          placeholder="65"
+          data-testid="age"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('osteoporosisRisk.sexLabel') }}
+        </label>
+        <select
+          v-model="sex"
+          data-testid="sex"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        >
+          <option value="female">{{ t('osteoporosisRisk.sexFemale') }}</option>
+          <option value="male">{{ t('osteoporosisRisk.sexMale') }}</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('osteoporosisRisk.weightLabel', { unit: weightUnit }) }}
+        </label>
+        <input
+          v-model.number="weight"
+          type="number"
+          step="0.1"
+          :placeholder="unit === 'metric' ? '65' : '143'"
+          data-testid="weight"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('osteoporosisRisk.heightLabel', { unit: heightUnit }) }}
+        </label>
+        <input
+          v-model.number="height"
+          type="number"
+          step="0.1"
+          :placeholder="unit === 'metric' ? '168' : '66'"
+          data-testid="height"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('osteoporosisRisk.riskFactorsLabel') }}</p>
+    <div class="space-y-3 mb-6">
+      <label
+        v-for="key in factorList"
+        :key="key"
+        :data-testid="'factor-' + key"
+        :class="factors[key] ? 'border-stone-900 bg-stone-50' : 'border-stone-200 hover:border-stone-300'"
+        class="flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-colors duration-150"
+      >
+        <input
+          v-model="factors[key]"
+          type="checkbox"
+          :data-testid="'checkbox-' + key"
+          class="mt-1 h-5 w-5 rounded border-stone-300 text-stone-900 focus:ring-stone-600"
+        />
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-semibold text-stone-900">{{ t('osteoporosisRisk.rf_' + key) }}</p>
+          <p class="text-xs text-stone-500 leading-relaxed mt-1">{{ t('osteoporosisRisk.rf_' + key + '_desc') }}</p>
+        </div>
+      </label>
+    </div>
+
+    <div>
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+        {{ t('osteoporosisRisk.tScoreLabel') }}
+      </label>
+      <input
+        v-model.number="tScore"
+        type="number"
+        step="0.1"
+        :placeholder="t('osteoporosisRisk.tScorePlaceholder')"
+        data-testid="t-score"
+        class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+      />
+      <p class="text-xs text-stone-500 mt-2">{{ t('osteoporosisRisk.tScoreHelp') }}</p>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('osteoporosisRisk.resultsLabel') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold tabular-nums tracking-tight leading-none" :class="categoryStyle.color" data-testid="result-status">{{ t('osteoporosisRisk.category_' + result.category) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (categoryLevel / 2 * 100) + '%' }"></div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="score">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('osteoporosisRisk.scoreLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.score }}</p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="bmi">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('osteoporosisRisk.bmiLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">
+          <span v-if="result.bmi">{{ result.bmi.toFixed(1) }}</span>
+          <span v-else class="text-stone-400 text-lg">—</span>
+        </p>
+      </div>
+    </div>
+
+    <div class="rounded-lg p-4 text-sm font-medium border" :class="categoryStyle.bg" data-testid="advice">
+      {{ t('osteoporosisRisk.advice_' + result.category) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('osteoporosisRisk.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('osteoporosisRisk.refCategory') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('osteoporosisRisk.refScore') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('osteoporosisRisk.refRisk') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('osteoporosisRisk.category_low') }}</td><td class="px-6 py-3 text-stone-600">0–3</td><td class="px-6 py-3 text-stone-600">&lt; 10 %</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('osteoporosisRisk.category_moderate') }}</td><td class="px-6 py-3 text-stone-600">4–7</td><td class="px-6 py-3 text-stone-600">10–20 %</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('osteoporosisRisk.category_high') }}</td><td class="px-6 py-3 text-stone-600">≥ 8</td><td class="px-6 py-3 text-stone-600">&gt; 20 %</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('osteoporosisRisk.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('osteoporosisRisk.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('osteoporosisRisk.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="osteoporosisRisk" />
+</template>

--- a/src/pages/blog/OsteoporoseRisikoBerechnen.vue
+++ b/src/pages/blog/OsteoporoseRisikoBerechnen.vue
@@ -1,0 +1,171 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Osteoporose-Risiko berechnen: FRAX 10-Jahres-Frakturrisiko verstehen | Health Calculators',
+  description: 'Schätze dein 10-Jahres-Frakturrisiko mit dem FRAX-basierten Osteoporose-Rechner. Risikofaktoren, T-Score, DVO-Behandlungsschwelle und Prävention — verständlich erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Osteoporose-Risiko berechnen: FRAX 10-Jahres-Frakturrisiko verstehen',
+    description: 'Schätze dein 10-Jahres-Frakturrisiko mit dem FRAX-basierten Osteoporose-Rechner. Risikofaktoren, T-Score, DVO-Behandlungsschwelle und Prävention — verständlich erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-06',
+    dateModified: '2026-05-06',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/osteoporose-risiko-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Osteoporose-Risiko berechnen: FRAX 10-Jahres-Frakturrisiko verstehen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">6. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In Deutschland leben rund <strong>6 Millionen Menschen mit Osteoporose</strong> — die Mehrheit Frauen nach der Menopause. Jährlich werden über 700.000 osteoporotische Frakturen registriert, davon ca. 130.000 Hüftbrüche mit erheblicher Morbidität. Dabei ist Osteoporose gut vermeidbar und behandelbar — wenn sie erkannt wird.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Ratgeber zeigt, wie du dein <strong>10-Jahres-Frakturrisiko</strong> mit einem FRAX-basierten Score abschätzt — ohne DXA-Knochendichtemessung, aber präzise genug, um den Bedarf für ärztliche Abklärung zu erkennen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist Osteoporose?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Osteoporose ist eine systemische Skeletterkrankung mit <strong>verminderter Knochenmasse und gestörter Mikroarchitektur</strong>. Die Knochen werden brüchig — typische Frakturlokalisationen sind Wirbelkörper, Hüfte, Handgelenk und Oberarmkopf. Ein Drittel aller Frauen über 50 erleidet im Laufe ihres Lebens eine osteoporotische Fraktur.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Diagnostisch wird die Knochendichte per <strong>DXA-Messung am Femurhals und Lendenwirbelsäule</strong> bestimmt. Der T-Score vergleicht den Wert mit gesunden jungen Erwachsenen: T ≤ -2,5 entspricht der WHO-Definition Osteoporose, -2,4 bis -1,0 ist Osteopenie (Vorstufe).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">FRAX — der Goldstandard für die Risikoschätzung</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die WHO entwickelte mit FRAX (Fracture Risk Assessment Tool) einen Algorithmus, der das <strong>10-Jahres-Risiko für eine schwere osteoporotische Fraktur</strong> aus 11 klinischen Risikofaktoren berechnet — optional mit Knochendichte. FRAX bildet die Grundlage der DVO- und NOF-Behandlungsleitlinien.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Unser Rechner überträgt die FRAX-Logik in einen einfachen Punktescore — ideal als Vorscreening, bevor du eine DXA durchführen lässt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die 11 wichtigsten Risikofaktoren</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Risikofaktor</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Punkte</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bedeutung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Alter</td><td class="px-6 py-3 text-stone-600">0–7</td><td class="px-6 py-3 text-stone-600">Stärkster nicht-modifizierbarer Faktor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Weibliches Geschlecht</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Östrogen-Mangel nach Menopause</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">BMI &lt; 19</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">Untergewicht reduziert Knochenmasse</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Frühere Fraktur</td><td class="px-6 py-3 text-stone-600">+3</td><td class="px-6 py-3 text-stone-600">Stärkster modifizierbarer Prädiktor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hüftfraktur Elternteil</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">Wichtigster genetischer Faktor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Rauchen</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Hemmt Osteoblasten, fördert Frakturheilungsstörungen</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Glukokortikoide ≥ 3 Mon.</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">Sekundäre Osteoporose Nr. 1</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Rheumatoide Arthritis</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Entzündung + Glukokortikoide</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Sekundäre Ursachen</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Diabetes Typ 1, Hyperthyreose, frühe Menopause</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Alkohol ≥ 3 E/Tag</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">Hemmt Osteoblasten, erhöht Sturzrisiko</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">T-Score (DXA)</td><td class="px-6 py-3 text-stone-600">0–3</td><td class="px-6 py-3 text-stone-600">Optional, wenn Knochendichtemessung vorliegt</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt Osteoporose-Risiko berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">FRAX-basiertes 10-Jahres-Frakturrisiko aus Alter, BMI und 8 Risikofaktoren — sofort, anonym, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('osteoporosisRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann ist eine Therapie nötig?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die DVO-Leitlinie empfiehlt eine medikamentöse Therapie ab einem <strong>10-Jahres-Risiko von ≥ 20 % für schwere Frakturen</strong> — entspricht in unserem Score ≥ 8 Punkten. Klare Therapieindikationen sind außerdem:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed">T-Score ≤ -2,5 in der DXA</li>
+          <li class="text-base text-stone-600 leading-relaxed">Stattgehabte Wirbelfraktur (radiologisch nachgewiesen)</li>
+          <li class="text-base text-stone-600 leading-relaxed">Hüftfraktur ohne adäquates Trauma</li>
+          <li class="text-base text-stone-600 leading-relaxed">Langzeit-Glukokortikoid-Therapie ≥ 7,5 mg Prednisolon-Äquivalent</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Therapieoptionen im Überblick</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Bisphosphonate</strong> (Alendronat, Risedronat, Zoledronat): First-Line, oral oder i.v., reduzieren Frakturrate um ca. 50 %.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Denosumab</strong>: Antikörper gegen RANKL, alle 6 Monate s.c. — Vorsicht beim Absetzen (Rebound-Frakturen).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Teriparatid</strong>: PTH-Analog, anabol, für schwere Osteoporose mit hohem Frakturrisiko.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Romosozumab</strong>: Sklerostin-Antikörper, dual wirksam, neue Option bei sehr hohem Risiko.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Basistherapie</strong>: Immer 1000 mg Kalzium und 800–1000 IE Vitamin D — siehe auch unseren <router-link :to="localeBlogPath('vitamin-d-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Vitamin-D-Rechner</router-link>.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Prävention: Was du selbst tun kannst</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Belastung &amp; Krafttraining:</strong> 2–3× pro Woche, am besten mit Springen oder Krafttraining gegen Widerstand.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Eiweiß:</strong> 1,0–1,2 g pro kg Körpergewicht, gleichmäßig über den Tag verteilt.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Kalzium:</strong> 1000 mg pro Tag, bevorzugt aus Milchprodukten und kalziumreichem Wasser.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Vitamin D:</strong> 800–1000 IE pro Tag, höher bei Mangel oder geringer Sonnenexposition.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Sturzprophylaxe:</strong> Sehkraft prüfen, rutschfeste Schuhe, sichere Wohnumgebung.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Verzicht auf:</strong> Nikotin, Alkohol &gt; 2 Einheiten/Tag, exzessives Untergewicht.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Knochengesundheit hängt eng mit anderen Stoffwechsel- und Lebensstilfaktoren zusammen. Mit dem
+          <router-link :to="localeBlogPath('vitamin-d-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Vitamin-D-Rechner</router-link>
+          ermittelst du deinen Bedarf für eine ausreichende Kalziumresorption. Der
+          <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Rechner für biologisches Alter</router-link>
+          bewertet dein Alterungstempo holistisch — Knochen- und Muskelmasse gehören dazu. Und wer untergewichtig ist, profitiert vom
+          <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner</router-link>
+          zur ersten Orientierung — niedriger BMI ist ein etablierter Frakturrisikofaktor.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Osteoporose entwickelt sich über Jahre still — die erste Fraktur ist oft das erste Symptom. Mit unserem
+          <router-link :to="localePath('osteoporosisRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Osteoporose-Risiko-Rechner</router-link>
+          siehst du in Sekunden, ob eine DXA-Messung sinnvoll ist. Frühzeitige Diagnose plus konsequente Basis- und ggf. medikamentöse Therapie reduziert das Frakturrisiko nachweislich um die Hälfte.
+        </p>
+      </div>
+
+      <RelatedArticles slug="osteoporose-risiko-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/OsteoporosisRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/OsteoporosisRiskCalculatorGuide.vue
@@ -1,0 +1,171 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Osteoporosis Risk Calculator: Understand Your 10-Year FRAX Fracture Risk | Health Calculators',
+  description: 'Estimate your 10-year fracture risk with a FRAX-inspired osteoporosis calculator. Risk factors, T-score, treatment thresholds, and prevention — clearly explained.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Osteoporosis Risk Calculator: Understand Your 10-Year FRAX Fracture Risk',
+    description: 'Estimate your 10-year fracture risk with a FRAX-inspired osteoporosis calculator. Risk factors, T-score, treatment thresholds, and prevention — clearly explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-06',
+    dateModified: '2026-05-06',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/osteoporosis-risk-calculator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Osteoporosis Risk Calculator: Understand Your 10-Year FRAX Fracture Risk</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 6, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Worldwide, around <strong>200 million people have osteoporosis</strong> — most of them post-menopausal women. Each year, osteoporosis causes more than 9 million fragility fractures globally, including 1.6 million hip fractures with high morbidity and mortality. Yet osteoporosis is largely preventable and treatable — once it is recognized.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide shows how to estimate your <strong>10-year fracture risk</strong> with a FRAX-inspired score — without bone density (DXA) imaging, but precise enough to flag the need for clinical assessment.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is osteoporosis?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Osteoporosis is a systemic skeletal disease with <strong>reduced bone mass and disrupted micro-architecture</strong>. Bones become brittle — typical fracture sites are spine, hip, wrist, and humerus. About one in three women over 50 will experience an osteoporotic fracture in her remaining lifetime.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The diagnosis is based on bone density (BMD) measured by <strong>DXA at the femoral neck and lumbar spine</strong>. The T-score compares your BMD to that of young healthy adults: T ≤ -2.5 meets the WHO definition of osteoporosis, while -2.4 to -1.0 is osteopenia (a precursor state).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">FRAX — the gold standard for risk estimation</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The WHO developed FRAX (Fracture Risk Assessment Tool), an algorithm that calculates the <strong>10-year probability of major osteoporotic fracture</strong> from 11 clinical risk factors — optionally including bone density. FRAX underpins the treatment guidelines of NOF (USA) and DVO (Germany).
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Our calculator translates FRAX logic into a simple point score — ideal as a pre-screen before getting a DXA scan.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The 11 most important risk factors</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Risk factor</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Points</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Why it matters</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Age</td><td class="px-6 py-3 text-stone-600">0–7</td><td class="px-6 py-3 text-stone-600">Strongest non-modifiable factor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Female sex</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Estrogen loss after menopause</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">BMI &lt; 19</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">Underweight reduces bone mass</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Previous fracture</td><td class="px-6 py-3 text-stone-600">+3</td><td class="px-6 py-3 text-stone-600">Strongest modifiable predictor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Parent hip fracture</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">Strongest genetic factor</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Smoking</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Inhibits osteoblasts, impairs healing</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Glucocorticoids ≥ 3 mo</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">#1 cause of secondary osteoporosis</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Rheumatoid arthritis</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Inflammation plus glucocorticoids</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Secondary causes</td><td class="px-6 py-3 text-stone-600">+1</td><td class="px-6 py-3 text-stone-600">Type 1 diabetes, hyperthyroidism, early menopause</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Alcohol ≥ 3 units/day</td><td class="px-6 py-3 text-stone-600">+2</td><td class="px-6 py-3 text-stone-600">Inhibits osteoblasts, raises fall risk</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">T-score (DXA)</td><td class="px-6 py-3 text-stone-600">0–3</td><td class="px-6 py-3 text-stone-600">Optional, when bone density is known</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your osteoporosis risk now</h3>
+        <p class="text-stone-300 text-sm mb-5">FRAX-based 10-year fracture risk from age, BMI, and 8 risk factors — instant, anonymous, no sign-up.</p>
+        <router-link
+          :to="localePath('osteoporosisRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Try the calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">When is treatment indicated?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Most guidelines recommend pharmacologic therapy when the <strong>10-year major fracture risk exceeds 20 %</strong> — corresponding to ≥ 8 points in our calculator. Other clear treatment indications:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed">DXA T-score ≤ -2.5</li>
+          <li class="text-base text-stone-600 leading-relaxed">Prevalent vertebral fracture (radiographically confirmed)</li>
+          <li class="text-base text-stone-600 leading-relaxed">Hip fracture without adequate trauma</li>
+          <li class="text-base text-stone-600 leading-relaxed">Long-term glucocorticoid therapy ≥ 7.5 mg prednisone equivalent</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Treatment options</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Bisphosphonates</strong> (alendronate, risedronate, zoledronate): first-line, oral or IV, reduce fracture rates by ~50 %.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Denosumab</strong>: anti-RANKL antibody every 6 months SC — caution when stopping (rebound fractures).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Teriparatide</strong>: PTH analog, anabolic, for severe osteoporosis with high fracture risk.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Romosozumab</strong>: sclerostin antibody, dual-acting, an option for very high risk.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Baseline therapy</strong>: always 1000 mg calcium and 800–1000 IU vitamin D — see our <router-link :to="localeBlogPath('vitamin-d-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">vitamin D calculator</router-link>.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Prevention: what you can do</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Weight-bearing &amp; resistance exercise:</strong> 2–3× per week, ideally with jumping or strength training against resistance.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Protein:</strong> 1.0–1.2 g per kg body weight, evenly spread across the day.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Calcium:</strong> 1000 mg/day, ideally from dairy and calcium-rich water.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Vitamin D:</strong> 800–1000 IU/day, more if deficient or with low sun exposure.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Fall prevention:</strong> check vision, wear non-slip footwear, secure your home.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Avoid:</strong> tobacco, alcohol &gt; 2 units/day, sustained underweight.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bone health is tied to other metabolic and lifestyle factors. The
+          <router-link :to="localeBlogPath('vitamin-d-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">vitamin D calculator</router-link>
+          helps you set the right dose for adequate calcium absorption. The
+          <router-link :to="localeBlogPath('biological-age-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biological age calculator</router-link>
+          gives a holistic view of your aging trajectory — bone and muscle mass are part of it. And if you are underweight, start with the
+          <router-link :to="localeBlogPath('calculate-bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI calculator</router-link>
+          — low BMI is an established fracture risk factor.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Osteoporosis develops silently over years — the first fracture is often the first symptom. With our
+          <router-link :to="localePath('osteoporosisRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">osteoporosis risk calculator</router-link>
+          you can see in seconds whether a DXA scan is warranted. Early diagnosis combined with consistent baseline and (when needed) pharmacologic therapy demonstrably halves fracture incidence.
+        </p>
+      </div>
+
+      <RelatedArticles slug="osteoporosis-risk-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/osteoporosisRisk.meta.js
+++ b/src/pages/osteoporosisRisk.meta.js
@@ -1,0 +1,16 @@
+import Component from './OsteoporosisRiskCalculator.vue'
+import BlogDe from './blog/OsteoporoseRisikoBerechnen.vue'
+import BlogEn from './blog/en/OsteoporosisRiskCalculatorGuide.vue'
+
+export default {
+  key: 'osteoporosisRisk',
+  component: Component,
+  slugs: { de: 'osteoporose-risiko-rechner', en: 'osteoporosis-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 37,
+  blog: {
+    de: { slug: 'osteoporose-risiko-berechnen', component: BlogDe },
+    en: { slug: 'osteoporosis-risk-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/osteoporosisRisk.js
+++ b/src/utils/osteoporosisRisk.js
@@ -1,0 +1,105 @@
+// Osteoporosis 10-year fracture risk screen (FRAX-inspired simplified model).
+//
+// Inputs combine demographic and clinical risk factors. The result is a
+// weighted point score plus a low / moderate / high category.
+//
+// Risk-factor weights (points):
+//   Age band:  <50 = 0, 50–64 = 1, 65–74 = 3, 75–84 = 5, ≥85 = 7
+//   Sex:       female = 1
+//   Low BMI:   <19 = 2, 19–20 = 1, ≥20 = 0
+//   Previous fragility fracture:  3
+//   Parent had hip fracture:      2
+//   Current smoking:              1
+//   Glucocorticoids ≥3 months:    2
+//   Rheumatoid arthritis:         1
+//   Secondary osteoporosis:       1
+//   Alcohol ≥3 units/day:         2
+//   Femoral-neck T-score (optional, overrides nothing):
+//     ≤ -2.5  → +3 (osteoporosis)
+//     -2.4 to -1.0 → +1 (osteopenia)
+//     > -1.0  → 0
+//
+// Categories:
+//   0–3   → low       (<10 % 10-year major fracture risk)
+//   4–7   → moderate  (10–20 %)
+//   ≥ 8   → high      (>20 %, treatment threshold)
+
+const VALID_SEX = new Set(['female', 'male'])
+
+function ageBand(age) {
+  if (typeof age !== 'number' || !Number.isFinite(age) || age < 0) return null
+  if (age < 50) return 0
+  if (age < 65) return 1
+  if (age < 75) return 3
+  if (age < 85) return 5
+  return 7
+}
+
+function bmiBand(bmi) {
+  if (typeof bmi !== 'number' || !Number.isFinite(bmi) || bmi <= 0) return 0
+  if (bmi < 19) return 2
+  if (bmi < 20) return 1
+  return 0
+}
+
+function tScoreBand(t) {
+  if (typeof t !== 'number' || !Number.isFinite(t)) return 0
+  if (t <= -2.5) return 3
+  if (t <= -1.0) return 1
+  return 0
+}
+
+export function calcBmi(weightKg, heightCm) {
+  if (
+    typeof weightKg !== 'number' || !Number.isFinite(weightKg) || weightKg <= 0 ||
+    typeof heightCm !== 'number' || !Number.isFinite(heightCm) || heightCm <= 0
+  ) return null
+  const m = heightCm / 100
+  return weightKg / (m * m)
+}
+
+export function categorize(score) {
+  if (score >= 8) return 'high'
+  if (score >= 4) return 'moderate'
+  return 'low'
+}
+
+export function calcOsteoporosisRisk({
+  age,
+  sex,
+  weightKg,
+  heightCm,
+  previousFracture = false,
+  parentHipFracture = false,
+  smoking = false,
+  glucocorticoids = false,
+  rheumatoidArthritis = false,
+  secondaryOsteoporosis = false,
+  alcohol3Plus = false,
+  tScore = null,
+} = {}) {
+  if (!VALID_SEX.has(sex)) return null
+  const aBand = ageBand(age)
+  if (aBand === null) return null
+
+  const bmi = calcBmi(weightKg, heightCm)
+
+  let score = 0
+  score += aBand
+  if (sex === 'female') score += 1
+  score += bmiBand(bmi)
+  if (previousFracture) score += 3
+  if (parentHipFracture) score += 2
+  if (smoking) score += 1
+  if (glucocorticoids) score += 2
+  if (rheumatoidArthritis) score += 1
+  if (secondaryOsteoporosis) score += 1
+  if (alcohol3Plus) score += 2
+  score += tScoreBand(tScore)
+
+  return {
+    score,
+    category: categorize(score),
+    bmi,
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-156-osteoporosis-risk
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-156-osteoporosis-risk-20260506-220030`
**Cost:** $8.2878605

Closes jenslaufer/health-calculators#156

### Prompt
> Implement the Osteoporosis Risk Calculator as described in issue #156.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- FRAX fracture risk assessment
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/osteoporosisRisk.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/osteoporosisRisk.test.js` with 6+ test cases covering edge cases. Run `npm test -- osteoporosisRisk` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/OsteoporosisRiskCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/osteoporosisRisk.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/osteoporosisRisk.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'osteoporosisRisk'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/osteoporosisRisk.json` + `src/locales/calculators/en/osteoporosisRisk.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/osteoporosisRisk.js (or shared util — verify pattern in repo first)`
- `src/__tests__/osteoporosisRisk.test.js`
- `src/pages/OsteoporosisRiskCalculator.vue`
- `src/pages/osteoporosisRisk.meta.js`
- `src/locales/calculators/de/osteoporosisRisk.json`
- `src/locales/calculators/en/osteoporosisRisk.json`
- `e2e/osteoporosisRisk.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'osteoporosisRisk',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks