### PR TITLE
hc-135-pregnancy-b-m-i: Implement the Pregnancy B M I Calculator as described in iss

### DIFF
--- a/e2e/pregnancyBMI.spec.js
+++ b/e2e/pregnancyBMI.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/bmi-schwangerschaft-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/BMI-Rechner Schwangerschaft/)
+})
+
+test('60 kg / 165 cm → BMI ~22 (Normalgewicht)', async ({ page }) => {
+  await page.getByTestId('weight').fill('60')
+  await page.getByTestId('height').fill('165')
+
+  const result = page.getByTestId('bmi-result')
+  await expect(result).toBeVisible()
+  const bmi = parseFloat(await result.textContent())
+  expect(bmi).toBeGreaterThanOrEqual(21.5)
+  expect(bmi).toBeLessThanOrEqual(22.5)
+
+  await expect(page.getByTestId('bmi-category')).toHaveText('Normalgewicht')
+})
+
+test('50 kg / 170 cm → underweight', async ({ page }) => {
+  await page.getByTestId('weight').fill('50')
+  await page.getByTestId('height').fill('170')
+
+  await expect(page.getByTestId('bmi-category')).toHaveText('Untergewicht')
+})
+
+test('80 kg / 170 cm → overweight', async ({ page }) => {
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('170')
+
+  await expect(page.getByTestId('bmi-category')).toHaveText('Übergewicht')
+})
+
+test('100 kg / 170 cm → obese, gain range 5–9 kg', async ({ page }) => {
+  await page.getByTestId('weight').fill('100')
+  await page.getByTestId('height').fill('170')
+
+  await expect(page.getByTestId('bmi-category')).toHaveText('Adipositas')
+  await expect(page.getByTestId('gain-range')).toContainText('5')
+  await expect(page.getByTestId('gain-range')).toContainText('9')
+})
+
+test('twins toggle changes recommendation for normal BMI', async ({ page }) => {
+  await page.getByTestId('weight').fill('60')
+  await page.getByTestId('height').fill('165')
+
+  // singleton normal: 11.5–16
+  await expect(page.getByTestId('gain-range')).toContainText('11.5')
+
+  await page.getByTestId('btn-twins').click()
+
+  // twins normal: 17–25
+  await expect(page.getByTestId('gain-range')).toContainText('17')
+  await expect(page.getByTestId('gain-range')).toContainText('25')
+})
+
+test('imperial unit toggle works', async ({ page }) => {
+  await page.getByTestId('unit-imperial').click()
+  await page.getByTestId('weight').fill('143')
+  await page.getByTestId('height').fill('65')
+
+  // 143 lbs = ~64.8 kg; 65 in = ~165.1 cm; BMI ≈ 23.8
+  const result = page.getByTestId('bmi-result')
+  await expect(result).toBeVisible()
+  const bmi = parseFloat(await result.textContent())
+  expect(bmi).toBeGreaterThanOrEqual(23)
+  expect(bmi).toBeLessThanOrEqual(25)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -25,6 +25,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
+  'pregnancyBMI',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency']
@@ -102,6 +103,7 @@ const EXPECTED_ROUTE_MAP = {
   schritteKalorienRechner: { de: 'schritte-kalorien-rechner', en: 'steps-to-calories-calculator' },
   childCalories: { de: 'kinder-kalorienbedarf-rechner', en: 'child-calorie-needs-calculator' },
   pediatricBloodPressure: { de: 'kinder-blutdruck-rechner', en: 'pediatric-blood-pressure-calculator' },
+  pregnancyBMI: { de: 'bmi-schwangerschaft-rechner', en: 'pregnancy-bmi-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -166,6 +168,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-kalorienbedarf-berechnen',
   'kinder-blutdruck-perzentile',
   'vitamin-d-mangel',
+  'bmi-schwangerschaft-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -230,19 +233,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'child-calorie-needs-guide',
   'pediatric-blood-pressure-guide',
   'vitamin-d-deficiency',
+  'pregnancy-bmi-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 74 calculators', () => {
-    expect(calculatorMetas).toHaveLength(74)
+  it('discovers all 75 calculators', () => {
+    expect(calculatorMetas).toHaveLength(75)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 74 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(74)
+  it('builds calculatorComponents map for all 75 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(75)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -265,15 +269,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 73 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(73)
+  it('discovers all 74 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(74)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 73 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(73)
+  it('discovers all 74 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(74)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -298,10 +302,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 74 calculators with no duplicates', () => {
+  it('groups contain all 75 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(74)
-    expect(new Set(allKeys).size).toBe(74)
+    expect(allKeys).toHaveLength(75)
+    expect(new Set(allKeys).size).toBe(75)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -328,7 +332,7 @@ describe('calculator groups', () => {
 
   it('pregnancy group has correct calculators in order', () => {
     expect(calculatorGroups[3].calculators).toEqual([
-      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
+      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'pregnancyBMI', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
       'babyMilestones', 'babyFeedingAmount', 'newbornBilirubin',
     ])
   })
@@ -371,8 +375,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 409 routes', () => {
-    expect(routes).toHaveLength(409)
+  it('generates exactly 414 routes', () => {
+    expect(routes).toHaveLength(414)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 294 links (74 calcs × 2 locales + 73 blogs × 2 locales)', () => {
+  it('generates 298 links (75 calcs × 2 locales + 74 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(294)
+    expect(links).toHaveLength(298)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/pregnancyBMI.test.js
+++ b/src/__tests__/pregnancyBMI.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcBmi,
+  getBmiCategory,
+  getRecommendedGain,
+  lbsToKg,
+  inchesToCm,
+} from '../utils/pregnancyBMI.js'
+
+describe('Pregnancy BMI calculation', () => {
+  it('60 kg / 165 cm → ~22.04 (normal)', () => {
+    expect(calcBmi(60, 165)).toBeCloseTo(22.04, 2)
+  })
+
+  it('50 kg / 170 cm → ~17.30 (underweight)', () => {
+    expect(calcBmi(50, 170)).toBeCloseTo(17.30, 1)
+  })
+
+  it('80 kg / 170 cm → ~27.68 (overweight)', () => {
+    expect(calcBmi(80, 170)).toBeCloseTo(27.68, 1)
+  })
+
+  it('100 kg / 170 cm → ~34.6 (obese)', () => {
+    expect(calcBmi(100, 170)).toBeCloseTo(34.6, 1)
+  })
+
+  it('returns null for missing weight', () => {
+    expect(calcBmi(null, 170)).toBeNull()
+  })
+
+  it('returns null for missing height', () => {
+    expect(calcBmi(70, null)).toBeNull()
+  })
+
+  it('returns null for zero or negative input', () => {
+    expect(calcBmi(0, 170)).toBeNull()
+    expect(calcBmi(70, 0)).toBeNull()
+    expect(calcBmi(-10, 170)).toBeNull()
+  })
+})
+
+describe('Pregnancy BMI category (WHO / IOM 2009)', () => {
+  it('< 18.5 → underweight', () => {
+    expect(getBmiCategory(17)).toBe('underweight')
+    expect(getBmiCategory(18.4)).toBe('underweight')
+  })
+
+  it('18.5–24.9 → normal', () => {
+    expect(getBmiCategory(18.5)).toBe('normal')
+    expect(getBmiCategory(22)).toBe('normal')
+    expect(getBmiCategory(24.9)).toBe('normal')
+  })
+
+  it('25–29.9 → overweight', () => {
+    expect(getBmiCategory(25)).toBe('overweight')
+    expect(getBmiCategory(29.9)).toBe('overweight')
+  })
+
+  it('≥ 30 → obese', () => {
+    expect(getBmiCategory(30)).toBe('obese')
+    expect(getBmiCategory(40)).toBe('obese')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(getBmiCategory(null)).toBeNull()
+    expect(getBmiCategory(0)).toBeNull()
+    expect(getBmiCategory(-5)).toBeNull()
+  })
+})
+
+describe('IOM 2009 recommended weight gain by category', () => {
+  it('singleton underweight → 12.5–18 kg', () => {
+    expect(getRecommendedGain('underweight')).toEqual({ min: 12.5, max: 18 })
+  })
+
+  it('singleton normal → 11.5–16 kg', () => {
+    expect(getRecommendedGain('normal')).toEqual({ min: 11.5, max: 16 })
+  })
+
+  it('singleton overweight → 7–11.5 kg', () => {
+    expect(getRecommendedGain('overweight')).toEqual({ min: 7, max: 11.5 })
+  })
+
+  it('singleton obese → 5–9 kg', () => {
+    expect(getRecommendedGain('obese')).toEqual({ min: 5, max: 9 })
+  })
+
+  it('twins normal → 17–25 kg', () => {
+    expect(getRecommendedGain('normal', true)).toEqual({ min: 17, max: 25 })
+  })
+
+  it('twins obese → 11–19 kg', () => {
+    expect(getRecommendedGain('obese', true)).toEqual({ min: 11, max: 19 })
+  })
+
+  it('returns null for missing category', () => {
+    expect(getRecommendedGain(null)).toBeNull()
+  })
+})
+
+describe('Imperial unit conversion', () => {
+  it('150 lbs → ~68.04 kg', () => {
+    expect(lbsToKg(150)).toBeCloseTo(68.04, 1)
+  })
+
+  it('66 inches → 167.64 cm', () => {
+    expect(inchesToCm(66)).toBeCloseTo(167.64, 2)
+  })
+
+  it('returns null for zero or negative input', () => {
+    expect(lbsToKg(0)).toBeNull()
+    expect(inchesToCm(-1)).toBeNull()
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -19,6 +19,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
+  'pregnancyBMI',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -82,6 +83,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-kalorienbedarf-berechnen',
   'kinder-blutdruck-perzentile',
   'vitamin-d-mangel',
+  'bmi-schwangerschaft-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -145,12 +147,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'child-calorie-needs-guide',
   'pediatric-blood-pressure-guide',
   'vitamin-d-deficiency',
+  'pregnancy-bmi-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 74 calculator meta files', () => {
+  it('discovers all 75 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(74)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(75)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -188,19 +191,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 73 DE blog slugs', () => {
+  it('returns all 74 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(73)
+    expect(de).toHaveLength(74)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 73 EN blog slugs', () => {
+  it('returns all 74 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(73)
+    expect(en).toHaveLength(74)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -268,9 +271,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 148 calcs + 2 blog index + 146 blog articles = 298)', () => {
+  it('generates correct total URL count (2 home + 150 calcs + 2 blog index + 148 blog articles = 302)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(298)
+    expect(urlCount).toBe(302)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -656,6 +656,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'vitaminDDeficiency',
     related: ['vitamin-d-calculator', 'osteoporosis-risk-calculator-guide', 'corrected-calcium-calculator'],
   },
+  {
+    slug: 'pregnancy-bmi-guide',
+    title: 'Pregnancy BMI Calculator — Pre-Pregnancy BMI & IOM 2009',
+    description: 'Calculate your pre-pregnancy BMI by WHO classification and see recommended weight gain by IOM 2009 — for singletons and twins. Why pre-pregnancy BMI matters most.',
+    date: '2026-05-10',
+    readTime: '7 min',
+    calculatorKey: 'pregnancyBMI',
+    related: ['pregnancy-weight-gain-guide', 'calculate-bmi', 'calculate-due-date'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -656,6 +656,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'vitaminDDeficiency',
     related: ['vitamin-d-berechnen', 'osteoporose-risiko-berechnen', 'korrigiertes-calcium-rechner'],
   },
+  {
+    slug: 'bmi-schwangerschaft-berechnen',
+    title: 'BMI in der Schwangerschaft berechnen — Vor-Schwangerschafts-BMI & IOM 2009',
+    description: 'Vor-Schwangerschafts-BMI berechnen und nach WHO-Klassifikation einordnen. Empfohlene Gewichtszunahme nach IOM 2009 für Einlinge und Zwillinge — verständlich erklärt.',
+    date: '2026-05-10',
+    readTime: '7 min',
+    calculatorKey: 'pregnancyBMI',
+    related: ['gewichtszunahme-schwangerschaft-berechnen', 'bmi-berechnen', 'geburtstermin-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/pregnancyBMI.json
+++ b/src/locales/calculators/de/pregnancyBMI.json
@@ -1,0 +1,71 @@
+{
+  "home": {
+    "calculators": {
+      "pregnancyBMI": {
+        "name": "BMI-Rechner Schwangerschaft",
+        "description": "Vor-Schwangerschafts-BMI berechnen und nach IOM-Kategorie einordnen."
+      }
+    }
+  },
+  "pregnancyBMI": {
+    "meta": {
+      "title": "BMI-Rechner Schwangerschaft — Vor-Schwangerschafts-BMI berechnen",
+      "description": "Berechne deinen Vor-Schwangerschafts-BMI und ordne ihn in die IOM-2009-Kategorien ein. Mit empfohlener Gewichtszunahme für Einlinge und Zwillinge. Kostenlos, ohne Anmeldung."
+    },
+    "title": "BMI-Rechner Schwangerschaft",
+    "description": "Berechne deinen Vor-Schwangerschafts-BMI nach WHO-Klassifikation und sieh die empfohlene Gewichtszunahme nach IOM 2009.",
+    "weight": "Gewicht vor Schwangerschaft",
+    "height": "Körpergröße",
+    "pregnancyType": "Schwangerschaftstyp",
+    "singleton": "Einling",
+    "twins": "Zwillinge",
+    "yourBmi": "Dein Vor-Schwangerschafts-BMI",
+    "category": "Kategorie",
+    "underweight": "Untergewicht",
+    "normal": "Normalgewicht",
+    "overweight": "Übergewicht",
+    "obese": "Adipositas",
+    "recommendedGain": "Empfohlene Gewichtszunahme",
+    "totalGain": "Gesamtzunahme (40 Wochen)",
+    "rangeTitle": "BMI-Klassifikation (WHO)",
+    "rangeBmi": "BMI",
+    "rangeCategory": "Kategorie",
+    "rangeGain": "Empf. Zunahme (Einling)",
+    "underweightDesc": "Niedriges Vor-Gewicht. Höhere Zunahme empfohlen, um das Geburtsgewicht zu sichern.",
+    "normalDesc": "Gesunder Ausgangs-BMI. Moderate Zunahme reduziert Risiken für Mutter und Kind.",
+    "overweightDesc": "Erhöhter Ausgangs-BMI. Geringere Zunahme empfohlen, um Komplikationen vorzubeugen.",
+    "obeseDesc": "Stark erhöhter Ausgangs-BMI. Geringe Zunahme reduziert Risiko für Schwangerschaftsdiabetes und Präeklampsie.",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der BMI wird mit der Standard-Formel berechnet: Gewicht (kg) ÷ Körpergröße² (m). Verwende dein Gewicht VOR der Schwangerschaft. Die Empfehlungen für die Gewichtszunahme stammen vom Institute of Medicine (IOM 2009) und sind weltweiter Standard. Bei Erkrankungen wie Schwangerschaftsdiabetes können individuelle Empfehlungen abweichen.",
+    "linkPregnancyWeightGain": "Wochenverlauf der Gewichtszunahme",
+    "linkBmi": "Allgemeiner BMI-Rechner",
+    "linkPregnancy": "Schwangerschaftswoche",
+    "source": "Quelle: Institute of Medicine (IOM, 2009) — Weight Gain During Pregnancy",
+    "faq": [
+      {
+        "q": "Welches Gewicht zählt für den BMI in der Schwangerschaft?",
+        "a": "Dein Gewicht VOR der Schwangerschaft. Es bestimmt die empfohlene Gesamtzunahme nach IOM 2009. Aktuelles Schwangerschaftsgewicht ist hier nicht aussagekräftig."
+      },
+      {
+        "q": "Warum ist der Vor-Schwangerschafts-BMI wichtig?",
+        "a": "Er steuert die empfohlene Gewichtszunahme. Untergewichtige Frauen sollten mehr zunehmen, adipöse weniger — beides reduziert Risiken für Frühgeburt, Schwangerschaftsdiabetes und Präeklampsie."
+      },
+      {
+        "q": "Was, wenn mein BMI in der Grauzone liegt?",
+        "a": "Bei BMI nahe einer Grenze (z. B. 24,8 oder 25,2) sprich mit deiner Gynäkologin. Individuelle Faktoren wie Muskelmasse, Vorgeschichte und Risiken können die Empfehlung verschieben."
+      },
+      {
+        "q": "Gilt die IOM-Empfehlung weltweit?",
+        "a": "Ja, die IOM-2009-Leitlinien sind weltweit anerkannt. Auch deutsche Leitlinien (DGGG) orientieren sich daran. Die Klassifikation nutzt WHO-BMI-Kategorien."
+      },
+      {
+        "q": "Wie unterscheidet sich der BMI bei Zwillingen?",
+        "a": "Die BMI-Klassifikation ist gleich. Aber die empfohlene Gesamtzunahme ist deutlich höher: 17–25 kg bei Normalgewicht, 14–23 kg bei Übergewicht, 11–19 kg bei Adipositas."
+      },
+      {
+        "q": "Mein BMI ist über 30 — was bedeutet das?",
+        "a": "Adipositas in der Schwangerschaft bringt erhöhte Risiken (Schwangerschaftsdiabetes, Präeklampsie, Kaiserschnitt). Eine geringere Gewichtszunahme von 5–9 kg reduziert diese Risiken. Engmaschige Betreuung wird empfohlen."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/pregnancyBMI.json
+++ b/src/locales/calculators/en/pregnancyBMI.json
@@ -1,0 +1,71 @@
+{
+  "home": {
+    "calculators": {
+      "pregnancyBMI": {
+        "name": "Pregnancy BMI Calculator",
+        "description": "Calculate your pre-pregnancy BMI and classify it per IOM 2009."
+      }
+    }
+  },
+  "pregnancyBMI": {
+    "meta": {
+      "title": "Pregnancy BMI Calculator — Pre-Pregnancy BMI by IOM 2009",
+      "description": "Calculate your pre-pregnancy BMI and classify it into IOM 2009 categories. Includes recommended weight gain for singletons and twins. Free, no sign-up."
+    },
+    "title": "Pregnancy BMI Calculator",
+    "description": "Calculate your pre-pregnancy BMI by WHO classification and see recommended weight gain per IOM 2009.",
+    "weight": "Pre-pregnancy weight",
+    "height": "Height",
+    "pregnancyType": "Pregnancy type",
+    "singleton": "Singleton",
+    "twins": "Twins",
+    "yourBmi": "Your pre-pregnancy BMI",
+    "category": "Category",
+    "underweight": "Underweight",
+    "normal": "Normal weight",
+    "overweight": "Overweight",
+    "obese": "Obese",
+    "recommendedGain": "Recommended weight gain",
+    "totalGain": "Total gain (40 weeks)",
+    "rangeTitle": "BMI classification (WHO)",
+    "rangeBmi": "BMI",
+    "rangeCategory": "Category",
+    "rangeGain": "Rec. gain (singleton)",
+    "underweightDesc": "Low pre-pregnancy weight. Higher gain recommended to support birth weight.",
+    "normalDesc": "Healthy starting BMI. Moderate gain reduces risks for mother and baby.",
+    "overweightDesc": "Elevated starting BMI. Lower gain recommended to limit complications.",
+    "obeseDesc": "High starting BMI. Lower gain reduces risk of gestational diabetes and preeclampsia.",
+    "howItWorks": "How it works",
+    "howItWorksText": "BMI uses the standard formula: weight (kg) ÷ height² (m). Use your weight BEFORE pregnancy. Weight-gain ranges follow the Institute of Medicine (IOM 2009) guidelines, the global standard. Conditions like gestational diabetes may shift individual targets.",
+    "linkPregnancyWeightGain": "Weekly weight gain progression",
+    "linkBmi": "General BMI calculator",
+    "linkPregnancy": "Current pregnancy week",
+    "source": "Source: Institute of Medicine (IOM, 2009) — Weight Gain During Pregnancy",
+    "faq": [
+      {
+        "q": "Which weight should I use for pregnancy BMI?",
+        "a": "Your weight BEFORE pregnancy. That number sets the recommended total gain per IOM 2009. Current pregnancy weight is not used here."
+      },
+      {
+        "q": "Why does pre-pregnancy BMI matter?",
+        "a": "It drives the recommended gain. Underweight women should gain more, women with obesity less — both reduce risks of preterm birth, gestational diabetes, and preeclampsia."
+      },
+      {
+        "q": "What if my BMI sits on a boundary?",
+        "a": "If your BMI is close to a category cutoff (e.g. 24.8 or 25.2), talk to your OB/GYN. Muscle mass, history, and individual risks can move the target."
+      },
+      {
+        "q": "Is the IOM 2009 guideline used worldwide?",
+        "a": "Yes. IOM 2009 is the global reference and uses WHO BMI categories. National guidelines (NICE, ACOG, DGGG) align with these ranges."
+      },
+      {
+        "q": "How does it differ for twins?",
+        "a": "BMI categories are the same. Total recommended gain is higher: 17–25 kg (normal), 14–23 kg (overweight), 11–19 kg (obese). Underweight twins use the singleton range."
+      },
+      {
+        "q": "My BMI is over 30 — what does that mean?",
+        "a": "Pregnancy with obesity carries higher risks (gestational diabetes, preeclampsia, cesarean). A modest gain of 5–9 kg reduces those risks. Closer prenatal monitoring is advised."
+      }
+    ]
+  }
+}

--- a/src/pages/PregnancyBMICalculator.vue
+++ b/src/pages/PregnancyBMICalculator.vue
@@ -1,0 +1,228 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  calcBmi,
+  getBmiCategory,
+  getRecommendedGain,
+  lbsToKg,
+  inchesToCm,
+} from '../utils/pregnancyBMI.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+const faqItems = computed(() => tm('pregnancyBMI.faq') || [])
+
+useHead(() => ({
+  title: t('pregnancyBMI.meta.title'),
+  description: t('pregnancyBMI.meta.description'),
+  routeKey: 'pregnancyBMI',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Pregnancy BMI Calculator',
+    url: 'https://healthcalculator.app/pregnancy-bmi-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const unit = ref('metric')
+const weight = ref(null)
+const height = ref(null)
+const twins = ref(false)
+
+const weightKg = computed(() =>
+  unit.value === 'imperial' ? lbsToKg(weight.value) : weight.value
+)
+const heightCm = computed(() =>
+  unit.value === 'imperial' ? inchesToCm(height.value) : height.value
+)
+
+const bmi = computed(() => calcBmi(weightKg.value, heightCm.value))
+const category = computed(() => getBmiCategory(bmi.value))
+const gain = computed(() => getRecommendedGain(category.value, twins.value))
+
+const categoryColor = computed(() => {
+  switch (category.value) {
+    case 'underweight': return 'text-blue-600'
+    case 'normal': return 'text-emerald-600'
+    case 'overweight': return 'text-yellow-600'
+    case 'obese': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('pregnancyBMI.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('pregnancyBMI.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="unit = 'metric'"
+        :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        data-testid="unit-metric"
+      >{{ t('common.metric') }}</button>
+      <button
+        @click="unit = 'imperial'"
+        :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+        data-testid="unit-imperial"
+      >{{ t('common.imperial') }}</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('pregnancyBMI.weight') }} ({{ unit === 'metric' ? 'kg' : 'lbs' }})
+        </label>
+        <input
+          v-model.number="weight"
+          type="number"
+          :placeholder="unit === 'metric' ? '65' : '143'"
+          min="20"
+          max="300"
+          data-testid="weight"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('pregnancyBMI.height') }} ({{ unit === 'metric' ? 'cm' : 'in' }})
+        </label>
+        <input
+          v-model.number="height"
+          type="number"
+          :placeholder="unit === 'metric' ? '170' : '67'"
+          min="50"
+          max="250"
+          data-testid="height"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <div>
+      <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+        {{ t('pregnancyBMI.pregnancyType') }}
+      </label>
+      <div class="flex gap-2">
+        <button
+          @click="twins = false"
+          :class="!twins ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          data-testid="btn-singleton"
+        >{{ t('pregnancyBMI.singleton') }}</button>
+        <button
+          @click="twins = true"
+          :class="twins ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          data-testid="btn-twins"
+        >{{ t('pregnancyBMI.twins') }}</button>
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="bmi !== null" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums leading-none" data-testid="bmi-result">{{ bmi.toFixed(1) }}</span>
+      <span class="text-lg text-stone-400">BMI</span>
+      <span v-if="category" :class="categoryColor" class="text-lg font-semibold" data-testid="bmi-category">
+        {{ t('pregnancyBMI.' + category) }}
+      </span>
+    </div>
+
+    <p v-if="category" class="text-sm text-stone-600 leading-relaxed mb-6" data-testid="category-description">
+      {{ t('pregnancyBMI.' + category + 'Desc') }}
+    </p>
+
+    <div v-if="gain" class="grid grid-cols-2 gap-4 mb-6">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('pregnancyBMI.recommendedGain') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="gain-range">
+          {{ gain.min }}–{{ gain.max }} <span class="text-sm text-stone-400">kg</span>
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('pregnancyBMI.totalGain') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">
+          {{ ((gain.min + gain.max) / 2).toFixed(1) }} <span class="text-sm text-stone-400">kg</span>
+        </p>
+      </div>
+    </div>
+
+    <p class="text-xs text-stone-400">{{ t('pregnancyBMI.source') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('pregnancyBMI.rangeBmi') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('pregnancyBMI.rangeCategory') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('pregnancyBMI.rangeGain') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 18.5</td>
+          <td class="px-6 py-3 text-blue-700 font-medium">{{ t('pregnancyBMI.underweight') }}</td>
+          <td class="px-6 py-3 text-stone-700 tabular-nums">12.5–18 kg</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">18.5–24.9</td>
+          <td class="px-6 py-3 text-emerald-700 font-medium">{{ t('pregnancyBMI.normal') }}</td>
+          <td class="px-6 py-3 text-stone-700 tabular-nums">11.5–16 kg</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">25–29.9</td>
+          <td class="px-6 py-3 text-yellow-700 font-medium">{{ t('pregnancyBMI.overweight') }}</td>
+          <td class="px-6 py-3 text-stone-700 tabular-nums">7–11.5 kg</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 30</td>
+          <td class="px-6 py-3 text-red-700 font-medium">{{ t('pregnancyBMI.obese') }}</td>
+          <td class="px-6 py-3 text-stone-700 tabular-nums">5–9 kg</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="flex flex-wrap gap-3 mb-6 text-sm">
+    <router-link :to="localePath('pregnancyWeightGain')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('pregnancyBMI.linkPregnancyWeightGain') }}
+    </router-link>
+    <span class="text-stone-300">&middot;</span>
+    <router-link :to="localePath('bmi')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('pregnancyBMI.linkBmi') }}
+    </router-link>
+    <span class="text-stone-300">&middot;</span>
+    <router-link :to="localePath('pregnancy')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('pregnancyBMI.linkPregnancy') }}
+    </router-link>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('pregnancyBMI.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('pregnancyBMI.howItWorksText') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="pregnancyBMI" />
+</template>

--- a/src/pages/blog/BmiSchwangerschaftBerechnen.vue
+++ b/src/pages/blog/BmiSchwangerschaftBerechnen.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'BMI in der Schwangerschaft berechnen — Vor-Schwangerschafts-BMI & IOM 2009 | Health Calculators',
+  description: 'Vor-Schwangerschafts-BMI berechnen und nach WHO-Klassifikation einordnen. Empfohlene Gewichtszunahme nach IOM 2009 für Einlinge und Zwillinge — verständlich erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'BMI in der Schwangerschaft berechnen — Vor-Schwangerschafts-BMI & IOM 2009',
+    description: 'Vor-Schwangerschafts-BMI berechnen und nach WHO-Klassifikation einordnen. Empfohlene Gewichtszunahme nach IOM 2009 für Einlinge und Zwillinge.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-10',
+    dateModified: '2026-05-10',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/bmi-schwangerschaft-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">BMI in der Schwangerschaft berechnen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">10. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <strong>Vor-Schwangerschafts-BMI</strong> ist die wichtigste Kennzahl für deine empfohlene
+          Gewichtszunahme in der Schwangerschaft. Er entscheidet, ob 5 kg, 12 kg oder 18 kg das richtige Ziel sind.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das Institute of Medicine (IOM) hat 2009 evidenzbasierte Richtwerte veröffentlicht — sie gelten weltweit als
+          Goldstandard. Sie nutzen die WHO-BMI-Klassifikation und schützen Mutter und Kind vor zu wenig oder zu viel Zunahme.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">So berechnest du den BMI in der Schwangerschaft</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wichtig: Verwende dein <strong>Gewicht VOR der Schwangerschaft</strong>, nicht dein aktuelles. Die Formel ist
+          die gleiche wie beim normalen <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link>:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-6 text-center">
+          <p class="text-lg font-semibold text-stone-900">BMI = Gewicht (kg) ÷ Körpergröße² (m)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beispiel: 65 kg Vor-Gewicht bei 1,68 m Körpergröße ergibt einen BMI von 65 ÷ (1,68 × 1,68) = <strong>23,0</strong> —
+          also <em>Normalgewicht</em>.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI-Kategorien & empfohlene Zunahme (IOM 2009)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Vor-Schwangerschafts-BMI</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfohlene Zunahme</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">&lt; 18,5</td>
+                <td class="px-6 py-3 font-medium text-blue-700">Untergewicht</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">12,5 – 18 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">18,5 – 24,9</td>
+                <td class="px-6 py-3 font-medium text-emerald-700">Normalgewicht</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">11,5 – 16 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">25 – 29,9</td>
+                <td class="px-6 py-3 font-medium text-yellow-700">Übergewicht</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">7 – 11,5 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">&ge; 30</td>
+                <td class="px-6 py-3 font-medium text-red-700">Adipositas</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">5 – 9 kg</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum der BMI vor der Schwangerschaft zählt</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Studien zeigen einen klaren Zusammenhang: Untergewichtige Frauen mit zu wenig Zunahme haben ein höheres Risiko
+          für Frühgeburten und niedriges Geburtsgewicht. Frauen mit Übergewicht oder Adipositas, die zu viel zunehmen,
+          haben höhere Risiken für Schwangerschaftsdiabetes, Präeklampsie und Kaiserschnitt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die IOM-2009-Richtwerte balancieren beide Risiken aus. Der Vor-Schwangerschafts-BMI ist also kein Etikett —
+          er ist die Grundlage für eine individuell sichere Empfehlung.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Deinen BMI in der Schwangerschaft berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Vor-Schwangerschafts-BMI mit IOM-Empfehlung — kostenlos, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('pregnancyBMI')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Zwillinge: höhere Zunahme empfohlen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei Zwillingsschwangerschaften gilt die gleiche BMI-Kategorisierung — aber die empfohlene Gesamtzunahme ist
+          deutlich höher:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <div class="space-y-2 text-sm text-stone-700">
+            <div class="flex justify-between"><span>Normalgewicht (BMI 18,5–24,9)</span><span class="font-semibold tabular-nums">17 – 25 kg</span></div>
+            <div class="flex justify-between"><span>Übergewicht (BMI 25–29,9)</span><span class="font-semibold tabular-nums">14 – 23 kg</span></div>
+            <div class="flex justify-between"><span>Adipositas (BMI ≥ 30)</span><span class="font-semibold tabular-nums">11 – 19 kg</span></div>
+          </div>
+        </div>
+        <p class="text-sm text-stone-500">
+          Für untergewichtige Zwillingsschwangerschaften gibt das IOM keinen separaten Wert vor — Empfehlung erfolgt individuell durch den Frauenarzt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Soll ich den BMI während der Schwangerschaft regelmäßig nachmessen?</h3>
+            <p class="text-sm text-stone-600">
+              Nein. Der BMI in der Schwangerschaft bezieht sich immer auf das Vor-Gewicht. Für den Verlauf nutzt du
+              besser die <router-link :to="localePath('pregnancyWeightGain')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">wöchentliche Gewichtszunahme</router-link>.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Was tun, wenn ich mein Vor-Gewicht nicht genau kenne?</h3>
+            <p class="text-sm text-stone-600">
+              Schätze das Gewicht von vor Eintritt der Schwangerschaft so gut wie möglich. Krankenkassen, Arztpraxen oder
+              Fitness-Apps haben oft historische Daten. Auch grobe Werte sind besser als ein aktuelles Schwangerschaftsgewicht.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Mein BMI war 24,8 — gilt für mich Normalgewicht oder Übergewicht?</h3>
+            <p class="text-sm text-stone-600">
+              Bei einem BMI von 24,8 zählt formal Normalgewicht (Cutoff: 25,0). Sprich aber mit deiner Gynäkologin —
+              individuelle Faktoren wie Muskelmasse oder Familiengeschichte können die Empfehlung beeinflussen.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der Vor-Schwangerschafts-BMI bestimmt deine empfohlene Gewichtszunahme nach IOM 2009. Berechne ihn mit unserem
+          <router-link :to="localePath('pregnancyBMI')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner Schwangerschaft</router-link>,
+          verfolge die wöchentliche Zunahme mit dem
+          <router-link :to="localePath('pregnancyWeightGain')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Gewichtszunahme-Rechner</router-link>
+          und ermittle deine Schwangerschaftswoche mit dem
+          <router-link :to="localePath('pregnancy')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Schwangerschafts-Rechner</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticles slug="bmi-schwangerschaft-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/PregnancyBmiGuide.vue
+++ b/src/pages/blog/en/PregnancyBmiGuide.vue
@@ -1,0 +1,182 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Pregnancy BMI Calculator — Pre-Pregnancy BMI & IOM 2009 | Health Calculators',
+  description: 'Calculate your pre-pregnancy BMI by WHO classification and see recommended weight gain by IOM 2009 — for singletons and twins. Why pre-pregnancy BMI matters most.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Pregnancy BMI Calculator — Pre-Pregnancy BMI & IOM 2009',
+    description: 'Calculate your pre-pregnancy BMI by WHO classification and see recommended weight gain by IOM 2009 — for singletons and twins.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-10',
+    dateModified: '2026-05-10',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/pregnancy-bmi-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Pregnancy BMI — Why Your Pre-Pregnancy Number Sets Everything</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 10, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Your <strong>pre-pregnancy BMI</strong> is the single most important number for setting your recommended weight gain in pregnancy.
+          It decides whether the right target is 5 kg, 12 kg, or 18 kg — not your current bump weight, not your trimester.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The Institute of Medicine (IOM) published its evidence-based ranges in 2009. They use WHO BMI categories and remain the global
+          standard, used by NICE, ACOG, and most national guidelines. The ranges balance the dual risks of too little and too much gain.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How to calculate pregnancy BMI</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Critical detail: use your weight <strong>before pregnancy</strong>, not your current weight. The formula is the same as a regular
+          <router-link :to="localeBlogPath('calculate-bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link>:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-6 text-center">
+          <p class="text-lg font-semibold text-stone-900">BMI = weight (kg) ÷ height² (m)</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Example: 65 kg pre-pregnancy weight at 1.68 m height gives a BMI of 65 ÷ (1.68 × 1.68) = <strong>23.0</strong> —
+          which lands in the <em>normal</em> category.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI categories & recommended gain (IOM 2009)</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Pre-pregnancy BMI</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Recommended gain</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">&lt; 18.5</td>
+                <td class="px-6 py-3 font-medium text-blue-700">Underweight</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">12.5 – 18 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">18.5 – 24.9</td>
+                <td class="px-6 py-3 font-medium text-emerald-700">Normal</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">11.5 – 16 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">25 – 29.9</td>
+                <td class="px-6 py-3 font-medium text-yellow-700">Overweight</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">7 – 11.5 kg</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600 tabular-nums">&ge; 30</td>
+                <td class="px-6 py-3 font-medium text-red-700">Obese</td>
+                <td class="px-6 py-3 font-semibold text-stone-900 tabular-nums">5 – 9 kg</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why pre-pregnancy BMI matters more than current weight</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The data is consistent: women with low pre-pregnancy BMI who gain too little face higher risk of preterm birth and low birth weight.
+          Women with elevated pre-pregnancy BMI who gain too much face higher risk of gestational diabetes, preeclampsia, and cesarean delivery.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          IOM 2009 picks ranges that balance both. So pre-pregnancy BMI isn't a label — it's the input that personalises a safer target.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your pregnancy BMI</h3>
+        <p class="text-stone-300 text-sm mb-5">Pre-pregnancy BMI with IOM gain target — free, no sign-up.</p>
+        <router-link
+          :to="localePath('pregnancyBMI')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate now &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Twin pregnancies: higher gain</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Twin pregnancies use the same BMI categories — but the recommended total gain is higher:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <div class="space-y-2 text-sm text-stone-700">
+            <div class="flex justify-between"><span>Normal (BMI 18.5–24.9)</span><span class="font-semibold tabular-nums">17 – 25 kg</span></div>
+            <div class="flex justify-between"><span>Overweight (BMI 25–29.9)</span><span class="font-semibold tabular-nums">14 – 23 kg</span></div>
+            <div class="flex justify-between"><span>Obese (BMI ≥ 30)</span><span class="font-semibold tabular-nums">11 – 19 kg</span></div>
+          </div>
+        </div>
+        <p class="text-sm text-stone-500">
+          IOM 2009 doesn't define a separate range for underweight twin pregnancies — recommendations should be individualised with your provider.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequent questions</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">Should I recalculate my BMI as I gain weight?</h3>
+            <p class="text-sm text-stone-600">
+              No. Pregnancy BMI is fixed at your pre-pregnancy weight. To track progress, use the
+              <router-link :to="localePath('pregnancyWeightGain')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">weekly weight-gain tracker</router-link>.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">What if I don't know my exact pre-pregnancy weight?</h3>
+            <p class="text-sm text-stone-600">
+              Estimate as best you can — fitness apps, doctor records, or memory all help. A reasonable estimate is much better than using current pregnancy weight.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-bold text-stone-900 mb-2">My BMI was 24.8 — am I normal or overweight?</h3>
+            <p class="text-sm text-stone-600">
+              Formally normal weight (cutoff: 25.0). But if you're close to a boundary, your provider may adjust the target based on muscle mass, family history, or risk factors.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Pre-pregnancy BMI sets your IOM 2009 target. Calculate it with our
+          <router-link :to="localePath('pregnancyBMI')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Pregnancy BMI Calculator</router-link>,
+          track progression with the
+          <router-link :to="localePath('pregnancyWeightGain')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Weight Gain Calculator</router-link>,
+          and find your week with the
+          <router-link :to="localePath('pregnancy')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Pregnancy Calculator</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="pregnancy-bmi-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/pregnancyBMI.meta.js
+++ b/src/pages/pregnancyBMI.meta.js
@@ -1,0 +1,16 @@
+import Component from './PregnancyBMICalculator.vue'
+import BlogDe from './blog/BmiSchwangerschaftBerechnen.vue'
+import BlogEn from './blog/en/PregnancyBmiGuide.vue'
+
+export default {
+  key: 'pregnancyBMI',
+  component: Component,
+  slugs: { de: 'bmi-schwangerschaft-rechner', en: 'pregnancy-bmi-calculator' },
+  group: 'pregnancy',
+  groupOrder: 3,
+  order: 1.5,
+  blog: {
+    de: { slug: 'bmi-schwangerschaft-berechnen', component: BlogDe },
+    en: { slug: 'pregnancy-bmi-guide', component: BlogEn },
+  },
+}

--- a/src/utils/pregnancyBMI.js
+++ b/src/utils/pregnancyBMI.js
@@ -1,0 +1,54 @@
+// Pregnancy BMI — pre-pregnancy BMI classification per IOM 2009 / WHO categories.
+// BMI = weight (kg) / height (m)^2
+// Classification thresholds (WHO, used by IOM 2009 for pregnancy guidance):
+//   < 18.5  — underweight
+//   18.5–24.9 — normal
+//   25–29.9 — overweight
+//   ≥ 30    — obese
+
+export function calcBmi(weightKg, heightCm) {
+  if (!weightKg || !heightCm || weightKg <= 0 || heightCm <= 0) return null
+  const heightM = heightCm / 100
+  return weightKg / (heightM * heightM)
+}
+
+export function getBmiCategory(bmi) {
+  if (bmi == null || bmi <= 0) return null
+  if (bmi < 18.5) return 'underweight'
+  if (bmi < 25) return 'normal'
+  if (bmi < 30) return 'overweight'
+  return 'obese'
+}
+
+// IOM 2009 total weight gain ranges (kg) by pre-pregnancy BMI category.
+const IOM_GAIN = {
+  singleton: {
+    underweight: { min: 12.5, max: 18 },
+    normal: { min: 11.5, max: 16 },
+    overweight: { min: 7, max: 11.5 },
+    obese: { min: 5, max: 9 },
+  },
+  twins: {
+    underweight: { min: 12.5, max: 18 },
+    normal: { min: 17, max: 25 },
+    overweight: { min: 14, max: 23 },
+    obese: { min: 11, max: 19 },
+  },
+}
+
+export function getRecommendedGain(category, twins = false) {
+  if (!category) return null
+  const set = twins ? IOM_GAIN.twins : IOM_GAIN.singleton
+  return set[category] || null
+}
+
+// Convert imperial inputs (lbs, inches) to metric.
+export function lbsToKg(lbs) {
+  if (!lbs || lbs <= 0) return null
+  return lbs * 0.453592
+}
+
+export function inchesToCm(inches) {
+  if (!inches || inches <= 0) return null
+  return inches * 2.54
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-135-pregnancy-b-m-i
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-135-pregnancy-b-m-i-20260510-120030`
**Cost:** $7.848232999999997

Closes jenslaufer/health-calculators#135

### Prompt
> Implement the Pregnancy B M I Calculator as described in issue #135.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- BMI classification during pregnancy
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.


## PARTIAL-COMMIT GUARD (MANDATORY — added 2026-05-07 after FK #270 + HC #231 partial; validated 3-of-3 on FK #280 + HC #232 + HC #233, 4-of-3 on FK #281)
Before `git push`, run:
  git diff --name-only main..HEAD | sort

Output MUST contain ALL of these paths (substitute <DeBlogPascal> + <EnBlogPascal> with your chosen blog Vue component names):
  e2e/pregnancyBMI.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/pregnancyBMI.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/pregnancyBMI.json
  src/locales/calculators/en/pregnancyBMI.json
  src/pages/PregnancyBMICalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/pregnancyBMI.meta.js
  src/utils/pregnancyBMI.js

If ANY path is missing → DO NOT push. Stage + commit the missing files first.
Counter check: `git diff --name-only main..HEAD | wc -l` MUST be >= 14.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/pregnancyBMI.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/pregnancyBMI.test.js` with 6+ test cases covering edge cases. Run `npm test -- pregnancyBMI` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/PregnancyBMICalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/pregnancyBMI.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/pregnancyBMI.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'pregnancyBMI'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/pregnancyBMI.json` + `src/locales/calculators/en/pregnancyBMI.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/pregnancyBMI.js (or shared util — verify pattern in repo first)`
- `src/__tests__/pregnancyBMI.test.js`
- `src/pages/PregnancyBMICalculator.vue`
- `src/pages/pregnancyBMI.meta.js`
- `src/locales/calculators/de/pregnancyBMI.json`
- `src/locales/calculators/en/pregnancyBMI.json`
- `e2e/pregnancyBMI.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'pregnancyBMI',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks