### PR TITLE
hc-155: add Hepatitis Risk Calculator

### DIFF
--- a/e2e/hepatitisRisk.spec.js
+++ b/e2e/hepatitisRisk.spec.js
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/hepatitis-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Hepatitis-Risiko-Rechner/)
+})
+
+test('no factors → no risk', async ({ page }) => {
+  await expect(page.getByTestId('result-status')).toHaveText('Kein Risiko')
+})
+
+test('single low-weight factor (tattoo) → low risk', async ({ page }) => {
+  await page.getByTestId('checkbox-tattooPiercingUnsterile').check()
+  await expect(page.getByTestId('result-status')).toHaveText('Niedrig')
+})
+
+test('IDU alone (4 pts) → moderate', async ({ page }) => {
+  await page.getByTestId('checkbox-injectionDrugUse').check()
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+})
+
+test('IDU + transfusion + HIV (9 pts) → high', async ({ page }) => {
+  await page.getByTestId('checkbox-injectionDrugUse').check()
+  await page.getByTestId('checkbox-transfusionBefore1992').check()
+  await page.getByTestId('checkbox-hivPositive').check()
+  await expect(page.getByTestId('result-status')).toHaveText('Hoch')
+})
+
+test('HBV vaccination subtracts 2 from score', async ({ page }) => {
+  await page.getByTestId('checkbox-birthCohort1945to1965').check()
+  await page.getByTestId('checkbox-hivPositive').check()
+  // 2+2 = 4 → moderate without vaccine
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+  await page.getByTestId('checkbox-hbvVaccinated').check()
+  // 4-2 = 2 → low with vaccine
+  await expect(page.getByTestId('result-status')).toHaveText('Niedrig')
+})
+
+test('risk score reflects checked factors', async ({ page }) => {
+  await page.getByTestId('checkbox-injectionDrugUse').check()
+  await page.getByTestId('checkbox-tattooPiercingUnsterile').check()
+  await expect(page.getByTestId('risk-score')).toContainText('5')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -23,7 +23,7 @@ const EXPECTED_KEYS = [
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore', 'osteoporosisRisk',
+  'apgarScore', 'osteoporosisRisk', 'hepatitisRisk',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -86,6 +86,7 @@ const EXPECTED_ROUTE_MAP = {
   anemiaRisk: { de: 'anaemie-risiko-rechner', en: 'anemia-risk-calculator' },
   apgarScore: { de: 'apgar-score-rechner', en: 'apgar-score-calculator' },
   osteoporosisRisk: { de: 'osteoporose-risiko-rechner', en: 'osteoporosis-risk-calculator' },
+  hepatitisRisk: { de: 'hepatitis-risiko-rechner', en: 'hepatitis-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -136,6 +137,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'anaemie-risiko-berechnen',
   'apgar-score-bewerten',
   'osteoporose-risiko-berechnen',
+  'hepatitis-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -186,11 +188,12 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'anemia-risk-calculator-guide',
   'apgar-score-calculator-guide',
   'osteoporosis-risk-calculator-guide',
+  'hepatitis-risk-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
   it('discovers all 60 calculators', () => {
-    expect(calculatorMetas).toHaveLength(61)
+    expect(calculatorMetas).toHaveLength(62)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
@@ -198,7 +201,7 @@ describe('calculator discovery', () => {
   })
 
   it('builds calculatorComponents map for all 60 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(61)
+    expect(Object.keys(calculatorComponents)).toHaveLength(62)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -222,14 +225,14 @@ describe('calculator discovery', () => {
 
 describe('blog component discovery', () => {
   it('discovers all 58 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(59)
+    expect(Object.keys(blogComponentsDe)).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
   it('discovers all 58 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(59)
+    expect(Object.keys(blogComponentsEn)).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -247,8 +250,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 60 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(61)
-    expect(new Set(allKeys).size).toBe(61)
+    expect(allKeys).toHaveLength(62)
+    expect(new Set(allKeys).size).toBe(62)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -269,7 +272,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk',
     ])
   })
 
@@ -318,7 +321,7 @@ describe('i18n completeness', () => {
 
 describe('SSG routes', () => {
   it('generates exactly 336 routes', () => {
-    expect(routes).toHaveLength(341)
+    expect(routes).toHaveLength(346)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/hepatitisRisk.test.js
+++ b/src/__tests__/hepatitisRisk.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcRiskScore,
+  classifyRisk,
+  calcHepatitisRisk,
+  FACTOR_KEYS,
+} from '../utils/hepatitisRisk.js'
+
+// Hepatitis risk screening from CDC/WHO exposure factors.
+//
+// Factor weights:
+//   bornHighPrevalence (2), birthCohort1945to1965 (2),
+//   injectionDrugUse (4), transfusionBefore1992 (3),
+//   tattooPiercingUnsterile (1), multipleSexPartners (1),
+//   hivPositive (2), healthcareNeedlestick (2),
+//   householdContactInfected (2), hemodialysis (3),
+//   incarcerated (1), maternalInfection (3),
+//   elevatedLiverEnzymes (2).
+//
+// HBV vaccine subtracts 2 from the total (capped at 0).
+//
+// Bands: 0 → none, 1–3 → low, 4–7 → moderate, ≥8 → high.
+
+describe('calcRiskScore', () => {
+  it('returns 0 for no factors', () => {
+    expect(calcRiskScore({})).toBe(0)
+  })
+
+  it('returns 0 for null / non-object', () => {
+    expect(calcRiskScore(null)).toBe(0)
+    expect(calcRiskScore(undefined)).toBe(0)
+    expect(calcRiskScore('foo')).toBe(0)
+  })
+
+  it('weights injectionDrugUse as 4 (highest single factor)', () => {
+    expect(calcRiskScore({ injectionDrugUse: true })).toBe(4)
+  })
+
+  it('weights tattooPiercingUnsterile as 1', () => {
+    expect(calcRiskScore({ tattooPiercingUnsterile: true })).toBe(1)
+  })
+
+  it('sums multiple factors correctly', () => {
+    expect(
+      calcRiskScore({
+        injectionDrugUse: true,        // 4
+        transfusionBefore1992: true,   // 3
+        hivPositive: true,             // 2
+      }),
+    ).toBe(9)
+  })
+
+  it('ignores unknown flags', () => {
+    expect(calcRiskScore({ injectionDrugUse: true, foo: true })).toBe(4)
+  })
+
+  it('subtracts 2 for HBV vaccination', () => {
+    expect(calcRiskScore({ tattooPiercingUnsterile: true, hbvVaccinated: true })).toBe(0)
+    expect(calcRiskScore({ injectionDrugUse: true, hbvVaccinated: true })).toBe(2)
+  })
+
+  it('vaccine bonus is capped at 0 — never goes negative', () => {
+    expect(calcRiskScore({ hbvVaccinated: true })).toBe(0)
+  })
+})
+
+describe('classifyRisk', () => {
+  it('score 0 → none', () => {
+    expect(classifyRisk(0)).toBe('none')
+  })
+
+  it('score 1 → low', () => {
+    expect(classifyRisk(1)).toBe('low')
+  })
+
+  it('score 3 → low', () => {
+    expect(classifyRisk(3)).toBe('low')
+  })
+
+  it('score 4 → moderate', () => {
+    expect(classifyRisk(4)).toBe('moderate')
+  })
+
+  it('score 7 → moderate', () => {
+    expect(classifyRisk(7)).toBe('moderate')
+  })
+
+  it('score 8 → high', () => {
+    expect(classifyRisk(8)).toBe('high')
+  })
+
+  it('score 30 → high', () => {
+    expect(classifyRisk(30)).toBe('high')
+  })
+
+  it('handles invalid input as none', () => {
+    expect(classifyRisk(null)).toBe('none')
+    expect(classifyRisk(NaN)).toBe('none')
+    expect(classifyRisk(-1)).toBe('none')
+  })
+})
+
+describe('calcHepatitisRisk integration', () => {
+  it('no factors → none, score 0', () => {
+    const r = calcHepatitisRisk({})
+    expect(r.category).toBe('none')
+    expect(r.score).toBe(0)
+    expect(r.maxScore).toBeGreaterThan(20)
+  })
+
+  it('single low-weight factor → low', () => {
+    const r = calcHepatitisRisk({ tattooPiercingUnsterile: true })
+    expect(r.category).toBe('low')
+    expect(r.score).toBe(1)
+  })
+
+  it('two moderate factors → moderate', () => {
+    const r = calcHepatitisRisk({
+      birthCohort1945to1965: true,   // 2
+      hivPositive: true,             // 2
+    })
+    expect(r.score).toBe(4)
+    expect(r.category).toBe('moderate')
+  })
+
+  it('IDU plus pre-1992 transfusion → high', () => {
+    const r = calcHepatitisRisk({
+      injectionDrugUse: true,        // 4
+      transfusionBefore1992: true,   // 3
+      hivPositive: true,             // 2
+    })
+    expect(r.score).toBe(9)
+    expect(r.category).toBe('high')
+  })
+
+  it('IDU alone (4 pts) is moderate, not high', () => {
+    const r = calcHepatitisRisk({ injectionDrugUse: true })
+    expect(r.category).toBe('moderate')
+  })
+
+  it('HBV vaccination drops borderline moderate back to low', () => {
+    // 4 raw → 2 after vaccine bonus
+    const r = calcHepatitisRisk({
+      birthCohort1945to1965: true,
+      hivPositive: true,
+      hbvVaccinated: true,
+    })
+    expect(r.score).toBe(2)
+    expect(r.category).toBe('low')
+  })
+
+  it('exposes a stable list of factor keys without hbvVaccinated', () => {
+    expect(FACTOR_KEYS).not.toContain('hbvVaccinated')
+    expect(FACTOR_KEYS).toContain('injectionDrugUse')
+    expect(FACTOR_KEYS.length).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -67,7 +67,7 @@ describe('generateLlmsTxt', () => {
 
   it('generates 240 links (61 calcs × 2 locales + 59 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(240)
+    expect(links).toHaveLength(244)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -17,7 +17,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore', 'osteoporosisRisk',
+  'apgarScore', 'osteoporosisRisk', 'hepatitisRisk',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -67,6 +67,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'anaemie-risiko-berechnen',
   'apgar-score-bewerten',
   'osteoporose-risiko-berechnen',
+  'hepatitis-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -116,12 +117,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'anemia-risk-calculator-guide',
   'apgar-score-calculator-guide',
   'osteoporosis-risk-calculator-guide',
+  'hepatitis-risk-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
   it('discovers all 60 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(61)
+    expect(metas).toHaveLength(62)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -162,7 +164,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 58 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(59)
+    expect(de).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
@@ -171,7 +173,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 58 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(59)
+    expect(en).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -241,7 +243,7 @@ describe('generateSitemap', () => {
 
   it('generates correct total URL count (2 home + 120 calcs + 2 blog index + 116 blog articles = 240)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(244)
+    expect(urlCount).toBe(248)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -530,6 +530,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'osteoporosisRisk',
     related: ['vitamin-d-calculator', 'biological-age-calculator', 'calculate-bmi'],
   },
+  {
+    slug: 'hepatitis-risk-calculator-guide',
+    title: 'Hepatitis Risk Calculator: Screen for Hepatitis B and C from Exposure Factors',
+    description: 'Estimate hepatitis B and C risk from 13 evidence-based exposure factors. Transmission routes, vaccination, post-exposure prophylaxis, and diagnostics — clearly explained.',
+    date: '2026-05-07',
+    readTime: '9 min',
+    calculatorKey: 'hepatitisRisk',
+    related: ['blood-alcohol-calculator', 'alcohol-unit-calculator', 'anemia-risk-calculator-guide'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -530,6 +530,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'osteoporosisRisk',
     related: ['vitamin-d-berechnen', 'biologisches-alter-berechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'hepatitis-risiko-berechnen',
+    title: 'Hepatitis-Risiko berechnen: Hepatitis B und C aus Expositionsfaktoren erkennen',
+    description: 'Hepatitis-B- und -C-Risiko aus 13 evidenzbasierten Expositionsfaktoren einschätzen. Übertragungswege, Impfschutz, Postexpositionsprophylaxe und Diagnostik — kompakt erklärt.',
+    date: '2026-05-07',
+    readTime: '9 min',
+    calculatorKey: 'hepatitisRisk',
+    related: ['promille-berechnen', 'alkohol-einheiten-berechnen', 'anaemie-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/hepatitisRisk.json
+++ b/src/locales/calculators/de/hepatitisRisk.json
@@ -1,0 +1,96 @@
+{
+  "home": {
+    "calculators": {
+      "hepatitisRisk": {
+        "name": "Hepatitis-Risiko-Rechner",
+        "description": "Schätze dein Risiko für Hepatitis B und C aus Expositionsfaktoren ein."
+      }
+    }
+  },
+  "hepatitisRisk": {
+    "meta": {
+      "title": "Hepatitis-Risiko-Rechner — Hepatitis B & C aus Risikofaktoren einschätzen",
+      "description": "Berechne dein Risiko für Hepatitis B und C aus 13 evidenzbasierten Expositionsfaktoren. CDC- und WHO-Empfehlungen, Schweregrad-Einstufung, klare Handlungsempfehlung. Kostenlos, sofort, ohne Anmeldung."
+    },
+    "title": "Hepatitis-Risiko-Rechner",
+    "description": "Schätze dein Risiko für eine Hepatitis-B- oder -C-Infektion aus 13 typischen Expositionsfaktoren — basierend auf CDC- und WHO-Screening-Empfehlungen.",
+    "factorsLabel": "Risikofaktoren (alle zutreffenden ankreuzen)",
+    "protectionLabel": "Schutzfaktoren",
+    "factor_bornHighPrevalence": "Geboren in HBV-Hochprävalenzland",
+    "factor_bornHighPrevalence_desc": "Asien, Afrika südlich der Sahara, Pazifik-Inseln, Osteuropa — chronische HBV-Prävalenz ≥ 2 %",
+    "factor_birthCohort1945to1965": "Geboren zwischen 1945 und 1965",
+    "factor_birthCohort1945to1965_desc": "CDC-HCV-Geburtskohorte mit erhöhter HCV-Prävalenz",
+    "factor_injectionDrugUse": "Intravenöser Drogenkonsum (jemals)",
+    "factor_injectionDrugUse_desc": "Auch einmaliger Nadeltausch — wichtigster Risikofaktor für HCV",
+    "factor_transfusionBefore1992": "Bluttransfusion vor 1992",
+    "factor_transfusionBefore1992_desc": "Vor systematischem HCV-Screening; auch Organtransplantate vor 1992",
+    "factor_tattooPiercingUnsterile": "Tattoo / Piercing in nicht zertifizierter Praxis",
+    "factor_tattooPiercingUnsterile_desc": "Im Ausland, im Gefängnis oder ohne Einwegnadeln gestochen",
+    "factor_multipleSexPartners": "Mehrere ungeschützte Sexualpartner",
+    "factor_multipleSexPartners_desc": "≥ 4 Partner in 6 Monaten oder ungeschützter Analverkehr",
+    "factor_hivPositive": "HIV-Infektion",
+    "factor_hivPositive_desc": "Gleiche Übertragungswege — Koinfektion ist häufig",
+    "factor_healthcareNeedlestick": "Nadelstichverletzung im Gesundheitswesen",
+    "factor_healthcareNeedlestick_desc": "Beruflicher Kontakt mit Blut oder Körperflüssigkeiten",
+    "factor_householdContactInfected": "Hepatitis-positiver Haushaltskontakt",
+    "factor_householdContactInfected_desc": "Gemeinsame Rasierer, Zahnbürsten oder Spritzen möglich",
+    "factor_hemodialysis": "Langzeit-Hämodialyse",
+    "factor_hemodialysis_desc": "Erhöhtes nosokomiales HCV-Risiko bei chronischer Dialyse",
+    "factor_incarcerated": "Längere Haftaufenthalte",
+    "factor_incarcerated_desc": "≥ 6 Monate Haft — erhöhte HCV-Prävalenz im Strafvollzug",
+    "factor_maternalInfection": "Mutter HBV- oder HCV-positiv",
+    "factor_maternalInfection_desc": "Perinatales Übertragungsrisiko, besonders bei HBV ohne Impfung",
+    "factor_elevatedLiverEnzymes": "Erhöhte Leberwerte (ALT/AST)",
+    "factor_elevatedLiverEnzymes_desc": "Unklar erhöhte Transaminasen — Hepatitis muss ausgeschlossen werden",
+    "factor_hbvVaccinated": "Vollständige HBV-Impfung",
+    "factor_hbvVaccinated_desc": "Drei Dosen Hepatitis-B-Impfung mit dokumentierter Anti-HBs-Antwort > 10 IU/L",
+    "resultsLabel": "Dein Hepatitis-Risiko",
+    "scoreLabel": "Risiko-Score",
+    "bandLabel": "Schweregrad",
+    "category_none": "Kein Risiko",
+    "category_low": "Niedrig",
+    "category_moderate": "Moderat",
+    "category_high": "Hoch",
+    "advice_none": "Keine bekannten Risikofaktoren. Eine Routine-Hepatitis-Untersuchung ist nicht zwingend nötig — sprich beim Hausarzt aber bei unklaren Beschwerden.",
+    "advice_low": "Niedriges Risiko — eine einmalige Hepatitis-B- und -C-Testung beim Hausarzt ist sinnvoll. Bestehender Impfschutz für HBV sollte aufgefrischt werden.",
+    "advice_moderate": "Moderates Risiko — zeitnahe Testung auf HBsAg, Anti-HBc und Anti-HCV-Antikörper empfohlen. Bei Risikoexposition zusätzlich HCV-RNA-PCR. HBV-Impfung prüfen.",
+    "advice_high": "Hohes Risiko — Sofortige hausärztliche Vorstellung mit kompletter Hepatitis-Serologie inklusive HCV-PCR. Bei akuter Exposition (Nadelstich, ungeschützter Sex mit Infiziertem) Postexpositionsprophylaxe innerhalb von 72 Stunden möglich.",
+    "refTitle": "Risiko-Bänder & Empfehlungen",
+    "refBand": "Schweregrad",
+    "refScore": "Score",
+    "refAction": "Empfehlung",
+    "refAction_none": "Keine routinemäßige Testung nötig",
+    "refAction_low": "Einmalige Testung sinnvoll",
+    "refAction_moderate": "Zeitnahe Serologie + ggf. PCR",
+    "refAction_high": "Sofortige Diagnostik & Beratung",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner gewichtet 13 von CDC und WHO empfohlene Screening-Faktoren. Intravenöser Drogenkonsum (4 Punkte) hat das höchste Einzelgewicht, da er der wichtigste HCV-Übertragungsweg ist. Bluttransfusionen vor 1992 (3) und perinatale Übertragung (3) wiegen ebenfalls schwer. Eine vollständige HBV-Impfung subtrahiert 2 Punkte vom Score (mindestens 0), da sie HBV-Infektionen verhindert — HCV bleibt jedoch unabhängig davon möglich. Score-Bänder: 0 keine, 1–3 niedrig, 4–7 moderat, ≥ 8 hoch.",
+    "disclaimer": "Dieser Rechner dient zur Selbsteinschätzung und ersetzt keine ärztliche Diagnostik. Eine sichere Diagnose ist nur über Bluttests möglich (HBsAg, Anti-HBc, Anti-HCV). Bei akuter Exposition mit infiziertem Material — z. B. Nadelstich, sexueller Kontakt mit nachgewiesenem Träger — sofort die Notaufnahme oder den ärztlichen Notdienst aufsuchen, da eine Postexpositionsprophylaxe nur innerhalb der ersten 72 Stunden wirksam ist.",
+    "faq": [
+      {
+        "q": "Was ist Hepatitis B und C?",
+        "a": "Hepatitis B (HBV) und Hepatitis C (HCV) sind virale Leberentzündungen. HBV wird vor allem sexuell und perinatal übertragen, HCV überwiegend durch Blut. Beide können chronisch verlaufen und langfristig zu Leberzirrhose oder Leberkrebs führen."
+      },
+      {
+        "q": "Wie wird Hepatitis übertragen?",
+        "a": "HBV: ungeschützter Geschlechtsverkehr, Mutter-Kind-Übertragung, Nadelstiche, geteilte Spritzen. HCV: vor allem geteilte Spritzen, unsteril gestochene Tattoos, Bluttransfusionen vor 1992, seltener sexuell. HAV (Hepatitis A) wird hingegen fäkal-oral via verseuchte Lebensmittel übertragen — und ist durch unseren Rechner nicht abgedeckt."
+      },
+      {
+        "q": "Wer sollte sich auf Hepatitis testen lassen?",
+        "a": "CDC und WHO empfehlen ein einmaliges HCV-Screening für alle Erwachsenen ≥ 18 Jahre und ein HBV-Screening bei jedem Risikofaktor. Schwangere werden in Deutschland routinemäßig auf HBsAg getestet. Bei Personen mit erhöhten Leberwerten ist immer eine Hepatitis-Diagnostik angezeigt."
+      },
+      {
+        "q": "Welche Tests werden gemacht?",
+        "a": "Für HBV: HBsAg (akute oder chronische Infektion), Anti-HBc (durchgemachte Infektion), Anti-HBs (Impfschutz). Für HCV: Anti-HCV-Antikörper (Screening), bei positivem Ergebnis HCV-RNA-PCR zur Bestätigung einer aktiven Infektion. Plus ALT/AST als Marker für Leberentzündung."
+      },
+      {
+        "q": "Ist Hepatitis heilbar?",
+        "a": "Hepatitis C ist seit 2014 durch direkt wirksame Antivirale (DAA) in über 95 % der Fälle in 8–12 Wochen heilbar. Hepatitis B ist meist nicht heilbar, aber mit Tenofovir oder Entecavir gut kontrollierbar; eine akute HBV bei Erwachsenen heilt in 90–95 % spontan aus."
+      },
+      {
+        "q": "Wie kann ich mich schützen?",
+        "a": "HBV: Impfung mit drei Dosen schützt langfristig (in Deutschland Standardimpfung ab Geburt seit 1995). Sicherer Sex, keine geteilten Nadeln, sterile Tätowierung. HCV: Es gibt keinen Impfstoff — daher konsequent Risikoexposition vermeiden, vor allem keine geteilten Spritzen oder Schnupfröhrchen."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/hepatitisRisk.json
+++ b/src/locales/calculators/en/hepatitisRisk.json
@@ -1,0 +1,96 @@
+{
+  "home": {
+    "calculators": {
+      "hepatitisRisk": {
+        "name": "Hepatitis Risk Calculator",
+        "description": "Estimate your hepatitis B and C risk from exposure factors."
+      }
+    }
+  },
+  "hepatitisRisk": {
+    "meta": {
+      "title": "Hepatitis Risk Calculator — Screen for Hepatitis B & C from Exposure Factors",
+      "description": "Estimate your hepatitis B and C risk from 13 evidence-based exposure factors. CDC and WHO screening criteria, severity grading, and clear next steps. Free, instant, no sign-up."
+    },
+    "title": "Hepatitis Risk Calculator",
+    "description": "Estimate your hepatitis B and C infection risk from 13 typical exposure factors — based on CDC and WHO screening recommendations.",
+    "factorsLabel": "Risk factors (check all that apply)",
+    "protectionLabel": "Protective factors",
+    "factor_bornHighPrevalence": "Born in HBV high-prevalence country",
+    "factor_bornHighPrevalence_desc": "Asia, sub-Saharan Africa, Pacific Islands, Eastern Europe — chronic HBV prevalence ≥ 2 %",
+    "factor_birthCohort1945to1965": "Born between 1945 and 1965",
+    "factor_birthCohort1945to1965_desc": "CDC HCV birth cohort with elevated HCV prevalence",
+    "factor_injectionDrugUse": "Injection drug use (ever)",
+    "factor_injectionDrugUse_desc": "Even one-time needle sharing — the dominant HCV transmission route",
+    "factor_transfusionBefore1992": "Blood transfusion before 1992",
+    "factor_transfusionBefore1992_desc": "Pre-systematic HCV screening era; also organ transplants before 1992",
+    "factor_tattooPiercingUnsterile": "Tattoo / piercing in non-licensed setting",
+    "factor_tattooPiercingUnsterile_desc": "Done abroad, in prison, or without single-use needles",
+    "factor_multipleSexPartners": "Multiple unprotected sex partners",
+    "factor_multipleSexPartners_desc": "≥ 4 partners in 6 months or unprotected anal intercourse",
+    "factor_hivPositive": "HIV infection",
+    "factor_hivPositive_desc": "Shared transmission routes — co-infection is common",
+    "factor_healthcareNeedlestick": "Healthcare needlestick injury",
+    "factor_healthcareNeedlestick_desc": "Occupational exposure to blood or body fluids",
+    "factor_householdContactInfected": "Hepatitis-positive household contact",
+    "factor_householdContactInfected_desc": "Shared razors, toothbrushes, or needles possible",
+    "factor_hemodialysis": "Long-term hemodialysis",
+    "factor_hemodialysis_desc": "Elevated nosocomial HCV risk during chronic dialysis",
+    "factor_incarcerated": "Long-term incarceration",
+    "factor_incarcerated_desc": "≥ 6 months — elevated HCV prevalence in correctional settings",
+    "factor_maternalInfection": "Mother HBV- or HCV-positive",
+    "factor_maternalInfection_desc": "Perinatal transmission risk, especially HBV without vaccination",
+    "factor_elevatedLiverEnzymes": "Elevated liver enzymes (ALT/AST)",
+    "factor_elevatedLiverEnzymes_desc": "Unexplained transaminase elevation — hepatitis must be ruled out",
+    "factor_hbvVaccinated": "Complete HBV vaccination",
+    "factor_hbvVaccinated_desc": "Three-dose hepatitis B vaccine with documented anti-HBs response > 10 IU/L",
+    "resultsLabel": "Your hepatitis risk",
+    "scoreLabel": "Risk score",
+    "bandLabel": "Severity",
+    "category_none": "No risk",
+    "category_low": "Low",
+    "category_moderate": "Moderate",
+    "category_high": "High",
+    "advice_none": "No known risk factors. Routine hepatitis screening is not strictly required — speak to your GP if you have unexplained symptoms.",
+    "advice_low": "Low risk — a one-time hepatitis B and C test through your GP is sensible. Verify HBV vaccine immunity and consider a booster.",
+    "advice_moderate": "Moderate risk — book HBsAg, anti-HBc, and anti-HCV antibody testing soon. With exposure also test HCV-RNA by PCR. Review HBV vaccination status.",
+    "advice_high": "High risk — see a clinician promptly for full hepatitis serology including HCV-PCR. After acute exposure (needlestick, unprotected sex with a known carrier) post-exposure prophylaxis is possible within 72 hours.",
+    "refTitle": "Risk bands & recommendations",
+    "refBand": "Severity",
+    "refScore": "Score",
+    "refAction": "Recommendation",
+    "refAction_none": "No routine testing needed",
+    "refAction_low": "One-time test advised",
+    "refAction_moderate": "Prompt serology + possible PCR",
+    "refAction_high": "Immediate workup & counseling",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator weights 13 CDC- and WHO-recommended screening factors. Injection drug use carries the highest single weight (4 points) because it is the leading HCV transmission route. Pre-1992 transfusions (3) and perinatal transmission (3) also weigh heavily. A complete HBV vaccination subtracts 2 points (floor at 0) because it prevents HBV infection — HCV remains independently possible. Bands: 0 none, 1–3 low, 4–7 moderate, ≥ 8 high.",
+    "disclaimer": "This calculator is for self-assessment and does not replace clinical diagnostics. Confirmed diagnosis requires blood tests (HBsAg, anti-HBc, anti-HCV). After acute exposure to known infected material — needlestick, sex with a confirmed carrier — go to an emergency department immediately, since post-exposure prophylaxis is only effective within the first 72 hours.",
+    "faq": [
+      {
+        "q": "What are hepatitis B and C?",
+        "a": "Hepatitis B (HBV) and Hepatitis C (HCV) are viral liver infections. HBV is mostly transmitted sexually and perinatally; HCV mostly through blood. Both can become chronic and lead to cirrhosis or liver cancer over the long term."
+      },
+      {
+        "q": "How is hepatitis transmitted?",
+        "a": "HBV: unprotected sex, mother-to-child transmission, needlesticks, shared injection equipment. HCV: shared injection equipment, unsterile tattoos, transfusions before 1992, less commonly sexual. HAV (hepatitis A) spreads via the fecal-oral route through contaminated food and is not covered by this calculator."
+      },
+      {
+        "q": "Who should be tested for hepatitis?",
+        "a": "CDC and WHO recommend a one-time HCV screen for all adults aged ≥ 18 and HBV screening for anyone with a risk factor. Pregnant women are routinely tested for HBsAg. Anyone with unexplained elevated liver enzymes should also be screened."
+      },
+      {
+        "q": "What tests are run?",
+        "a": "For HBV: HBsAg (acute or chronic infection), anti-HBc (past infection), anti-HBs (vaccine immunity). For HCV: anti-HCV antibodies (screening), confirmed by HCV-RNA PCR for active infection. Plus ALT/AST as markers of liver inflammation."
+      },
+      {
+        "q": "Is hepatitis curable?",
+        "a": "Hepatitis C has been curable since 2014 with direct-acting antivirals (DAAs) in over 95 % of cases within 8–12 weeks. Hepatitis B is usually not curable but well controlled with tenofovir or entecavir; acute HBV in adults clears spontaneously in 90–95 % of cases."
+      },
+      {
+        "q": "How can I protect myself?",
+        "a": "HBV: a three-dose vaccine provides long-term protection (standard immunization in many countries since the 1990s). Practice safer sex, avoid shared needles, use licensed tattoo and piercing studios. HCV: there is no vaccine — strict avoidance of risk exposure, especially shared injection or snorting equipment."
+      }
+    ]
+  }
+}

--- a/src/pages/HepatitisRiskCalculator.vue
+++ b/src/pages/HepatitisRiskCalculator.vue
@@ -1,0 +1,189 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcHepatitisRisk, FACTOR_WEIGHTS } from '../utils/hepatitisRisk.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('hepatitisRisk.faq') || [])
+
+useHead(() => ({
+  title: t('hepatitisRisk.meta.title'),
+  description: t('hepatitisRisk.meta.description'),
+  routeKey: 'hepatitisRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Hepatitis Risk Calculator',
+    url: 'https://healthcalculator.app/hepatitis-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const factors = ref({
+  bornHighPrevalence: false,
+  birthCohort1945to1965: false,
+  injectionDrugUse: false,
+  transfusionBefore1992: false,
+  tattooPiercingUnsterile: false,
+  multipleSexPartners: false,
+  hivPositive: false,
+  healthcareNeedlestick: false,
+  householdContactInfected: false,
+  hemodialysis: false,
+  incarcerated: false,
+  maternalInfection: false,
+  elevatedLiverEnzymes: false,
+  hbvVaccinated: false,
+})
+
+const factorList = Object.keys(FACTOR_WEIGHTS).map(key => ({
+  key,
+  points: FACTOR_WEIGHTS[key],
+}))
+
+const result = computed(() => calcHepatitisRisk(factors.value))
+
+const categoryStyle = computed(() => {
+  switch (result.value.category) {
+    case 'none': return { color: 'text-green-600', bg: 'bg-green-50 border-green-200 text-green-900' }
+    case 'low': return { color: 'text-yellow-600', bg: 'bg-yellow-50 border-yellow-200 text-yellow-900' }
+    case 'moderate': return { color: 'text-orange-500', bg: 'bg-orange-50 border-orange-200 text-orange-900' }
+    case 'high': return { color: 'text-red-700', bg: 'bg-red-100 border-red-300 text-red-900' }
+    default: return { color: '', bg: '' }
+  }
+})
+
+const categoryLevel = computed(() => {
+  return { none: 0, low: 1, moderate: 2, high: 3 }[result.value.category] ?? 0
+})
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('hepatitisRisk.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('hepatitisRisk.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('hepatitisRisk.factorsLabel') }}</p>
+    <div class="space-y-3">
+      <label
+        v-for="f in factorList"
+        :key="f.key"
+        :data-testid="'factor-' + f.key"
+        :class="factors[f.key] ? 'border-stone-900 bg-stone-50' : 'border-stone-200 hover:border-stone-300'"
+        class="flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-colors duration-150"
+      >
+        <input
+          v-model="factors[f.key]"
+          type="checkbox"
+          :data-testid="'checkbox-' + f.key"
+          class="mt-1 h-5 w-5 rounded border-stone-300 text-stone-900 focus:ring-stone-600"
+        />
+        <div class="flex-1 min-w-0">
+          <div class="flex items-baseline justify-between gap-3">
+            <p class="text-sm font-semibold text-stone-900">{{ t('hepatitisRisk.factor_' + f.key) }}</p>
+            <span class="text-xs font-semibold text-stone-400 tabular-nums">+{{ f.points }}</span>
+          </div>
+          <p class="text-xs text-stone-500 leading-relaxed mt-1">{{ t('hepatitisRisk.factor_' + f.key + '_desc') }}</p>
+        </div>
+      </label>
+    </div>
+
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mt-8 mb-3">{{ t('hepatitisRisk.protectionLabel') }}</p>
+    <label
+      data-testid="factor-hbvVaccinated"
+      :class="factors.hbvVaccinated ? 'border-green-700 bg-green-50' : 'border-stone-200 hover:border-stone-300'"
+      class="flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-colors duration-150"
+    >
+      <input
+        v-model="factors.hbvVaccinated"
+        type="checkbox"
+        data-testid="checkbox-hbvVaccinated"
+        class="mt-1 h-5 w-5 rounded border-stone-300 text-stone-900 focus:ring-stone-600"
+      />
+      <div class="flex-1 min-w-0">
+        <div class="flex items-baseline justify-between gap-3">
+          <p class="text-sm font-semibold text-stone-900">{{ t('hepatitisRisk.factor_hbvVaccinated') }}</p>
+          <span class="text-xs font-semibold text-green-700 tabular-nums">−2</span>
+        </div>
+        <p class="text-xs text-stone-500 leading-relaxed mt-1">{{ t('hepatitisRisk.factor_hbvVaccinated_desc') }}</p>
+      </div>
+    </label>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('hepatitisRisk.resultsLabel') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold tabular-nums tracking-tight leading-none" :class="categoryStyle.color" data-testid="result-status">{{ t('hepatitisRisk.category_' + result.category) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-yellow-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (categoryLevel / 3 * 100) + '%' }"></div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="risk-score">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('hepatitisRisk.scoreLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.score }}<span class="text-lg text-stone-400 font-medium"> / {{ result.maxScore }}</span></p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="risk-band">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('hepatitisRisk.bandLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900">{{ t('hepatitisRisk.category_' + result.category) }}</p>
+      </div>
+    </div>
+
+    <div class="rounded-lg p-4 text-sm font-medium border" :class="categoryStyle.bg" data-testid="advice">
+      {{ t('hepatitisRisk.advice_' + result.category) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('hepatitisRisk.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('hepatitisRisk.refBand') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('hepatitisRisk.refScore') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('hepatitisRisk.refAction') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('hepatitisRisk.category_none') }}</td><td class="px-6 py-3 text-stone-600">0</td><td class="px-6 py-3 text-stone-600">{{ t('hepatitisRisk.refAction_none') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('hepatitisRisk.category_low') }}</td><td class="px-6 py-3 text-stone-600">1–3</td><td class="px-6 py-3 text-stone-600">{{ t('hepatitisRisk.refAction_low') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('hepatitisRisk.category_moderate') }}</td><td class="px-6 py-3 text-stone-600">4–7</td><td class="px-6 py-3 text-stone-600">{{ t('hepatitisRisk.refAction_moderate') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('hepatitisRisk.category_high') }}</td><td class="px-6 py-3 text-stone-600">≥ 8</td><td class="px-6 py-3 text-stone-600">{{ t('hepatitisRisk.refAction_high') }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('hepatitisRisk.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('hepatitisRisk.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('hepatitisRisk.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="hepatitisRisk" />
+</template>

--- a/src/pages/blog/HepatitisRisikoBerechnen.vue
+++ b/src/pages/blog/HepatitisRisikoBerechnen.vue
@@ -1,0 +1,183 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Hepatitis-Risiko berechnen: Hepatitis B und C aus Expositionsfaktoren erkennen | Health Calculators',
+  description: 'Hepatitis-B- und -C-Risiko aus 13 evidenzbasierten Expositionsfaktoren einschätzen. Übertragungswege, CDC-Geburtskohorte, Impfschutz, Postexpositionsprophylaxe und Diagnostik — kompakt erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Hepatitis-Risiko berechnen: Hepatitis B und C aus Expositionsfaktoren erkennen',
+    description: 'Hepatitis-B- und -C-Risiko aus 13 evidenzbasierten Expositionsfaktoren einschätzen. Übertragungswege, CDC-Geburtskohorte, Impfschutz, Postexpositionsprophylaxe und Diagnostik — kompakt erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-07',
+    dateModified: '2026-05-07',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/hepatitis-risiko-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Hepatitis-Risiko berechnen: Hepatitis B und C aus Expositionsfaktoren erkennen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">7. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Weltweit leben rund <strong>296 Millionen Menschen mit chronischer Hepatitis B</strong> und <strong>58 Millionen mit Hepatitis C</strong> — die meisten ohne es zu wissen. Beide Erkrankungen verlaufen jahrelang stumm, bevor Leberzirrhose oder Leberkrebs entstehen. Frühe Erkennung ändert den Verlauf radikal.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Ratgeber zeigt, wie du dein persönliches Hepatitis-Risiko quantifizierst — anhand von 13 von CDC und WHO empfohlenen Expositionsfaktoren. Wer in eine moderate oder hohe Kategorie fällt, sollte sich gezielt testen lassen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hepatitis B vs. Hepatitis C — was unterscheidet sie?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Beide Viren befallen die Leber, unterscheiden sich aber in Übertragungsweg, Verlauf und Therapie:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Merkmal</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Hepatitis B (HBV)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Hepatitis C (HCV)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Übertragung</td><td class="px-6 py-3 text-stone-600">Sex, perinatal, Blut</td><td class="px-6 py-3 text-stone-600">Vorrangig Blut (i.v.)</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Chronifizierung</td><td class="px-6 py-3 text-stone-600">5–10 % der Erwachsenen</td><td class="px-6 py-3 text-stone-600">75–85 % aller Infektionen</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Impfung</td><td class="px-6 py-3 text-stone-600">Ja (3 Dosen, hoch wirksam)</td><td class="px-6 py-3 text-stone-600">Nein</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Therapie</td><td class="px-6 py-3 text-stone-600">Tenofovir / Entecavir (Suppression)</td><td class="px-6 py-3 text-stone-600">DAA — Heilung in &gt; 95 %</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Inkubationszeit</td><td class="px-6 py-3 text-stone-600">30–180 Tage</td><td class="px-6 py-3 text-stone-600">14–180 Tage</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wichtig: <strong>Hepatitis A</strong> wird fäkal-oral via verseuchte Lebensmittel übertragen und ist von dieser Risikoanalyse nicht erfasst. Reisende in Endemiegebiete sollten sich gegen HAV impfen lassen — der Schutz hält 20+ Jahre.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die 13 wichtigsten Risikofaktoren</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Unser Rechner gewichtet 13 Faktoren, die in den CDC- und WHO-Empfehlungen explizit als Screening-Indikation genannt werden:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Faktor</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Punkte</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bedeutung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">i.v.-Drogenkonsum</td><td class="px-6 py-3 text-stone-600">4</td><td class="px-6 py-3 text-stone-600">Wichtigster HCV-Übertragungsweg weltweit</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Transfusion vor 1992</td><td class="px-6 py-3 text-stone-600">3</td><td class="px-6 py-3 text-stone-600">Vor systematischem Spender-Screening</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hämodialyse</td><td class="px-6 py-3 text-stone-600">3</td><td class="px-6 py-3 text-stone-600">Erhöhtes nosokomiales Risiko</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Infizierte Mutter</td><td class="px-6 py-3 text-stone-600">3</td><td class="px-6 py-3 text-stone-600">Perinatale HBV-Übertragung in 70–90 % ohne Impfung</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">HBV-Hochprävalenzland</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Ostasien, Subsahara-Afrika, Pazifik</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Geboren 1945–1965</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">CDC-Geburtskohorte mit erhöhter HCV-Prävalenz</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">HIV-Infektion</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Gleiche Übertragungswege, häufige Koinfektion</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Nadelstich beruflich</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">HBV 30 %, HCV 1,8 % Übertragung pro Vorfall</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Erhöhte Leberwerte</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Unklare ALT/AST-Erhöhung muss abgeklärt werden</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hep+-Haushaltskontakt</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Geteilte Rasierer/Zahnbürsten als Übertragungsquelle</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Unsteriles Tattoo/Piercing</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Im Ausland oder ohne Einwegnadel</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Mehrere Sexpartner</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">≥ 4 Partner in 6 Monaten oder ungeschützt</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Längere Haft</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Erhöhte Prävalenz im Strafvollzug</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Eine vollständige <strong>HBV-Impfung subtrahiert 2 Punkte</strong> vom Score, aber nie unter null — sie schützt nur vor HBV, nicht vor HCV.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt Hepatitis-Risiko berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">13 Expositionsfaktoren plus Impfstatus — sofortiges Ergebnis mit Schweregrad und ärztlicher Empfehlung. Anonym und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('hepatitisRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Welche Tests bei Verdacht?</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HBsAg:</strong> Hepatitis-B-Oberflächenantigen — positiv bei akuter oder chronischer Infektion.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anti-HBc:</strong> Antikörper gegen das Core-Antigen — Marker für durchgemachte oder bestehende HBV-Infektion.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anti-HBs:</strong> Schutzantikörper nach Impfung oder ausgeheilter Infektion (Titer &gt; 10 IU/L gilt als immun).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anti-HCV:</strong> Hepatitis-C-Antikörper-Suchtest. Bei positivem Ergebnis Bestätigung mit HCV-RNA-PCR.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HCV-RNA-PCR:</strong> Direkter Virusnachweis — unterscheidet aktive Infektion von ausgeheilter.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>ALT/AST:</strong> Transaminasen als Marker für Leberentzündung — meist erhöht, aber nicht spezifisch.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Postexpositionsprophylaxe (PEP)</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei akuter Exposition — etwa Nadelstich oder ungeschützter Sexualkontakt mit nachgewiesenem HBV-Träger — sollte <strong>innerhalb von 72 Stunden</strong> eine Postexpositionsprophylaxe erwogen werden:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HBV-PEP:</strong> Aktive Impfung plus Hepatitis-B-Hyperimmunglobulin (HBIG) bei ungeimpften oder seronegativen Exponierten.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HCV:</strong> Keine PEP verfügbar — engmaschige Verlaufskontrolle (HCV-RNA nach 4 und 12 Wochen). Bei nachgewiesener Infektion frühe DAA-Therapie möglich.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Therapie und Heilung</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Hepatitis C ist heute heilbar.</strong> Direkt wirksame Antivirale (Sofosbuvir/Velpatasvir, Glecaprevir/Pibrentasvir) erreichen in 8–12 Wochen Heilungsraten von &gt; 95 % — fast ohne Nebenwirkungen. Die Therapiekosten werden in Deutschland von den gesetzlichen Krankenkassen übernommen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Hepatitis B</strong> ist meist nicht eliminierbar, aber mit Tenofovir oder Entecavir gut suppressierbar — die Virus-DNA fällt unter die Nachweisgrenze, und das Risiko für Zirrhose und Leberkrebs sinkt deutlich. Eine akute Hepatitis B beim Erwachsenen heilt in 90–95 % der Fälle spontan aus.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hepatitis-Risiko überschneidet sich mit anderen Lebererkrankungen und Übertragungsrisiken. Wer Alkohol als zusätzlichen Leberstressor einschätzen möchte, nutzt den
+          <router-link :to="localeBlogPath('promille-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Promille-Rechner</router-link>
+          oder die längerfristigen
+          <router-link :to="localeBlogPath('alkohol-einheiten-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Alkohol-Einheiten</router-link>.
+          Bei chronischer Müdigkeit als HCV-Frühzeichen lohnt zudem der Blick auf den
+          <router-link :to="localeBlogPath('anaemie-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Anämie-Risiko-Rechner</router-link>,
+          da chronische Lebererkrankungen häufig mit Blutarmut einhergehen.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Hepatitis B und C sind häufig, aber meist symptomarm. Die wichtigste Frage lautet: gibt es Risikofaktoren? Mit unserem
+          <router-link :to="localePath('hepatitisRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Hepatitis-Risiko-Rechner</router-link>
+          erkennst du in Sekunden, ob ein Test sinnvoll ist. Je früher eine chronische Hepatitis entdeckt wird, desto besser sind die Therapie- und Heilungsaussichten — und HCV ist heute in den allermeisten Fällen vollständig heilbar.
+        </p>
+      </div>
+
+      <RelatedArticles slug="hepatitis-risiko-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/HepatitisRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/HepatitisRiskCalculatorGuide.vue
@@ -1,0 +1,183 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Hepatitis Risk Calculator: Screen for Hepatitis B and C from Exposure Factors | Health Calculators',
+  description: 'Estimate hepatitis B and C risk from 13 evidence-based exposure factors. Transmission routes, CDC birth cohort, vaccination, post-exposure prophylaxis, and diagnostics — explained clearly.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Hepatitis Risk Calculator: Screen for Hepatitis B and C from Exposure Factors',
+    description: 'Estimate hepatitis B and C risk from 13 evidence-based exposure factors. Transmission routes, CDC birth cohort, vaccination, post-exposure prophylaxis, and diagnostics — explained clearly.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-07',
+    dateModified: '2026-05-07',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/hepatitis-risk-calculator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Hepatitis Risk Calculator: Screen for Hepatitis B and C from Exposure Factors</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 7, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Worldwide, an estimated <strong>296 million people live with chronic hepatitis B</strong> and <strong>58 million with hepatitis C</strong> — most without knowing it. Both diseases progress silently for years before cirrhosis or liver cancer appear. Early detection changes the trajectory dramatically.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide shows how to quantify your personal hepatitis risk — based on 13 CDC- and WHO-recommended exposure factors. Anyone in the moderate or high band should pursue targeted testing.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hepatitis B vs. hepatitis C — what's different?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Both viruses target the liver, but differ in transmission, course, and treatment:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Feature</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Hepatitis B (HBV)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Hepatitis C (HCV)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Transmission</td><td class="px-6 py-3 text-stone-600">Sex, perinatal, blood</td><td class="px-6 py-3 text-stone-600">Primarily blood (IV)</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Chronicity</td><td class="px-6 py-3 text-stone-600">5–10 % in adults</td><td class="px-6 py-3 text-stone-600">75–85 % of all infections</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Vaccine</td><td class="px-6 py-3 text-stone-600">Yes (3-dose, highly effective)</td><td class="px-6 py-3 text-stone-600">No</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Treatment</td><td class="px-6 py-3 text-stone-600">Tenofovir / entecavir (suppression)</td><td class="px-6 py-3 text-stone-600">DAAs — cure in &gt; 95 %</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Incubation</td><td class="px-6 py-3 text-stone-600">30–180 days</td><td class="px-6 py-3 text-stone-600">14–180 days</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Note: <strong>Hepatitis A</strong> spreads through contaminated food (fecal-oral route) and is not part of this risk model. Travelers to endemic regions should get the HAV vaccine, which protects for 20+ years.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The 13 most important risk factors</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The calculator weights 13 factors that CDC and WHO explicitly cite as a screening indication:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Factor</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Points</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Why it matters</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Injection drug use</td><td class="px-6 py-3 text-stone-600">4</td><td class="px-6 py-3 text-stone-600">Leading HCV transmission route worldwide</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Transfusion before 1992</td><td class="px-6 py-3 text-stone-600">3</td><td class="px-6 py-3 text-stone-600">Pre-systematic donor screening era</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Long-term hemodialysis</td><td class="px-6 py-3 text-stone-600">3</td><td class="px-6 py-3 text-stone-600">Elevated nosocomial risk</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Infected mother</td><td class="px-6 py-3 text-stone-600">3</td><td class="px-6 py-3 text-stone-600">Perinatal HBV transmission in 70–90 % without vaccine</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">High-prevalence country of birth</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">East Asia, sub-Saharan Africa, Pacific</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Born 1945–1965</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">CDC HCV birth cohort</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">HIV infection</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Shared routes; co-infection is common</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Occupational needlestick</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">HBV ~30 %, HCV ~1.8 % per incident</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Elevated liver enzymes</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Unexplained ALT/AST elevation needs workup</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hep+ household contact</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Shared razors / toothbrushes possible</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Unsterile tattoo / piercing</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Done abroad or without single-use needles</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Multiple sex partners</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">≥ 4 in 6 months or unprotected</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Long incarceration</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Elevated prevalence in correctional settings</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A complete <strong>HBV vaccination subtracts 2 points</strong> from the score (never below zero) — it protects against HBV, but not HCV.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Run the hepatitis risk calculator</h3>
+        <p class="text-stone-300 text-sm mb-5">13 exposure factors plus vaccination status — instant result with severity grade and clinical guidance. Anonymous and no sign-up.</p>
+        <router-link
+          :to="localePath('hepatitisRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What tests should you run?</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HBsAg:</strong> Hepatitis-B surface antigen — positive in acute or chronic infection.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anti-HBc:</strong> Antibody to the core antigen — marker of past or current HBV infection.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anti-HBs:</strong> Protective antibody from vaccine or cleared infection (titer &gt; 10 IU/L = immune).</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Anti-HCV:</strong> Hepatitis-C antibody screen. If positive, confirm with HCV-RNA PCR.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HCV-RNA PCR:</strong> Direct virus detection — distinguishes active from cleared infection.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>ALT/AST:</strong> Transaminases as markers of liver inflammation — usually elevated, but not specific.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Post-exposure prophylaxis (PEP)</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          After acute exposure — needlestick or unprotected sex with a confirmed HBV carrier — post-exposure prophylaxis should be considered <strong>within 72 hours</strong>:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HBV PEP:</strong> Active vaccination plus hepatitis-B immune globulin (HBIG) for unvaccinated or seronegative contacts.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>HCV:</strong> No PEP available — close monitoring (HCV-RNA at 4 and 12 weeks). If infection confirmed, early DAA therapy is possible.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Treatment and cure</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Hepatitis C is curable today.</strong> Direct-acting antivirals (sofosbuvir/velpatasvir, glecaprevir/pibrentasvir) achieve cure rates above 95 % in 8–12 weeks with virtually no side effects. In most countries, treatment cost is fully covered by insurance.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Hepatitis B</strong> usually cannot be eradicated, but tenofovir or entecavir suppress viral DNA below the detection limit and dramatically reduce the risk of cirrhosis and liver cancer. Acute hepatitis B in adults clears spontaneously in 90–95 % of cases.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hepatitis risk overlaps with other liver and transmission risks. To estimate alcohol as an additional liver stressor, see the
+          <router-link :to="localeBlogPath('blood-alcohol-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">blood alcohol calculator</router-link>
+          or the longer-term
+          <router-link :to="localeBlogPath('alcohol-unit-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">alcohol units guide</router-link>.
+          Chronic fatigue can be an early sign of HCV — the
+          <router-link :to="localeBlogPath('anemia-risk-calculator-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">anemia risk calculator</router-link>
+          is helpful here, since chronic liver disease often comes with anemia.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Summary</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Hepatitis B and C are common but mostly silent. The key question is: are there risk factors? With our
+          <router-link :to="localePath('hepatitisRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">hepatitis risk calculator</router-link>
+          you can answer that in seconds. The earlier chronic hepatitis is detected, the better treatment outcomes are — and HCV is now curable in the vast majority of cases.
+        </p>
+      </div>
+
+      <RelatedArticles slug="hepatitis-risk-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/hepatitisRisk.meta.js
+++ b/src/pages/hepatitisRisk.meta.js
@@ -1,0 +1,16 @@
+import Component from './HepatitisRiskCalculator.vue'
+import BlogDe from './blog/HepatitisRisikoBerechnen.vue'
+import BlogEn from './blog/en/HepatitisRiskCalculatorGuide.vue'
+
+export default {
+  key: 'hepatitisRisk',
+  component: Component,
+  slugs: { de: 'hepatitis-risiko-rechner', en: 'hepatitis-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 38,
+  blog: {
+    de: { slug: 'hepatitis-risiko-berechnen', component: BlogDe },
+    en: { slug: 'hepatitis-risk-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/hepatitisRisk.js
+++ b/src/utils/hepatitisRisk.js
@@ -1,0 +1,74 @@
+// Hepatitis B/C risk screening from CDC/WHO exposure-factor recommendations.
+//
+// Each risk factor adds weighted points. Total score maps to a band:
+//   0     → none
+//   1–3   → low
+//   4–7   → moderate
+//   ≥ 8   → high
+//
+// HBV vaccination subtracts 2 points (cap at 0) — it markedly reduces HBV
+// transmission risk but does not eliminate HCV risk, so the bonus is partial.
+//
+// Factor weights:
+//   bornHighPrevalence         (2)  CDC: HBV-endemic country of birth
+//   birthCohort1945to1965      (2)  CDC HCV-cohort
+//   injectionDrugUse           (4)  highest single risk factor for HCV
+//   transfusionBefore1992      (3)  pre-screening era
+//   tattooPiercingUnsterile    (1)  non-licensed setting
+//   multipleSexPartners        (1)  ≥4 partners in 6 months / unprotected
+//   hivPositive                (2)  shared transmission routes
+//   healthcareNeedlestick      (2)  occupational sharps exposure
+//   householdContactInfected   (2)  shared razors / toothbrushes possible
+//   hemodialysis               (3)  long-term dialysis
+//   incarcerated               (1)  long-term incarceration history
+//   maternalInfection          (3)  perinatal transmission risk
+//   elevatedLiverEnzymes       (2)  unexplained ALT/AST elevation
+
+const FACTOR_POINTS = {
+  bornHighPrevalence: 2,
+  birthCohort1945to1965: 2,
+  injectionDrugUse: 4,
+  transfusionBefore1992: 3,
+  tattooPiercingUnsterile: 1,
+  multipleSexPartners: 1,
+  hivPositive: 2,
+  healthcareNeedlestick: 2,
+  householdContactInfected: 2,
+  hemodialysis: 3,
+  incarcerated: 1,
+  maternalInfection: 3,
+  elevatedLiverEnzymes: 2,
+}
+
+const VACCINE_BONUS = 2
+const MAX_SCORE = Object.values(FACTOR_POINTS).reduce((a, b) => a + b, 0)
+
+export function calcRiskScore(factors) {
+  if (!factors || typeof factors !== 'object') return 0
+  let score = 0
+  for (const [key, points] of Object.entries(FACTOR_POINTS)) {
+    if (factors[key]) score += points
+  }
+  if (factors.hbvVaccinated) score = Math.max(0, score - VACCINE_BONUS)
+  return score
+}
+
+export function classifyRisk(score) {
+  if (typeof score !== 'number' || !Number.isFinite(score) || score < 0) return 'none'
+  if (score >= 8) return 'high'
+  if (score >= 4) return 'moderate'
+  if (score >= 1) return 'low'
+  return 'none'
+}
+
+export function calcHepatitisRisk(factors = {}) {
+  const score = calcRiskScore(factors)
+  return {
+    score,
+    maxScore: MAX_SCORE,
+    category: classifyRisk(score),
+  }
+}
+
+export const FACTOR_KEYS = Object.keys(FACTOR_POINTS)
+export const FACTOR_WEIGHTS = { ...FACTOR_POINTS }


### PR DESCRIPTION
## Summary
- Hepatitis B/C risk screening calculator from 13 CDC/WHO exposure factors (IDU, transfusion <1992, hemodialysis, perinatal, HIV, etc.) plus HBV vaccine bonus.
- Auto-discovered via `src/pages/hepatitisRisk.meta.js`. DE slug `hepatitis-risiko-rechner`, EN slug `hepatitis-risk-calculator`.
- Full DE/EN locales, SEO-optimized blog articles, internal links to alcohol/anemia calculators.

## Test plan
- [x] 23 unit tests for calc/classification (npm test → 1631 pass)
- [x] 8 E2E tests cover no-risk, low/moderate/high paths, vaccine bonus
- [x] SSG build green — sitemap 248 URLs, llms.txt 244 links
- [x] Auto-discovery + sitemap test counts bumped to 62 calcs / 60 blogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)