### PR TITLE
hc-132: add Child Calorie Needs Calculator (IOM EER)

### DIFF
--- a/e2e/childCalories.spec.js
+++ b/e2e/childCalories.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/kinder-kalorienbedarf-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Kinder-Kalorienbedarf-Rechner/)
+})
+
+test('5y boy 18 kg 110 cm low active shows ~1465 kcal', async ({ page }) => {
+  await page.getByTestId('input-age').fill('5')
+  await page.getByTestId('input-sex').selectOption('boy')
+  await page.getByTestId('input-weight').fill('18')
+  await page.getByTestId('input-height').fill('110')
+  await page.getByTestId('input-activity').selectOption('low_active')
+
+  await expect(page.getByTestId('result-kcal')).toContainText('1465')
+})
+
+test('12y girl 40 kg 150 cm very active shows ~2600 kcal', async ({ page }) => {
+  await page.getByTestId('input-age').fill('12')
+  await page.getByTestId('input-sex').selectOption('girl')
+  await page.getByTestId('input-weight').fill('40')
+  await page.getByTestId('input-height').fill('150')
+  await page.getByTestId('input-activity').selectOption('very_active')
+
+  await expect(page.getByTestId('result-kcal')).toContainText('2600')
+})
+
+test('imperial toggle calculates result', async ({ page }) => {
+  await page.getByTestId('unit-imperial').click()
+  await page.getByTestId('input-age').fill('10')
+  await page.getByTestId('input-sex').selectOption('boy')
+  await page.getByTestId('input-weight').fill('70')
+  await page.getByTestId('input-height').fill('54')
+  await page.getByTestId('input-activity').selectOption('active')
+
+  await expect(page.getByTestId('result-kcal')).toBeVisible()
+})
+
+test('toddler age (2y) shows fixed IOM value without weight/height', async ({ page }) => {
+  await page.getByTestId('input-age').fill('2')
+  await page.getByTestId('input-sex').selectOption('boy')
+
+  await expect(page.getByTestId('note-toddler')).toBeVisible()
+  await expect(page.getByTestId('result-kcal')).toContainText('1046')
+})
+
+test('shows age warning for implausible age', async ({ page }) => {
+  await page.getByTestId('input-age').fill('19')
+  await expect(page.getByTestId('warning-age')).toBeVisible()
+})
+
+test('shows weight warning for implausible weight', async ({ page }) => {
+  await page.getByTestId('input-age').fill('10')
+  await page.getByTestId('input-weight').fill('200')
+  await page.getByTestId('input-height').fill('140')
+  await expect(page.getByTestId('warning-weight')).toBeVisible()
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -25,7 +25,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'babyFeedingAmount', 'asthmaControl', 'copdAssessment', 'babyMilestones', 'creatinineClearance',
-  'painScale', 'newbornBilirubin',
+  'painScale', 'newbornBilirubin', 'childCalories',
 ]
 
 const EXPECTED_ROUTE_MAP = {
@@ -98,6 +98,7 @@ const EXPECTED_ROUTE_MAP = {
   creatinineClearance: { de: 'kreatinin-clearance-rechner', en: 'creatinine-clearance-calculator' },
   painScale: { de: 'schmerzskala-rechner', en: 'pain-scale-calculator' },
   newbornBilirubin: { de: 'neugeborenen-bilirubin-rechner', en: 'newborn-bilirubin-calculator' },
+  childCalories: { de: 'kinder-kalorienbedarf-rechner', en: 'child-calorie-needs-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -158,6 +159,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kreatinin-clearance-berechnen',
   'schmerzskala-berechnen',
   'neugeborenen-gelbsucht-risiko',
+  'kinder-kalorienbedarf-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -218,19 +220,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'creatinine-clearance-calculator-guide',
   'pain-scale-calculator-guide',
   'newborn-jaundice-calculator-guide',
+  'child-calorie-needs-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 71 calculators', () => {
-    expect(calculatorMetas).toHaveLength(71)
+  it('discovers all 72 calculators', () => {
+    expect(calculatorMetas).toHaveLength(72)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 71 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(71)
+  it('builds calculatorComponents map for all 72 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(72)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -253,15 +256,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 69 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(69)
+  it('discovers all 70 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(70)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 69 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(69)
+  it('discovers all 70 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(70)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -277,10 +280,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 71 calculators with no duplicates', () => {
+  it('groups contain all 72 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(71)
-    expect(new Set(allKeys).size).toBe(71)
+    expect(allKeys).toHaveLength(72)
+    expect(new Set(allKeys).size).toBe(72)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -295,7 +298,7 @@ describe('calculator groups', () => {
   it('nutritionEnergy group has correct calculators in order', () => {
     expect(calculatorGroups[1].calculators).toEqual([
       'bmr', 'tdee', 'macro', 'water', 'calorieDeficit',
-      'protein', 'caloriesBurned', 'proteinNeed', 'caffeine', 'intermittentFasting', 'keto',
+      'protein', 'caloriesBurned', 'proteinNeed', 'caffeine', 'intermittentFasting', 'keto', 'childCalories',
     ])
   })
 
@@ -350,8 +353,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 391 routes', () => {
-    expect(routes).toHaveLength(391)
+  it('generates exactly 396 routes', () => {
+    expect(routes).toHaveLength(396)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/childCalories.test.js
+++ b/src/__tests__/childCalories.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcEER,
+  childCalories,
+  isPlausibleAge,
+  isPlausibleWeightKg,
+  isPlausibleHeightCm,
+  lbToKg,
+  inToCm,
+  ftInToCm,
+  PA,
+} from '../utils/childCalories.js'
+
+// Reference: Institute of Medicine (IOM) DRI for Energy (2002/2005).
+// EER (Estimated Energy Requirement) for children ages 3–18.
+
+describe('calcEER — boys', () => {
+  it('5y boy, 18 kg, 110 cm, low active → ~1366 kcal', () => {
+    // 88.5 − 61.9·5 + 1.13·(26.7·18 + 903·1.10) + 20
+    // = 88.5 − 309.5 + 1.13·(480.6 + 993.3) + 20
+    // = 88.5 − 309.5 + 1.13·1473.9 + 20
+    // = 88.5 − 309.5 + 1665.51 + 20 = 1464.51
+    expect(calcEER({ age: 5, sex: 'boy', weightKg: 18, heightCm: 110, activity: 'low_active' })).toBeCloseTo(1464.5, 0)
+  })
+
+  it('10y boy, 32 kg, 138 cm, active → ~2049 kcal', () => {
+    // 88.5 − 61.9·10 + 1.26·(26.7·32 + 903·1.38) + 25
+    // = 88.5 − 619 + 1.26·(854.4 + 1246.14) + 25
+    // = 88.5 − 619 + 1.26·2100.54 + 25 = 2141.18
+    const v = calcEER({ age: 10, sex: 'boy', weightKg: 32, heightCm: 138, activity: 'active' })
+    expect(v).toBeCloseTo(2141.18, 0)
+  })
+
+  it('15y boy, 60 kg, 170 cm, sedentary → ~2484 kcal', () => {
+    // 88.5 − 61.9·15 + 1.0·(26.7·60 + 903·1.70) + 25
+    // = 88.5 − 928.5 + 1602 + 1535.1 + 25 = 2322.1
+    const v = calcEER({ age: 15, sex: 'boy', weightKg: 60, heightCm: 170, activity: 'sedentary' })
+    expect(v).toBeCloseTo(2322.1, 0)
+  })
+})
+
+describe('calcEER — girls', () => {
+  it('5y girl, 18 kg, 110 cm, low active → ~1389 kcal', () => {
+    // 135.3 − 30.8·5 + 1.16·(10·18 + 934·1.10) + 20
+    // = 135.3 − 154 + 1.16·(180 + 1027.4) + 20
+    // = 135.3 − 154 + 1.16·1207.4 + 20 = 1401.88
+    const v = calcEER({ age: 5, sex: 'girl', weightKg: 18, heightCm: 110, activity: 'low_active' })
+    expect(v).toBeCloseTo(1401.88, 0)
+  })
+
+  it('12y girl, 40 kg, 150 cm, very active → ~2412 kcal', () => {
+    // 135.3 − 30.8·12 + 1.56·(10·40 + 934·1.50) + 25
+    // = 135.3 − 369.6 + 1.56·(400 + 1401) + 25
+    // = 135.3 − 369.6 + 1.56·1801 + 25 = 2600.26
+    const v = calcEER({ age: 12, sex: 'girl', weightKg: 40, heightCm: 150, activity: 'very_active' })
+    expect(v).toBeCloseTo(2600.26, 0)
+  })
+
+  it('17y girl, 55 kg, 165 cm, sedentary → ~1969 kcal', () => {
+    // 135.3 − 30.8·17 + 1.0·(10·55 + 934·1.65) + 25
+    // = 135.3 − 523.6 + 550 + 1541.1 + 25 = 1727.8
+    const v = calcEER({ age: 17, sex: 'girl', weightKg: 55, heightCm: 165, activity: 'sedentary' })
+    expect(v).toBeCloseTo(1727.8, 0)
+  })
+})
+
+describe('toddler fixed values (ages 1–2)', () => {
+  it('1y boy → 948 kcal regardless of weight/height', () => {
+    expect(calcEER({ age: 1, sex: 'boy', weightKg: 10, heightCm: 75, activity: 'sedentary' })).toBe(948)
+  })
+
+  it('2y girl → 992 kcal regardless of activity', () => {
+    expect(calcEER({ age: 2, sex: 'girl', weightKg: 12, heightCm: 85, activity: 'active' })).toBe(992)
+  })
+})
+
+describe('input validation', () => {
+  it('returns null for invalid age (< 1 or > 18)', () => {
+    expect(calcEER({ age: 0.5, sex: 'boy', weightKg: 10, heightCm: 75, activity: 'sedentary' })).toBeNull()
+    expect(calcEER({ age: 19, sex: 'boy', weightKg: 60, heightCm: 175, activity: 'sedentary' })).toBeNull()
+  })
+
+  it('returns null for invalid sex', () => {
+    expect(calcEER({ age: 10, sex: 'unknown', weightKg: 30, heightCm: 140, activity: 'active' })).toBeNull()
+  })
+
+  it('returns null for invalid activity', () => {
+    expect(calcEER({ age: 10, sex: 'boy', weightKg: 30, heightCm: 140, activity: 'extreme' })).toBeNull()
+  })
+
+  it('returns null for missing weight or height (ages ≥ 3)', () => {
+    expect(calcEER({ age: 5, sex: 'boy', weightKg: null, heightCm: 110, activity: 'active' })).toBeNull()
+    expect(calcEER({ age: 5, sex: 'boy', weightKg: 18, heightCm: null, activity: 'active' })).toBeNull()
+  })
+})
+
+describe('plausibility helpers', () => {
+  it('isPlausibleAge accepts 1–18', () => {
+    expect(isPlausibleAge(1)).toBe(true)
+    expect(isPlausibleAge(18)).toBe(true)
+    expect(isPlausibleAge(0)).toBe(false)
+    expect(isPlausibleAge(19)).toBe(false)
+  })
+
+  it('isPlausibleWeightKg rejects extremes', () => {
+    expect(isPlausibleWeightKg(4)).toBe(false)
+    expect(isPlausibleWeightKg(151)).toBe(false)
+    expect(isPlausibleWeightKg(20)).toBe(true)
+  })
+
+  it('isPlausibleHeightCm rejects extremes', () => {
+    expect(isPlausibleHeightCm(50)).toBe(false)
+    expect(isPlausibleHeightCm(221)).toBe(false)
+    expect(isPlausibleHeightCm(120)).toBe(true)
+  })
+})
+
+describe('unit conversions', () => {
+  it('lbToKg: 22 lb ≈ 9.98 kg', () => {
+    expect(lbToKg(22)).toBeCloseTo(9.979, 2)
+  })
+
+  it('inToCm: 43 in ≈ 109.22 cm', () => {
+    expect(inToCm(43)).toBeCloseTo(109.22, 2)
+  })
+
+  it('ftInToCm: 4 ft 6 in ≈ 137.16 cm', () => {
+    expect(ftInToCm(4, 6)).toBeCloseTo(137.16, 2)
+  })
+})
+
+describe('PA coefficients match IOM', () => {
+  it('boy active = 1.26', () => {
+    expect(PA.boy.active).toBe(1.26)
+  })
+
+  it('girl very_active = 1.56', () => {
+    expect(PA.girl.very_active).toBe(1.56)
+  })
+})
+
+describe('childCalories one-shot helper', () => {
+  it('returns rounded integer kcal', () => {
+    const r = childCalories({ age: 5, sex: 'boy', weightKg: 18, heightCm: 110, activity: 'low_active' })
+    expect(r).not.toBeNull()
+    expect(r.dailyKcal).toBe(1465)
+    expect(r.activity).toBe('low_active')
+    expect(r.sex).toBe('boy')
+    expect(r.age).toBe(5)
+  })
+
+  it('returns null on invalid input', () => {
+    expect(childCalories({ age: 0, sex: 'boy', weightKg: 10, heightCm: 75, activity: 'active' })).toBeNull()
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 280 links (71 calcs × 2 locales + 69 blogs × 2 locales)', () => {
+  it('generates 284 links (72 calcs × 2 locales + 70 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(280)
+    expect(links).toHaveLength(284)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -19,7 +19,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'babyFeedingAmount', 'asthmaControl', 'copdAssessment', 'babyMilestones', 'creatinineClearance',
-  'painScale', 'newbornBilirubin',
+  'painScale', 'newbornBilirubin', 'childCalories',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -79,6 +79,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kreatinin-clearance-berechnen',
   'schmerzskala-berechnen',
   'neugeborenen-gelbsucht-risiko',
+  'kinder-kalorienbedarf-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -138,12 +139,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'creatinine-clearance-calculator-guide',
   'pain-scale-calculator-guide',
   'newborn-jaundice-calculator-guide',
+  'child-calorie-needs-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 71 calculator meta files', () => {
+  it('discovers all 72 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas).toHaveLength(71)
+    expect(metas).toHaveLength(72)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -181,19 +183,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 69 DE blog slugs', () => {
+  it('returns all 70 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(69)
+    expect(de).toHaveLength(70)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 69 EN blog slugs', () => {
+  it('returns all 70 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(69)
+    expect(en).toHaveLength(70)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -261,9 +263,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 142 calcs + 2 blog index + 138 blog articles = 284)', () => {
+  it('generates correct total URL count (2 home + 144 calcs + 2 blog index + 140 blog articles = 288)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(284)
+    expect(urlCount).toBe(288)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -620,6 +620,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'newbornBilirubin',
     related: ['apgar-score-calculator-guide', 'baby-feeding-amount-calculator', 'baby-milestone-tracker-guide'],
   },
+  {
+    slug: 'child-calorie-needs-guide',
+    title: 'Child Calorie Needs: How Many Calories Does My Child Need?',
+    description: 'How many calories does a child need per day? IOM EER formula, table by age and activity, growth, puberty — everything parents need to know.',
+    date: '2026-05-08',
+    readTime: '7 min',
+    calculatorKey: 'childCalories',
+    related: ['calculate-tdee', 'child-growth-percentile-chart', 'baby-feeding-amount-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -620,6 +620,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'newbornBilirubin',
     related: ['apgar-score-bewerten', 'baby-trinkmenge-berechnen', 'baby-meilensteine-tracker'],
   },
+  {
+    slug: 'kinder-kalorienbedarf-berechnen',
+    title: 'Kinder-Kalorienbedarf berechnen: Wie viele Kalorien braucht mein Kind?',
+    description: 'Wie viele Kalorien braucht ein Kind pro Tag? IOM-Formel, Tabelle nach Alter und Aktivität, Wachstum, Pubertät — alles, was Eltern wissen müssen.',
+    date: '2026-05-08',
+    readTime: '7 min',
+    calculatorKey: 'childCalories',
+    related: ['tdee-berechnen', 'wachstumsperzentile-kinder', 'baby-trinkmenge-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/childCalories.json
+++ b/src/locales/calculators/de/childCalories.json
@@ -1,0 +1,83 @@
+{
+  "home": {
+    "calculators": {
+      "childCalories": {
+        "name": "Kinder-Kalorienbedarf-Rechner",
+        "description": "Täglicher Kalorienbedarf für Kinder (1–18 Jahre) nach Alter, Geschlecht, Größe, Gewicht und Aktivität — IOM-Formel."
+      }
+    }
+  },
+  "childCalories": {
+    "meta": {
+      "title": "Kinder-Kalorienbedarf-Rechner — Tägliche Kalorien für Kinder",
+      "description": "Berechne den täglichen Kalorienbedarf deines Kindes (1–18 Jahre) nach Alter, Geschlecht, Größe, Gewicht und Aktivität. IOM-Referenzwerte. Kostenlos."
+    },
+    "title": "Kinder-Kalorienbedarf-Rechner",
+    "description": "Wie viele Kalorien braucht dein Kind pro Tag? Berechnung nach Alter, Geschlecht, Größe, Gewicht und Aktivität.",
+    "age": "Alter (Jahre)",
+    "ageHint": "1–18 Jahre",
+    "agePlaceholder": "z. B. 8",
+    "sex": "Geschlecht",
+    "sexBoy": "Junge",
+    "sexGirl": "Mädchen",
+    "weight": "Gewicht",
+    "height": "Größe",
+    "weightKg": "Gewicht (kg)",
+    "weightLb": "Gewicht (lb)",
+    "heightCm": "Größe (cm)",
+    "heightIn": "Größe (in)",
+    "weightPlaceholder": "z. B. 25",
+    "weightPlaceholderLb": "z. B. 55",
+    "heightPlaceholder": "z. B. 130",
+    "heightPlaceholderIn": "z. B. 51",
+    "activity": "Aktivitätsniveau",
+    "activitySedentary": "Wenig aktiv (kaum Sport)",
+    "activityLowActive": "Leicht aktiv (Schulweg + Spielen)",
+    "activityActive": "Aktiv (regelmäßig Sport)",
+    "activityVeryActive": "Sehr aktiv (Leistungssport)",
+    "implausibleAge": "Bitte ein Alter zwischen 1 und 18 Jahren eingeben.",
+    "implausibleWeight": "Bitte ein realistisches Gewicht zwischen 5 und 150 kg eingeben.",
+    "implausibleHeight": "Bitte eine realistische Größe zwischen 60 und 220 cm eingeben.",
+    "toddlerNote": "Für Kleinkinder (1–2 Jahre) verwendet der Rechner die festen IOM-Referenzwerte — Größe und Gewicht spielen keine Rolle.",
+    "result": "Täglicher Kalorienbedarf",
+    "kcalPerDay": "kcal/Tag",
+    "table": "Richtwerte nach Alter (kcal/Tag)",
+    "tableNote": "Werte für moderates Aktivitätsniveau, IOM-Referenz.",
+    "ageRange": "Alter",
+    "boy": "Junge",
+    "girl": "Mädchen",
+    "row1to3": "1–3 Jahre",
+    "row4to8": "4–8 Jahre",
+    "row9to13": "9–13 Jahre",
+    "row14to18": "14–18 Jahre",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner nutzt die EER-Formel (Estimated Energy Requirement) des Institute of Medicine (IOM). Sie berücksichtigt Alter, Geschlecht, Größe, Gewicht und einen altersspezifischen Aktivitätsfaktor (PA). Für Kinder unter drei Jahren werden feste Referenzwerte verwendet (1-jähriger Junge: 948 kcal, 2-jähriges Mädchen: 992 kcal usw.). Ab 3 Jahren gilt: kcal/Tag = Konstanten + Alter + PA·(Gewicht + Größe). Wachstumsschübe, Pubertät und sportliche Aktivität verändern den Bedarf erheblich.",
+    "disclaimer": "Wichtig: Diese Werte sind Richtwerte. Wachstum, Krankheit und Aktivität schwanken stark. Bei Unter- oder Überernährung sprich mit Kinderärztin oder Ernährungsberaterin.",
+    "faq": [
+      {
+        "q": "Wie viele Kalorien braucht ein Kind pro Tag?",
+        "a": "Das hängt stark vom Alter ab. Ein 4-jähriges Mädchen mit moderater Aktivität benötigt rund 1300 kcal, ein 14-jähriger Junge im Sport rund 2800 kcal. Genaue Werte berechnet der Rechner nach IOM-Formel."
+      },
+      {
+        "q": "Welche Formel wird verwendet?",
+        "a": "Die Estimated Energy Requirement (EER) des U.S. Institute of Medicine (DRI 2002/2005). Sie ist Standard in Pädiatrie und Ernährungswissenschaft und berücksichtigt das Wachstum."
+      },
+      {
+        "q": "Was bedeuten die Aktivitätsstufen?",
+        "a": "Sedentary = Schule + Hausaufgaben, kaum Sport. Low active = Schulweg + Spielen draußen. Active = Vereinssport mehrmals pro Woche. Very active = Leistungssport oder mehrere Stunden Bewegung täglich."
+      },
+      {
+        "q": "Warum braucht mein Kind mehr Kalorien als ich?",
+        "a": "Kinder wachsen — Wachstum, Aufbau von Muskel- und Knochenmasse sowie ein höherer Grundumsatz pro kg Körpergewicht erhöhen den Energiebedarf. In der Pubertät steigt der Bedarf nochmals deutlich."
+      },
+      {
+        "q": "Soll ich die Kalorien zählen?",
+        "a": "Nein. Bei gesunden Kindern lieber auf ausgewogene Mahlzeiten und Sättigungsgefühl achten. Der Rechner hilft, den Größenordnungsbereich einzuschätzen — etwa bei Gewichtssorgen oder besonderem Aktivitätsniveau."
+      },
+      {
+        "q": "Gilt das auch für Säuglinge?",
+        "a": "Nein. Für Babys unter 1 Jahr gelten andere Empfehlungen — siehe unseren Baby-Trinkmenge-Rechner. Ab 1 Jahr greift dieser Kinder-Kalorienbedarf-Rechner."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/childCalories.json
+++ b/src/locales/calculators/en/childCalories.json
@@ -1,0 +1,83 @@
+{
+  "home": {
+    "calculators": {
+      "childCalories": {
+        "name": "Child Calorie Needs Calculator",
+        "description": "Daily calorie needs for children (ages 1–18) by age, sex, height, weight and activity level — IOM formula."
+      }
+    }
+  },
+  "childCalories": {
+    "meta": {
+      "title": "Child Calorie Needs Calculator — Daily Calories for Kids",
+      "description": "Calculate your child's daily calorie needs (ages 1–18) by age, sex, height, weight and activity level. IOM reference values. Free, instant."
+    },
+    "title": "Child Calorie Needs Calculator",
+    "description": "How many calories does your child need per day? Calculation by age, sex, height, weight and activity level.",
+    "age": "Age (years)",
+    "ageHint": "1–18 years",
+    "agePlaceholder": "e.g. 8",
+    "sex": "Sex",
+    "sexBoy": "Boy",
+    "sexGirl": "Girl",
+    "weight": "Weight",
+    "height": "Height",
+    "weightKg": "Weight (kg)",
+    "weightLb": "Weight (lb)",
+    "heightCm": "Height (cm)",
+    "heightIn": "Height (in)",
+    "weightPlaceholder": "e.g. 25",
+    "weightPlaceholderLb": "e.g. 55",
+    "heightPlaceholder": "e.g. 130",
+    "heightPlaceholderIn": "e.g. 51",
+    "activity": "Activity level",
+    "activitySedentary": "Sedentary (little exercise)",
+    "activityLowActive": "Low active (walking + play)",
+    "activityActive": "Active (regular sports)",
+    "activityVeryActive": "Very active (competitive sport)",
+    "implausibleAge": "Please enter an age between 1 and 18 years.",
+    "implausibleWeight": "Please enter a realistic weight between 5 and 150 kg.",
+    "implausibleHeight": "Please enter a realistic height between 60 and 220 cm.",
+    "toddlerNote": "For toddlers (ages 1–2), the calculator uses the fixed IOM reference values — height and weight are not used.",
+    "result": "Daily calorie needs",
+    "kcalPerDay": "kcal/day",
+    "table": "Reference values by age (kcal/day)",
+    "tableNote": "Values for moderate activity, IOM reference.",
+    "ageRange": "Age",
+    "boy": "Boy",
+    "girl": "Girl",
+    "row1to3": "1–3 years",
+    "row4to8": "4–8 years",
+    "row9to13": "9–13 years",
+    "row14to18": "14–18 years",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator uses the Estimated Energy Requirement (EER) formula from the U.S. Institute of Medicine (IOM). It accounts for age, sex, height, weight and an age-specific physical activity coefficient (PA). For children under three, fixed reference values apply (1-year-old boy: 948 kcal, 2-year-old girl: 992 kcal etc.). From age 3: kcal/day = constants − age + PA·(weight + height). Growth spurts, puberty and exercise change needs significantly.",
+    "disclaimer": "Important: these are guideline values. Growth, illness and activity vary widely. If you are concerned about under- or overeating, talk to your pediatrician or a registered dietitian.",
+    "faq": [
+      {
+        "q": "How many calories does a child need per day?",
+        "a": "It depends heavily on age. A 4-year-old girl with moderate activity needs around 1300 kcal, a 14-year-old active boy around 2800 kcal. The calculator uses the IOM EER formula for precise values."
+      },
+      {
+        "q": "Which formula is used?",
+        "a": "The Estimated Energy Requirement (EER) from the U.S. Institute of Medicine (DRI 2002/2005). It is the standard in pediatrics and nutrition science and accounts for growth."
+      },
+      {
+        "q": "What do the activity levels mean?",
+        "a": "Sedentary = school plus homework, little sport. Low active = walking to school plus outdoor play. Active = club sports several times a week. Very active = competitive sport or several hours of movement daily."
+      },
+      {
+        "q": "Why does my child need more calories than me?",
+        "a": "Children grow — building muscle and bone, plus a higher resting metabolic rate per kg of body weight, raises energy needs. During puberty, requirements rise again significantly."
+      },
+      {
+        "q": "Should I count calories for my child?",
+        "a": "No. For healthy children, focus on balanced meals and hunger cues. The calculator helps you estimate the order of magnitude — useful when there are concerns about weight or unusual activity levels."
+      },
+      {
+        "q": "Does this apply to babies?",
+        "a": "No. Babies under 1 year follow different recommendations — see our Baby Feeding Amount Calculator. From age 1, this Child Calorie Needs Calculator applies."
+      }
+    ]
+  }
+}

--- a/src/pages/ChildCaloriesCalculator.vue
+++ b/src/pages/ChildCaloriesCalculator.vue
@@ -1,0 +1,278 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  childCalories,
+  isPlausibleAge,
+  isPlausibleWeightKg,
+  isPlausibleHeightCm,
+  lbToKg,
+  inToCm,
+  ACTIVITY_LEVELS,
+} from '../utils/childCalories.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('childCalories.faq') || [])
+
+useHead(() => ({
+  title: t('childCalories.meta.title'),
+  description: t('childCalories.meta.description'),
+  routeKey: 'childCalories',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Child Calorie Needs Calculator',
+    url: 'https://healthcalculator.app/en/child-calorie-needs-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const age = ref(null)
+const sex = ref('boy')
+const weight = ref(null)
+const height = ref(null)
+const activity = ref('low_active')
+const unit = ref('metric')
+
+const weightKg = computed(() => {
+  if (typeof weight.value !== 'number' || !Number.isFinite(weight.value)) return null
+  return unit.value === 'imperial' ? lbToKg(weight.value) : weight.value
+})
+
+const heightCm = computed(() => {
+  if (typeof height.value !== 'number' || !Number.isFinite(height.value)) return null
+  return unit.value === 'imperial' ? inToCm(height.value) : height.value
+})
+
+const isToddler = computed(() => typeof age.value === 'number' && age.value >= 1 && age.value < 3)
+
+const ageWarning = computed(() => {
+  if (age.value === null || age.value === undefined || age.value === '') return false
+  return !isPlausibleAge(age.value)
+})
+
+const weightWarning = computed(() => {
+  if (isToddler.value) return false
+  if (weightKg.value === null) return false
+  return !isPlausibleWeightKg(weightKg.value)
+})
+
+const heightWarning = computed(() => {
+  if (isToddler.value) return false
+  if (heightCm.value === null) return false
+  return !isPlausibleHeightCm(heightCm.value)
+})
+
+const result = computed(() => {
+  if (ageWarning.value || weightWarning.value || heightWarning.value) return null
+  if (!isPlausibleAge(age.value)) return null
+  if (isToddler.value) {
+    return childCalories({ age: age.value, sex: sex.value, activity: activity.value, weightKg: 10, heightCm: 80 })
+  }
+  if (weightKg.value === null || heightCm.value === null) return null
+  return childCalories({
+    age: age.value,
+    sex: sex.value,
+    weightKg: weightKg.value,
+    heightCm: heightCm.value,
+    activity: activity.value,
+  })
+})
+
+const refRows = [
+  { range: 'row1to3', boy: 1100, girl: 1050 },
+  { range: 'row4to8', boy: 1500, girl: 1400 },
+  { range: 'row9to13', boy: 2000, girl: 1800 },
+  { range: 'row14to18', boy: 2700, girl: 2100 },
+]
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('childCalories.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('childCalories.description') }}</p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <!-- Unit toggle -->
+      <div class="flex gap-2 mb-6">
+        <button
+          @click="unit = 'metric'"
+          data-testid="unit-metric"
+          :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('common.metric') }}</button>
+        <button
+          @click="unit = 'imperial'"
+          data-testid="unit-imperial"
+          :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        >{{ t('common.imperial') }}</button>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-5 mb-5">
+        <div>
+          <label for="input-age" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('childCalories.age') }}
+          </label>
+          <input
+            id="input-age"
+            v-model.number="age"
+            data-testid="input-age"
+            type="number"
+            min="1"
+            max="18"
+            step="1"
+            :placeholder="t('childCalories.agePlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+          <p class="text-xs text-stone-400 mt-1.5">{{ t('childCalories.ageHint') }}</p>
+        </div>
+        <div>
+          <label for="input-sex" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('childCalories.sex') }}
+          </label>
+          <select
+            id="input-sex"
+            v-model="sex"
+            data-testid="input-sex"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          >
+            <option value="boy">{{ t('childCalories.sexBoy') }}</option>
+            <option value="girl">{{ t('childCalories.sexGirl') }}</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-5 mb-5">
+        <div>
+          <label for="input-weight" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ unit === 'metric' ? t('childCalories.weightKg') : t('childCalories.weightLb') }}
+          </label>
+          <input
+            id="input-weight"
+            v-model.number="weight"
+            data-testid="input-weight"
+            type="number"
+            step="0.1"
+            min="0"
+            :disabled="isToddler"
+            :placeholder="unit === 'metric' ? t('childCalories.weightPlaceholder') : t('childCalories.weightPlaceholderLb')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150 disabled:bg-stone-100 disabled:text-stone-400"
+          />
+        </div>
+        <div>
+          <label for="input-height" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ unit === 'metric' ? t('childCalories.heightCm') : t('childCalories.heightIn') }}
+          </label>
+          <input
+            id="input-height"
+            v-model.number="height"
+            data-testid="input-height"
+            type="number"
+            step="0.1"
+            min="0"
+            :disabled="isToddler"
+            :placeholder="unit === 'metric' ? t('childCalories.heightPlaceholder') : t('childCalories.heightPlaceholderIn')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150 disabled:bg-stone-100 disabled:text-stone-400"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label for="input-activity" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('childCalories.activity') }}
+        </label>
+        <select
+          id="input-activity"
+          v-model="activity"
+          data-testid="input-activity"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        >
+          <option value="sedentary">{{ t('childCalories.activitySedentary') }}</option>
+          <option value="low_active">{{ t('childCalories.activityLowActive') }}</option>
+          <option value="active">{{ t('childCalories.activityActive') }}</option>
+          <option value="very_active">{{ t('childCalories.activityVeryActive') }}</option>
+        </select>
+      </div>
+
+      <div v-if="ageWarning" data-testid="warning-age" class="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-4">
+        <span class="text-amber-500 text-lg leading-none mt-0.5">⚠</span>
+        <p class="text-sm text-amber-700">{{ t('childCalories.implausibleAge') }}</p>
+      </div>
+      <div v-if="weightWarning" data-testid="warning-weight" class="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-4">
+        <span class="text-amber-500 text-lg leading-none mt-0.5">⚠</span>
+        <p class="text-sm text-amber-700">{{ t('childCalories.implausibleWeight') }}</p>
+      </div>
+      <div v-if="heightWarning" data-testid="warning-height" class="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-4">
+        <span class="text-amber-500 text-lg leading-none mt-0.5">⚠</span>
+        <p class="text-sm text-amber-700">{{ t('childCalories.implausibleHeight') }}</p>
+      </div>
+      <div v-if="isToddler" data-testid="note-toddler" class="bg-stone-50 border border-stone-200 rounded-lg px-4 py-3 mt-4">
+        <p class="text-sm text-stone-600">{{ t('childCalories.toddlerNote') }}</p>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Results -->
+    <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('childCalories.result') }}</div>
+      <div data-testid="result-kcal" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight">
+        {{ result.dailyKcal }}
+        <span class="text-base font-normal text-stone-500 ml-1">{{ t('childCalories.kcalPerDay') }}</span>
+      </div>
+    </div>
+
+    <!-- Reference table -->
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+      <div class="px-6 pt-6">
+        <h2 class="text-lg font-semibold text-stone-900 mb-1">{{ t('childCalories.table') }}</h2>
+        <p class="text-xs text-stone-400 mb-4">{{ t('childCalories.tableNote') }}</p>
+      </div>
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-stone-50 border-b border-stone-200">
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('childCalories.ageRange') }}</th>
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('childCalories.boy') }}</th>
+            <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('childCalories.girl') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-stone-100">
+          <tr v-for="row in refRows" :key="row.range">
+            <td class="px-6 py-3 text-stone-900 font-medium">{{ t('childCalories.' + row.range) }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ row.boy }}</td>
+            <td class="px-6 py-3 text-stone-600 tabular-nums">{{ row.girl }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- How it works -->
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('childCalories.howItWorks') }}</h2>
+      <p class="text-sm text-stone-500 leading-relaxed">{{ t('childCalories.howItWorksText') }}</p>
+    </div>
+
+    <!-- Disclaimer -->
+    <div class="bg-stone-50 border border-stone-200 rounded-xl px-6 py-4 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('childCalories.disclaimer') }}</p>
+    </div>
+
+    <AdSlot class="mt-8" />
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <BlogArticleLink calculator-key="childCalories" />
+  </div>
+</template>

--- a/src/pages/blog/KinderKalorienbedarfBerechnen.vue
+++ b/src/pages/blog/KinderKalorienbedarfBerechnen.vue
@@ -1,0 +1,239 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Kinder-Kalorienbedarf berechnen: Wie viele Kalorien braucht mein Kind? | Health Calculators',
+  description: 'Wie viele Kalorien braucht ein Kind pro Tag? IOM-Formel, Tabelle nach Alter und Aktivität, Wachstum, Pubertät — alles, was Eltern wissen müssen.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Kinder-Kalorienbedarf berechnen: Wie viele Kalorien braucht mein Kind?',
+      description: 'IOM-EER-Formel, Tabellen nach Alter und Aktivität, Pubertätsschub und praktische Tipps für Eltern.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-08',
+      dateModified: '2026-05-08',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/kinder-kalorienbedarf-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Wie viele Kalorien braucht ein Kind pro Tag?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Sehr stark altersabhängig — von rund 1000 kcal bei 2-Jährigen bis 2800 kcal bei aktiven 14-jährigen Jungen. Geschlecht, Aktivität und Wachstumsphase bestimmen den genauen Bedarf.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welche Formel nutzt der Rechner?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die Estimated Energy Requirement (EER) des U.S. Institute of Medicine (DRI 2002/2005). Sie gilt als Standard in Pädiatrie und Ernährungswissenschaft.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Kinder-Kalorienbedarf berechnen: Wie viele Kalorien braucht mein Kind?</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">8. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eltern fragen sich oft: <strong>Isst mein Kind genug? Oder zu viel?</strong> Der Kalorienbedarf von Kindern unterscheidet sich stark vom Erwachsenenbedarf — er ist <strong>pro Kilogramm Körpergewicht höher</strong>, weil Wachstum, Hirnentwicklung und Bewegungsdrang Energie verschlingen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die <strong>Estimated Energy Requirement (EER)</strong> des U.S. Institute of Medicine ist der pädiatrische Standard. Sie berücksichtigt Alter, Geschlecht, Größe, Gewicht und ein altersgerechtes Aktivitätsniveau — und liefert eine realistische Tageszahl statt grober Faustregeln.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum Kinder mehr Kalorien pro kg brauchen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein 6-jähriges Kind mit 22 kg braucht ca. 1500 kcal — also rund <strong>68 kcal pro kg</strong>. Ein 80 kg schwerer Erwachsener mit Bürotätigkeit kommt mit ca. 30 kcal/kg aus. Der Grund: Wachstum baut neues Gewebe auf, das Gehirn wächst rasant, und Kinder bewegen sich im Alltag deutlich mehr — selbst „ruhige" Kinder sind aktiver als die meisten Erwachsenen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das ist auch der Grund, warum die alte Faustregel „Kalorienbedarf = Körpergewicht × 30" für Kinder krass falsch liegt. Der Bedarf hängt vor allem vom <em>Alter</em> ab — und vom Aktivitätsniveau.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Richtwerte nach Alter und Geschlecht (kcal/Tag)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Alter</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Junge (moderat)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Mädchen (moderat)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Aktiv (zusätzlich)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">1–3 Jahre</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1000–1200</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">950–1150</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+100–200</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">4–8 Jahre</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1400–1600</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1300–1500</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+200–400</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">9–13 Jahre</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1800–2200</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1600–2000</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+400–600</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">14–18 Jahre</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">2400–2800</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1800–2200</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+400–800</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Diese Werte sind <strong>Mittel über die Altersspanne</strong>. Innerhalb einer Altersgruppe variieren sie mit Größe und Wachstumsgeschwindigkeit. Der genaue Wert kommt aus dem Rechner.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die vier Aktivitätsstufen — was sie bedeuten</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Sedentary</strong> — Schule, Hausaufgaben, Bildschirm. Kaum geplante Bewegung. PA-Faktor 1.00.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Low active</strong> — typischer Schulalltag mit Gehen, Spielen draußen, gelegentlichem Sportunterricht. PA 1.13 (Junge) / 1.16 (Mädchen).</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Active</strong> — regelmäßiges Vereinstraining (2–4×/Woche), aktiver Lebensstil. PA 1.26 / 1.31.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Very active</strong> — Leistungssport, mehrere Stunden tägliches Training, Wettkampfniveau. PA 1.42 / 1.56.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Pubertätsschub: Bedarf explodiert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Zwischen 10 und 16 Jahren steigt der Energiebedarf <strong>schubweise</strong>. Wachstumshormone schießen hoch, Knochen werden länger, Muskeln wachsen. Ein 14-jähriger Junge im Sport kann in dieser Phase <strong>3000 kcal und mehr</strong> brauchen — temporär mehr als viele Erwachsene.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Eltern bemerken das oft: Plötzlich verschwindet der gesamte Kühlschrank-Inhalt, Portionen werden riesig. Das ist normal — und endet, sobald das Längenwachstum abgeschlossen ist (Mädchen meist mit 14–16, Jungen mit 16–18).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was zählt mehr als die Zahl</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Sättigungsgefühl</strong> — Kinder regulieren ihren Hunger sehr gut. Erzwungenes Aufessen oder strenge Portionen stört diese Selbstregulation.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Lebensmittelqualität</strong> — Vollkorn, Gemüse, Eiweiß, gesunde Fette. Eine 1500-kcal-Pizza-Diät ist nicht dasselbe wie 1500 kcal aus ausgewogener Kost.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Wachstumskurve</strong> — wichtiger als Tageskalorien. Wenn Größe und Gewicht stabil auf einer Perzentile bleiben, passt der Bedarf.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Mahlzeiten-Rhythmus</strong> — 3 Hauptmahlzeiten + 1–2 Snacks. Kinder brauchen häufiger Energie als Erwachsene.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen &amp; Rechner</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>TDEE (Erwachsene)</strong> — Kalorienbedarf für Erwachsene mit der Mifflin-St-Jeor-Formel. Zum <router-link :to="localeBlogPath('tdee-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">TDEE-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Wachstumsperzentile</strong> — wo liegt dein Kind im Vergleich zur Norm? Zum <router-link :to="localeBlogPath('wachstumsperzentile-kinder')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Wachstumsperzentile-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Baby-Trinkmenge</strong> — für Säuglinge unter 1 Jahr gilt eine eigene Berechnung nach kg Körpergewicht. Zum <router-link :to="localeBlogPath('baby-trinkmenge-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Trinkmengen-Rechner</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt den Kalorienbedarf deines Kindes berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">IOM-Formel, anonym, sofort. Mit metrischen und imperialen Einheiten.</p>
+        <router-link
+          :to="localePath('childCalories')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum Kinder-Kalorienbedarf-Rechner &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Soll ich Kalorien für mein Kind zählen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Bei gesunden Kindern: nein. Wachstumskurve, Sättigungsgefühl und Energie sind die besseren Indikatoren. Der Rechner hilft beim Einordnen, etwa wenn ein Kind plötzlich viel mehr oder weniger isst — oder bei Sportlerkindern.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Mein Teenager isst riesige Mengen — ist das normal?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Sehr wahrscheinlich ja. Während des Pubertätsschubs steigt der Bedarf um 30–50 %. Solange Wachstum und Allgemeinzustand gut sind, ist der Hunger ein Signal des Körpers, nicht der Bequemlichkeit.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Mein Kind ist übergewichtig — soll ich die Kalorien reduzieren?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Nicht ohne ärztlichen Rat. Bei Kindern wird in der Regel nicht auf Gewichtsabnahme, sondern auf Gewichts-stabilisierung gesetzt — der wachsende Körper „dehnt" das Gewicht aus. Sprich mit Kinderarzt oder Ernährungsberatung.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Ab wann gilt der Rechner?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Ab 1 Jahr. Für Babys unter 12 Monaten gelten andere Empfehlungen — siehe Baby-Trinkmenge-Rechner. Bei Kleinkindern (1–2 Jahre) verwendet der Rechner die festen IOM-Referenzwerte ohne Größe und Gewicht.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/pages/blog/en/ChildCalorieNeedsGuide.vue
+++ b/src/pages/blog/en/ChildCalorieNeedsGuide.vue
@@ -1,0 +1,239 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Child Calorie Needs: How Many Calories Does My Child Need? | Health Calculators',
+  description: 'How many calories does a child need per day? IOM EER formula, table by age and activity, growth, puberty — everything parents need to know.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Child Calorie Needs: How Many Calories Does My Child Need?',
+      description: 'IOM EER formula explained. Tables by age and activity. Growth spurts, puberty and practical tips for parents.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-08',
+      dateModified: '2026-05-08',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/child-calorie-needs-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'How many calories does a child need per day?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Highly age-dependent — from around 1000 kcal in 2-year-olds to 2800 kcal in active 14-year-old boys. Sex, activity level and growth phase determine the exact need.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Which formula does the calculator use?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The Estimated Energy Requirement (EER) from the U.S. Institute of Medicine (DRI 2002/2005). It is the standard in pediatrics and nutrition science.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Child Calorie Needs: How Many Calories Does My Child Need?</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 8, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Parents often wonder: <strong>Is my child eating enough? Or too much?</strong> Children's calorie needs differ sharply from adult needs — they are <strong>higher per kilogram of body weight</strong>, because growth, brain development and movement burn through energy.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The <strong>Estimated Energy Requirement (EER)</strong> from the U.S. Institute of Medicine is the pediatric standard. It accounts for age, sex, height, weight and an age-appropriate activity level — giving a realistic daily number instead of crude rules of thumb.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why children need more calories per kg</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A 6-year-old child weighing 22 kg needs about 1500 kcal — roughly <strong>68 kcal per kg</strong>. An 80 kg adult with a desk job manages on about 30 kcal/kg. The reason: growth builds new tissue, the brain develops rapidly, and children move much more in everyday life — even "calm" children are more active than most adults.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          That is also why the old "body weight × 30" rule of thumb is wildly wrong for children. Their needs depend mostly on <em>age</em> — and on activity level.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Reference values by age and sex (kcal/day)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Age</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Boy (moderate)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Girl (moderate)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Active (extra)</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">1–3 years</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1000–1200</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">950–1150</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+100–200</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">4–8 years</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1400–1600</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1300–1500</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+200–400</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">9–13 years</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1800–2200</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1600–2000</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+400–600</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium">14–18 years</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">2400–2800</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">1800–2200</td>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">+400–800</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          These values are <strong>averages across the age range</strong>. Within a band they vary with size and growth speed. The exact number comes from the calculator.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The four activity levels — what they mean</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Sedentary</strong> — school, homework, screen. Little planned movement. PA factor 1.00.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Low active</strong> — typical school day with walking, outdoor play, occasional PE. PA 1.13 (boy) / 1.16 (girl).</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Active</strong> — regular club training (2–4×/week), active lifestyle. PA 1.26 / 1.31.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Very active</strong> — competitive sport, multiple hours of daily training. PA 1.42 / 1.56.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Puberty growth spurt: needs explode</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Between ages 10 and 16, energy needs rise <strong>in surges</strong>. Growth hormones spike, bones lengthen, muscles develop. A 14-year-old boy in sport may need <strong>3000 kcal or more</strong> during this phase — temporarily more than many adults.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Parents notice this fast: suddenly the entire fridge disappears, portions become huge. This is normal — and ends once linear growth completes (girls usually 14–16, boys 16–18).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What matters more than the number</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Hunger and fullness cues</strong> — children regulate appetite well. Forced clean plates or strict portions interfere with self-regulation.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Food quality</strong> — whole grains, vegetables, protein, healthy fats. A 1500-kcal pizza diet is not the same as 1500 kcal of balanced food.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Growth curve</strong> — more important than daily calories. If height and weight stay on a stable percentile, the intake fits.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Meal rhythm</strong> — 3 main meals + 1–2 snacks. Children need refueling more often than adults.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics &amp; calculators</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>TDEE (adults)</strong> — adult calorie needs using the Mifflin-St Jeor formula. Read the <router-link :to="localeBlogPath('calculate-tdee')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">TDEE article</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Child growth percentile</strong> — where does your child sit compared to the norm? Read the <router-link :to="localeBlogPath('child-growth-percentile-chart')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">growth percentile guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Baby feeding amount</strong> — for infants under 1 year, a separate calculation by body weight applies. Open the <router-link :to="localeBlogPath('baby-feeding-amount-calculator')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">feeding amount guide</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Estimate your child's calorie needs now</h3>
+        <p class="text-stone-300 text-sm mb-5">IOM formula, anonymous, instant. With metric and imperial units.</p>
+        <router-link
+          :to="localePath('childCalories')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Open the Child Calorie Needs Calculator &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequently asked questions</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Should I count calories for my child?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              For healthy children: no. The growth curve, hunger cues and energy levels are better indicators. The calculator helps you estimate the order of magnitude — useful when a child suddenly eats much more or less, or for kids in serious sport.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">My teenager eats huge amounts — is that normal?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Most likely yes. During the puberty growth spurt, needs rise by 30–50 %. As long as growth and overall well-being are good, the hunger is a body signal, not boredom.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">My child is overweight — should I cut calories?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Not without medical advice. In children, the standard approach is usually weight stabilization rather than weight loss — the growing body "stretches" the existing weight. Talk to a pediatrician or registered dietitian.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">From what age does the calculator apply?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              From age 1. Babies under 12 months follow different recommendations — see the Baby Feeding Amount Calculator. For toddlers (1–2 years), the calculator uses the fixed IOM reference values without using height or weight.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles />
+  </article>
+</template>

--- a/src/pages/childCalories.meta.js
+++ b/src/pages/childCalories.meta.js
@@ -1,0 +1,16 @@
+import Component from './ChildCaloriesCalculator.vue'
+import BlogDe from './blog/KinderKalorienbedarfBerechnen.vue'
+import BlogEn from './blog/en/ChildCalorieNeedsGuide.vue'
+
+export default {
+  key: 'childCalories',
+  component: Component,
+  slugs: { de: 'kinder-kalorienbedarf-rechner', en: 'child-calorie-needs-calculator' },
+  group: 'nutritionEnergy',
+  groupOrder: 1,
+  order: 12,
+  blog: {
+    de: { slug: 'kinder-kalorienbedarf-berechnen', component: BlogDe },
+    en: { slug: 'child-calorie-needs-guide', component: BlogEn },
+  },
+}

--- a/src/utils/childCalories.js
+++ b/src/utils/childCalories.js
@@ -1,0 +1,108 @@
+// Child Calories Calculator — Estimated Energy Requirement (EER)
+//
+// Source: Institute of Medicine (IOM) / National Academies, Dietary Reference
+// Intakes for Energy, Carbohydrate, Fiber, Fat, Fatty Acids, Cholesterol,
+// Protein, and Amino Acids (2002/2005). Equations for "normal-weight" boys
+// and girls, ages 3–18 years.
+//
+// EER (kcal/day) — Boys 3–8y:    88.5 − 61.9·age + PA·(26.7·weight + 903·height) + 20
+// EER (kcal/day) — Boys 9–18y:   88.5 − 61.9·age + PA·(26.7·weight + 903·height) + 25
+// EER (kcal/day) — Girls 3–8y:  135.3 − 30.8·age + PA·(10.0·weight + 934·height) + 20
+// EER (kcal/day) — Girls 9–18y: 135.3 − 30.8·age + PA·(10.0·weight + 934·height) + 25
+//
+// weight in kg, height in metres. PA = Physical Activity coefficient.
+//
+// Physical Activity coefficients (IOM, ages 3–18):
+//   sedentary:    boys 1.00, girls 1.00
+//   low_active:   boys 1.13, girls 1.16
+//   active:       boys 1.26, girls 1.31
+//   very_active:  boys 1.42, girls 1.56
+//
+// For toddlers (ages 1–2), the IOM specifies fixed values:
+//   1y boy 948, 1y girl 865; 2y boy 1046, 2y girl 992 (kcal/day)
+//
+// This is an estimate. Individual needs vary with growth spurts, body
+// composition and health status. Always consult a pediatrician.
+
+export const KG_PER_LB = 0.453592
+export const CM_PER_IN = 2.54
+
+export const PA = {
+  boy: { sedentary: 1.00, low_active: 1.13, active: 1.26, very_active: 1.42 },
+  girl: { sedentary: 1.00, low_active: 1.16, active: 1.31, very_active: 1.56 },
+}
+
+export const ACTIVITY_LEVELS = ['sedentary', 'low_active', 'active', 'very_active']
+export const SEXES = ['boy', 'girl']
+
+const TODDLER_KCAL = {
+  boy: { 1: 948, 2: 1046 },
+  girl: { 1: 865, 2: 992 },
+}
+
+export function isFiniteNumber(v) {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+export function isPlausibleAge(age) {
+  return isFiniteNumber(age) && age >= 1 && age <= 18
+}
+
+export function isPlausibleWeightKg(kg) {
+  return isFiniteNumber(kg) && kg >= 5 && kg <= 150
+}
+
+export function isPlausibleHeightCm(cm) {
+  return isFiniteNumber(cm) && cm >= 60 && cm <= 220
+}
+
+export function lbToKg(lb) {
+  return lb * KG_PER_LB
+}
+
+export function inToCm(inches) {
+  return inches * CM_PER_IN
+}
+
+export function ftInToCm(ft, inches = 0) {
+  return ft * 12 * CM_PER_IN + inches * CM_PER_IN
+}
+
+function ageOffset(age) {
+  return age < 9 ? 20 : 25
+}
+
+export function calcEER({ age, sex, weightKg, heightCm, activity }) {
+  if (!isPlausibleAge(age)) return null
+  if (!SEXES.includes(sex)) return null
+  if (!ACTIVITY_LEVELS.includes(activity)) return null
+
+  // Toddler fixed values for ages 1 and 2 (IOM)
+  if (age < 3) {
+    const yr = Math.floor(age) === 0 ? 1 : Math.floor(age)
+    return TODDLER_KCAL[sex][yr] || null
+  }
+
+  if (!isPlausibleWeightKg(weightKg)) return null
+  if (!isPlausibleHeightCm(heightCm)) return null
+
+  const heightM = heightCm / 100
+  const pa = PA[sex][activity]
+  const offset = ageOffset(age)
+
+  if (sex === 'boy') {
+    return 88.5 - 61.9 * age + pa * (26.7 * weightKg + 903 * heightM) + offset
+  }
+  return 135.3 - 30.8 * age + pa * (10.0 * weightKg + 934 * heightM) + offset
+}
+
+export function childCalories(input) {
+  const eer = calcEER(input)
+  if (eer === null) return null
+  return {
+    dailyKcal: Math.round(eer),
+    activity: input.activity,
+    sex: input.sex,
+    age: input.age,
+  }
+}


### PR DESCRIPTION
## Summary
- New **Child Calorie Needs Calculator** estimating daily kcal for children ages 1–18 via the IOM Estimated Energy Requirement formula.
- Sex × age × weight × height × activity level. Toddlers (1–2 y) use fixed IOM reference values.
- Metric ⇄ Imperial unit toggle for weight (kg/lb) and height (cm/in).
- DE + EN locales, SEO-optimized blog articles in both languages.
- Internal links: blog → calculator (DE+EN), blog → TDEE / child growth percentile / baby feeding amount, calculator → blog.

## Test plan
- [x] Unit tests: 22 cases for EER formula + helpers (boys, girls, toddlers, validation, conversions).
- [x] All 1942 unit tests green (vitest).
- [x] E2E: 8 Playwright tests cover load, two known calculations, imperial toggle, toddler path, warnings, back link.
- [x] SSG build green — new DE/EN calculator + blog routes pre-rendered.
- [x] Sitemap (288 URLs) and llms.txt (284 links) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)