### PR TITLE
hc-159-pain-scale: Implement the Pain Scale Calculator as described in issue #1

### DIFF
--- a/e2e/painScale.spec.js
+++ b/e2e/painScale.spec.js
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Pain Scale Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/schmerzskala-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Schmerzskala-Rechner/)
+  })
+
+  test('h1 matches', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Schmerzskala-Rechner')
+  })
+
+  test('back link navigates home', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('result hidden before input', async ({ page }) => {
+    await expect(page.getByTestId('result-score')).not.toBeVisible()
+    await expect(page.getByTestId('incomplete-hint')).toBeVisible()
+  })
+
+  test('NRS 0 → no pain', async ({ page }) => {
+    await page.getByTestId('nrs-0').click()
+    await expect(page.getByTestId('result-status')).toHaveText('Kein Schmerz')
+    await expect(page.getByTestId('result-score')).toContainText('0.0')
+  })
+
+  test('NRS 2 → mild pain', async ({ page }) => {
+    await page.getByTestId('nrs-2').click()
+    await expect(page.getByTestId('result-status')).toHaveText('Leichter Schmerz')
+  })
+
+  test('NRS 5 → moderate pain', async ({ page }) => {
+    await page.getByTestId('nrs-5').click()
+    await expect(page.getByTestId('result-status')).toHaveText('Mäßiger Schmerz')
+  })
+
+  test('NRS 8 → severe pain', async ({ page }) => {
+    await page.getByTestId('nrs-8').click()
+    await expect(page.getByTestId('result-status')).toHaveText('Starker Schmerz')
+  })
+
+  test('VAS scale switch shows slider', async ({ page }) => {
+    await page.getByTestId('scale-vas').click()
+    await expect(page.getByTestId('vas-slider')).toBeVisible()
+  })
+
+  test('Wong-Baker face 6 → moderate pain', async ({ page }) => {
+    await page.getByTestId('scale-wong').click()
+    await page.getByTestId('wong-6').click()
+    await expect(page.getByTestId('result-status')).toHaveText('Mäßiger Schmerz')
+    await expect(page.getByTestId('result-score')).toContainText('6.0')
+  })
+
+  test('blog article link is rendered', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('Pain Scale Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/pain-scale-calculator')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Pain Scale Calculator/)
+  })
+
+  test('NRS 7 → severe pain', async ({ page }) => {
+    await page.getByTestId('nrs-7').click()
+    await expect(page.getByTestId('result-status')).toHaveText('Severe pain')
+    await expect(page.getByTestId('result-score')).toContainText('7.0')
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -25,6 +25,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'babyFeedingAmount', 'asthmaControl', 'copdAssessment', 'babyMilestones', 'creatinineClearance',
+  'painScale',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -95,6 +96,7 @@ const EXPECTED_ROUTE_MAP = {
   copdAssessment: { de: 'copd-assessment-rechner', en: 'copd-assessment-calculator' },
   babyMilestones: { de: 'baby-meilensteine-rechner', en: 'baby-milestones-calculator' },
   creatinineClearance: { de: 'kreatinin-clearance-rechner', en: 'creatinine-clearance-calculator' },
+  painScale: { de: 'schmerzskala-rechner', en: 'pain-scale-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -153,6 +155,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'copd-assessment-berechnen',
   'baby-meilensteine-tracker',
   'kreatinin-clearance-berechnen',
+  'schmerzskala-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -211,19 +214,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'copd-assessment-guide',
   'baby-milestone-tracker-guide',
   'creatinine-clearance-calculator-guide',
+  'pain-scale-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 69 calculators', () => {
-    expect(calculatorMetas).toHaveLength(69)
+  it('discovers all 70 calculators', () => {
+    expect(calculatorMetas).toHaveLength(70)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 69 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(69)
+  it('builds calculatorComponents map for all 70 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(70)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -246,15 +250,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 67 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(67)
+  it('discovers all 68 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(68)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 67 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(67)
+  it('discovers all 68 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(68)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -270,10 +274,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 69 calculators with no duplicates', () => {
+  it('groups contain all 70 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(69)
-    expect(new Set(allKeys).size).toBe(69)
+    expect(allKeys).toHaveLength(70)
+    expect(new Set(allKeys).size).toBe(70)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -294,7 +298,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale',
     ])
   })
 
@@ -343,8 +347,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 381 routes', () => {
-    expect(routes).toHaveLength(381)
+  it('generates exactly 386 routes', () => {
+    expect(routes).toHaveLength(386)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 272 links (69 calcs × 2 locales + 67 blogs × 2 locales)', () => {
+  it('generates 276 links (70 calcs × 2 locales + 68 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(272)
+    expect(links).toHaveLength(276)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/painScale.test.js
+++ b/src/__tests__/painScale.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyPain,
+  vasToNrs,
+  nrsToVas,
+  evaluatePainScore,
+} from '../utils/painScale.js'
+
+// Pain scales:
+//   NRS  — Numeric Rating Scale, 0–10 integer.
+//   VAS  — Visual Analog Scale, 0–100 mm continuous.
+//   Wong-Baker FACES — 0, 2, 4, 6, 8, 10 (six-point scale).
+//
+// Standard categorical bands (Serlin et al. 1995, adopted by IASP / WHO):
+//   0      → none
+//   1–3    → mild
+//   4–6    → moderate
+//   7–10   → severe
+
+describe('classifyPain — categorical bands on a 0–10 scale', () => {
+  it('0 → none', () => {
+    expect(classifyPain(0)).toBe('none')
+  })
+
+  it('1 → mild (lower bound)', () => {
+    expect(classifyPain(1)).toBe('mild')
+  })
+
+  it('3 → mild (upper bound)', () => {
+    expect(classifyPain(3)).toBe('mild')
+  })
+
+  it('4 → moderate (lower bound)', () => {
+    expect(classifyPain(4)).toBe('moderate')
+  })
+
+  it('6 → moderate (upper bound)', () => {
+    expect(classifyPain(6)).toBe('moderate')
+  })
+
+  it('7 → severe (lower bound)', () => {
+    expect(classifyPain(7)).toBe('severe')
+  })
+
+  it('10 → severe (upper bound)', () => {
+    expect(classifyPain(10)).toBe('severe')
+  })
+
+  it('decimal values are accepted (VAS conversion)', () => {
+    expect(classifyPain(3.4)).toBe('mild')
+    expect(classifyPain(6.5)).toBe('moderate')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(classifyPain(null)).toBe(null)
+    expect(classifyPain(-1)).toBe(null)
+    expect(classifyPain(11)).toBe(null)
+    expect(classifyPain('5')).toBe(null)
+    expect(classifyPain(NaN)).toBe(null)
+  })
+})
+
+describe('vasToNrs — VAS (0–100 mm) → NRS (0–10)', () => {
+  it('0 mm → 0', () => {
+    expect(vasToNrs(0)).toBe(0)
+  })
+
+  it('50 mm → 5', () => {
+    expect(vasToNrs(50)).toBe(5)
+  })
+
+  it('100 mm → 10', () => {
+    expect(vasToNrs(100)).toBe(10)
+  })
+
+  it('33 mm → 3.3', () => {
+    expect(vasToNrs(33)).toBeCloseTo(3.3, 2)
+  })
+
+  it('returns null for invalid input', () => {
+    expect(vasToNrs(-1)).toBe(null)
+    expect(vasToNrs(101)).toBe(null)
+    expect(vasToNrs(null)).toBe(null)
+    expect(vasToNrs('50')).toBe(null)
+  })
+})
+
+describe('nrsToVas — NRS (0–10) → VAS (0–100 mm)', () => {
+  it('0 → 0 mm', () => {
+    expect(nrsToVas(0)).toBe(0)
+  })
+
+  it('5 → 50 mm', () => {
+    expect(nrsToVas(5)).toBe(50)
+  })
+
+  it('10 → 100 mm', () => {
+    expect(nrsToVas(10)).toBe(100)
+  })
+
+  it('returns null for invalid input', () => {
+    expect(nrsToVas(-1)).toBe(null)
+    expect(nrsToVas(11)).toBe(null)
+    expect(nrsToVas(null)).toBe(null)
+  })
+})
+
+describe('evaluatePainScore — combined pipeline', () => {
+  it('NRS 7 → severe, vas 70', () => {
+    const r = evaluatePainScore({ scale: 'nrs', value: 7 })
+    expect(r.score).toBe(7)
+    expect(r.category).toBe('severe')
+    expect(r.vas).toBe(70)
+  })
+
+  it('VAS 25 mm → mild, score 2.5', () => {
+    const r = evaluatePainScore({ scale: 'vas', value: 25 })
+    expect(r.score).toBeCloseTo(2.5, 2)
+    expect(r.category).toBe('mild')
+    expect(r.vas).toBe(25)
+  })
+
+  it('Wong-Baker 6 → moderate', () => {
+    const r = evaluatePainScore({ scale: 'wongBaker', value: 6 })
+    expect(r.score).toBe(6)
+    expect(r.category).toBe('moderate')
+    expect(r.vas).toBe(60)
+  })
+
+  it('Wong-Baker rejects odd values', () => {
+    expect(evaluatePainScore({ scale: 'wongBaker', value: 5 })).toBe(null)
+    expect(evaluatePainScore({ scale: 'wongBaker', value: 3 })).toBe(null)
+  })
+
+  it('NRS rejects non-integer values', () => {
+    expect(evaluatePainScore({ scale: 'nrs', value: 4.5 })).toBe(null)
+  })
+
+  it('returns null for unknown scale', () => {
+    expect(evaluatePainScore({ scale: 'mystery', value: 5 })).toBe(null)
+  })
+
+  it('returns null for missing value', () => {
+    expect(evaluatePainScore({ scale: 'nrs' })).toBe(null)
+    expect(evaluatePainScore({})).toBe(null)
+  })
+
+  it('returns null for value outside scale range', () => {
+    expect(evaluatePainScore({ scale: 'nrs', value: 12 })).toBe(null)
+    expect(evaluatePainScore({ scale: 'vas', value: 110 })).toBe(null)
+    expect(evaluatePainScore({ scale: 'wongBaker', value: 12 })).toBe(null)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -19,6 +19,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'babyFeedingAmount', 'asthmaControl', 'copdAssessment', 'babyMilestones', 'creatinineClearance',
+  'painScale',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -76,6 +77,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'copd-assessment-berechnen',
   'baby-meilensteine-tracker',
   'kreatinin-clearance-berechnen',
+  'schmerzskala-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -133,12 +135,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'copd-assessment-guide',
   'baby-milestone-tracker-guide',
   'creatinine-clearance-calculator-guide',
+  'pain-scale-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 69 calculator meta files', () => {
+  it('discovers all 70 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(69)
+    expect(metas).toHaveLength(70)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -176,19 +179,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 67 DE blog slugs', () => {
+  it('returns all 68 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(67)
+    expect(de).toHaveLength(68)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 67 EN blog slugs', () => {
+  it('returns all 68 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(67)
+    expect(en).toHaveLength(68)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -256,9 +259,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 138 calcs + 2 blog index + 134 blog articles = 276)', () => {
+  it('generates correct total URL count (2 home + 140 calcs + 2 blog index + 136 blog articles = 280)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(276)
+    expect(urlCount).toBe(280)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -602,6 +602,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'creatinineClearance',
     related: ['gfr-calculator-kidney-function', 'measure-blood-pressure', 'diabetes-risk-score'],
   },
+  {
+    slug: 'pain-scale-calculator-guide',
+    title: 'Pain Scale Guide — NRS, VAS, Wong-Baker Explained',
+    description: 'How to use the NRS, VAS, and Wong-Baker FACES pain scales: when each is appropriate, what scores mean, and how to track pain over time.',
+    date: '2026-05-08',
+    readTime: '7 min',
+    calculatorKey: 'painScale',
+    related: ['asthma-control-test-guide', 'copd-assessment-guide', 'creatinine-clearance-calculator-guide'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -602,6 +602,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'creatinineClearance',
     related: ['gfr-rechner', 'blutdruck-richtig-messen', 'diabetes-risiko-berechnen'],
   },
+  {
+    slug: 'schmerzskala-berechnen',
+    title: 'Schmerzskala richtig nutzen — NRS, VAS, Wong-Baker erklärt',
+    description: 'NRS, VAS und Wong-Baker FACES — wie du Schmerzen richtig bewertest, was die Werte bedeuten und wie du Verläufe sinnvoll dokumentierst.',
+    date: '2026-05-08',
+    readTime: '7 min',
+    calculatorKey: 'painScale',
+    related: ['asthma-kontrolle-testen', 'copd-assessment-berechnen', 'kreatinin-clearance-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/painScale.json
+++ b/src/locales/calculators/de/painScale.json
@@ -1,0 +1,81 @@
+{
+  "home": {
+    "calculators": {
+      "painScale": {
+        "name": "Schmerzskala-Rechner",
+        "description": "NRS, VAS und Wong-Baker — Schmerzintensität bewerten und einordnen."
+      }
+    }
+  },
+  "painScale": {
+    "meta": {
+      "title": "Schmerzskala-Rechner — NRS, VAS, Wong-Baker | Health Calculators",
+      "description": "Schmerzintensität mit NRS (0–10), VAS (0–100 mm) und Wong-Baker-FACES bewerten. Klassifikation nach IASP/WHO. Kostenlos, sofort, anonym."
+    },
+    "title": "Schmerzskala-Rechner",
+    "description": "Bewerte deine Schmerzintensität mit drei etablierten klinischen Skalen — NRS, VAS und Wong-Baker. Ergebnis mit Einordnung nach IASP/WHO.",
+    "scaleLabel": "Schmerz-Skala",
+    "scales": {
+      "nrs": "NRS",
+      "vas": "VAS",
+      "wongBaker": "Wong-Baker"
+    },
+    "scaleHints": {
+      "nrs": "Numerische Rating-Skala — wähle eine ganze Zahl von 0 bis 10.",
+      "vas": "Visuelle Analog-Skala — Position auf einer 100 mm langen Linie (0 = kein Schmerz, 100 = stärkster Schmerz).",
+      "wongBaker": "Wong-Baker FACES — sechs Gesichter, jeweils 0, 2, 4, 6, 8, 10."
+    },
+    "scoreLabel": "Schmerz-Wert",
+    "vasLabel": "VAS (mm)",
+    "selectFace": "Gesicht wählen",
+    "incompleteHint": "Wähle eine Skala und gib einen Wert ein, um deine Schmerzintensität zu klassifizieren.",
+    "categoryLabel": "Einordnung",
+    "categories": {
+      "none": "Kein Schmerz",
+      "mild": "Leichter Schmerz",
+      "moderate": "Mäßiger Schmerz",
+      "severe": "Starker Schmerz"
+    },
+    "hints": {
+      "none": "0/10: Kein Schmerz. Keine Behandlung erforderlich. Achte trotzdem auf Veränderungen — chronische Schmerzen bleiben oft unbemerkt.",
+      "mild": "1–3/10: Leichter Schmerz. Tägliche Aktivitäten sind kaum beeinträchtigt. Selbsthilfe (Wärme, Kälte, Bewegung) ist meist ausreichend; Schmerzmittel selten nötig.",
+      "moderate": "4–6/10: Mäßiger Schmerz. Aktivität wird spürbar eingeschränkt. Medikamentöse Behandlung kann sinnvoll sein. Bei Persistenz > 1 Woche ärztlich abklären.",
+      "severe": "7–10/10: Starker Schmerz. Eindeutige Beeinträchtigung des Alltags. Ärztliche Vorstellung empfohlen — bei plötzlichem Auftreten oder begleitenden Symptomen sofort."
+    },
+    "rangeLabel": "Wertebereich",
+    "interpretationLabel": "Bedeutung",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Drei klinisch validierte Schmerz-Skalen werden hier verwendet: NRS (Numerische Rating-Skala, 0–10), VAS (Visuelle Analog-Skala, 0–100 mm) und Wong-Baker FACES (Gesichter-Skala für Kinder und Personen mit Sprachbarriere). Alle Werte werden auf eine 0–10-Skala normiert und nach Serlin et al. 1995 (IASP/WHO) in Kategorien eingeteilt: 0 kein Schmerz, 1–3 leicht, 4–6 mäßig, 7–10 stark.",
+    "disclaimer": "Diese Bewertung ist eine Selbsteinschätzung und ersetzt keine ärztliche Diagnose. Bei plötzlich auftretenden, persistenten oder mit Begleitsymptomen einhergehenden Schmerzen umgehend medizinische Hilfe suchen.",
+    "faq": [
+      {
+        "q": "Was ist die NRS-Schmerzskala?",
+        "a": "Die Numerische Rating-Skala (NRS) ist eine 11-stufige Skala von 0 bis 10. 0 bedeutet kein Schmerz, 10 stärkster vorstellbarer Schmerz. Sie ist weltweit die häufigste Schmerz-Skala in Klinik und Praxis."
+      },
+      {
+        "q": "Wie unterscheidet sich VAS von NRS?",
+        "a": "Die Visuelle Analog-Skala (VAS) ist eine 100 mm lange Linie ohne Beschriftung. Patienten markieren ihre Schmerzintensität als Position auf der Linie. Die VAS ist feiner aufgelöst, dafür aufwändiger zu erheben."
+      },
+      {
+        "q": "Wann wird Wong-Baker FACES eingesetzt?",
+        "a": "Die FACES-Skala wurde 1983 für Kinder ab 3 Jahren entwickelt, ist heute aber auch bei Erwachsenen mit Sprachbarrieren oder kognitiven Einschränkungen Standard. Sechs Gesichter zeigen eine Skala von 0 bis 10 in 2-er Schritten."
+      },
+      {
+        "q": "Welche Werte gelten als 'klinisch relevant'?",
+        "a": "Schmerzwerte ab 4/10 gelten in den meisten Leitlinien als behandlungsbedürftig. Eine Reduktion um mindestens 30 % bzw. 2 Punkte gilt als klinisch bedeutsame Verbesserung."
+      },
+      {
+        "q": "Wie oft sollte ich meine Schmerzen messen?",
+        "a": "Bei akutem Schmerz: vor und 30–60 Minuten nach jeder Behandlung. Bei chronischem Schmerz: täglich zur gleichen Tageszeit, idealerweise mit Schmerztagebuch über mindestens zwei Wochen."
+      },
+      {
+        "q": "Was ist der Unterschied zwischen Schmerz und Leiden?",
+        "a": "Schmerz ist die sensorische Komponente, Leiden umfasst die emotionale und funktionale Belastung. Die NRS misst nur die Intensität — für eine vollständige Beurteilung sind Skalen wie der Brief Pain Inventory (BPI) sinnvoll."
+      },
+      {
+        "q": "Sind Selbst-Bewertungen verlässlich?",
+        "a": "Ja — Selbst-Bewertungen sind der Goldstandard, weil Schmerz subjektiv ist. Beobachterskalen kommen nur bei Patienten zum Einsatz, die ihre Schmerzen nicht kommunizieren können (z. B. Demenz, Bewusstlosigkeit)."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/painScale.json
+++ b/src/locales/calculators/en/painScale.json
@@ -1,0 +1,81 @@
+{
+  "home": {
+    "calculators": {
+      "painScale": {
+        "name": "Pain Scale Calculator",
+        "description": "NRS, VAS, and Wong-Baker — rate and classify pain intensity."
+      }
+    }
+  },
+  "painScale": {
+    "meta": {
+      "title": "Pain Scale Calculator — NRS, VAS, Wong-Baker | Health Calculators",
+      "description": "Rate pain intensity using the NRS (0–10), VAS (0–100 mm), and Wong-Baker FACES scales. IASP/WHO classification. Free, instant, anonymous."
+    },
+    "title": "Pain Scale Calculator",
+    "description": "Rate your pain intensity with three validated clinical scales — NRS, VAS, and Wong-Baker. Returns a category aligned with IASP/WHO standards.",
+    "scaleLabel": "Pain scale",
+    "scales": {
+      "nrs": "NRS",
+      "vas": "VAS",
+      "wongBaker": "Wong-Baker"
+    },
+    "scaleHints": {
+      "nrs": "Numeric Rating Scale — pick a whole number from 0 to 10.",
+      "vas": "Visual Analog Scale — position on a 100 mm line (0 = no pain, 100 = worst pain).",
+      "wongBaker": "Wong-Baker FACES — six faces, scored 0, 2, 4, 6, 8, 10."
+    },
+    "scoreLabel": "Pain score",
+    "vasLabel": "VAS (mm)",
+    "selectFace": "Select a face",
+    "incompleteHint": "Pick a scale and enter a value to classify your pain intensity.",
+    "categoryLabel": "Category",
+    "categories": {
+      "none": "No pain",
+      "mild": "Mild pain",
+      "moderate": "Moderate pain",
+      "severe": "Severe pain"
+    },
+    "hints": {
+      "none": "0/10: No pain. No treatment needed. Stay alert to changes — chronic pain often goes unnoticed in early stages.",
+      "mild": "1–3/10: Mild pain. Daily activities are barely affected. Self-care (heat, cold, movement) usually suffices; medication is rarely needed.",
+      "moderate": "4–6/10: Moderate pain. Activity is noticeably limited. Medication may be appropriate. If pain persists more than a week, see a clinician.",
+      "severe": "7–10/10: Severe pain. Daily life is clearly impaired. See a clinician — and seek immediate care if pain is sudden or accompanied by other symptoms."
+    },
+    "rangeLabel": "Range",
+    "interpretationLabel": "Meaning",
+    "howItWorks": "How it works",
+    "howItWorksText": "Three clinically validated pain scales are used here: NRS (Numeric Rating Scale, 0–10), VAS (Visual Analog Scale, 0–100 mm) and Wong-Baker FACES (a faces scale for children and people with language barriers). All values are normalised to a 0–10 scale and binned per Serlin et al. 1995 (IASP/WHO): 0 no pain, 1–3 mild, 4–6 moderate, 7–10 severe.",
+    "disclaimer": "This is a self-assessment and does not replace medical diagnosis. For sudden, persistent, or symptom-accompanied pain, seek medical help promptly.",
+    "faq": [
+      {
+        "q": "What is the NRS pain scale?",
+        "a": "The Numeric Rating Scale (NRS) is an 11-point scale from 0 to 10. 0 means no pain, 10 means worst pain imaginable. It is the most widely used pain scale in clinical practice worldwide."
+      },
+      {
+        "q": "How does VAS differ from NRS?",
+        "a": "The Visual Analog Scale (VAS) is an unmarked 100 mm line. Patients mark their pain intensity as a position on the line. VAS offers finer resolution but is more cumbersome to administer."
+      },
+      {
+        "q": "When is Wong-Baker FACES used?",
+        "a": "The FACES scale was developed in 1983 for children aged 3 and older, and is now standard for adults with language barriers or cognitive impairment. Six faces show a 0–10 scale in 2-point steps."
+      },
+      {
+        "q": "Which scores are 'clinically meaningful'?",
+        "a": "Pain ≥ 4/10 is treatment-worthy in most guidelines. A reduction of at least 30 % or 2 points is considered a clinically meaningful improvement."
+      },
+      {
+        "q": "How often should I rate my pain?",
+        "a": "Acute pain: rate before and 30–60 minutes after each intervention. Chronic pain: daily at the same time of day, ideally with a pain diary over at least two weeks."
+      },
+      {
+        "q": "What's the difference between pain and suffering?",
+        "a": "Pain is the sensory component; suffering covers the emotional and functional burden. NRS only measures intensity — for full assessment use multidimensional tools such as the Brief Pain Inventory (BPI)."
+      },
+      {
+        "q": "Are self-ratings reliable?",
+        "a": "Yes — self-ratings are the gold standard because pain is subjective. Observer-rated scales are reserved for patients who cannot communicate (e.g. dementia, unconsciousness)."
+      }
+    ]
+  }
+}

--- a/src/pages/PainScaleCalculator.vue
+++ b/src/pages/PainScaleCalculator.vue
@@ -1,0 +1,226 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { evaluatePainScore } from '../utils/painScale.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('painScale.faq') || [])
+
+useHead(() => ({
+  title: t('painScale.meta.title'),
+  description: t('painScale.meta.description'),
+  routeKey: 'painScale',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Pain Scale Calculator',
+    url: 'https://healthcalculator.app/pain-scale-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const scale = ref('nrs')
+const nrsValue = ref(null)
+const vasValue = ref(null)
+const wongBakerValue = ref(null)
+
+const wongBakerOptions = [
+  { value: 0, face: '😀' },
+  { value: 2, face: '🙂' },
+  { value: 4, face: '😐' },
+  { value: 6, face: '🙁' },
+  { value: 8, face: '😣' },
+  { value: 10, face: '😭' },
+]
+
+const nrsOptions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+const result = computed(() => {
+  if (scale.value === 'nrs') {
+    return evaluatePainScore({ scale: 'nrs', value: nrsValue.value })
+  }
+  if (scale.value === 'vas') {
+    return evaluatePainScore({ scale: 'vas', value: vasValue.value })
+  }
+  if (scale.value === 'wongBaker') {
+    return evaluatePainScore({ scale: 'wongBaker', value: wongBakerValue.value })
+  }
+  return null
+})
+
+const interpretation = computed(() => {
+  if (!result.value) return null
+  const map = {
+    none: { color: 'text-green-600', bg: 'bg-green-600' },
+    mild: { color: 'text-green-500', bg: 'bg-green-500' },
+    moderate: { color: 'text-orange-500', bg: 'bg-orange-500' },
+    severe: { color: 'text-red-600', bg: 'bg-red-600' },
+  }
+  return { key: result.value.category, ...map[result.value.category] }
+})
+
+const categoryRows = [
+  { range: '0', key: 'none' },
+  { range: '1 – 3', key: 'mild' },
+  { range: '4 – 6', key: 'moderate' },
+  { range: '7 – 10', key: 'severe' },
+]
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('painScale.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('painScale.description') }}</p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <div class="mb-6">
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('painScale.scaleLabel') }}</label>
+        <div class="flex gap-2 flex-wrap">
+          <button
+            @click="scale = 'nrs'"
+            data-testid="scale-nrs"
+            :class="scale === 'nrs' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('painScale.scales.nrs') }}</button>
+          <button
+            @click="scale = 'vas'"
+            data-testid="scale-vas"
+            :class="scale === 'vas' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('painScale.scales.vas') }}</button>
+          <button
+            @click="scale = 'wongBaker'"
+            data-testid="scale-wong"
+            :class="scale === 'wongBaker' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('painScale.scales.wongBaker') }}</button>
+        </div>
+        <p class="text-sm text-stone-500 mt-3" data-testid="scale-hint">{{ t('painScale.scaleHints.' + scale) }}</p>
+      </div>
+
+      <div v-if="scale === 'nrs'">
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('painScale.scoreLabel') }}</label>
+        <div class="grid grid-cols-11 gap-1.5">
+          <button
+            v-for="n in nrsOptions"
+            :key="n"
+            @click="nrsValue = n"
+            :data-testid="'nrs-' + n"
+            :class="nrsValue === n ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-700 hover:bg-stone-200'"
+            class="aspect-square rounded-lg text-base font-semibold tabular-nums transition-colors duration-150"
+          >{{ n }}</button>
+        </div>
+      </div>
+
+      <div v-else-if="scale === 'vas'">
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('painScale.vasLabel') }}</label>
+        <input
+          v-model.number="vasValue"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          data-testid="vas-slider"
+          class="w-full accent-stone-900"
+        />
+        <div class="flex justify-between text-xs text-stone-400 mt-2 tabular-nums">
+          <span>0</span>
+          <span class="text-stone-900 font-semibold text-base" data-testid="vas-value">{{ vasValue ?? 0 }} mm</span>
+          <span>100</span>
+        </div>
+      </div>
+
+      <div v-else-if="scale === 'wongBaker'">
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('painScale.selectFace') }}</label>
+        <div class="grid grid-cols-6 gap-2">
+          <button
+            v-for="opt in wongBakerOptions"
+            :key="opt.value"
+            @click="wongBakerValue = opt.value"
+            :data-testid="'wong-' + opt.value"
+            :class="wongBakerValue === opt.value ? 'bg-stone-900 text-white border-stone-900' : 'bg-white text-stone-700 border-stone-200 hover:border-stone-400'"
+            class="flex flex-col items-center gap-1 px-3 py-3 rounded-lg border-2 transition-colors duration-150"
+          >
+            <span class="text-3xl leading-none">{{ opt.face }}</span>
+            <span class="text-xs font-semibold tabular-nums">{{ opt.value }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <div class="flex items-center gap-3 mb-6">
+        <span
+          data-testid="result-status"
+          :class="[interpretation.bg, 'text-white text-sm font-semibold px-3 py-1 rounded-full']"
+        >{{ t('painScale.categories.' + interpretation.key) }}</span>
+      </div>
+
+      <div class="mb-6">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('painScale.scoreLabel') }}</div>
+        <div class="flex items-baseline gap-3">
+          <span data-testid="result-score" class="text-6xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ result.score.toFixed(1) }}</span>
+          <span class="text-base text-stone-400">/ 10</span>
+        </div>
+      </div>
+
+      <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+        <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-orange-500 to-red-600 rounded-full" style="width: 100%"></div>
+        <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: Math.min(result.score / 10 * 100, 100) + '%' }"></div>
+      </div>
+
+      <div class="border border-stone-200 rounded-lg px-4 py-3 bg-stone-50">
+        <p data-testid="result-hint" class="text-sm text-stone-700 leading-relaxed">{{ t('painScale.hints.' + interpretation.key) }}</p>
+      </div>
+    </div>
+
+    <div v-else class="bg-stone-50 border border-stone-200 rounded-xl p-6 mb-6">
+      <p data-testid="incomplete-hint" class="text-sm text-stone-500">{{ t('painScale.incompleteHint') }}</p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-stone-50 border-b border-stone-200">
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('painScale.rangeLabel') }}</th>
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('painScale.interpretationLabel') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-stone-100">
+          <tr v-for="row in categoryRows" :key="row.key">
+            <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">{{ row.range }}</td>
+            <td class="px-6 py-3 text-stone-600">{{ t('painScale.categories.' + row.key) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('painScale.howItWorks') }}</h2>
+      <p class="text-sm text-stone-500 leading-relaxed">{{ t('painScale.howItWorksText') }}</p>
+    </div>
+
+    <div class="bg-stone-50 border border-stone-200 rounded-xl px-6 py-4 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('painScale.disclaimer') }}</p>
+    </div>
+
+    <AdSlot class="mt-8" />
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <BlogArticleLink calculator-key="painScale" />
+  </div>
+</template>

--- a/src/pages/blog/SchmerzskalaBerechnen.vue
+++ b/src/pages/blog/SchmerzskalaBerechnen.vue
@@ -1,0 +1,246 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Schmerzskala richtig nutzen — NRS, VAS, Wong-Baker erklärt | Health Calculators',
+  description: 'NRS, VAS und Wong-Baker FACES — wie du Schmerzen richtig bewertest, was die Werte bedeuten und wie du Verläufe sinnvoll dokumentierst.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Schmerzskala richtig nutzen — NRS, VAS, Wong-Baker erklärt',
+      description: 'Welche Schmerz-Skala wann sinnvoll ist, wie du Werte korrekt deutest und wann ein Wert behandlungsbedürftig wird.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-08',
+      dateModified: '2026-05-08',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/schmerzskala-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist die NRS-Schmerzskala?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die Numerische Rating-Skala (NRS) bewertet Schmerz auf einer 11-stufigen Skala von 0 (kein Schmerz) bis 10 (stärkster vorstellbarer Schmerz). Sie ist der weltweite Standard.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Ab welchem Wert sollte ich einen Arzt aufsuchen?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Werte ab 4/10 sind in den meisten Leitlinien behandlungsbedürftig. Bei Werten ≥ 7/10 oder plötzlich auftretenden Schmerzen umgehend ärztliche Hilfe.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Schmerzskala richtig nutzen — NRS, VAS, Wong-Baker erklärt</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">8. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          „Wie stark sind Ihre Schmerzen, von 0 bis 10?" — diese Frage hörst du in praktisch jeder Notaufnahme und Hausarztpraxis. Dahinter steht die <strong>Numerische Rating-Skala (NRS)</strong>: das einfachste, am häufigsten validierte Werkzeug zur Schmerzbewertung.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Daneben sind <strong>VAS (Visuelle Analog-Skala)</strong> und <strong>Wong-Baker FACES</strong> Standardinstrumente. Welche Skala wann passt, was deine Werte bedeuten und wie du Verläufe sinnvoll dokumentierst — hier kompakt erklärt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum überhaupt eine Schmerzskala?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Schmerz ist subjektiv — er lässt sich nicht objektiv messen. Eine standardisierte Skala macht ihn trotzdem <strong>vergleichbar</strong>: über die Zeit, zwischen Patienten, zwischen Behandlungen. Ohne sie würde aus einem „besser" oder „schlimmer" eine reine Bauchgefühl-Diskussion.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Konkret nutzt man Schmerzskalen zur <strong>Therapie-Steuerung</strong> (was wirkt?), zur <strong>Verlaufsdokumentation</strong> (wird es besser?) und zur <strong>Triage</strong> (wer ist akut?).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die drei wichtigsten Skalen im Vergleich</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Skala</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bereich</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Einsatz</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">NRS</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0 – 10 (ganzzahlig)</td>
+                <td class="px-6 py-3 text-stone-600">Routine in Klinik &amp; Praxis</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">VAS</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0 – 100 mm (kontinuierlich)</td>
+                <td class="px-6 py-3 text-stone-600">Studien, Schmerz-Forschung</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Wong-Baker FACES</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0, 2, 4, 6, 8, 10</td>
+                <td class="px-6 py-3 text-stone-600">Kinder ab 3 J., Sprachbarrieren</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Alle drei Skalen lassen sich auf einen <strong>0–10-Wert normieren</strong>. Vergleichbarkeit ist also gegeben — das ist auch die Grundlage unseres Schmerzskala-Rechners.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was bedeuten die Werte?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die heute gültige Einteilung geht auf <strong>Serlin et al. 1995</strong> zurück und wurde von IASP und WHO übernommen:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Wert</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Einordnung</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Konsequenz</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0</td>
+                <td class="px-6 py-3 text-stone-600">Kein Schmerz</td>
+                <td class="px-6 py-3 text-stone-600">Beobachten</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">1 – 3</td>
+                <td class="px-6 py-3 text-stone-600">Leichter Schmerz</td>
+                <td class="px-6 py-3 text-stone-600">Selbsthilfe, ggf. einfache Analgetika</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">4 – 6</td>
+                <td class="px-6 py-3 text-stone-600">Mäßiger Schmerz</td>
+                <td class="px-6 py-3 text-stone-600">Behandlungsbedürftig</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">7 – 10</td>
+                <td class="px-6 py-3 text-stone-600">Starker Schmerz</td>
+                <td class="px-6 py-3 text-stone-600">Ärztliche Vorstellung empfohlen</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>4/10</strong> ist die wichtigste Schwelle: Ab hier wird die Lebensqualität spürbar eingeschränkt — und ab hier ist nach den meisten Leitlinien eine aktive Behandlung sinnvoll.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist eine „klinisch bedeutsame" Verbesserung?</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Nicht jede Veränderung ist relevant. Studien zeigen: Eine Reduktion um <strong>mindestens 30 % oder 2 Punkte</strong> auf der NRS gilt als minimal klinisch bedeutsamer Unterschied (MCID). Werte darunter erleben Patienten nicht als Verbesserung — auch wenn sie statistisch signifikant sind.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Schmerzwerte sinnvoll dokumentieren</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Akut</strong>: vor und 30–60 Minuten nach jeder Intervention.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Chronisch</strong>: täglich zur gleichen Tageszeit; idealerweise drei Werte (Ruhe, Belastung, schlimmster Wert in 24 h).</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Schmerztagebuch</strong> über mindestens 2 Wochen — Auslöser, Begleitumstände, Wirkung von Maßnahmen.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base">Werte allein reichen nicht. Beschreibe auch <strong>Qualität</strong> (stechend, brennend), <strong>Lokalisation</strong> und <strong>Begleitsymptome</strong>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen &amp; Rechner</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Asthma-Kontrolle (ACT)</strong> — eine andere validierte Selbst-Bewertung mit fünf Fragen. Zum <router-link :to="localeBlogPath('asthma-kontrolle-testen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">ACT-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>COPD-Assessment (CAT)</strong> — Symptom-Bewertung für Atemwegserkrankungen, ähnlich strukturiert. Zum <router-link :to="localeBlogPath('copd-assessment-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">CAT-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Kreatinin-Clearance</strong> — wichtig bei chronischen Schmerzen unter Langzeit-Analgetika (NSAR, Opioide). Zum <router-link :to="localeBlogPath('kreatinin-clearance-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">CrCl-Artikel</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deinen Schmerz bewerten</h3>
+        <p class="text-stone-300 text-sm mb-5">NRS, VAS, Wong-Baker — eine Skala wählen, Wert eingeben, Einordnung erhalten.</p>
+        <router-link
+          :to="localePath('painScale')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum Schmerzskala-Rechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Was unterscheidet Schmerz von Leiden?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Schmerz ist die rein sensorische Komponente. Leiden umfasst die emotionale Belastung, Einschränkungen im Alltag und sozialen Folgen. Die NRS misst nur Intensität — für eine vollständige Bewertung sind multidimensionale Tools wie der Brief Pain Inventory (BPI) sinnvoll.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Sind Selbst-Bewertungen verlässlich?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Ja — Selbst-Bewertung ist der Goldstandard, weil Schmerz definitionsgemäß subjektiv ist. Beobachterskalen kommen nur dann zum Einsatz, wenn der Patient sich nicht äußern kann (z. B. Demenz, Bewusstlosigkeit, Säuglinge).
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Warum nutzt man bei Kindern Gesichter?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Abstrakte Zahlen verstehen kleine Kinder nicht zuverlässig. Die Wong-Baker FACES-Skala wurde 1983 für die Pflege pädiatrischer Patienten entwickelt und ist heute der internationale Standard für die Altersgruppe 3–10 Jahre.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Mein Wert ist 7 — was sollte ich tun?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Werte ≥ 7/10 entsprechen starkem Schmerz. Bei plötzlichem Auftreten, Brustschmerz, Atemnot, Bewusstseinsstörungen oder akutem Bauchschmerz: Notruf 112. In allen anderen Fällen zeitnahe Vorstellung beim Hausarzt oder einer Schmerzambulanz.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/pages/blog/en/PainScaleCalculatorGuide.vue
+++ b/src/pages/blog/en/PainScaleCalculatorGuide.vue
@@ -1,0 +1,246 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Pain Scale Guide — NRS, VAS, Wong-Baker Explained | Health Calculators',
+  description: 'How to use the NRS, VAS, and Wong-Baker FACES pain scales: when each is appropriate, what scores mean, and how to track pain over time.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Pain Scale Guide — NRS, VAS, Wong-Baker Explained',
+      description: 'Pick the right pain scale, interpret your score correctly, and decide when a pain level needs treatment.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-08',
+      dateModified: '2026-05-08',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/pain-scale-calculator-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is the NRS pain scale?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The Numeric Rating Scale (NRS) rates pain from 0 (no pain) to 10 (worst pain imaginable). It is the most common pain scale in clinical practice worldwide.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'When should I see a doctor?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Most guidelines call pain ≥ 4/10 treatment-worthy. Pain ≥ 7/10 or sudden new pain warrants prompt medical attention.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Pain Scale Guide — NRS, VAS, Wong-Baker Explained</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 8, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          „How bad is your pain, on a scale from 0 to 10?" You hear that question in nearly every emergency department and primary care office. Behind it sits the <strong>Numeric Rating Scale (NRS)</strong> — the simplest, most widely validated pain assessment tool in medicine.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Two other clinical scales sit alongside it: the <strong>Visual Analog Scale (VAS)</strong> and <strong>Wong-Baker FACES</strong>. This guide covers when each is appropriate, what the numbers mean, and how to track pain over time.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why use a pain scale at all?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Pain is subjective — it can't be measured objectively. A standardised scale still makes it <strong>comparable</strong>: across time, across patients, across treatments. Without one, you're left arguing about „better" or „worse" with no reference point.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Practically, pain scales drive <strong>therapy decisions</strong> (is this working?), <strong>tracking</strong> (is it getting better?), and <strong>triage</strong> (who needs urgent attention?).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The three main scales compared</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Scale</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Range</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Best for</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">NRS</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0 – 10 (integers)</td>
+                <td class="px-6 py-3 text-stone-600">Routine clinical practice</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">VAS</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0 – 100 mm (continuous)</td>
+                <td class="px-6 py-3 text-stone-600">Studies, pain research</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">Wong-Baker FACES</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">0, 2, 4, 6, 8, 10</td>
+                <td class="px-6 py-3 text-stone-600">Children ≥ 3 y, language barriers</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          All three scales normalise to the <strong>same 0 – 10 reference</strong>, so scores remain comparable. That's the basis our pain scale calculator builds on.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What do the scores mean?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The standard categorical bands trace back to <strong>Serlin et al. 1995</strong> and were adopted by IASP and WHO:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Action</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0</td>
+                <td class="px-6 py-3 text-stone-600">No pain</td>
+                <td class="px-6 py-3 text-stone-600">Observe</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">1 – 3</td>
+                <td class="px-6 py-3 text-stone-600">Mild</td>
+                <td class="px-6 py-3 text-stone-600">Self-care, simple analgesics if needed</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">4 – 6</td>
+                <td class="px-6 py-3 text-stone-600">Moderate</td>
+                <td class="px-6 py-3 text-stone-600">Treatment-worthy</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">7 – 10</td>
+                <td class="px-6 py-3 text-stone-600">Severe</td>
+                <td class="px-6 py-3 text-stone-600">See a clinician</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>4/10 is the key threshold</strong>: above it, pain noticeably impairs daily life — and most guidelines recommend active treatment at that point.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What counts as a clinically meaningful change?</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Not every change matters. Studies show that a reduction of <strong>at least 30 % or 2 points</strong> on the NRS is the minimal clinically important difference (MCID). Smaller changes are often statistically detectable but not perceived by patients as improvement.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How to track pain over time</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Acute pain</strong>: rate before and 30–60 min after each intervention.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Chronic pain</strong>: same time daily, ideally three numbers (rest, activity, worst in last 24 h).</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base">Keep a <strong>pain diary</strong> for at least 2 weeks — triggers, context, what helps.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base">A number alone isn't enough. Add <strong>quality</strong> (sharp, burning), <strong>location</strong>, and <strong>associated symptoms</strong>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics &amp; calculators</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Asthma Control Test (ACT)</strong> — another validated five-question self-assessment. See the <router-link :to="localeBlogPath('asthma-control-test-guide')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">ACT guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>COPD Assessment Test (CAT)</strong> — symptom rating with a similar structure. See the <router-link :to="localeBlogPath('copd-assessment-guide')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">CAT guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Creatinine clearance</strong> — important for chronic pain patients on long-term NSAIDs or opioids. See the <router-link :to="localeBlogPath('creatinine-clearance-calculator-guide')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">CrCl guide</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Rate your pain now</h3>
+        <p class="text-stone-300 text-sm mb-5">NRS, VAS, Wong-Baker — pick a scale, enter a value, get an evidence-based category.</p>
+        <router-link
+          :to="localePath('painScale')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Open the Pain Scale Calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequently asked questions</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">What's the difference between pain and suffering?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Pain is the sensory component. Suffering covers the emotional load, daily-life impact, and social consequences. NRS measures intensity only — for full assessment use multidimensional tools such as the Brief Pain Inventory (BPI).
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Are self-ratings reliable?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Yes — self-rating is the gold standard because pain is subjective by definition. Observer-rated scales are reserved for patients who cannot communicate (e.g. dementia, unconsciousness, infants).
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Why use faces for children?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Young children don't reliably grasp abstract numbers. The Wong-Baker FACES scale was developed in 1983 for paediatric nursing and is now the international standard for ages 3–10.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">My score is 7 — what should I do?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Scores ≥ 7/10 indicate severe pain. If onset is sudden or paired with chest pain, breathing difficulty, altered consciousness, or acute abdominal pain — call emergency services. Otherwise, see your primary care clinician or a pain clinic promptly.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/pages/painScale.meta.js
+++ b/src/pages/painScale.meta.js
@@ -1,0 +1,16 @@
+import Component from './PainScaleCalculator.vue'
+import BlogDe from './blog/SchmerzskalaBerechnen.vue'
+import BlogEn from './blog/en/PainScaleCalculatorGuide.vue'
+
+export default {
+  key: 'painScale',
+  component: Component,
+  slugs: { de: 'schmerzskala-rechner', en: 'pain-scale-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 102,
+  blog: {
+    de: { slug: 'schmerzskala-berechnen', component: BlogDe },
+    en: { slug: 'pain-scale-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/painScale.js
+++ b/src/utils/painScale.js
@@ -1,0 +1,53 @@
+// Pain Scale calculator — NRS, VAS, Wong-Baker FACES.
+//
+// Categorical bands (Serlin et al. 1995, IASP/WHO):
+//   0       → none
+//   1 – 3   → mild
+//   4 – 6   → moderate
+//   7 – 10  → severe
+
+export function classifyPain(score) {
+  if (typeof score !== 'number' || !Number.isFinite(score)) return null
+  if (score < 0 || score > 10) return null
+  if (score === 0) return 'none'
+  if (score < 4) return 'mild'
+  if (score < 7) return 'moderate'
+  return 'severe'
+}
+
+export function vasToNrs(mm) {
+  if (typeof mm !== 'number' || !Number.isFinite(mm)) return null
+  if (mm < 0 || mm > 100) return null
+  return mm / 10
+}
+
+export function nrsToVas(score) {
+  if (typeof score !== 'number' || !Number.isFinite(score)) return null
+  if (score < 0 || score > 10) return null
+  return score * 10
+}
+
+const WONG_BAKER_FACES = new Set([0, 2, 4, 6, 8, 10])
+
+export function evaluatePainScore({ scale, value } = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+
+  let score
+  if (scale === 'nrs') {
+    if (!Number.isInteger(value) || value < 0 || value > 10) return null
+    score = value
+  } else if (scale === 'vas') {
+    const nrs = vasToNrs(value)
+    if (nrs === null) return null
+    score = nrs
+  } else if (scale === 'wongBaker') {
+    if (!WONG_BAKER_FACES.has(value)) return null
+    score = value
+  } else {
+    return null
+  }
+
+  const category = classifyPain(score)
+  if (category === null) return null
+  return { score, category, vas: nrsToVas(score) }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-159-pain-scale
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-159-pain-scale-20260508-120030`
**Cost:** $8.492070500000002

Closes jenslaufer/health-calculators#159

### Prompt
> Implement the Pain Scale Calculator as described in issue #159.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Pain assessment (NRS, VAS, Wong-Baker)
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.


## PARTIAL-COMMIT GUARD (MANDATORY — added 2026-05-07 after FK #270 + HC #231 partial; validated 3-of-3 on FK #280 + HC #232 + HC #233, 4-of-3 on FK #281)
Before `git push`, run:
  git diff --name-only main..HEAD | sort

Output MUST contain ALL of these paths (substitute <DeBlogPascal> + <EnBlogPascal> with your chosen blog Vue component names):
  e2e/painScale.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/painScale.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/painScale.json
  src/locales/calculators/en/painScale.json
  src/pages/PainScaleCalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/painScale.meta.js
  src/utils/painScale.js

If ANY path is missing → DO NOT push. Stage + commit the missing files first.
Counter check: `git diff --name-only main..HEAD | wc -l` MUST be >= 14.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/painScale.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/painScale.test.js` with 6+ test cases covering edge cases. Run `npm test -- painScale` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/PainScaleCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/painScale.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/painScale.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'painScale'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/painScale.json` + `src/locales/calculators/en/painScale.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/painScale.js (or shared util — verify pattern in repo first)`
- `src/__tests__/painScale.test.js`
- `src/pages/PainScaleCalculator.vue`
- `src/pages/painScale.meta.js`
- `src/locales/calculators/de/painScale.json`
- `src/locales/calculators/en/painScale.json`
- `e2e/painScale.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'painScale',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks