### PR TITLE
hc-190: WHtR-Rechner (Taille-zu-Größe-Verhältnis)

### DIFF
--- a/e2e/whtrRechner.spec.js
+++ b/e2e/whtrRechner.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/whtr-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/WHtR-Rechner/)
+})
+
+test('Taille 85 / Größe 175, Alter 35 → 0.486 low', async ({ page }) => {
+  await page.getByTestId('waist-input').fill('85')
+  await page.getByTestId('height-input').fill('175')
+  await page.getByTestId('age-input').fill('35')
+
+  const result = page.getByTestId('whtr-result')
+  await expect(result).toBeVisible()
+  expect(parseFloat(await result.textContent())).toBeCloseTo(0.486, 2)
+
+  await expect(page.getByTestId('whtr-zone')).toHaveText(/Niedriges Risiko/)
+})
+
+test('Taille 92 / Größe 175, Alter 35 → moderate', async ({ page }) => {
+  await page.getByTestId('waist-input').fill('92')
+  await page.getByTestId('height-input').fill('175')
+  await page.getByTestId('age-input').fill('35')
+
+  await expect(page.getByTestId('whtr-zone')).toHaveText(/Erhöhtes Risiko/)
+})
+
+test('Taille 110 / Größe 170, Alter 35 → high risk', async ({ page }) => {
+  await page.getByTestId('waist-input').fill('110')
+  await page.getByTestId('height-input').fill('170')
+  await page.getByTestId('age-input').fill('35')
+
+  await expect(page.getByTestId('whtr-zone')).toHaveText(/Sehr hohes Risiko/)
+})
+
+test('age over 50 shifts thresholds (95cm waist / 175cm at age 60 still low)', async ({ page }) => {
+  await page.getByTestId('waist-input').fill('95')
+  await page.getByTestId('height-input').fill('175')
+  await page.getByTestId('age-input').fill('60')
+
+  await expect(page.getByTestId('whtr-zone')).toHaveText(/Niedriges Risiko/)
+})
+
+test('result hidden until both values entered', async ({ page }) => {
+  await expect(page.getByTestId('whtr-result')).toHaveCount(0)
+  await page.getByTestId('waist-input').fill('85')
+  await expect(page.getByTestId('whtr-result')).toHaveCount(0)
+})
+
+test('back link navigates to home', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})
+
+test('trailing-slash canonical URL resolves', async ({ page }) => {
+  const response = await page.goto('/de/whtr-rechner/')
+  expect(response?.status()).toBeLessThan(400)
+  await expect(page).toHaveTitle(/WHtR-Rechner/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -23,7 +23,7 @@ const EXPECTED_KEYS = [
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore', 'osteoporosisRisk',
+  'apgarScore', 'osteoporosisRisk', 'whtrRechner',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -86,6 +86,7 @@ const EXPECTED_ROUTE_MAP = {
   anemiaRisk: { de: 'anaemie-risiko-rechner', en: 'anemia-risk-calculator' },
   apgarScore: { de: 'apgar-score-rechner', en: 'apgar-score-calculator' },
   osteoporosisRisk: { de: 'osteoporose-risiko-rechner', en: 'osteoporosis-risk-calculator' },
+  whtrRechner: { de: 'whtr-rechner', en: 'waist-to-height-ratio-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -136,6 +137,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'anaemie-risiko-berechnen',
   'apgar-score-bewerten',
   'osteoporose-risiko-berechnen',
+  'whtr-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -186,11 +188,12 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'anemia-risk-calculator-guide',
   'apgar-score-calculator-guide',
   'osteoporosis-risk-calculator-guide',
+  'calculate-waist-to-height-ratio',
 ]
 
 describe('calculator discovery', () => {
   it('discovers all 60 calculators', () => {
-    expect(calculatorMetas).toHaveLength(61)
+    expect(calculatorMetas).toHaveLength(62)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
@@ -198,7 +201,7 @@ describe('calculator discovery', () => {
   })
 
   it('builds calculatorComponents map for all 60 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(61)
+    expect(Object.keys(calculatorComponents)).toHaveLength(62)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -222,14 +225,14 @@ describe('calculator discovery', () => {
 
 describe('blog component discovery', () => {
   it('discovers all 58 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(59)
+    expect(Object.keys(blogComponentsDe)).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
   it('discovers all 58 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(59)
+    expect(Object.keys(blogComponentsEn)).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -247,8 +250,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 60 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(61)
-    expect(new Set(allKeys).size).toBe(61)
+    expect(allKeys).toHaveLength(62)
+    expect(new Set(allKeys).size).toBe(62)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -256,7 +259,7 @@ describe('calculator groups', () => {
 
   it('bodyComposition group has correct calculators in order', () => {
     expect(calculatorGroups[0].calculators).toEqual([
-      'bmi', 'bodyFat', 'idealWeight', 'waistHipRatio', 'leanBodyMass', 'bsa', 'bodyType', 'bmiFrauen', 'bmiMaenner',
+      'bmi', 'bodyFat', 'idealWeight', 'waistHipRatio', 'whtrRechner', 'leanBodyMass', 'bsa', 'bodyType', 'bmiFrauen', 'bmiMaenner',
     ])
   })
 
@@ -318,7 +321,7 @@ describe('i18n completeness', () => {
 
 describe('SSG routes', () => {
   it('generates exactly 336 routes', () => {
-    expect(routes).toHaveLength(341)
+    expect(routes).toHaveLength(346)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -89,7 +89,6 @@ const EXPECTED_ROUTE_MAP = {
   whtrRechner: { de: 'whtr-rechner', en: 'waist-to-height-ratio-calculator' },
   hepatitisRisk: { de: 'hepatitis-risiko-rechner', en: 'hepatitis-risk-calculator' },
   correctedCalcium: { de: 'korrigiertes-calcium-rechner', en: 'corrected-calcium-calculator' },
-  whtrRechner: { de: 'whtr-rechner', en: 'waist-to-height-ratio-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -143,7 +142,6 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'whtr-berechnen',
   'hepatitis-risiko-berechnen',
   'korrigiertes-calcium-rechner',
-  'whtr-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -256,7 +254,7 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 63 calculators with no duplicates', () => {
+  it('groups contain all 64 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
     expect(allKeys).toHaveLength(64)
     expect(new Set(allKeys).size).toBe(64)

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -67,7 +67,7 @@ describe('generateLlmsTxt', () => {
 
   it('generates 240 links (61 calcs × 2 locales + 59 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(240)
+    expect(links).toHaveLength(244)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -17,7 +17,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore', 'osteoporosisRisk',
+  'apgarScore', 'osteoporosisRisk', 'whtrRechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -67,6 +67,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'anaemie-risiko-berechnen',
   'apgar-score-bewerten',
   'osteoporose-risiko-berechnen',
+  'whtr-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -116,12 +117,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'anemia-risk-calculator-guide',
   'apgar-score-calculator-guide',
   'osteoporosis-risk-calculator-guide',
+  'calculate-waist-to-height-ratio',
 ]
 
 describe('discoverMetas', () => {
   it('discovers all 60 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(61)
+    expect(metas).toHaveLength(62)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -162,7 +164,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 58 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(59)
+    expect(de).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
@@ -171,7 +173,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 58 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(59)
+    expect(en).toHaveLength(60)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -241,7 +243,7 @@ describe('generateSitemap', () => {
 
   it('generates correct total URL count (2 home + 120 calcs + 2 blog index + 116 blog articles = 240)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(244)
+    expect(urlCount).toBe(248)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/__tests__/whtrRechner.test.js
+++ b/src/__tests__/whtrRechner.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { calcWhtr, getWhtrRiskZone } from '../utils/whtrRechner.js'
+
+describe('WHtR formula (waist / height)', () => {
+  it('Taille 85 / Größe 175 ≈ 0.486', () => {
+    expect(calcWhtr(85, 175)).toBeCloseTo(0.486, 3)
+  })
+
+  it('Taille 70 / Größe 165 ≈ 0.424', () => {
+    expect(calcWhtr(70, 165)).toBeCloseTo(0.424, 3)
+  })
+
+  it('Taille 100 / Größe 180 ≈ 0.556', () => {
+    expect(calcWhtr(100, 180)).toBeCloseTo(0.556, 3)
+  })
+
+  it('returns null for missing waist', () => {
+    expect(calcWhtr(null, 175)).toBeNull()
+  })
+
+  it('returns null for missing height', () => {
+    expect(calcWhtr(85, null)).toBeNull()
+  })
+
+  it('returns null for zero height (no division by zero)', () => {
+    expect(calcWhtr(85, 0)).toBeNull()
+  })
+
+  it('returns null for negative inputs', () => {
+    expect(calcWhtr(-85, 175)).toBeNull()
+    expect(calcWhtr(85, -175)).toBeNull()
+  })
+})
+
+describe('WHtR risk zones (Ashwell 2012, age-bracketed)', () => {
+  describe('adults under 40', () => {
+    it('< 0.40 → underweight (slim)', () => {
+      expect(getWhtrRiskZone(0.39, 30)).toBe('slim')
+    })
+
+    it('0.40–0.49 → low (healthy)', () => {
+      expect(getWhtrRiskZone(0.45, 30)).toBe('low')
+    })
+
+    it('0.50–0.54 → moderate (consider action)', () => {
+      expect(getWhtrRiskZone(0.52, 30)).toBe('moderate')
+    })
+
+    it('0.55–0.59 → increased', () => {
+      expect(getWhtrRiskZone(0.57, 30)).toBe('increased')
+    })
+
+    it('≥ 0.60 → high', () => {
+      expect(getWhtrRiskZone(0.65, 30)).toBe('high')
+    })
+  })
+
+  describe('adults 40–50', () => {
+    // Ashwell adds +0.01 per decade above 40 to the boundary 0.50
+    it('0.50 at age 45 → low (boundary shifts up by 0.005)', () => {
+      expect(getWhtrRiskZone(0.50, 45)).toBe('low')
+    })
+
+    it('0.55 at age 45 → moderate', () => {
+      expect(getWhtrRiskZone(0.55, 45)).toBe('moderate')
+    })
+
+    it('0.60 at age 45 → increased', () => {
+      expect(getWhtrRiskZone(0.60, 45)).toBe('increased')
+    })
+  })
+
+  describe('adults over 50', () => {
+    it('0.54 at age 60 → low (boundary shifts up by 0.05)', () => {
+      expect(getWhtrRiskZone(0.54, 60)).toBe('low')
+    })
+
+    it('0.58 at age 60 → moderate', () => {
+      expect(getWhtrRiskZone(0.58, 60)).toBe('moderate')
+    })
+
+    it('0.66 at age 60 → high', () => {
+      expect(getWhtrRiskZone(0.66, 60)).toBe('high')
+    })
+  })
+
+  it('returns null for missing inputs', () => {
+    expect(getWhtrRiskZone(null, 30)).toBeNull()
+    expect(getWhtrRiskZone(0.5, null)).toBeNull()
+  })
+})

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -530,6 +530,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'osteoporosisRisk',
     related: ['vitamin-d-calculator', 'biological-age-calculator', 'calculate-bmi'],
   },
+  {
+    slug: 'calculate-waist-to-height-ratio',
+    title: 'Waist-to-Height Ratio (WHtR): Calculator, Risk & Ashwell Chart',
+    description: 'Calculate your waist-to-height ratio (WHtR). Ashwell classification, measurement guide, and why WHtR outperforms BMI as a cardiometabolic risk marker.',
+    date: '2026-05-07',
+    readTime: '7 min',
+    calculatorKey: 'whtrRechner',
+    related: ['calculate-bmi', 'calculate-waist-hip-ratio', 'calculate-body-fat'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -530,6 +530,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'osteoporosisRisk',
     related: ['vitamin-d-berechnen', 'biologisches-alter-berechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'whtr-berechnen',
+    title: 'WHtR berechnen: Taille-zu-Größe-Verhältnis & Gesundheitsrisiko',
+    description: 'WHtR berechnen: Taille-zu-Größe-Verhältnis nach Ashwell. Klassifikation, Messanleitung und warum WHtR den BMI als Risikomarker übertrifft.',
+    date: '2026-05-07',
+    readTime: '7 min',
+    calculatorKey: 'whtrRechner',
+    related: ['bmi-berechnen', 'taille-hueft-verhaeltnis-berechnen', 'koerperfett-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/whtrRechner.json
+++ b/src/locales/calculators/de/whtrRechner.json
@@ -1,0 +1,71 @@
+{
+  "home": {
+    "calculators": {
+      "whtrRechner": {
+        "name": "WHtR-Rechner",
+        "description": "Taille zu Größe: das aussagekräftigste Maß für viszerales Bauchfett."
+      }
+    }
+  },
+  "whtrRechner": {
+    "meta": {
+      "title": "WHtR-Rechner — Taille-Größe-Verhältnis berechnen",
+      "description": "WHtR-Rechner: Taille-zu-Größe-Verhältnis berechnen. Risikoeinschätzung nach Ashwell. Aussagekräftiger als der BMI. Kostenlos, sofort, ohne Anmeldung."
+    },
+    "title": "WHtR-Rechner",
+    "description": "Berechne dein Taille-zu-Größe-Verhältnis (Waist-to-Height Ratio) — gilt als verlässlicheres Risikosignal als der BMI.",
+    "waist": "Taillenumfang (cm)",
+    "height": "Körpergröße (cm)",
+    "age": "Alter (Jahre)",
+    "result": "WHtR",
+    "rule": "Faustregel: Halte deinen Taillenumfang unter der Hälfte deiner Körpergröße.",
+    "slim": "Untergewicht",
+    "low": "Niedriges Risiko",
+    "moderate": "Erhöhtes Risiko (handeln)",
+    "increased": "Stark erhöhtes Risiko",
+    "high": "Sehr hohes Risiko",
+    "thresholdsTitle": "Klassifikation nach Ashwell (altersabhängig)",
+    "ageHintLabel": "Altersgruppe",
+    "ageHintUnder40": "unter 40 Jahre",
+    "ageHint40to50": "40–50 Jahre",
+    "ageHintOver50": "über 50 Jahre",
+    "categoryColumn": "Kategorie",
+    "rangeColumn": "WHtR-Bereich",
+    "exampleTitle": "Beispiel",
+    "exampleText": "Eine Frau mit 85 cm Taille und 175 cm Körpergröße hat ein WHtR von 85 ÷ 175 = 0,486. Wert unter 0,50 — niedriges Risiko nach Ashwell. Bei 92 cm Taille läge das Verhältnis bei 0,526 und damit bereits im erhöhten Risikobereich.",
+    "aboutTitle": "Warum WHtR statt BMI?",
+    "aboutText": "Das Taille-zu-Größe-Verhältnis (Waist-to-Height Ratio, WHtR) ist ein einfaches Maß zur Einschätzung des Risikos für Herz-Kreislauf-Erkrankungen, Typ-2-Diabetes und das metabolische Syndrom. Anders als der BMI berücksichtigt es die Verteilung des Körperfetts — und genau das viszerale Bauchfett gilt heute als der entscheidende Risikofaktor für die kardiometabolische Gesundheit. Eine Meta-Analyse von Ashwell, Gunn & Gibson (2012) zeigte, dass das WHtR den BMI in der Vorhersage von Diabetes, Bluthochdruck und Herz-Kreislauf-Erkrankungen übertrifft. Der Vorteil liegt in der Skalierbarkeit über alle Körpergrößen und Geschlechter hinweg: Die Faustregel «Taille unter halbe Körpergröße» gilt universell — von Teenagern bis zu älteren Erwachsenen, mit einer leichten altersabhängigen Anpassung. Im Vergleich zum Taille-Hüft-Verhältnis (WHR) ist das WHtR einfacher zu messen, da nur ein einziger Umfang plus die Körpergröße benötigt wird. Damit eignet es sich hervorragend für regelmäßiges Selbst-Monitoring. Wichtig: Miss den Taillenumfang morgens, nüchtern, auf Nabelhöhe und nach normalem Ausatmen. Das Maßband sollte waagerecht und eng anliegen, ohne in die Haut einzuschneiden. Kombiniere das WHtR mit weiteren Indikatoren wie dem BMI, dem Körperfettanteil und dem Idealgewicht, um ein vollständiges Bild deiner Körperzusammensetzung zu erhalten.",
+    "disclaimer": "Hinweis: Dieser Rechner ersetzt keine medizinische Diagnose. Bei Auffälligkeiten besprich deine Werte mit einer Ärztin oder einem Arzt.",
+    "relatedTitle": "Verwandte Rechner",
+    "relatedBmi": "BMI berechnen",
+    "relatedWhr": "Taille-Hüft-Verhältnis",
+    "relatedBodyFat": "Körperfettanteil",
+    "relatedIdealWeight": "Idealgewicht",
+    "faq": [
+      {
+        "q": "Was ist das WHtR?",
+        "a": "Das WHtR (Waist-to-Height Ratio) ist das Verhältnis von Taillenumfang zu Körpergröße. Beide werden in derselben Einheit gemessen (cm). Ein Wert unter 0,5 gilt als gesund."
+      },
+      {
+        "q": "Wie wird das WHtR berechnet?",
+        "a": "WHtR = Taillenumfang ÷ Körpergröße. Beispiel: 85 cm Taille und 175 cm Größe ergeben 85 ÷ 175 = 0,486."
+      },
+      {
+        "q": "Welche Werte sind gesund?",
+        "a": "Nach Ashwell (2012) gilt: unter 0,40 Untergewicht, 0,40–0,49 niedriges Risiko, 0,50–0,54 erhöht, 0,55–0,59 stark erhöht, ab 0,60 sehr hoch. Ab 40 Jahren steigen die Grenzen leicht an."
+      },
+      {
+        "q": "Ist WHtR aussagekräftiger als der BMI?",
+        "a": "Ja. Studien zeigen, dass das WHtR den BMI bei der Vorhersage von Herz-Kreislauf-Risiken und Typ-2-Diabetes übertrifft, weil es die Fettverteilung berücksichtigt."
+      },
+      {
+        "q": "WHtR oder Taille-Hüft-Verhältnis?",
+        "a": "Beide messen abdominale Adipositas. WHtR ist einfacher (nur ein Umfang plus Größe) und international gleich anwendbar. WHR ist etabliert in der WHO-Klassifikation."
+      },
+      {
+        "q": "Wie messe ich den Taillenumfang richtig?",
+        "a": "Stehend, morgens, nüchtern, auf Nabelhöhe, nach normalem Ausatmen. Maßband waagerecht, eng anliegend, aber ohne Einschnürung."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/whtrRechner.json
+++ b/src/locales/calculators/en/whtrRechner.json
@@ -1,0 +1,71 @@
+{
+  "home": {
+    "calculators": {
+      "whtrRechner": {
+        "name": "Waist-to-Height Ratio",
+        "description": "Waist-to-height ratio (WHtR) — a stronger predictor of metabolic risk than BMI."
+      }
+    }
+  },
+  "whtrRechner": {
+    "meta": {
+      "title": "Waist-to-Height Ratio Calculator (WHtR)",
+      "description": "Calculate your waist-to-height ratio (WHtR). Ashwell-based risk classification — a stronger predictor of cardiometabolic risk than BMI. Free, instant, no sign-up."
+    },
+    "title": "Waist-to-Height Ratio Calculator",
+    "description": "Calculate your waist-to-height ratio (WHtR) — considered a more reliable risk signal than BMI.",
+    "waist": "Waist circumference (cm)",
+    "height": "Height (cm)",
+    "age": "Age (years)",
+    "result": "WHtR",
+    "rule": "Rule of thumb: keep your waist below half your height.",
+    "slim": "Underweight",
+    "low": "Low risk",
+    "moderate": "Increased risk (consider action)",
+    "increased": "Substantially increased risk",
+    "high": "Very high risk",
+    "thresholdsTitle": "Ashwell classification (age-adjusted)",
+    "ageHintLabel": "Age group",
+    "ageHintUnder40": "under 40 years",
+    "ageHint40to50": "40–50 years",
+    "ageHintOver50": "over 50 years",
+    "categoryColumn": "Category",
+    "rangeColumn": "WHtR range",
+    "exampleTitle": "Example",
+    "exampleText": "A woman with an 85 cm waist and 175 cm height has a WHtR of 85 ÷ 175 = 0.486. Below 0.50 — low risk per Ashwell. With a 92 cm waist the ratio would be 0.526, already in the increased-risk zone.",
+    "aboutTitle": "Why WHtR instead of BMI?",
+    "aboutText": "The waist-to-height ratio (WHtR) is a simple measure for estimating the risk of cardiovascular disease, type 2 diabetes and the metabolic syndrome. Unlike BMI, it accounts for the distribution of body fat — and visceral abdominal fat is now considered the decisive risk factor for cardiometabolic health. A meta-analysis by Ashwell, Gunn & Gibson (2012) showed that WHtR outperforms BMI in predicting diabetes, hypertension and cardiovascular disease. Its key advantage is scalability across all heights and sexes: the simple rule «keep your waist below half your height» applies universally — from teenagers to older adults, with a small age-based adjustment. Compared to the waist-to-hip ratio (WHR), WHtR is easier to measure because it requires only one circumference plus height. That makes it ideal for regular self-monitoring. Important: measure your waist in the morning, fasted, at navel height, after a normal exhale. The tape should be horizontal and snug, but not compressing the skin. Combine WHtR with other indicators such as BMI, body fat percentage and ideal weight for a complete picture of body composition.",
+    "disclaimer": "Note: this calculator does not replace medical diagnosis. Discuss any concerning values with a physician.",
+    "relatedTitle": "Related calculators",
+    "relatedBmi": "BMI calculator",
+    "relatedWhr": "Waist-to-hip ratio",
+    "relatedBodyFat": "Body fat",
+    "relatedIdealWeight": "Ideal weight",
+    "faq": [
+      {
+        "q": "What is WHtR?",
+        "a": "WHtR (Waist-to-Height Ratio) is the ratio of waist circumference to height. Both are measured in the same unit (cm). A value below 0.5 is considered healthy."
+      },
+      {
+        "q": "How is WHtR calculated?",
+        "a": "WHtR = waist circumference ÷ height. Example: 85 cm waist and 175 cm height give 85 ÷ 175 = 0.486."
+      },
+      {
+        "q": "Which values are healthy?",
+        "a": "Per Ashwell (2012): below 0.40 underweight, 0.40–0.49 low risk, 0.50–0.54 increased, 0.55–0.59 substantially increased, 0.60 and above very high. Thresholds rise slightly from age 40."
+      },
+      {
+        "q": "Is WHtR more meaningful than BMI?",
+        "a": "Yes. Studies show WHtR outperforms BMI in predicting cardiovascular risk and type 2 diabetes because it accounts for fat distribution."
+      },
+      {
+        "q": "WHtR or waist-to-hip ratio?",
+        "a": "Both measure abdominal adiposity. WHtR is simpler (one circumference plus height) and applies universally. WHR is established in WHO classification."
+      },
+      {
+        "q": "How do I measure waist correctly?",
+        "a": "Standing, in the morning, fasted, at navel height, after a normal exhale. Tape horizontal and snug but not compressing."
+      }
+    ]
+  }
+}

--- a/src/pages/WhtrRechnerCalculator.vue
+++ b/src/pages/WhtrRechnerCalculator.vue
@@ -1,0 +1,176 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcWhtr, getWhtrRiskZone } from '../utils/whtrRechner.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('whtrRechner.faq') || [])
+
+useHead(() => ({
+  title: t('whtrRechner.meta.title'),
+  description: t('whtrRechner.meta.description'),
+  routeKey: 'whtrRechner',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Waist-to-Height Ratio Calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const waist = ref(null)
+const height = ref(null)
+const age = ref(35)
+
+const whtr = computed(() => calcWhtr(waist.value, height.value))
+const whtrFormatted = computed(() => whtr.value?.toFixed(3))
+
+const zone = computed(() => getWhtrRiskZone(whtr.value, age.value))
+
+const zoneColors = {
+  slim: 'text-blue-500',
+  low: 'text-green-600',
+  moderate: 'text-yellow-500',
+  increased: 'text-orange-500',
+  high: 'text-red-500',
+}
+
+const ageHint = computed(() => {
+  if (age.value > 50) return t('whtrRechner.ageHintOver50')
+  if (age.value >= 40) return t('whtrRechner.ageHint40to50')
+  return t('whtrRechner.ageHintUnder40')
+})
+
+const fmt = (n) => n.toFixed(2).replace('.', ',')
+
+const thresholds = computed(() => {
+  const off = age.value > 50 ? 0.05 : age.value >= 40 ? 0.005 : 0
+  return [
+    { key: 'slim', range: '< 0,40', bg: 'bg-blue-500' },
+    { key: 'low', range: `0,40 – ${fmt(0.50 + off - 0.001)}`, bg: 'bg-green-600' },
+    { key: 'moderate', range: `${fmt(0.50 + off)} – ${fmt(0.55 + off - 0.001)}`, bg: 'bg-yellow-500' },
+    { key: 'increased', range: `${fmt(0.55 + off)} – ${fmt(0.60 + off - 0.001)}`, bg: 'bg-orange-500' },
+    { key: 'high', range: `≥ ${fmt(0.60 + off)}`, bg: 'bg-red-500' },
+  ]
+})
+
+const halfHeight = computed(() => (height.value ? (height.value / 2).toFixed(1) : null))
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('whtrRechner.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('whtrRechner.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-2">
+      <div>
+        <label for="waist" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('whtrRechner.waist') }}
+        </label>
+        <input id="waist" v-model.number="waist" type="number" min="40" max="200" placeholder="85" data-testid="waist-input"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label for="height" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('whtrRechner.height') }}
+        </label>
+        <input id="height" v-model.number="height" type="number" min="100" max="230" placeholder="175" data-testid="height-input"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label for="age" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('whtrRechner.age') }}
+        </label>
+        <input id="age" v-model.number="age" type="number" min="10" max="120" placeholder="35" data-testid="age-input"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+    <p class="text-xs text-stone-400 mt-2">{{ t('whtrRechner.rule') }}</p>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="whtr" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-4">
+      <span data-testid="whtr-result" class="text-5xl font-bold text-stone-900 tabular-nums leading-none">{{ whtrFormatted }}</span>
+      <span v-if="zone" :class="zoneColors[zone]" data-testid="whtr-zone" class="text-lg font-semibold">{{ t('whtrRechner.' + zone) }}</span>
+    </div>
+
+    <div v-if="halfHeight" class="bg-stone-50 rounded-lg p-4 mt-5">
+      <p class="text-sm text-stone-600 leading-relaxed">
+        {{ t('whtrRechner.rule') }}
+        <span class="block mt-1 text-stone-500">
+          <span class="tabular-nums">{{ height }} cm ÷ 2 = {{ halfHeight }} cm</span> &middot;
+          <span class="tabular-nums">{{ t('whtrRechner.waist') }}: {{ waist }} cm</span>
+        </span>
+      </p>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline justify-between mb-4">
+      <h2 class="text-lg font-semibold text-stone-900">{{ t('whtrRechner.thresholdsTitle') }}</h2>
+      <span class="text-xs text-stone-400">{{ t('whtrRechner.ageHintLabel') }}: {{ ageHint }}</span>
+    </div>
+    <div class="overflow-hidden rounded-lg border border-stone-100">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-stone-50 border-b border-stone-100">
+            <th class="text-left px-4 py-2.5 font-semibold text-stone-600">{{ t('whtrRechner.categoryColumn') }}</th>
+            <th class="text-right px-4 py-2.5 font-semibold text-stone-600">{{ t('whtrRechner.rangeColumn') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-stone-100">
+          <tr v-for="th in thresholds" :key="th.key">
+            <td class="px-4 py-3 text-stone-700">
+              <span class="inline-block w-2.5 h-2.5 rounded-full mr-2 align-middle" :class="th.bg"></span>
+              {{ t('whtrRechner.' + th.key) }}
+            </td>
+            <td class="px-4 py-3 text-right text-stone-900 font-medium tabular-nums">{{ th.range }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('whtrRechner.exampleTitle') }}</h2>
+    <p class="text-sm text-stone-600 leading-relaxed">{{ t('whtrRechner.exampleText') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('whtrRechner.aboutTitle') }}</h2>
+    <p class="text-sm text-stone-600 leading-relaxed whitespace-pre-line">{{ t('whtrRechner.aboutText') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-6 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('whtrRechner.relatedTitle') }}</h2>
+    <ul class="grid grid-cols-2 gap-2 text-sm">
+      <li><router-link :to="localePath('bmi')" class="text-stone-700 hover:text-stone-900 underline underline-offset-2">{{ t('whtrRechner.relatedBmi') }}</router-link></li>
+      <li><router-link :to="localePath('waistHipRatio')" class="text-stone-700 hover:text-stone-900 underline underline-offset-2">{{ t('whtrRechner.relatedWhr') }}</router-link></li>
+      <li><router-link :to="localePath('bodyFat')" class="text-stone-700 hover:text-stone-900 underline underline-offset-2">{{ t('whtrRechner.relatedBodyFat') }}</router-link></li>
+      <li><router-link :to="localePath('idealWeight')" class="text-stone-700 hover:text-stone-900 underline underline-offset-2">{{ t('whtrRechner.relatedIdealWeight') }}</router-link></li>
+    </ul>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('whtrRechner.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="whtrRechner" />
+</template>

--- a/src/pages/blog/WhtrBerechnen.vue
+++ b/src/pages/blog/WhtrBerechnen.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'WHtR berechnen: Taille-zu-Größe-Verhältnis & Gesundheitsrisiko | Health Calculators',
+  description: 'WHtR berechnen: Taille-zu-Größe-Verhältnis nach Ashwell. Klassifikation, Messanleitung und warum WHtR den BMI als Risikomarker übertrifft.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'WHtR berechnen: Taille-zu-Größe-Verhältnis & Gesundheitsrisiko',
+    description: 'WHtR berechnen: Taille-zu-Größe-Verhältnis nach Ashwell. Klassifikation, Messanleitung und warum WHtR den BMI als Risikomarker übertrifft.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-07',
+    dateModified: '2026-05-07',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/whtr-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">WHtR berechnen: Taille-zu-Größe-Verhältnis &amp; Gesundheitsrisiko</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">7. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das <strong>Taille-zu-Größe-Verhältnis</strong> (Waist-to-Height Ratio, WHtR) gilt heute in vielen Studien als der einfachste und zugleich aussagekräftigste Marker für viszerales Bauchfett — und damit für das Risiko von Herz-Kreislauf-Erkrankungen, Typ-2-Diabetes und metabolischem Syndrom.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Beitrag erfährst du, wie das WHtR berechnet wird, welche Grenzwerte nach Ashwell gelten, wie du richtig misst und warum das WHtR den klassischen <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> in der Risikoeinschätzung übertrifft.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel</h2>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 text-center">
+          <p class="text-lg font-semibold text-stone-900">WHtR = Taillenumfang &divide; Körpergröße</p>
+          <p class="text-sm text-stone-500 mt-2">beide in derselben Einheit (cm)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mt-4">
+          Die Faustregel: <strong>Halte deinen Taillenumfang unter der Hälfte deiner Körpergröße.</strong> Bei 175 cm Körpergröße bedeutet das eine Taille unter 87,5 cm. Diese «Half-Waist-Rule» wurde von Margaret Ashwell und Kollegen 2012 in einer großen Meta-Analyse als robustes Screening-Kriterium etabliert.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Klassifikation nach Ashwell (2012)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">WHtR (unter 40 J.)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">WHtR (über 50 J.)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-blue-500 mr-2"></span>Untergewicht</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 0,40</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 0,40</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-green-600 mr-2"></span>Niedriges Risiko</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0,40 – 0,49</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0,40 – 0,54</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-yellow-500 mr-2"></span>Erhöhtes Risiko</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0,50 – 0,54</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0,55 – 0,59</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-orange-500 mr-2"></span>Stark erhöht</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0,55 – 0,59</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0,60 – 0,64</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-red-500 mr-2"></span>Sehr hohes Risiko</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 0,60</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 0,65</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500">Zwischen 40 und 50 Jahren werden die Grenzen um 0,005 nach oben verschoben.</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Beispiel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eine 35-jährige Frau hat einen Taillenumfang von 85 cm und eine Körpergröße von 175 cm:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6">
+          <p class="text-base text-stone-700 tabular-nums">85 cm ÷ 175 cm = <strong class="text-stone-900">0,486</strong></p>
+          <p class="text-sm text-stone-500 mt-2">Ergebnis: niedriges Risiko nach Ashwell.</p>
+        </div>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Berechne dein WHtR jetzt</h3>
+        <p class="text-stone-300 text-sm mb-5">Ashwell-basierte Risikoeinschätzung — kostenlos und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('whtrRechner')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Zum WHtR-Rechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Richtig messen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Miss morgens, nüchtern, im Stehen. Das Maßband liegt waagerecht auf Nabelhöhe an, eng anliegend, aber ohne in die Haut einzuschnüren. Atme normal aus und halte dann den Atem für die Messung an. Wiederhole zur Sicherheit zwei Mal und nimm den Mittelwert.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die Körpergröße misst du barfuß, an der Wand stehend, mit geradem Rücken und Blick nach vorn.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">WHtR vs. BMI vs. WHR</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> berücksichtigt nur Gewicht und Größe — er unterscheidet nicht zwischen Muskel- und Fettmasse und sagt nichts über die Fettverteilung aus. Das <router-link :to="localeBlogPath('taille-hueft-verhaeltnis-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Taille-Hüft-Verhältnis (WHR)</router-link> erfasst die Fettverteilung, benötigt aber zwei Umfänge.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das WHtR vereint die Vorteile: Es misst die abdominale Fettverteilung mit nur einem zusätzlichen Maß und ist über alle Körpergrößen hinweg anwendbar. In Meta-Analysen schnitt es bei der Vorhersage kardiometabolischer Risiken besser ab als BMI und WHR.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das WHtR ist schnell berechnet, leicht zu messen und gilt als verlässlicher Marker für viszerales Bauchfett. Nutze unseren <router-link :to="localePath('whtrRechner')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">WHtR-Rechner</router-link> und ergänze ihn mit <router-link :to="localePath('bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> und <router-link :to="localePath('bodyFat')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Körperfettanteil</router-link> für ein vollständiges Bild.
+        </p>
+      </div>
+
+      <RelatedArticles slug="whtr-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/CalculateWaistToHeightRatio.vue
+++ b/src/pages/blog/en/CalculateWaistToHeightRatio.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+
+useHead({
+  title: 'Waist-to-Height Ratio (WHtR): Calculator, Risk & Ashwell Chart | Health Calculators',
+  description: 'Calculate your waist-to-height ratio (WHtR). Ashwell classification, measurement guide, and why WHtR outperforms BMI as a cardiometabolic risk marker.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Waist-to-Height Ratio (WHtR): Calculator, Risk & Ashwell Chart',
+    description: 'Calculate your waist-to-height ratio (WHtR). Ashwell classification, measurement guide, and why WHtR outperforms BMI as a cardiometabolic risk marker.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-07',
+    dateModified: '2026-05-07',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/calculate-waist-to-height-ratio',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link to="/en/blog" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Waist-to-Height Ratio (WHtR): Calculator, Risk &amp; Ashwell Chart</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 7, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>waist-to-height ratio</strong> (WHtR) is the simplest and arguably most informative single number for visceral abdominal fat — and therefore for the risk of cardiovascular disease, type&nbsp;2 diabetes and the metabolic syndrome.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article covers the formula, the Ashwell classification, how to measure correctly, and why WHtR outperforms <router-link to="/en/blog/calculate-bmi" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> as a risk marker.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The Formula</h2>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 text-center">
+          <p class="text-lg font-semibold text-stone-900">WHtR = waist circumference &divide; height</p>
+          <p class="text-sm text-stone-500 mt-2">both in the same unit (cm)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mt-4">
+          Rule of thumb: <strong>keep your waist below half your height.</strong> At 175 cm, that means a waist below 87.5 cm. Margaret Ashwell and colleagues established this «half-waist rule» in a 2012 meta-analysis as a robust screening criterion across populations.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Ashwell Classification (2012)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">WHtR (under 40)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">WHtR (over 50)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-blue-500 mr-2"></span>Underweight</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 0.40</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 0.40</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-green-600 mr-2"></span>Low risk</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0.40 – 0.49</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0.40 – 0.54</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-yellow-500 mr-2"></span>Increased</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0.50 – 0.54</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0.55 – 0.59</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-orange-500 mr-2"></span>Substantially increased</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0.55 – 0.59</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0.60 – 0.64</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600"><span class="inline-block w-2.5 h-2.5 rounded-full bg-red-500 mr-2"></span>Very high risk</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 0.60</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 0.65</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm text-stone-500">Between ages 40 and 50 the boundaries shift up by 0.005.</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Worked Example</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A 35-year-old woman with a waist of 85 cm and height of 175 cm:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6">
+          <p class="text-base text-stone-700 tabular-nums">85 cm ÷ 175 cm = <strong class="text-stone-900">0.486</strong></p>
+          <p class="text-sm text-stone-500 mt-2">Result: low risk per Ashwell.</p>
+        </div>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your WHtR now</h3>
+        <p class="text-stone-300 text-sm mb-5">Ashwell-based risk classification — free, instant, no sign-up.</p>
+        <router-link
+          to="/en/waist-to-height-ratio-calculator"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Open WHtR calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How to measure correctly</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Measure in the morning, fasted, standing upright. Place the tape horizontally at navel height, snug but without compressing the skin. Exhale normally and hold the breath for the measurement. For accuracy, repeat twice and take the mean.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Measure height barefoot against a wall, with a straight back and head facing forward.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">WHtR vs. BMI vs. WHR</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <router-link to="/en/blog/calculate-bmi" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> uses only weight and height — it can't tell muscle from fat and ignores fat distribution. The <router-link to="/en/blog/calculate-waist-hip-ratio" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">waist-to-hip ratio (WHR)</router-link> captures distribution but requires two circumferences.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          WHtR combines the strengths: it captures abdominal fat with one extra measurement and scales across heights and sexes. In meta-analyses it predicted cardiometabolic risk better than both BMI and WHR.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          WHtR is fast to compute, easy to measure, and one of the most reliable single-number markers of visceral fat. Use our <router-link to="/en/waist-to-height-ratio-calculator" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">WHtR calculator</router-link> and combine it with <router-link to="/en/bmi-calculator" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> and <router-link to="/en/body-fat-calculator" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">body fat</router-link> for a complete picture.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="calculate-waist-to-height-ratio" />
+    </div>
+  </article>
+</template>

--- a/src/pages/whtrRechner.meta.js
+++ b/src/pages/whtrRechner.meta.js
@@ -1,0 +1,16 @@
+import Component from './WhtrRechnerCalculator.vue'
+import BlogDe from './blog/WhtrBerechnen.vue'
+import BlogEn from './blog/en/CalculateWaistToHeightRatio.vue'
+
+export default {
+  key: 'whtrRechner',
+  component: Component,
+  slugs: { de: 'whtr-rechner', en: 'waist-to-height-ratio-calculator' },
+  group: 'bodyComposition',
+  groupOrder: 0,
+  order: 3.5,
+  blog: {
+    de: { slug: 'whtr-berechnen', component: BlogDe },
+    en: { slug: 'calculate-waist-to-height-ratio', component: BlogEn },
+  },
+}

--- a/src/utils/whtrRechner.js
+++ b/src/utils/whtrRechner.js
@@ -1,0 +1,28 @@
+// WHtR — Waist-to-Height Ratio
+// Reference: Ashwell M, Gunn P, Gibson S. (2012). Obesity Reviews, 13(3): 275-286.
+// "Keep your waist circumference to less than half your height."
+
+export function calcWhtr(waistCm, heightCm) {
+  if (!waistCm || !heightCm || waistCm <= 0 || heightCm <= 0) return null
+  return waistCm / heightCm
+}
+
+// Ashwell age-adjusted boundaries: lower edge of "moderate" rises with age.
+// Under 40: standard; 40-50: +0.005; over 50: +0.05.
+function ageOffset(ageYears) {
+  if (ageYears > 50) return 0.05
+  if (ageYears >= 40) return 0.005
+  return 0
+}
+
+export function getWhtrRiskZone(whtr, ageYears) {
+  if (whtr == null || ageYears == null) return null
+
+  const off = ageOffset(ageYears)
+
+  if (whtr < 0.40) return 'slim'
+  if (whtr < 0.50 + off) return 'low'
+  if (whtr < 0.55 + off) return 'moderate'
+  if (whtr < 0.60 + off) return 'increased'
+  return 'high'
+}


### PR DESCRIPTION
## Summary
- New SSR calculator at `/de/whtr-rechner` (DE) and `/en/waist-to-height-ratio-calculator` (EN)
- WHtR = Taille ÷ Größe with age-adjusted Ashwell (2012) risk classification (slim / low / moderate / increased / high)
- Worked example, unique ~300-word content block, FAQPage + WebApplication + BreadcrumbList JSON-LD
- DE blog `whtr-berechnen` + EN blog `calculate-waist-to-height-ratio`
- Cross-links: BMI, WHR, Körperfett, Idealgewicht
- Sibling to `/de/taille-hueft-verhaeltnis` (WHR), targeting 4–10k/mo "WHtR Rechner" search demand

## Test plan
- [x] Unit tests (19) pass — formula + age-bracketed risk zones
- [x] Full vitest suite green (1627/1627)
- [x] Playwright suite green (911 passed) including 8 new whtrRechner specs
- [x] `npm run build` succeeds — 248 sitemap URLs, 244 llms.txt links
- [x] Trailing-slash canonical resolves
- [x] Discovery counts bumped (62 calculators / 60 blogs / 346 routes)

Closes jenslaufer/health-calculators#190

🤖 Generated with [Claude Code](https://claude.com/claude-code)