### PR TITLE
hc-172-robots-llms-txt: Add llms.txt reference to robots.txt as described in issue #

### DIFF
--- a/e2e/seo.spec.js
+++ b/e2e/seo.spec.js
@@ -1,5 +1,14 @@
 import { test, expect } from '@playwright/test'
 
+test.describe('robots.txt', () => {
+  test('contains llms.txt reference', async ({ request }) => {
+    const response = await request.get('/robots.txt')
+    expect(response.status()).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('https://healthcalculator.app/llms.txt')
+  })
+})
+
 test.describe('SEO fallback files', () => {
   test('404.html serves the app shell with rendered content', async ({ page }) => {
     const response = await page.goto('404.html')

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,6 @@ User-agent: *
 Allow: /
 Disallow: /assets/
 
+# LLMs
+# See https://healthcalculator.app/llms.txt
 Sitemap: https://healthcalculator.app/sitemap.xml


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-172-robots-llms-txt
**Agent:** claude
**Model:** claude-sonnet-4-6
**Branch:** `agent/hc-172-robots-llms-txt-20260508-220030`
**Cost:** $0.1734398

Closes jenslaufer/health-calculators#172

### Prompt
> Add llms.txt reference to robots.txt as described in issue #172.

Add these two comment lines BEFORE the Sitemap line in public/robots.txt:

# LLMs
# See https://healthcalculator.app/llms.txt

DO NOT modify any other files. DO NOT change existing robots.txt directives.
Write a simple test that verifies robots.txt contains the llms.txt reference.