### PR TITLE
hc-129-baby-feeding-amount: Implement the Baby Feeding Amount Calculator as described in

### DIFF
--- a/e2e/babyFeedingAmount.spec.js
+++ b/e2e/babyFeedingAmount.spec.js
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/baby-trinkmenge-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Baby-Trinkmenge-Rechner/)
+})
+
+test('5 kg and 2 months shows expected daily and per-feeding amount', async ({ page }) => {
+  await page.getByTestId('input-age').fill('2')
+  await page.getByTestId('input-weight').fill('5')
+
+  await expect(page.getByTestId('result-daily-ml')).toContainText('750')
+  await expect(page.getByTestId('result-per-feeding-ml')).toContainText('107')
+  await expect(page.getByTestId('result-feedings')).toHaveText('7')
+})
+
+test('imperial toggle calculates and shows results', async ({ page }) => {
+  await page.getByTestId('unit-imperial').click()
+  await page.getByTestId('input-age').fill('2')
+  await page.getByTestId('input-weight').fill('11')
+
+  await expect(page.getByTestId('result-daily-ml')).toBeVisible()
+  await expect(page.getByTestId('result-per-feeding-ml')).toBeVisible()
+  await expect(page.getByTestId('result-feedings')).toHaveText('7')
+})
+
+test('shows age warning for implausible age', async ({ page }) => {
+  await page.getByTestId('input-age').fill('25')
+  await expect(page.getByTestId('warning-age')).toBeVisible()
+})
+
+test('shows weight warning for implausible weight', async ({ page }) => {
+  await page.getByTestId('input-age').fill('2')
+  await page.getByTestId('input-weight').fill('0.5')
+  await expect(page.getByTestId('warning-weight')).toBeVisible()
+})
+
+test('shows capped note when daily amount reaches cap', async ({ page }) => {
+  await page.getByTestId('input-age').fill('2')
+  await page.getByTestId('input-weight').fill('10')
+
+  await expect(page.getByTestId('result-daily-ml')).toContainText('960')
+  await expect(page.getByTestId('note-capped')).toBeVisible()
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -23,7 +23,7 @@ const EXPECTED_KEYS = [
   'prostateRisk', 'pcosSymptoms', 'testosteroneLevel', 'erectileDysfunction',
   'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
+  'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium', 'babyFeedingAmount',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -89,6 +89,7 @@ const EXPECTED_ROUTE_MAP = {
   whtrRechner: { de: 'whtr-rechner', en: 'waist-to-height-ratio-calculator' },
   hepatitisRisk: { de: 'hepatitis-risiko-rechner', en: 'hepatitis-risk-calculator' },
   correctedCalcium: { de: 'korrigiertes-calcium-rechner', en: 'corrected-calcium-calculator' },
+  babyFeedingAmount: { de: 'baby-trinkmenge-rechner', en: 'baby-feeding-amount-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -142,6 +143,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'whtr-berechnen',
   'hepatitis-risiko-berechnen',
   'korrigiertes-calcium-rechner',
+  'baby-trinkmenge-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -195,19 +197,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-waist-to-height-ratio',
   'hepatitis-risk-calculator-guide',
   'corrected-calcium-calculator',
+  'baby-feeding-amount-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 64 calculators', () => {
-    expect(calculatorMetas).toHaveLength(64)
+  it('discovers all 65 calculators', () => {
+    expect(calculatorMetas).toHaveLength(65)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 64 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(64)
+  it('builds calculatorComponents map for all 65 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(65)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -230,15 +233,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 62 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(62)
+  it('discovers all 63 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 62 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(62)
+  it('discovers all 63 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -254,10 +257,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 64 calculators with no duplicates', () => {
+  it('groups contain all 65 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(64)
-    expect(new Set(allKeys).size).toBe(64)
+    expect(allKeys).toHaveLength(65)
+    expect(new Set(allKeys).size).toBe(65)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -285,6 +288,7 @@ describe('calculator groups', () => {
   it('pregnancy group has correct calculators in order', () => {
     expect(calculatorGroups[3].calculators).toEqual([
       'pregnancy', 'ovulation', 'pregnancyWeightGain', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
+      'babyFeedingAmount',
     ])
   })
 })
@@ -326,8 +330,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 356 routes', () => {
-    expect(routes).toHaveLength(356)
+  it('generates exactly 361 routes', () => {
+    expect(routes).toHaveLength(361)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/babyFeedingAmount.test.js
+++ b/src/__tests__/babyFeedingAmount.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcDailyAmountMl,
+  feedingsPerDay,
+  calcPerFeedingMl,
+  babyFeedingAmount,
+  mlToOz,
+  lbToKg,
+  isPlausibleAge,
+  isPlausibleWeightKg,
+} from '../utils/babyFeedingAmount.js'
+
+// Pediatric reference: ~150 ml of formula per kg of body weight per day
+// during the first ~6 months. After 6 months, complementary foods reduce
+// milk needs to ~120 ml/kg/day. Daily intake capped at 960 ml (~32 oz).
+
+describe('calcDailyAmountMl', () => {
+  it('newborn 3 kg, 0 months → 450 ml/day (3 × 150)', () => {
+    expect(calcDailyAmountMl(3, 0)).toBeCloseTo(450, 1)
+  })
+
+  it('infant 5 kg, 2 months → 750 ml/day', () => {
+    expect(calcDailyAmountMl(5, 2)).toBeCloseTo(750, 1)
+  })
+
+  it('infant 6 kg, 4 months → 900 ml/day', () => {
+    expect(calcDailyAmountMl(6, 4)).toBeCloseTo(900, 1)
+  })
+
+  it('caps at 960 ml/day for large infants under 6 months', () => {
+    // 8 kg × 150 = 1200 → capped at 960
+    expect(calcDailyAmountMl(8, 4)).toBe(960)
+  })
+
+  it('after 6 months uses 120 ml/kg/day', () => {
+    // 8 kg × 120 = 960
+    expect(calcDailyAmountMl(8, 7)).toBeCloseTo(960, 1)
+  })
+
+  it('after 6 months also capped at 960', () => {
+    // 9 kg × 120 = 1080 → capped at 960
+    expect(calcDailyAmountMl(9, 8)).toBe(960)
+  })
+
+  it('returns null for missing/invalid weight', () => {
+    expect(calcDailyAmountMl(null, 2)).toBeNull()
+    expect(calcDailyAmountMl(0, 2)).toBeNull()
+    expect(calcDailyAmountMl(-1, 2)).toBeNull()
+  })
+
+  it('returns null for invalid age', () => {
+    expect(calcDailyAmountMl(5, null)).toBeNull()
+    expect(calcDailyAmountMl(5, -1)).toBeNull()
+  })
+})
+
+describe('feedingsPerDay', () => {
+  it('newborn (0 months) → 8 feedings', () => {
+    expect(feedingsPerDay(0)).toBe(8)
+  })
+
+  it('1 month → 7 feedings', () => {
+    expect(feedingsPerDay(1)).toBe(7)
+  })
+
+  it('3 months → 6 feedings', () => {
+    expect(feedingsPerDay(3)).toBe(6)
+  })
+
+  it('5 months → 5 feedings', () => {
+    expect(feedingsPerDay(5)).toBe(5)
+  })
+
+  it('7 months → 4 feedings', () => {
+    expect(feedingsPerDay(7)).toBe(4)
+  })
+
+  it('10 months → 3 feedings', () => {
+    expect(feedingsPerDay(10)).toBe(3)
+  })
+})
+
+describe('calcPerFeedingMl', () => {
+  it('newborn 3 kg → 450/8 = ~56 ml per feeding', () => {
+    expect(calcPerFeedingMl(3, 0)).toBeCloseTo(56.25, 1)
+  })
+
+  it('5 kg, 2 months → 750/7 = ~107 ml per feeding', () => {
+    expect(calcPerFeedingMl(5, 2)).toBeCloseTo(107.14, 1)
+  })
+
+  it('returns null when daily is null', () => {
+    expect(calcPerFeedingMl(null, 2)).toBeNull()
+  })
+})
+
+describe('unit conversions', () => {
+  it('30 ml ≈ 1.014 oz', () => {
+    expect(mlToOz(30)).toBeCloseTo(1.014, 2)
+  })
+
+  it('10 lb → 4.536 kg', () => {
+    expect(lbToKg(10)).toBeCloseTo(4.536, 2)
+  })
+})
+
+describe('plausibility checks', () => {
+  it('rejects age < 0 or > 24 months', () => {
+    expect(isPlausibleAge(-1)).toBe(false)
+    expect(isPlausibleAge(25)).toBe(false)
+    expect(isPlausibleAge(0)).toBe(true)
+    expect(isPlausibleAge(12)).toBe(true)
+  })
+
+  it('rejects implausible weights', () => {
+    expect(isPlausibleWeightKg(0)).toBe(false)
+    expect(isPlausibleWeightKg(0.5)).toBe(false)
+    expect(isPlausibleWeightKg(20)).toBe(false)
+    expect(isPlausibleWeightKg(3.5)).toBe(true)
+    expect(isPlausibleWeightKg(8)).toBe(true)
+  })
+})
+
+describe('babyFeedingAmount (one-shot helper)', () => {
+  it('returns null on invalid input', () => {
+    expect(babyFeedingAmount({ weightKg: null, ageMonths: 2 })).toBeNull()
+    expect(babyFeedingAmount({ weightKg: 5, ageMonths: -1 })).toBeNull()
+  })
+
+  it('returns full result for 5 kg, 2 months', () => {
+    const r = babyFeedingAmount({ weightKg: 5, ageMonths: 2 })
+    expect(r).not.toBeNull()
+    expect(r.dailyMl).toBeCloseTo(750, 1)
+    expect(r.feedings).toBe(7)
+    expect(r.perFeedingMl).toBeCloseTo(107.14, 1)
+  })
+
+  it('respects 6-month threshold', () => {
+    const r = babyFeedingAmount({ weightKg: 7, ageMonths: 7 })
+    expect(r.dailyMl).toBeCloseTo(840, 1)
+    expect(r.feedings).toBe(4)
+    expect(r.perFeedingMl).toBeCloseTo(210, 1)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 252 links (64 calcs × 2 locales + 62 blogs × 2 locales)', () => {
+  it('generates 256 links (65 calcs × 2 locales + 63 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(252)
+    expect(links).toHaveLength(256)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -17,7 +17,7 @@ const EXPECTED_KEYS = [
   'bodyType', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature',
   'bmiFrauen', 'bmiMaenner', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator',
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
-  'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
+  'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium', 'babyFeedingAmount',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -70,6 +70,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'whtr-berechnen',
   'hepatitis-risiko-berechnen',
   'korrigiertes-calcium-rechner',
+  'baby-trinkmenge-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -122,12 +123,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'calculate-waist-to-height-ratio',
   'hepatitis-risk-calculator-guide',
   'corrected-calcium-calculator',
+  'baby-feeding-amount-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 64 calculator meta files', () => {
+  it('discovers all 65 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(64)
+    expect(metas).toHaveLength(65)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -165,19 +167,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 61 DE blog slugs', () => {
+  it('returns all 63 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(62)
+    expect(de).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 61 EN blog slugs', () => {
+  it('returns all 63 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(62)
+    expect(en).toHaveLength(63)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -245,9 +247,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 128 calcs + 2 blog index + 124 blog articles = 256)', () => {
+  it('generates correct total URL count (2 home + 130 calcs + 2 blog index + 126 blog articles = 260)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(256)
+    expect(urlCount).toBe(260)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -557,6 +557,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'correctedCalcium',
     related: ['anion-gap', 'sodium-correction-calculator', 'gfr-calculator-kidney-function'],
   },
+  {
+    slug: 'baby-feeding-amount-calculator',
+    title: 'Baby Feeding Amount Calculator: How Much Milk Does a Baby Need?',
+    description: 'Calculate baby milk intake by age and weight. Evidence-based ml/kg guidance, amount per bottle, and practical signs of under- or overfeeding.',
+    date: '2026-05-07',
+    readTime: '8 min',
+    calculatorKey: 'babyFeedingAmount',
+    related: ['apgar-score-calculator-guide', 'child-growth-percentile-chart', 'child-dosage-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -557,6 +557,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'correctedCalcium',
     related: ['anionenluecke-rechner', 'natrium-korrektur-berechnen', 'gfr-rechner'],
   },
+  {
+    slug: 'baby-trinkmenge-berechnen',
+    title: 'Baby-Trinkmenge berechnen: So viel Milch braucht dein Baby wirklich',
+    description: 'Baby-Trinkmenge nach Alter und Gewicht berechnen. Richtwerte in ml/kg, Flaschenmenge pro Mahlzeit und Warnzeichen für Unter- und Überfütterung.',
+    date: '2026-05-07',
+    readTime: '8 min',
+    calculatorKey: 'babyFeedingAmount',
+    related: ['apgar-score-bewerten', 'wachstumsperzentile-kinder', 'kinder-dosierung-rechner'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/babyFeedingAmount.json
+++ b/src/locales/calculators/de/babyFeedingAmount.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "babyFeedingAmount": {
+        "name": "Baby-Trinkmenge-Rechner",
+        "description": "Berechne, wie viel Milch dein Baby pro Mahlzeit und Tag braucht — nach Alter und Gewicht."
+      }
+    }
+  },
+  "babyFeedingAmount": {
+    "meta": {
+      "title": "Baby-Trinkmenge-Rechner — Wie viel Milch braucht mein Baby?",
+      "description": "Berechne die tägliche und einzelne Trinkmenge deines Babys nach Alter und Gewicht. Pädiatrische Richtwerte (150 ml/kg) für Flaschen- und abgepumpte Muttermilch. Kostenlos."
+    },
+    "title": "Baby-Trinkmenge-Rechner",
+    "description": "Wie viel Milch braucht dein Baby pro Mahlzeit und Tag? Berechnung nach Alter und Gewicht.",
+    "ageMonths": "Alter (Monate)",
+    "ageMonthsHint": "0–24 Monate",
+    "weightKg": "Gewicht (kg)",
+    "weightLb": "Gewicht (lb)",
+    "ageMonthsPlaceholder": "z. B. 3",
+    "weightPlaceholder": "z. B. 5",
+    "weightPlaceholderLb": "z. B. 11",
+    "implausibleAge": "Bitte ein Alter zwischen 0 und 24 Monaten eingeben.",
+    "implausibleWeight": "Bitte ein realistisches Gewicht zwischen 1 und 18 kg eingeben.",
+    "dailyAmount": "Tägliche Trinkmenge",
+    "perFeeding": "Pro Mahlzeit",
+    "feedingsPerDay": "Mahlzeiten pro Tag",
+    "feedingsCount": "{count} Mahlzeiten",
+    "perDay": "pro Tag",
+    "noteCapped": "Tagesmenge auf 960 ml begrenzt — Babys regulieren ihren Bedarf selbst.",
+    "table": "Richtwerte nach Alter",
+    "ageRange": "Alter",
+    "feedings": "Mahlzeiten",
+    "amountPerKg": "ml/kg/Tag",
+    "row0to1": "0–1 Monat",
+    "row1to3": "1–3 Monate",
+    "row3to5": "3–5 Monate",
+    "row5to6": "5–6 Monate",
+    "row6to9": "6–9 Monate",
+    "row9to12": "9–12 Monate",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Die Faustregel der Pädiatrie: ca. 150 ml Säuglingsnahrung pro kg Körpergewicht und Tag in den ersten sechs Monaten, danach etwa 120 ml/kg/Tag, da Beikost hinzukommt. Die Tagesmenge wird auf 960 ml (32 oz) begrenzt. Diese Werte gelten für Flaschennahrung oder abgepumpte Muttermilch — gestillte Babys regulieren ihren Bedarf selbst und können nicht überfüttert werden.",
+    "disclaimer": "Wichtig: Diese Werte sind Orientierungshilfen. Achte auf Sättigungssignale deines Babys. Bei Bedenken zu Wachstum oder Trinkverhalten sprich mit Kinderärztin oder Hebamme.",
+    "faq": [
+      {
+        "q": "Wie viel sollte mein Baby pro Tag trinken?",
+        "a": "In den ersten sechs Monaten etwa 150 ml pro kg Körpergewicht. Beispiel: Ein 5-kg-Baby braucht ca. 750 ml/Tag. Ab sechs Monaten reduziert sich die Milchmenge auf rund 120 ml/kg/Tag, da Beikost hinzukommt."
+      },
+      {
+        "q": "Wie oft sollte ich mein Baby füttern?",
+        "a": "Neugeborene benötigen 8 Mahlzeiten/Tag, mit 1–2 Monaten sind es 7, mit 3–4 Monaten 6, mit 5 Monaten 5 und ab 6 Monaten 3–4 Mahlzeiten. Bei Bedarf flexibel nachfüttern."
+      },
+      {
+        "q": "Gilt das auch für gestillte Babys?",
+        "a": "Nein. Gestillte Babys regulieren ihren Bedarf selbst — der Rechner ist für Flaschennahrung und abgepumpte Muttermilch gedacht. Beim Stillen orientierst du dich an Hungerzeichen, nassen Windeln und Gewichtszunahme."
+      },
+      {
+        "q": "Kann ich mein Baby überfüttern?",
+        "a": "Mit der Flasche ja. Achte auf Sättigungszeichen: Kopf abdrehen, Saugen verlangsamen, Brustwarze loslassen. Erzwinge keine Restmenge. Spucken nach Mahlzeiten kann ein Hinweis sein."
+      },
+      {
+        "q": "Was, wenn mein Baby weniger trinkt?",
+        "a": "Babys trinken nicht jeden Tag gleich viel. Solange Gewichtszunahme, nasse Windeln und Verhalten passen, ist das normal. Sprich bei Sorge mit Kinderärztin/-arzt."
+      },
+      {
+        "q": "Wie lese ich die Tabelle ab?",
+        "a": "Suche das Alter deines Babys, multipliziere das Gewicht (kg) mit dem Wert in der Spalte ml/kg/Tag und teile durch die Anzahl Mahlzeiten. Das ergibt die Menge pro Flasche."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/babyFeedingAmount.json
+++ b/src/locales/calculators/en/babyFeedingAmount.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "babyFeedingAmount": {
+        "name": "Baby Feeding Amount Calculator",
+        "description": "Find out how much milk your baby needs per feeding and per day — by age and weight."
+      }
+    }
+  },
+  "babyFeedingAmount": {
+    "meta": {
+      "title": "Baby Feeding Amount Calculator — How Much Formula Per Day?",
+      "description": "Calculate daily and per-feeding milk amounts for your baby by age and weight. Pediatric guideline (150 ml/kg) for formula and pumped breast milk. Free, instant."
+    },
+    "title": "Baby Feeding Amount Calculator",
+    "description": "How much milk does your baby need per feeding and per day? Calculation by age and weight.",
+    "ageMonths": "Age (months)",
+    "ageMonthsHint": "0–24 months",
+    "weightKg": "Weight (kg)",
+    "weightLb": "Weight (lb)",
+    "ageMonthsPlaceholder": "e.g. 3",
+    "weightPlaceholder": "e.g. 5",
+    "weightPlaceholderLb": "e.g. 11",
+    "implausibleAge": "Please enter an age between 0 and 24 months.",
+    "implausibleWeight": "Please enter a realistic weight between 1 and 18 kg.",
+    "dailyAmount": "Daily amount",
+    "perFeeding": "Per feeding",
+    "feedingsPerDay": "Feedings per day",
+    "feedingsCount": "{count} feedings",
+    "perDay": "per day",
+    "noteCapped": "Daily amount capped at 960 ml — babies self-regulate their intake.",
+    "table": "Reference values by age",
+    "ageRange": "Age",
+    "feedings": "Feedings",
+    "amountPerKg": "ml/kg/day",
+    "row0to1": "0–1 month",
+    "row1to3": "1–3 months",
+    "row3to5": "3–5 months",
+    "row5to6": "5–6 months",
+    "row6to9": "6–9 months",
+    "row9to12": "9–12 months",
+    "howItWorks": "How it works",
+    "howItWorksText": "Pediatric rule of thumb: ~150 ml of infant formula per kg of body weight per day in the first six months, dropping to ~120 ml/kg/day from six months on as solids are introduced. Daily intake is capped at 960 ml (32 oz). These figures apply to formula or pumped breast milk — breastfed babies self-regulate and cannot be overfed.",
+    "disclaimer": "Important: these values are guidelines. Watch your baby's hunger and fullness cues. If you have concerns about growth or feeding, talk to your pediatrician.",
+    "faq": [
+      {
+        "q": "How much should my baby drink per day?",
+        "a": "In the first six months, about 150 ml per kg of body weight. Example: a 5 kg baby needs ~750 ml/day. From six months on, milk drops to ~120 ml/kg/day as complementary foods are added."
+      },
+      {
+        "q": "How often should I feed my baby?",
+        "a": "Newborns need 8 feedings/day, 1–2 months 7, 3–4 months 6, 5 months 5, and from 6 months 3–4 feedings. Always feed on demand if needed."
+      },
+      {
+        "q": "Does this apply to breastfed babies?",
+        "a": "No. Breastfed babies self-regulate intake — this calculator is for formula or pumped breast milk. For breastfeeding, watch hunger cues, wet diapers, and weight gain."
+      },
+      {
+        "q": "Can I overfeed my baby?",
+        "a": "With a bottle, yes. Watch fullness cues: turning the head, slowing the suck, releasing the nipple. Never force the rest of a bottle. Spitting up after feedings can be a sign."
+      },
+      {
+        "q": "What if my baby drinks less?",
+        "a": "Babies don't drink the same amount every day. As long as weight gain, wet diapers, and behavior are normal, that's fine. Check in with your pediatrician if you're worried."
+      },
+      {
+        "q": "How do I read the table?",
+        "a": "Find your baby's age, multiply weight (kg) by the ml/kg/day column, then divide by feedings per day. That gives you the amount per bottle."
+      }
+    ]
+  }
+}

--- a/src/pages/BabyFeedingAmountCalculator.vue
+++ b/src/pages/BabyFeedingAmountCalculator.vue
@@ -1,0 +1,247 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  babyFeedingAmount,
+  isPlausibleAge,
+  isPlausibleWeightKg,
+  lbToKg,
+  mlToOz,
+  DAILY_CAP_ML,
+} from '../utils/babyFeedingAmount.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('babyFeedingAmount.faq') || [])
+
+useHead(() => ({
+  title: t('babyFeedingAmount.meta.title'),
+  description: t('babyFeedingAmount.meta.description'),
+  routeKey: 'babyFeedingAmount',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Baby Feeding Amount Calculator',
+    url: 'https://healthcalculator.app/baby-feeding-amount-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const ageMonths = ref(null)
+const weight = ref(null)
+const unit = ref('metric')
+
+const weightKg = computed(() => {
+  if (typeof weight.value !== 'number' || !Number.isFinite(weight.value)) return null
+  return unit.value === 'imperial' ? lbToKg(weight.value) : weight.value
+})
+
+const ageWarning = computed(() => {
+  if (ageMonths.value === null || ageMonths.value === undefined || ageMonths.value === '') return false
+  return !isPlausibleAge(ageMonths.value)
+})
+
+const weightWarning = computed(() => {
+  if (weightKg.value === null) return false
+  return !isPlausibleWeightKg(weightKg.value)
+})
+
+const result = computed(() => {
+  if (ageWarning.value || weightWarning.value) return null
+  if (weightKg.value === null || ageMonths.value === null) return null
+  return babyFeedingAmount({ weightKg: weightKg.value, ageMonths: ageMonths.value })
+})
+
+const isCapped = computed(() => result.value && result.value.dailyMl >= DAILY_CAP_ML)
+
+const ref0to1 = computed(() => ({ feedings: 8, perKg: 150 }))
+const ref1to3 = computed(() => ({ feedings: 7, perKg: 150 }))
+const ref3to5 = computed(() => ({ feedings: 6, perKg: 150 }))
+const ref5to6 = computed(() => ({ feedings: 5, perKg: 150 }))
+const ref6to9 = computed(() => ({ feedings: 4, perKg: 120 }))
+const ref9to12 = computed(() => ({ feedings: 3, perKg: 120 }))
+
+function fmt(v, decimals = 0) {
+  if (v === null || v === undefined) return ''
+  return v.toFixed(decimals)
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('babyFeedingAmount.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('babyFeedingAmount.description') }}</p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <!-- Unit toggle (weight only) -->
+      <div class="flex gap-2 mb-6">
+        <button
+          @click="unit = 'metric'"
+          data-testid="unit-metric"
+          :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('common.metric') }}</button>
+        <button
+          @click="unit = 'imperial'"
+          data-testid="unit-imperial"
+          :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('common.imperial') }}</button>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        <div>
+          <label for="input-age" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('babyFeedingAmount.ageMonths') }}
+          </label>
+          <input
+            id="input-age"
+            v-model.number="ageMonths"
+            data-testid="input-age"
+            type="number"
+            min="0"
+            max="24"
+            step="1"
+            :placeholder="t('babyFeedingAmount.ageMonthsPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+          <p class="text-xs text-stone-400 mt-1.5">{{ t('babyFeedingAmount.ageMonthsHint') }}</p>
+        </div>
+        <div>
+          <label for="input-weight" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ unit === 'metric' ? t('babyFeedingAmount.weightKg') : t('babyFeedingAmount.weightLb') }}
+          </label>
+          <input
+            id="input-weight"
+            v-model.number="weight"
+            data-testid="input-weight"
+            type="number"
+            step="0.1"
+            min="0"
+            :placeholder="unit === 'metric' ? t('babyFeedingAmount.weightPlaceholder') : t('babyFeedingAmount.weightPlaceholderLb')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+
+      <div v-if="ageWarning" data-testid="warning-age" class="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-4">
+        <span class="text-amber-500 text-lg leading-none mt-0.5">⚠</span>
+        <p class="text-sm text-amber-700">{{ t('babyFeedingAmount.implausibleAge') }}</p>
+      </div>
+      <div v-if="weightWarning" data-testid="warning-weight" class="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-4">
+        <span class="text-amber-500 text-lg leading-none mt-0.5">⚠</span>
+        <p class="text-sm text-amber-700">{{ t('babyFeedingAmount.implausibleWeight') }}</p>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Results -->
+    <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-4">
+        <div>
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('babyFeedingAmount.dailyAmount') }}</div>
+          <div data-testid="result-daily-ml" class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight">
+            {{ fmt(result.dailyMl) }}
+            <span class="text-base font-normal text-stone-500">ml</span>
+          </div>
+          <div data-testid="result-daily-oz" class="text-sm text-stone-500 tabular-nums mt-1">≈ {{ fmt(result.dailyOz, 1) }} oz</div>
+        </div>
+        <div>
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('babyFeedingAmount.perFeeding') }}</div>
+          <div data-testid="result-per-feeding-ml" class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight">
+            {{ fmt(result.perFeedingMl) }}
+            <span class="text-base font-normal text-stone-500">ml</span>
+          </div>
+          <div data-testid="result-per-feeding-oz" class="text-sm text-stone-500 tabular-nums mt-1">≈ {{ fmt(result.perFeedingOz, 1) }} oz</div>
+        </div>
+        <div>
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('babyFeedingAmount.feedingsPerDay') }}</div>
+          <div data-testid="result-feedings" class="text-4xl font-bold text-stone-900 tabular-nums tracking-tight">
+            {{ result.feedings }}
+          </div>
+          <div class="text-sm text-stone-500 mt-1">{{ t('babyFeedingAmount.perDay') }}</div>
+        </div>
+      </div>
+
+      <div v-if="isCapped" data-testid="note-capped" class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 mt-4">
+        <p class="text-sm text-stone-600">{{ t('babyFeedingAmount.noteCapped') }}</p>
+      </div>
+    </div>
+
+    <!-- Reference table -->
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+      <div class="px-6 pt-6">
+        <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('babyFeedingAmount.table') }}</h2>
+      </div>
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-stone-50 border-b border-stone-200">
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('babyFeedingAmount.ageRange') }}</th>
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('babyFeedingAmount.feedings') }}</th>
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('babyFeedingAmount.amountPerKg') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-stone-100">
+          <tr>
+            <td class="px-6 py-3 text-stone-900 font-medium">{{ t('babyFeedingAmount.row0to1') }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref0to1.feedings }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref0to1.perKg }}</td>
+          </tr>
+          <tr>
+            <td class="px-6 py-3 text-stone-900 font-medium">{{ t('babyFeedingAmount.row1to3') }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref1to3.feedings }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref1to3.perKg }}</td>
+          </tr>
+          <tr>
+            <td class="px-6 py-3 text-stone-900 font-medium">{{ t('babyFeedingAmount.row3to5') }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref3to5.feedings }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref3to5.perKg }}</td>
+          </tr>
+          <tr>
+            <td class="px-6 py-3 text-stone-900 font-medium">{{ t('babyFeedingAmount.row5to6') }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref5to6.feedings }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref5to6.perKg }}</td>
+          </tr>
+          <tr>
+            <td class="px-6 py-3 text-stone-900 font-medium">{{ t('babyFeedingAmount.row6to9') }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref6to9.feedings }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref6to9.perKg }}</td>
+          </tr>
+          <tr>
+            <td class="px-6 py-3 text-stone-900 font-medium">{{ t('babyFeedingAmount.row9to12') }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref9to12.feedings }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ ref9to12.perKg }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- How it works -->
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('babyFeedingAmount.howItWorks') }}</h2>
+      <p class="text-sm text-stone-500 leading-relaxed">{{ t('babyFeedingAmount.howItWorksText') }}</p>
+    </div>
+
+    <!-- Disclaimer -->
+    <div class="bg-stone-50 border border-stone-200 rounded-xl px-6 py-4 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('babyFeedingAmount.disclaimer') }}</p>
+    </div>
+
+    <AdSlot class="mt-8" />
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <BlogArticleLink calculator-key="babyFeedingAmount" />
+  </div>
+</template>

--- a/src/pages/babyFeedingAmount.meta.js
+++ b/src/pages/babyFeedingAmount.meta.js
@@ -1,0 +1,16 @@
+import Component from './BabyFeedingAmountCalculator.vue'
+import BlogDe from './blog/BabyTrinkmengeBerechnen.vue'
+import BlogEn from './blog/en/BabyFeedingAmountCalculator.vue'
+
+export default {
+  key: 'babyFeedingAmount',
+  component: Component,
+  slugs: { de: 'baby-trinkmenge-rechner', en: 'baby-feeding-amount-calculator' },
+  group: 'pregnancy',
+  groupOrder: 4,
+  order: 99,
+  blog: {
+    de: { slug: 'baby-trinkmenge-berechnen', component: BlogDe },
+    en: { slug: 'baby-feeding-amount-calculator', component: BlogEn },
+  },
+}

--- a/src/pages/blog/BabyTrinkmengeBerechnen.vue
+++ b/src/pages/blog/BabyTrinkmengeBerechnen.vue
@@ -1,0 +1,103 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Baby-Trinkmenge berechnen: So viel Milch braucht dein Baby wirklich | Health Calculators',
+  description: 'Baby-Trinkmenge nach Alter und Gewicht berechnen. Richtwerte in ml/kg, Flaschenmenge pro Mahlzeit, Warnzeichen für Unter- und Überfütterung — kompakt erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Baby-Trinkmenge berechnen: So viel Milch braucht dein Baby wirklich',
+    description: 'Baby-Trinkmenge nach Alter und Gewicht berechnen. Richtwerte in ml/kg, Flaschenmenge pro Mahlzeit, Warnzeichen für Unter- und Überfütterung — kompakt erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-07',
+    dateModified: '2026-05-07',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/baby-trinkmenge-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Baby-Trinkmenge berechnen: So viel Milch braucht dein Baby wirklich</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">7. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Gerade in den ersten Monaten fragen sich viele Eltern: <strong>Trinkt mein Baby genug?</strong> Eine praktikable Orientierung liefert die ml/kg-Regel aus der Pädiatrie.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Mit unserem Rechner bestimmst du aus Alter und Gewicht die tägliche Trinkmenge und die Menge pro Flasche — für Pre-Nahrung, Folgemilch und abgepumpte Muttermilch.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Faustregel nach Alter</h2>
+        <ul class="space-y-2 text-base text-stone-600">
+          <li><strong>0–6 Monate:</strong> etwa 150 ml pro kg Körpergewicht und Tag</li>
+          <li><strong>ab 6 Monaten:</strong> etwa 120 ml pro kg und Tag (durch Beikost sinkt die Milchmenge)</li>
+          <li><strong>oberes Orientierungs-Limit:</strong> ca. 960 ml/Tag</li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Baby-Trinkmenge jetzt berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Alter und Gewicht eingeben, sofort Tagesmenge und Menge pro Mahlzeit erhalten.</p>
+        <router-link
+          :to="localePath('babyFeedingAmount')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Zum Baby-Trinkmengen-Rechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann die Werte nicht 1:1 passen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Babys trinken nicht jeden Tag gleich viel. Wachstumsschübe, Infekte, Hitze und Schlafphasen verändern den Bedarf kurzfristig. Entscheidend ist der Verlauf über mehrere Tage.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wichtig sind klinische Signale: nasse Windeln, altersgerechte Gewichtszunahme, waches Verhalten und eine entspannte Trinksituation ohne ständiges Erbrechen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Für die ersten Lebensmonate helfen auch der
+          <router-link :to="localePath('apgarScore')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">APGAR-Score-Rechner</router-link>,
+          die
+          <router-link :to="localePath('childGrowth')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Wachstumsperzentilen für Kinder</router-link>
+          und der
+          <router-link :to="localePath('childDosage')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Kinder-Dosierungsrechner</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die Berechnung der Baby-Trinkmenge gibt eine gute Orientierung, ersetzt aber keine individuelle Einschätzung. Nutze den
+          <router-link :to="localePath('babyFeedingAmount')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Baby-Trinkmengen-Rechner</router-link>
+          als praktische Hilfe im Alltag und sprich bei Unsicherheit mit Kinderarzt oder Hebamme.
+        </p>
+      </div>
+
+      <RelatedArticles slug="baby-trinkmenge-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/BabyFeedingAmountCalculator.vue
+++ b/src/pages/blog/en/BabyFeedingAmountCalculator.vue
@@ -1,0 +1,103 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Baby Feeding Amount Calculator: How Much Milk Does a Baby Need? | Health Calculators',
+  description: 'Calculate baby milk intake by age and weight. Evidence-based ml/kg reference, amount per bottle, and signs of under- or overfeeding for daily use.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Baby Feeding Amount Calculator: How Much Milk Does a Baby Need?',
+    description: 'Calculate baby milk intake by age and weight. Evidence-based ml/kg reference, amount per bottle, and signs of under- or overfeeding for daily use.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-07',
+    dateModified: '2026-05-07',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/baby-feeding-amount-calculator',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Baby Feeding Amount Calculator: How Much Milk Does a Baby Need?</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 7, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In the first months, many parents ask the same question: <strong>is my baby drinking enough?</strong> A practical clinical reference is the ml/kg method used in paediatrics.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Our calculator estimates both daily milk volume and amount per bottle from age and weight — useful for formula and pumped breast milk.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Rule of thumb by age</h2>
+        <ul class="space-y-2 text-base text-stone-600">
+          <li><strong>0–6 months:</strong> around 150 ml per kg body weight per day</li>
+          <li><strong>from 6 months:</strong> around 120 ml/kg/day as solids are introduced</li>
+          <li><strong>upper practical limit:</strong> about 960 ml/day</li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate feeding amount now</h3>
+        <p class="text-stone-300 text-sm mb-5">Enter age and weight to get daily volume and amount per feeding instantly.</p>
+        <router-link
+          :to="localePath('babyFeedingAmount')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Open baby feeding calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why real life can differ</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Babies do not drink exactly the same amount every day. Growth spurts, mild illness, temperature, and sleep changes can all shift intake temporarily.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Focus on trend and clinical signs: wet diapers, expected weight gain, alertness, and comfortable feeding without repeated vomiting.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          For the newborn and infant period, you may also use the
+          <router-link :to="localePath('apgarScore')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">APGAR score calculator</router-link>,
+          the
+          <router-link :to="localePath('childGrowth')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">child growth percentile calculator</router-link>,
+          and the
+          <router-link :to="localePath('childDosage')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">child dosage calculator</router-link>.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A baby feeding calculation is a practical guideline, not a diagnosis. Use the
+          <router-link :to="localePath('babyFeedingAmount')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">baby feeding amount calculator</router-link>
+          to structure daily feeds, and consult your pediatrician or midwife if intake or growth seems off.
+        </p>
+      </div>
+
+      <RelatedArticles slug="baby-feeding-amount-calculator" />
+    </div>
+  </article>
+</template>

--- a/src/utils/babyFeedingAmount.js
+++ b/src/utils/babyFeedingAmount.js
@@ -1,0 +1,74 @@
+// Baby feeding amount calculator (formula / pumped breast milk).
+//
+// Pediatric guideline (AAP, ESPGHAN): bottle-fed infants need approximately
+// 150 ml of formula per kg of body weight per day during the first ~6 months.
+// After 6 months, complementary foods reduce milk intake to ~120 ml/kg/day.
+// Daily intake is generally capped at ~960 ml (32 oz) regardless of weight.
+//
+// This is an estimate. Demand-feeding cues should always take precedence over
+// schedules. Breastfed infants self-regulate and these values do NOT apply.
+
+export const ML_PER_KG_UNDER_6M = 150
+export const ML_PER_KG_FROM_6M = 120
+export const DAILY_CAP_ML = 960
+export const ML_PER_OZ = 29.5735
+export const KG_PER_LB = 0.453592
+
+export function isFiniteNumber(v) {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+export function isPlausibleAge(months) {
+  if (!isFiniteNumber(months)) return false
+  return months >= 0 && months <= 24
+}
+
+export function isPlausibleWeightKg(kg) {
+  if (!isFiniteNumber(kg)) return false
+  return kg >= 1 && kg <= 18
+}
+
+export function mlToOz(ml) {
+  return ml / ML_PER_OZ
+}
+
+export function lbToKg(lb) {
+  return lb * KG_PER_LB
+}
+
+export function calcDailyAmountMl(weightKg, ageMonths) {
+  if (!isFiniteNumber(weightKg) || weightKg <= 0) return null
+  if (!isFiniteNumber(ageMonths) || ageMonths < 0) return null
+  const factor = ageMonths < 6 ? ML_PER_KG_UNDER_6M : ML_PER_KG_FROM_6M
+  return Math.min(weightKg * factor, DAILY_CAP_ML)
+}
+
+export function feedingsPerDay(ageMonths) {
+  if (ageMonths < 1) return 8
+  if (ageMonths < 3) return 7
+  if (ageMonths < 5) return 6
+  if (ageMonths < 6) return 5
+  if (ageMonths < 9) return 4
+  return 3
+}
+
+export function calcPerFeedingMl(weightKg, ageMonths) {
+  const daily = calcDailyAmountMl(weightKg, ageMonths)
+  if (daily === null) return null
+  return daily / feedingsPerDay(ageMonths)
+}
+
+export function babyFeedingAmount({ weightKg, ageMonths }) {
+  if (!isPlausibleAge(ageMonths)) return null
+  if (!isFiniteNumber(weightKg) || weightKg <= 0) return null
+  const dailyMl = calcDailyAmountMl(weightKg, ageMonths)
+  if (dailyMl === null) return null
+  const feedings = feedingsPerDay(ageMonths)
+  return {
+    dailyMl,
+    feedings,
+    perFeedingMl: dailyMl / feedings,
+    dailyOz: mlToOz(dailyMl),
+    perFeedingOz: mlToOz(dailyMl / feedings),
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-129-baby-feeding-amount
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-129-baby-feeding-amount-20260507-130033`
**Cost:** $2.841942

Closes jenslaufer/health-calculators#129

### Prompt
> Implement the Baby Feeding Amount Calculator as described in issue #129.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Breast milk/formula amount by age and weight
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/babyFeedingAmount.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/babyFeedingAmount.test.js` with 6+ test cases covering edge cases. Run `npm test -- babyFeedingAmount` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/BabyFeedingAmountCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/babyFeedingAmount.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/babyFeedingAmount.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'babyFeedingAmount'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/babyFeedingAmount.json` + `src/locales/calculators/en/babyFeedingAmount.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/babyFeedingAmount.js (or shared util — verify pattern in repo first)`
- `src/__tests__/babyFeedingAmount.test.js`
- `src/pages/BabyFeedingAmountCalculator.vue`
- `src/pages/babyFeedingAmount.meta.js`
- `src/locales/calculators/de/babyFeedingAmount.json`
- `src/locales/calculators/en/babyFeedingAmount.json`
- `e2e/babyFeedingAmount.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'babyFeedingAmount',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks