### PR TITLE
hc-157-asthma-control: Implement the Asthma Control Calculator as described in issu

### DIFF
--- a/e2e/asthmaControl.spec.js
+++ b/e2e/asthmaControl.spec.js
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Asthma Control Test (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/asthma-kontrolle-test')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Asthma Control Test/)
+  })
+
+  test('h1 matches', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Asthma Control Test')
+  })
+
+  test('back link navigates home', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('result hidden before all answers', async ({ page }) => {
+    await expect(page.getByTestId('result-score')).not.toBeVisible()
+    await expect(page.getByTestId('incomplete-hint')).toBeVisible()
+  })
+
+  test('answering all 5×5 → score 25, well controlled', async ({ page }) => {
+    await page.getByTestId('option-activityLimitation-5').click()
+    await page.getByTestId('option-shortnessOfBreath-5').click()
+    await page.getByTestId('option-nightSymptoms-5').click()
+    await page.getByTestId('option-rescueInhalerUse-5').click()
+    await page.getByTestId('option-selfRating-5').click()
+
+    await expect(page.getByTestId('result-score')).toBeVisible()
+    await expect(page.getByTestId('result-score')).toHaveText('25')
+    await expect(page.getByTestId('result-status')).toHaveText('Gut kontrolliert')
+  })
+
+  test('mid-range scoring → not well controlled (16–19)', async ({ page }) => {
+    // 4+3+4+4+4 = 19 → notWellControlled
+    await page.getByTestId('option-activityLimitation-4').click()
+    await page.getByTestId('option-shortnessOfBreath-3').click()
+    await page.getByTestId('option-nightSymptoms-4').click()
+    await page.getByTestId('option-rescueInhalerUse-4').click()
+    await page.getByTestId('option-selfRating-4').click()
+
+    await expect(page.getByTestId('result-score')).toHaveText('19')
+    await expect(page.getByTestId('result-status')).toHaveText('Nicht gut kontrolliert')
+  })
+
+  test('low scoring → poorly controlled (5–15)', async ({ page }) => {
+    // 1+1+2+1+2 = 7 → poorlyControlled
+    await page.getByTestId('option-activityLimitation-1').click()
+    await page.getByTestId('option-shortnessOfBreath-1').click()
+    await page.getByTestId('option-nightSymptoms-2').click()
+    await page.getByTestId('option-rescueInhalerUse-1').click()
+    await page.getByTestId('option-selfRating-2').click()
+
+    await expect(page.getByTestId('result-score')).toHaveText('7')
+    await expect(page.getByTestId('result-status')).toHaveText('Schlecht kontrolliert')
+  })
+
+  test('reset clears answers and hides result', async ({ page }) => {
+    for (const q of ['activityLimitation', 'shortnessOfBreath', 'nightSymptoms', 'rescueInhalerUse', 'selfRating']) {
+      await page.getByTestId(`option-${q}-3`).click()
+    }
+    await expect(page.getByTestId('result-score')).toBeVisible()
+    await page.getByTestId('reset').click()
+    await expect(page.getByTestId('result-score')).not.toBeVisible()
+    await expect(page.getByTestId('incomplete-hint')).toBeVisible()
+  })
+
+  test('score scale section visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Bewertungsskala/ })).toBeVisible()
+  })
+
+  test('blog article link is rendered', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('Asthma Control Test (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/asthma-control-test')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Asthma Control Test/)
+  })
+
+  test('all 5×5 → score 25, well controlled', async ({ page }) => {
+    for (const q of ['activityLimitation', 'shortnessOfBreath', 'nightSymptoms', 'rescueInhalerUse', 'selfRating']) {
+      await page.getByTestId(`option-${q}-5`).click()
+    }
+    await expect(page.getByTestId('result-score')).toHaveText('25')
+    await expect(page.getByTestId('result-status')).toHaveText('Well controlled')
+  })
+})

--- a/src/__tests__/asthmaControl.test.js
+++ b/src/__tests__/asthmaControl.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ACT_QUESTIONS,
+  calcActScore,
+  classifyAct,
+  evaluateAct,
+} from '../utils/asthmaControl.js'
+
+// ACT — Asthma Control Test (Nathan et al., J Allergy Clin Immunol, 2004)
+// 5 questions, each scored 1–5, total 5–25.
+//   25      : well controlled (perfect)
+//   20–24   : well controlled
+//   16–19   : not well controlled
+//    5–15   : poorly controlled
+
+describe('ACT_QUESTIONS', () => {
+  it('exposes 5 question keys', () => {
+    expect(ACT_QUESTIONS).toHaveLength(5)
+  })
+
+  it('uses canonical keys', () => {
+    expect(ACT_QUESTIONS).toEqual([
+      'activityLimitation',
+      'shortnessOfBreath',
+      'nightSymptoms',
+      'rescueInhalerUse',
+      'selfRating',
+    ])
+  })
+})
+
+describe('calcActScore', () => {
+  it('all 5s → total 25', () => {
+    const r = calcActScore({
+      activityLimitation: 5, shortnessOfBreath: 5, nightSymptoms: 5,
+      rescueInhalerUse: 5, selfRating: 5,
+    })
+    expect(r).toBe(25)
+  })
+
+  it('all 1s → total 5', () => {
+    const r = calcActScore({
+      activityLimitation: 1, shortnessOfBreath: 1, nightSymptoms: 1,
+      rescueInhalerUse: 1, selfRating: 1,
+    })
+    expect(r).toBe(5)
+  })
+
+  it('mixed answers sum correctly: 4+3+5+2+4 → 18', () => {
+    const r = calcActScore({
+      activityLimitation: 4, shortnessOfBreath: 3, nightSymptoms: 5,
+      rescueInhalerUse: 2, selfRating: 4,
+    })
+    expect(r).toBe(18)
+  })
+
+  it('returns null on missing answer', () => {
+    expect(calcActScore({
+      activityLimitation: 4, shortnessOfBreath: 3, nightSymptoms: 5,
+      rescueInhalerUse: 2,
+    })).toBe(null)
+  })
+
+  it('returns null on out-of-range value (0)', () => {
+    expect(calcActScore({
+      activityLimitation: 0, shortnessOfBreath: 3, nightSymptoms: 5,
+      rescueInhalerUse: 2, selfRating: 4,
+    })).toBe(null)
+  })
+
+  it('returns null on out-of-range value (6)', () => {
+    expect(calcActScore({
+      activityLimitation: 6, shortnessOfBreath: 3, nightSymptoms: 5,
+      rescueInhalerUse: 2, selfRating: 4,
+    })).toBe(null)
+  })
+
+  it('returns null on null/undefined input', () => {
+    expect(calcActScore(null)).toBe(null)
+    expect(calcActScore(undefined)).toBe(null)
+  })
+
+  it('returns null on non-integer (4.5)', () => {
+    expect(calcActScore({
+      activityLimitation: 4.5, shortnessOfBreath: 3, nightSymptoms: 5,
+      rescueInhalerUse: 2, selfRating: 4,
+    })).toBe(null)
+  })
+})
+
+describe('classifyAct', () => {
+  it('25 → wellControlled', () => {
+    expect(classifyAct(25)).toBe('wellControlled')
+  })
+
+  it('20 → wellControlled (boundary)', () => {
+    expect(classifyAct(20)).toBe('wellControlled')
+  })
+
+  it('19 → notWellControlled (boundary)', () => {
+    expect(classifyAct(19)).toBe('notWellControlled')
+  })
+
+  it('16 → notWellControlled (boundary)', () => {
+    expect(classifyAct(16)).toBe('notWellControlled')
+  })
+
+  it('15 → poorlyControlled (boundary)', () => {
+    expect(classifyAct(15)).toBe('poorlyControlled')
+  })
+
+  it('5 → poorlyControlled (minimum)', () => {
+    expect(classifyAct(5)).toBe('poorlyControlled')
+  })
+
+  it('returns null for out-of-range or invalid', () => {
+    expect(classifyAct(4)).toBe(null)
+    expect(classifyAct(26)).toBe(null)
+    expect(classifyAct(null)).toBe(null)
+    expect(classifyAct('20')).toBe(null)
+  })
+})
+
+describe('evaluateAct (one-shot)', () => {
+  it('all 5 → score 25, wellControlled', () => {
+    const r = evaluateAct({
+      activityLimitation: 5, shortnessOfBreath: 5, nightSymptoms: 5,
+      rescueInhalerUse: 5, selfRating: 5,
+    })
+    expect(r.score).toBe(25)
+    expect(r.category).toBe('wellControlled')
+  })
+
+  it('typical not-controlled scenario: 3+2+3+4+5 → 17, notWellControlled', () => {
+    const r = evaluateAct({
+      activityLimitation: 3, shortnessOfBreath: 2, nightSymptoms: 3,
+      rescueInhalerUse: 4, selfRating: 5,
+    })
+    expect(r.score).toBe(17)
+    expect(r.category).toBe('notWellControlled')
+  })
+
+  it('poorly controlled: 1+1+2+1+2 → 7, poorlyControlled', () => {
+    const r = evaluateAct({
+      activityLimitation: 1, shortnessOfBreath: 1, nightSymptoms: 2,
+      rescueInhalerUse: 1, selfRating: 2,
+    })
+    expect(r.score).toBe(7)
+    expect(r.category).toBe('poorlyControlled')
+  })
+
+  it('returns null on incomplete answers', () => {
+    expect(evaluateAct({ activityLimitation: 5 })).toBe(null)
+  })
+
+  it('returns null on null input', () => {
+    expect(evaluateAct(null)).toBe(null)
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -24,6 +24,7 @@ const EXPECTED_KEYS = [
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
+  'asthmaControl',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -89,6 +90,7 @@ const EXPECTED_ROUTE_MAP = {
   whtrRechner: { de: 'whtr-rechner', en: 'waist-to-height-ratio-calculator' },
   hepatitisRisk: { de: 'hepatitis-risiko-rechner', en: 'hepatitis-risk-calculator' },
   correctedCalcium: { de: 'korrigiertes-calcium-rechner', en: 'corrected-calcium-calculator' },
+  asthmaControl: { de: 'asthma-kontrolle-test', en: 'asthma-control-test' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -142,6 +144,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'whtr-berechnen',
   'hepatitis-risiko-berechnen',
   'korrigiertes-calcium-rechner',
+  'asthma-kontrolle-testen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -195,19 +198,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-waist-to-height-ratio',
   'hepatitis-risk-calculator-guide',
   'corrected-calcium-calculator',
+  'asthma-control-test-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 64 calculators', () => {
-    expect(calculatorMetas).toHaveLength(64)
+  it('discovers all 65 calculators', () => {
+    expect(calculatorMetas).toHaveLength(65)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 64 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(64)
+  it('builds calculatorComponents map for all 65 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(65)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -230,15 +234,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 62 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(62)
+  it('discovers all 63 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 62 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(62)
+  it('discovers all 63 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -254,10 +258,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 64 calculators with no duplicates', () => {
+  it('groups contain all 65 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(64)
-    expect(new Set(allKeys).size).toBe(64)
+    expect(allKeys).toHaveLength(65)
+    expect(new Set(allKeys).size).toBe(65)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -278,7 +282,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl',
     ])
   })
 
@@ -326,8 +330,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 356 routes', () => {
-    expect(routes).toHaveLength(356)
+  it('generates exactly 361 routes', () => {
+    expect(routes).toHaveLength(361)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 252 links (64 calcs × 2 locales + 62 blogs × 2 locales)', () => {
+  it('generates 256 links (65 calcs × 2 locales + 63 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(252)
+    expect(links).toHaveLength(256)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -18,6 +18,7 @@ const EXPECTED_KEYS = [
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
+  'asthmaControl',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -70,6 +71,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'whtr-berechnen',
   'hepatitis-risiko-berechnen',
   'korrigiertes-calcium-rechner',
+  'asthma-kontrolle-testen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -122,12 +124,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-waist-to-height-ratio',
   'hepatitis-risk-calculator-guide',
   'corrected-calcium-calculator',
+  'asthma-control-test-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 64 calculator meta files', () => {
+  it('discovers all 65 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(64)
+    expect(metas).toHaveLength(65)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -165,19 +168,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 61 DE blog slugs', () => {
+  it('returns all 63 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(62)
+    expect(de).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 61 EN blog slugs', () => {
+  it('returns all 63 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(62)
+    expect(en).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -245,9 +248,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 128 calcs + 2 blog index + 124 blog articles = 256)', () => {
+  it('generates correct total URL count (2 home + 130 calcs + 2 blog index + 126 blog articles = 260)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(256)
+    expect(urlCount).toBe(260)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -557,6 +557,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'correctedCalcium',
     related: ['anion-gap', 'sodium-correction-calculator', 'gfr-calculator-kidney-function'],
   },
+  {
+    slug: 'asthma-control-test-guide',
+    title: 'Asthma Control Test (ACT) Guide: Score, Ranges, and Next Steps',
+    description: 'How well is your asthma controlled? The validated 5-question ACT yields a 5–25 score with clear interpretation and step-up guidance for everyday management.',
+    date: '2026-05-07',
+    readTime: '8 min',
+    calculatorKey: 'asthmaControl',
+    related: ['calculate-vo2max', 'calculate-heart-rate-zones', 'vitamin-d-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -557,6 +557,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'correctedCalcium',
     related: ['anionenluecke-rechner', 'natrium-korrektur-berechnen', 'gfr-rechner'],
   },
+  {
+    slug: 'asthma-kontrolle-testen',
+    title: 'Asthma-Kontrolle testen: Der ACT-Score einfach erklärt',
+    description: 'Wie gut ist dein Asthma kontrolliert? Der validierte Asthma Control Test (ACT) gibt in fünf Fragen einen Score von 5–25 mit klarer Einordnung und Handlungsempfehlung.',
+    date: '2026-05-07',
+    readTime: '8 min',
+    calculatorKey: 'asthmaControl',
+    related: ['vo2max-berechnen', 'herzfrequenz-zonen-berechnen', 'vitamin-d-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/asthmaControl.json
+++ b/src/locales/calculators/de/asthmaControl.json
@@ -1,0 +1,124 @@
+{
+  "home": {
+    "calculators": {
+      "asthmaControl": {
+        "name": "Asthma-Kontrolle (ACT)",
+        "description": "ACT-Score berechnen — Asthma-Kontrolle der letzten 4 Wochen einschätzen."
+      }
+    }
+  },
+  "asthmaControl": {
+    "meta": {
+      "title": "Asthma Control Test (ACT) Rechner — Asthma-Kontrolle einschätzen | Health Calculators",
+      "description": "Asthma Control Test (ACT) online berechnen. 5 Fragen, Score 5–25, Klassifikation gut / nicht gut / schlecht kontrolliert. Kostenlos, sofort, anonym."
+    },
+    "title": "Asthma Control Test (ACT)",
+    "description": "Beantworte fünf Fragen zu den letzten vier Wochen. Der ACT-Score (5–25) hilft dir und deinem Arzt einzuschätzen, wie gut dein Asthma kontrolliert ist.",
+    "introNote": "Bezugszeitraum: die letzten 4 Wochen. Wähle pro Frage genau eine Antwort.",
+    "questions": {
+      "activityLimitation": {
+        "title": "1. Wie oft hat dein Asthma dich in den letzten 4 Wochen davon abgehalten, bei der Arbeit, in der Schule oder zu Hause so viel wie üblich zu schaffen?",
+        "options": [
+          { "value": 1, "label": "Die ganze Zeit" },
+          { "value": 2, "label": "Meistens" },
+          { "value": 3, "label": "Manchmal" },
+          { "value": 4, "label": "Selten" },
+          { "value": 5, "label": "Nie" }
+        ]
+      },
+      "shortnessOfBreath": {
+        "title": "2. Wie oft hattest du in den letzten 4 Wochen Atemnot?",
+        "options": [
+          { "value": 1, "label": "Mehr als 1× pro Tag" },
+          { "value": 2, "label": "1× pro Tag" },
+          { "value": 3, "label": "3–6× pro Woche" },
+          { "value": 4, "label": "1–2× pro Woche" },
+          { "value": 5, "label": "Gar nicht" }
+        ]
+      },
+      "nightSymptoms": {
+        "title": "3. Wie oft haben dich Asthma-Symptome (Husten, Pfeifen, Atemnot, Engegefühl) in den letzten 4 Wochen nachts oder früh morgens geweckt?",
+        "options": [
+          { "value": 1, "label": "4 oder mehr Nächte pro Woche" },
+          { "value": 2, "label": "2–3 Nächte pro Woche" },
+          { "value": 3, "label": "1× pro Woche" },
+          { "value": 4, "label": "1–2× insgesamt" },
+          { "value": 5, "label": "Gar nicht" }
+        ]
+      },
+      "rescueInhalerUse": {
+        "title": "4. Wie oft hast du in den letzten 4 Wochen dein Notfall-Spray (z. B. Salbutamol) oder Vernebler benutzt?",
+        "options": [
+          { "value": 1, "label": "3 oder mehr Mal pro Tag" },
+          { "value": 2, "label": "1–2× pro Tag" },
+          { "value": 3, "label": "2–3× pro Woche" },
+          { "value": 4, "label": "1× pro Woche oder seltener" },
+          { "value": 5, "label": "Gar nicht" }
+        ]
+      },
+      "selfRating": {
+        "title": "5. Wie würdest du selbst die Kontrolle deines Asthmas in den letzten 4 Wochen einschätzen?",
+        "options": [
+          { "value": 1, "label": "Überhaupt nicht kontrolliert" },
+          { "value": 2, "label": "Schlecht kontrolliert" },
+          { "value": 3, "label": "Etwas kontrolliert" },
+          { "value": 4, "label": "Gut kontrolliert" },
+          { "value": 5, "label": "Vollständig kontrolliert" }
+        ]
+      }
+    },
+    "categories": {
+      "wellControlled": "Gut kontrolliert",
+      "notWellControlled": "Nicht gut kontrolliert",
+      "poorlyControlled": "Schlecht kontrolliert"
+    },
+    "hints": {
+      "wellControlled": "Score 20–25: Dein Asthma scheint gut kontrolliert. Behalte deine Therapie und Auslöser-Vermeidung bei. Sprich beim nächsten Termin mit deinem Arzt über mögliche Anpassungen.",
+      "notWellControlled": "Score 16–19: Dein Asthma ist nicht ausreichend kontrolliert. Vereinbare einen Termin mit deinem Arzt — eine Anpassung der Dauertherapie ist häufig sinnvoll.",
+      "poorlyControlled": "Score 5–15: Dein Asthma ist schlecht kontrolliert. Suche zeitnah ärztliche Hilfe. Bei akuter Atemnot: Notfall-Spray nutzen und ggf. Notruf 112."
+    },
+    "reset": "Antworten zurücksetzen",
+    "scoreLabel": "ACT-Score",
+    "scoreScale": "von 25",
+    "incompleteHint": "Beantworte alle 5 Fragen, um deinen ACT-Score zu sehen.",
+    "scaleTitle": "Bewertungsskala",
+    "scaleRows": [
+      { "range": "20 – 25", "label": "Gut kontrolliert", "hint": "Therapie & Auslöser-Vermeidung beibehalten" },
+      { "range": "16 – 19", "label": "Nicht gut kontrolliert", "hint": "Therapie-Anpassung mit Arzt besprechen" },
+      { "range": "5 – 15", "label": "Schlecht kontrolliert", "hint": "Zeitnah ärztlich abklären lassen" }
+    ],
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Asthma Control Test (ACT) wurde 2004 von Nathan und Kollegen validiert (J Allergy Clin Immunol). Fünf Fragen mit je 1–5 Punkten ergeben einen Gesamtscore von 5 bis 25. Ein Score ≥ 20 entspricht gut kontrolliertem Asthma; ≤ 19 zeigt einen Therapie-Bedarf an. GINA empfiehlt den ACT als Verlaufsinstrument.",
+    "disclaimer": "Der ACT ist ein Screening- und Verlaufsinstrument. Er ersetzt keine ärztliche Diagnose. Bei akuter Atemnot, Notfallspray-Gebrauch über 4× pro Tag oder rapider Verschlechterung sofort ärztliche Hilfe suchen.",
+    "faq": [
+      {
+        "q": "Was misst der Asthma Control Test (ACT)?",
+        "a": "Der ACT misst, wie gut dein Asthma in den letzten 4 Wochen kontrolliert war. Er erfasst Aktivitätseinschränkung, Atemnot, nächtliche Symptome, Notfallspray-Gebrauch und deine subjektive Einschätzung."
+      },
+      {
+        "q": "Welche Score-Bereiche gibt es?",
+        "a": "20–25 Punkte: gut kontrolliert. 16–19 Punkte: nicht gut kontrolliert. 5–15 Punkte: schlecht kontrolliert. Ein Score von 25 bedeutet vollständige Kontrolle."
+      },
+      {
+        "q": "Wie oft sollte ich den ACT machen?",
+        "a": "Bei stabilem Asthma alle 3 Monate. Bei Therapieumstellung oder Verschlechterung häufiger. Trends über mehrere Tests sind aussagekräftiger als ein Einzelwert."
+      },
+      {
+        "q": "Was bedeutet ein Score unter 20?",
+        "a": "Ein Score unter 20 zeigt, dass dein Asthma in den letzten 4 Wochen nicht optimal kontrolliert war. Das ist ein Anlass, mit deinem Arzt über Therapie-Anpassungen oder Auslöser-Vermeidung zu sprechen — nicht zwingend ein Notfall."
+      },
+      {
+        "q": "Ist der ACT für Kinder geeignet?",
+        "a": "Der hier vorgestellte ACT ist für Erwachsene und Jugendliche ab 12 Jahren validiert. Für Kinder von 4–11 Jahren existiert der Childhood Asthma Control Test (cACT) mit kindgerechten Fragen."
+      },
+      {
+        "q": "Ersetzt der ACT eine Lungenfunktionsprüfung?",
+        "a": "Nein. Der ACT erfasst Symptome, nicht die Lungenfunktion. FEV1 oder Peak-Flow-Messungen ergänzen den ACT — beide zusammen geben das vollständige Bild der Asthma-Kontrolle."
+      },
+      {
+        "q": "Was tun bei akuter Atemnot trotz ACT-Score?",
+        "a": "Bei akuter Atemnot zählt nicht der ACT, sondern sofortiges Handeln: Notfallspray (Salbutamol) 2–4 Hübe, aufrecht hinsetzen, ruhig atmen. Bei ausbleibender Besserung Notruf 112."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/asthmaControl.json
+++ b/src/locales/calculators/en/asthmaControl.json
@@ -1,0 +1,124 @@
+{
+  "home": {
+    "calculators": {
+      "asthmaControl": {
+        "name": "Asthma Control Test (ACT)",
+        "description": "Calculate your ACT score — assess asthma control over the past 4 weeks."
+      }
+    }
+  },
+  "asthmaControl": {
+    "meta": {
+      "title": "Asthma Control Test (ACT) Calculator — Score 5–25 | Health Calculators",
+      "description": "Take the validated Asthma Control Test online. 5 questions, score 5–25, classification: well / not well / poorly controlled. Free, instant, anonymous."
+    },
+    "title": "Asthma Control Test (ACT)",
+    "description": "Answer five questions about the past four weeks. Your ACT score (5–25) helps you and your doctor judge how well your asthma is controlled.",
+    "introNote": "Reference period: the past 4 weeks. Pick exactly one answer per question.",
+    "questions": {
+      "activityLimitation": {
+        "title": "1. In the past 4 weeks, how much of the time did your asthma keep you from getting as much done at work, school, or home?",
+        "options": [
+          { "value": 1, "label": "All of the time" },
+          { "value": 2, "label": "Most of the time" },
+          { "value": 3, "label": "Some of the time" },
+          { "value": 4, "label": "A little of the time" },
+          { "value": 5, "label": "None of the time" }
+        ]
+      },
+      "shortnessOfBreath": {
+        "title": "2. During the past 4 weeks, how often have you had shortness of breath?",
+        "options": [
+          { "value": 1, "label": "More than once a day" },
+          { "value": 2, "label": "Once a day" },
+          { "value": 3, "label": "3 to 6 times a week" },
+          { "value": 4, "label": "Once or twice a week" },
+          { "value": 5, "label": "Not at all" }
+        ]
+      },
+      "nightSymptoms": {
+        "title": "3. During the past 4 weeks, how often did your asthma symptoms (wheezing, coughing, shortness of breath, chest tightness) wake you up at night or earlier than usual?",
+        "options": [
+          { "value": 1, "label": "4 or more nights a week" },
+          { "value": 2, "label": "2 to 3 nights a week" },
+          { "value": 3, "label": "Once a week" },
+          { "value": 4, "label": "Once or twice total" },
+          { "value": 5, "label": "Not at all" }
+        ]
+      },
+      "rescueInhalerUse": {
+        "title": "4. During the past 4 weeks, how often have you used your rescue inhaler or nebulizer (e.g. albuterol/salbutamol)?",
+        "options": [
+          { "value": 1, "label": "3 or more times a day" },
+          { "value": 2, "label": "1 to 2 times a day" },
+          { "value": 3, "label": "2 to 3 times a week" },
+          { "value": 4, "label": "Once a week or less" },
+          { "value": 5, "label": "Not at all" }
+        ]
+      },
+      "selfRating": {
+        "title": "5. How would you rate your asthma control during the past 4 weeks?",
+        "options": [
+          { "value": 1, "label": "Not controlled at all" },
+          { "value": 2, "label": "Poorly controlled" },
+          { "value": 3, "label": "Somewhat controlled" },
+          { "value": 4, "label": "Well controlled" },
+          { "value": 5, "label": "Completely controlled" }
+        ]
+      }
+    },
+    "categories": {
+      "wellControlled": "Well controlled",
+      "notWellControlled": "Not well controlled",
+      "poorlyControlled": "Poorly controlled"
+    },
+    "hints": {
+      "wellControlled": "Score 20–25: Your asthma appears well controlled. Stay on your current treatment and trigger avoidance. Discuss any step-down with your doctor at the next visit.",
+      "notWellControlled": "Score 16–19: Your asthma is not adequately controlled. Schedule a visit with your doctor — a step-up in controller therapy is often appropriate.",
+      "poorlyControlled": "Score 5–15: Your asthma is poorly controlled. Seek medical attention soon. For acute breathlessness use your rescue inhaler and call emergency services if needed."
+    },
+    "reset": "Reset answers",
+    "scoreLabel": "ACT score",
+    "scoreScale": "of 25",
+    "incompleteHint": "Answer all 5 questions to see your ACT score.",
+    "scaleTitle": "Score interpretation",
+    "scaleRows": [
+      { "range": "20 – 25", "label": "Well controlled", "hint": "Maintain therapy and trigger avoidance" },
+      { "range": "16 – 19", "label": "Not well controlled", "hint": "Discuss therapy adjustment with your doctor" },
+      { "range": "5 – 15", "label": "Poorly controlled", "hint": "Seek medical review promptly" }
+    ],
+    "howItWorks": "How it works",
+    "howItWorksText": "The Asthma Control Test (ACT) was validated by Nathan and colleagues in 2004 (J Allergy Clin Immunol). Five questions, scored 1–5 each, sum to 5–25 total. A score ≥ 20 indicates well-controlled asthma; ≤ 19 suggests treatment review. GINA recommends the ACT as a longitudinal monitoring tool.",
+    "disclaimer": "The ACT is a screening and monitoring tool. It does not replace clinical diagnosis. For acute breathlessness, rescue inhaler use exceeding 4× per day, or rapid deterioration, seek medical attention immediately.",
+    "faq": [
+      {
+        "q": "What does the Asthma Control Test (ACT) measure?",
+        "a": "The ACT measures how well your asthma was controlled over the past 4 weeks. It captures activity limitation, shortness of breath, nighttime symptoms, rescue inhaler use, and your subjective control rating."
+      },
+      {
+        "q": "What do the score ranges mean?",
+        "a": "20–25 points: well controlled. 16–19 points: not well controlled. 5–15 points: poorly controlled. A score of 25 indicates complete control."
+      },
+      {
+        "q": "How often should I take the ACT?",
+        "a": "Every 3 months when stable; more often during therapy changes or worsening. Trends across multiple tests carry more weight than a single value."
+      },
+      {
+        "q": "What does a score below 20 mean?",
+        "a": "A score below 20 indicates your asthma was not optimally controlled in the past 4 weeks. That is a reason to discuss therapy adjustments or trigger avoidance with your doctor — not necessarily an emergency."
+      },
+      {
+        "q": "Is the ACT suitable for children?",
+        "a": "The ACT shown here is validated for adults and adolescents 12+ years. For children aged 4–11, use the Childhood Asthma Control Test (cACT) with age-appropriate items."
+      },
+      {
+        "q": "Does the ACT replace lung function testing?",
+        "a": "No. The ACT captures symptoms, not lung function. Spirometry (FEV1) or peak flow measurements complement the ACT — together they give the full picture of asthma control."
+      },
+      {
+        "q": "What if I have acute breathlessness despite a high ACT score?",
+        "a": "An acute attack overrides the ACT. Use your rescue inhaler (2–4 puffs of albuterol/salbutamol), sit upright, breathe calmly. If symptoms do not improve, call emergency services."
+      }
+    ]
+  }
+}

--- a/src/pages/AsthmaControlCalculator.vue
+++ b/src/pages/AsthmaControlCalculator.vue
@@ -1,0 +1,189 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { ACT_QUESTIONS, evaluateAct } from '../utils/asthmaControl.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('asthmaControl.faq') || [])
+
+useHead(() => ({
+  title: t('asthmaControl.meta.title'),
+  description: t('asthmaControl.meta.description'),
+  routeKey: 'asthmaControl',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Asthma Control Test Calculator',
+    url: 'https://healthcalculator.app/asthma-control-test',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const answers = ref({
+  activityLimitation: null,
+  shortnessOfBreath: null,
+  nightSymptoms: null,
+  rescueInhalerUse: null,
+  selfRating: null,
+})
+
+const result = computed(() => evaluateAct(answers.value))
+
+const answeredCount = computed(() =>
+  ACT_QUESTIONS.filter(q => Number.isInteger(answers.value[q])).length,
+)
+
+const progressPct = computed(() => (answeredCount.value / ACT_QUESTIONS.length) * 100)
+
+const interpretation = computed(() => {
+  if (!result.value) return null
+  const k = result.value.category
+  if (k === 'wellControlled') return { key: k, color: 'text-green-600', bg: 'bg-green-600', border: 'border-green-200' }
+  if (k === 'notWellControlled') return { key: k, color: 'text-orange-500', bg: 'bg-orange-500', border: 'border-orange-200' }
+  return { key: k, color: 'text-red-500', bg: 'bg-red-500', border: 'border-red-200' }
+})
+
+function reset() {
+  for (const q of ACT_QUESTIONS) answers.value[q] = null
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('asthmaControl.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('asthmaControl.description') }}</p>
+    </div>
+
+    <!-- Intro / progress -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-6">
+      <p class="text-sm text-stone-600 mb-4">{{ t('asthmaControl.introNote') }}</p>
+      <div class="flex items-center gap-4">
+        <div class="flex-1 h-1.5 bg-stone-100 rounded-full overflow-hidden">
+          <div class="h-full bg-stone-900 transition-all duration-200" :style="{ width: progressPct + '%' }"></div>
+        </div>
+        <span class="text-xs font-semibold text-stone-500 tabular-nums">{{ answeredCount }} / 5</span>
+      </div>
+    </div>
+
+    <!-- Questions -->
+    <div class="space-y-6 mb-6">
+      <div
+        v-for="qKey in ACT_QUESTIONS"
+        :key="qKey"
+        class="bg-white border border-stone-200 rounded-xl shadow-sm p-6"
+        :data-testid="'question-' + qKey"
+      >
+        <p class="text-base font-semibold text-stone-900 mb-4 leading-snug">
+          {{ t(`asthmaControl.questions.${qKey}.title`) }}
+        </p>
+        <div class="space-y-2">
+          <button
+            v-for="opt in tm(`asthmaControl.questions.${qKey}.options`)"
+            :key="opt.value"
+            @click="answers[qKey] = opt.value"
+            :data-testid="`option-${qKey}-${opt.value}`"
+            :class="answers[qKey] === opt.value
+              ? 'bg-stone-900 text-white border-stone-900'
+              : 'bg-white text-stone-700 border-stone-200 hover:border-stone-400 hover:bg-stone-50'"
+            class="w-full text-left border rounded-lg px-4 py-3 text-sm font-medium transition-colors duration-150 flex items-center gap-3"
+          >
+            <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold tabular-nums shrink-0"
+              :class="answers[qKey] === opt.value ? 'bg-white text-stone-900' : 'bg-stone-100 text-stone-600'"
+            >{{ opt.value }}</span>
+            <span>{{ opt.label }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Result -->
+    <div v-if="result" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex items-center gap-3 mb-6">
+        <span
+          data-testid="result-status"
+          :class="[interpretation.bg, 'text-white text-sm font-semibold px-3 py-1 rounded-full']"
+        >{{ t('asthmaControl.categories.' + interpretation.key) }}</span>
+      </div>
+
+      <div class="mb-6">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('asthmaControl.scoreLabel') }}</div>
+        <div class="flex items-baseline gap-3">
+          <span data-testid="result-score" class="text-6xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ result.score }}</span>
+          <span class="text-base text-stone-400">{{ t('asthmaControl.scoreScale') }}</span>
+        </div>
+      </div>
+
+      <!-- Score scale bar -->
+      <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+        <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-red-500 via-orange-500 to-green-600 rounded-full" style="width: 100%"></div>
+        <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: ((result.score - 5) / 20) * 100 + '%' }"></div>
+      </div>
+
+      <div :class="[interpretation.border, 'border rounded-lg px-4 py-3 bg-stone-50']">
+        <p data-testid="result-hint" class="text-sm text-stone-700 leading-relaxed">{{ t('asthmaControl.hints.' + interpretation.key) }}</p>
+      </div>
+
+      <div class="mt-6 pt-4 border-t border-stone-100">
+        <button @click="reset" data-testid="reset"
+          class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150">{{ t('asthmaControl.reset') }}</button>
+      </div>
+    </div>
+
+    <div v-else class="bg-stone-50 border border-stone-200 rounded-xl p-6 mb-6">
+      <p data-testid="incomplete-hint" class="text-sm text-stone-500">{{ t('asthmaControl.incompleteHint') }}</p>
+    </div>
+
+    <!-- Score scale -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('asthmaControl.scaleTitle') }}</h2>
+      <div class="space-y-3">
+        <div
+          v-for="(row, i) in tm('asthmaControl.scaleRows')"
+          :key="i"
+          class="flex items-start justify-between border-b border-stone-100 pb-3 last:border-0 last:pb-0"
+        >
+          <div class="flex items-center gap-3">
+            <div :class="[
+              i === 0 ? 'bg-green-600' : i === 1 ? 'bg-orange-500' : 'bg-red-500',
+              'w-2.5 h-2.5 rounded-full shrink-0 mt-0.5',
+            ]"></div>
+            <div>
+              <span class="text-sm text-stone-900 font-medium">{{ row.label }}</span>
+              <p class="text-xs text-stone-500">{{ row.hint }}</p>
+            </div>
+          </div>
+          <div class="text-sm font-medium text-stone-900 tabular-nums shrink-0 ml-4">{{ row.range }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- How it works -->
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('asthmaControl.howItWorks') }}</h2>
+      <p class="text-sm text-stone-500 leading-relaxed">{{ t('asthmaControl.howItWorksText') }}</p>
+    </div>
+
+    <!-- Disclaimer -->
+    <div class="bg-stone-50 border border-stone-200 rounded-xl px-6 py-4 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('asthmaControl.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <BlogArticleLink calculator-key="asthmaControl" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/asthmaControl.meta.js
+++ b/src/pages/asthmaControl.meta.js
@@ -1,0 +1,16 @@
+import Component from './AsthmaControlCalculator.vue'
+import BlogDe from './blog/AsthmaKontrolleTesten.vue'
+import BlogEn from './blog/en/AsthmaControlTestGuide.vue'
+
+export default {
+  key: 'asthmaControl',
+  component: Component,
+  slugs: { de: 'asthma-kontrolle-test', en: 'asthma-control-test' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 100,
+  blog: {
+    de: { slug: 'asthma-kontrolle-testen', component: BlogDe },
+    en: { slug: 'asthma-control-test-guide', component: BlogEn },
+  },
+}

--- a/src/pages/blog/AsthmaKontrolleTesten.vue
+++ b/src/pages/blog/AsthmaKontrolleTesten.vue
@@ -1,0 +1,218 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Asthma-Kontrolle testen — der ACT-Score einfach erklärt | Health Calculators',
+  description: 'Asthma-Kontrolle mit dem Asthma Control Test (ACT) selbst einschätzen. Score 5–25, Bedeutung der Bereiche, klinische Relevanz und sinnvolle nächste Schritte — verständlich erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Asthma-Kontrolle testen — der ACT-Score einfach erklärt',
+      description: 'Wie gut ist dein Asthma kontrolliert? Der Asthma Control Test (ACT) gibt eine validierte Antwort in fünf Fragen.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-07',
+      dateModified: '2026-05-07',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/asthma-kontrolle-testen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was misst der Asthma Control Test?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Der ACT misst, wie gut dein Asthma in den letzten 4 Wochen kontrolliert war — anhand von Aktivitätseinschränkung, Atemnot, Nachtsymptomen, Notfallspray-Gebrauch und subjektiver Einschätzung.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was bedeuten die Score-Bereiche?',
+          acceptedAnswer: { '@type': 'Answer', text: '20–25: gut kontrolliert. 16–19: nicht gut kontrolliert. 5–15: schlecht kontrolliert. Score 25 = vollständige Kontrolle.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Asthma-Kontrolle testen — der ACT-Score einfach erklärt</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">7. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wie gut ist dein <strong>Asthma kontrolliert</strong>? Diese Frage entscheidet, ob die Therapie passt, ob Trigger im Alltag gemieden werden müssen oder ob ein Arztbesuch ansteht. Der <strong>Asthma Control Test (ACT)</strong> liefert in fünf Fragen eine validierte Antwort.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Beitrag erfährst du, wie der ACT funktioniert, was die Score-Bereiche bedeuten und welche Schritte je nach Ergebnis sinnvoll sind. Außerdem zeigen wir dir, wie der ACT mit anderen Gesundheitsdaten — etwa Lungenfunktion und allgemeiner Fitness — zusammenpasst.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist der ACT?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Asthma Control Test wurde 2004 von Nathan und Kollegen im <em>Journal of Allergy and Clinical Immunology</em> publiziert und seither in zahlreichen Studien validiert. GINA (Global Initiative for Asthma) empfiehlt ihn als Verlaufsinstrument zur Beurteilung der Asthma-Kontrolle.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Fünf Fragen, jeweils mit fünf Antwortoptionen (1–5 Punkte). Bezugsraum sind die letzten <strong>vier Wochen</strong>. Der Gesamtscore reicht von 5 bis 25.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die fünf Fragen des ACT</h2>
+        <ol class="space-y-3 mb-4 list-decimal list-inside">
+          <li class="text-stone-600 text-base"><strong>Aktivitätseinschränkung</strong> — Wie oft hat dich dein Asthma beim Arbeiten, in der Schule oder zu Hause gebremst?</li>
+          <li class="text-stone-600 text-base"><strong>Atemnot</strong> — Wie häufig hattest du Atemnot?</li>
+          <li class="text-stone-600 text-base"><strong>Nachtsymptome</strong> — Wie oft haben Asthma-Symptome dich nachts oder früh morgens geweckt?</li>
+          <li class="text-stone-600 text-base"><strong>Notfallspray-Gebrauch</strong> — Wie oft hast du dein SABA (Salbutamol) benutzt?</li>
+          <li class="text-stone-600 text-base"><strong>Selbsteinschätzung</strong> — Wie gut war dein Asthma deiner Meinung nach kontrolliert?</li>
+        </ol>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Score-Bereiche</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bedeutung</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfehlung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">20 – 25</td>
+                <td class="px-6 py-3 text-stone-600">Gut kontrolliert</td>
+                <td class="px-6 py-3 text-stone-600">Therapie & Trigger-Vermeidung beibehalten</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">16 – 19</td>
+                <td class="px-6 py-3 text-stone-600">Nicht gut kontrolliert</td>
+                <td class="px-6 py-3 text-stone-600">Therapie-Anpassung mit Arzt besprechen</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5 – 15</td>
+                <td class="px-6 py-3 text-stone-600">Schlecht kontrolliert</td>
+                <td class="px-6 py-3 text-stone-600">Zeitnah ärztlich abklären lassen</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Eine <strong>Score-Veränderung um ≥ 3 Punkte</strong> gilt als klinisch bedeutsam (MCID nach Schatz et al., 2009). Trends über mehrere Tests sind aussagekräftiger als ein Einzelwert.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was der ACT nicht ersetzt</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der ACT erfasst Symptome — nicht die <strong>Lungenfunktion</strong>. FEV1 oder Peak-Flow ergänzen den Score. Ein guter ACT-Score (z.&nbsp;B. 22) bei niedrigem FEV1 ist ein Warnzeichen: Patienten unterschätzen ihre Symptome häufig (Schatz 2006).
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Auch <strong>Exazerbationen</strong> und der Bedarf an oralen Steroiden gehören zur Risikoeinschätzung — beides erfragt der ACT nicht.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was du jetzt tun kannst</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score &lt; 20:</strong> Termin beim Hausarzt oder Pneumologen — meist genügt eine Step-up-Therapie nach GINA-Stufe.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Notfallspray &gt; 2× pro Woche:</strong> klares Zeichen für ungenügende Dauertherapie. SABA-Übergebrauch erhöht das Exazerbationsrisiko.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Trigger identifizieren:</strong> Pollen, Tierhaare, Rauch, Anstrengung, Infekte. Asthma-Tagebuch über 2 Wochen kann helfen.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Inhalator-Technik überprüfen:</strong> bis zu 70 % der Patienten inhalieren falsch. Ein 2-Minuten-Check beim Apotheker oder Arzt.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen & Rechner</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>VO₂max</strong> — die maximale Sauerstoffaufnahme ist bei kontrolliertem Asthma kaum vermindert. Sinkt sie spürbar, lohnt eine Lungenfunktion. Zum <router-link :to="localeBlogPath('vo2max-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">VO₂max-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Herzfrequenz beim Sport</strong> — Anstrengungs-induziertes Asthma ist häufig. Trainings-Zonen helfen, Symptome im Griff zu behalten. Zum <router-link :to="localeBlogPath('herzfrequenz-zonen-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Herzfrequenz-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Vitamin D</strong> — Vitamin-D-Mangel ist mit erhöhter Asthma-Aktivität assoziiert (Cochrane 2016). Zum <router-link :to="localeBlogPath('vitamin-d-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Vitamin-D-Artikel</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deinen ACT-Score berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Fünf Fragen, anonym, sofort. Direkte Einordnung deiner Asthma-Kontrolle der letzten 4 Wochen.</p>
+        <router-link
+          :to="localePath('asthmaControl')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum Asthma Control Test &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Wie oft sollte ich den ACT machen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Bei stabilem Asthma alle drei Monate. Bei Therapieumstellung oder Verschlechterung wöchentlich. Eine kontinuierliche Trend-Beobachtung ist aussagekräftiger als ein Einzelwert.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Mein Score liegt unter 16 — ist das ein Notfall?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Nein, ein niedriger Score ist kein akuter Notfall, aber ein klares Signal für unzureichende Kontrolle. Vereinbare zeitnah einen Termin. Bei akuter Atemnot oder schnell zunehmenden Symptomen unabhängig vom Score sofort ärztliche Hilfe oder Notruf 112.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Funktioniert der ACT auch bei Kindern?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Der hier vorgestellte ACT ist ab 12 Jahren validiert. Für Kinder von 4–11 Jahren existiert der Childhood Asthma Control Test (cACT) mit kindgerechter Sprache und einer Eltern-Komponente.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Welche Rolle spielen Trigger?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Trigger erklären oft, warum sich der Score plötzlich verschlechtert. Häufige Auslöser: Infekte, Pollen, Tierallergene, Rauch, kalte Luft, Anstrengung. Ein Asthma-Tagebuch über 2 Wochen deckt persönliche Trigger meist zuverlässig auf.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/pages/blog/en/AsthmaControlTestGuide.vue
+++ b/src/pages/blog/en/AsthmaControlTestGuide.vue
@@ -1,0 +1,218 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Asthma Control Test (ACT) — Score, Ranges, Next Steps | Health Calculators',
+  description: 'How well is your asthma controlled? The validated 5-question Asthma Control Test (ACT) gives a 5–25 score with clear interpretation and next-step guidance.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Asthma Control Test (ACT) — Score, Ranges, Next Steps',
+      description: 'The 5-question ACT translates four weeks of symptoms into a single score from 5 to 25 — a validated tool for monitoring asthma control.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-07',
+      dateModified: '2026-05-07',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/asthma-control-test-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What does the Asthma Control Test measure?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The ACT measures how well your asthma was controlled over the past 4 weeks across activity limitation, shortness of breath, nighttime symptoms, rescue inhaler use, and self-rated control.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What do the ACT score ranges mean?',
+          acceptedAnswer: { '@type': 'Answer', text: '20–25: well controlled. 16–19: not well controlled. 5–15: poorly controlled. A score of 25 indicates complete control.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Asthma Control Test (ACT) — Score, Ranges, Next Steps</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 7, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          How <strong>well controlled</strong> is your asthma right now? That single question shapes everything: whether your treatment plan still fits, whether environmental triggers are creeping in, and whether you need a clinic visit. The <strong>Asthma Control Test (ACT)</strong> answers it in five questions.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide walks you through the ACT — what it measures, what each score range means, and what to do next based on your result. We also place the ACT in context: how it complements lung function, fitness, and other health markers.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is the ACT?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The Asthma Control Test was published by Nathan and colleagues in the <em>Journal of Allergy and Clinical Immunology</em> in 2004 and has been validated in dozens of studies since. The Global Initiative for Asthma (GINA) recommends it as a longitudinal monitoring tool.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Five questions, scored 1–5 each. Reference period: the past <strong>four weeks</strong>. Total score: 5 to 25.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The five ACT questions</h2>
+        <ol class="space-y-3 mb-4 list-decimal list-inside">
+          <li class="text-stone-600 text-base"><strong>Activity limitation</strong> — How often did asthma keep you from getting things done at work, school, or home?</li>
+          <li class="text-stone-600 text-base"><strong>Shortness of breath</strong> — How often have you been short of breath?</li>
+          <li class="text-stone-600 text-base"><strong>Nighttime symptoms</strong> — How often did asthma wake you up at night or earlier than usual?</li>
+          <li class="text-stone-600 text-base"><strong>Rescue inhaler use</strong> — How often have you used your SABA (albuterol/salbutamol)?</li>
+          <li class="text-stone-600 text-base"><strong>Self-rating</strong> — How would you rate your overall asthma control?</li>
+        </ol>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Score ranges</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Meaning</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Suggested action</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">20 – 25</td>
+                <td class="px-6 py-3 text-stone-600">Well controlled</td>
+                <td class="px-6 py-3 text-stone-600">Maintain therapy and trigger avoidance</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">16 – 19</td>
+                <td class="px-6 py-3 text-stone-600">Not well controlled</td>
+                <td class="px-6 py-3 text-stone-600">Discuss therapy adjustment with your doctor</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5 – 15</td>
+                <td class="px-6 py-3 text-stone-600">Poorly controlled</td>
+                <td class="px-6 py-3 text-stone-600">Seek medical review promptly</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A change of <strong>≥ 3 points</strong> is considered clinically meaningful (MCID, Schatz et al. 2009). Trends across multiple ACTs carry more weight than a single value.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What the ACT does not replace</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The ACT captures <strong>symptoms</strong>, not <strong>lung function</strong>. Spirometry (FEV1) or peak flow complements the score. A reassuring ACT (e.g. 22) paired with a low FEV1 is a red flag — patients often underestimate their symptoms (Schatz 2006).
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The ACT also does not assess <strong>exacerbation risk</strong> directly. Frequent oral steroid courses or hospital visits are independent warning signs even if the ACT looks fine.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What to do based on your score</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score &lt; 20:</strong> book a primary care or pulmonology visit — usually a step-up in controller therapy by GINA stage is enough.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Rescue inhaler &gt; 2× per week:</strong> a clear sign that controller therapy is too light. Overuse increases exacerbation risk.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Identify triggers:</strong> pollen, animal dander, smoke, exercise, infections. A 2-week asthma diary surfaces personal triggers reliably.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Check inhaler technique:</strong> up to 70% of patients inhale incorrectly. A 2-minute review at the pharmacy or clinic.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics & calculators</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>VO₂max</strong> — maximum oxygen uptake stays normal in well-controlled asthma. A noticeable drop suggests further lung-function workup. See the <router-link :to="localeBlogPath('calculate-vo2max')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">VO₂max guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Heart-rate zones</strong> — exercise-induced asthma is common; targeted training zones help keep symptoms manageable. See the <router-link :to="localeBlogPath('calculate-heart-rate-zones')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">heart-rate guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Vitamin D</strong> — vitamin D deficiency is associated with higher asthma activity (Cochrane 2016). See the <router-link :to="localeBlogPath('vitamin-d-calculator')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">vitamin D guide</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Take the ACT now</h3>
+        <p class="text-stone-300 text-sm mb-5">Five questions, instant score, anonymous. Get a clear read on how well your asthma was controlled over the past 4 weeks.</p>
+        <router-link
+          :to="localePath('asthmaControl')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Open the Asthma Control Test &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequently asked questions</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">How often should I take the ACT?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Every three months when stable. Weekly during therapy changes or after an exacerbation. Watching the trend is more informative than any single value.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">My score is below 16 — is this an emergency?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              No, a low score is not an emergency, but it is a clear signal of insufficient control. Schedule a clinic visit soon. For acute breathlessness or rapid worsening, ignore the score and seek medical help or call emergency services.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Does the ACT work for children?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              The ACT shown here is validated for ages 12 and up. For children aged 4–11 use the Childhood ACT (cACT), which is age-appropriate and includes a parent-rated component.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">What role do triggers play?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Triggers often explain sudden score drops. Common ones: respiratory infections, pollen, pet allergens, smoke, cold air, exercise. A two-week asthma diary usually reveals personal patterns.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/utils/asthmaControl.js
+++ b/src/utils/asthmaControl.js
@@ -1,0 +1,50 @@
+// ACT — Asthma Control Test (Nathan RA et al., J Allergy Clin Immunol, 2004).
+//
+// Five questions about the past 4 weeks, each scored 1–5, total 5–25:
+//   1. Activity limitation
+//   2. Shortness of breath frequency
+//   3. Night-time / early-morning symptoms
+//   4. Rescue inhaler / SABA use
+//   5. Self-rated control
+//
+// Score classification (Nathan 2004; GINA 2024):
+//   25       : well controlled (perfect)
+//   20–24    : well controlled
+//   16–19    : not well controlled
+//    5–15    : poorly controlled
+
+export const ACT_QUESTIONS = [
+  'activityLimitation',
+  'shortnessOfBreath',
+  'nightSymptoms',
+  'rescueInhalerUse',
+  'selfRating',
+]
+
+function isValidAnswer(v) {
+  return Number.isInteger(v) && v >= 1 && v <= 5
+}
+
+export function calcActScore(answers) {
+  if (!answers || typeof answers !== 'object') return null
+  let total = 0
+  for (const q of ACT_QUESTIONS) {
+    if (!isValidAnswer(answers[q])) return null
+    total += answers[q]
+  }
+  return total
+}
+
+export function classifyAct(total) {
+  if (typeof total !== 'number' || !Number.isFinite(total)) return null
+  if (total < 5 || total > 25) return null
+  if (total >= 20) return 'wellControlled'
+  if (total >= 16) return 'notWellControlled'
+  return 'poorlyControlled'
+}
+
+export function evaluateAct(answers) {
+  const score = calcActScore(answers)
+  if (score === null) return null
+  return { score, category: classifyAct(score) }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-157-asthma-control
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-157-asthma-control-20260507-120031`
**Cost:** $8.5794585

Closes jenslaufer/health-calculators#157

### Prompt
> Implement the Asthma Control Calculator as described in issue #157.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- ACT (Asthma Control Test)
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/asthmaControl.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/asthmaControl.test.js` with 6+ test cases covering edge cases. Run `npm test -- asthmaControl` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/AsthmaControlCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/asthmaControl.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/asthmaControl.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'asthmaControl'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/asthmaControl.json` + `src/locales/calculators/en/asthmaControl.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/asthmaControl.js (or shared util — verify pattern in repo first)`
- `src/__tests__/asthmaControl.test.js`
- `src/pages/AsthmaControlCalculator.vue`
- `src/pages/asthmaControl.meta.js`
- `src/locales/calculators/de/asthmaControl.json`
- `src/locales/calculators/en/asthmaControl.json`
- `e2e/asthmaControl.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'asthmaControl',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks