### PR TITLE
hc-136-fertility-window: Implement the Fertility Window Calculator as described in is

### DIFF
--- a/e2e/fertilityWindow.spec.js
+++ b/e2e/fertilityWindow.spec.js
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/fruchtbares-fenster-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Fruchtbares Fenster/)
+})
+
+test('shows ovulation date for 28-day cycle starting 2026-03-01', async ({ page }) => {
+  await page.getByTestId('lmp').fill('2026-03-01')
+  await page.getByTestId('cycle-length').fill('28')
+
+  const ovulationDate = page.getByTestId('ovulation-date')
+  await expect(ovulationDate).toBeVisible()
+  await expect(ovulationDate).toContainText('März')
+  await expect(ovulationDate).toContainText('15')
+})
+
+test('shows expanded 10-day window', async ({ page }) => {
+  await page.getByTestId('lmp').fill('2026-03-01')
+  await page.getByTestId('cycle-length').fill('28')
+
+  const expanded = page.getByTestId('expanded-window')
+  await expect(expanded).toBeVisible()
+})
+
+test('shows LH surge window', async ({ page }) => {
+  await page.getByTestId('lmp').fill('2026-03-01')
+  await page.getByTestId('cycle-length').fill('28')
+
+  const lh = page.getByTestId('lh-surge')
+  await expect(lh).toBeVisible()
+})
+
+test('shows peak fertility window', async ({ page }) => {
+  await page.getByTestId('lmp').fill('2026-03-01')
+  await page.getByTestId('cycle-length').fill('28')
+
+  const peak = page.getByTestId('peak-window')
+  await expect(peak).toBeVisible()
+})
+
+test('shows next period prediction', async ({ page }) => {
+  await page.getByTestId('lmp').fill('2026-03-01')
+  await page.getByTestId('cycle-length').fill('28')
+
+  const next = page.getByTestId('next-period')
+  await expect(next).toBeVisible()
+})
+
+test('shows daily forecast table with 10 rows', async ({ page }) => {
+  await page.getByTestId('lmp').fill('2026-03-01')
+  await page.getByTestId('cycle-length').fill('28')
+
+  const rows = page.getByTestId('forecast-row')
+  await expect(rows).toHaveCount(10)
+})
+
+test('longer cycle shifts ovulation later', async ({ page }) => {
+  await page.getByTestId('lmp').fill('2026-03-01')
+  await page.getByTestId('cycle-length').fill('32')
+
+  const ovulationDate = page.getByTestId('ovulation-date')
+  await expect(ovulationDate).toContainText('19')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -25,7 +25,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
-  'pregnancyBMI',
+  'pregnancyBMI', 'fertilityWindow',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency']
@@ -104,6 +104,7 @@ const EXPECTED_ROUTE_MAP = {
   childCalories: { de: 'kinder-kalorienbedarf-rechner', en: 'child-calorie-needs-calculator' },
   pediatricBloodPressure: { de: 'kinder-blutdruck-rechner', en: 'pediatric-blood-pressure-calculator' },
   pregnancyBMI: { de: 'bmi-schwangerschaft-rechner', en: 'pregnancy-bmi-calculator' },
+  fertilityWindow: { de: 'fruchtbares-fenster-rechner', en: 'fertility-window-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -169,6 +170,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-blutdruck-perzentile',
   'vitamin-d-mangel',
   'bmi-schwangerschaft-berechnen',
+  'fruchtbares-fenster-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -234,19 +236,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pediatric-blood-pressure-guide',
   'vitamin-d-deficiency',
   'pregnancy-bmi-guide',
+  'fertility-window-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 75 calculators', () => {
-    expect(calculatorMetas).toHaveLength(75)
+  it('discovers all 76 calculators', () => {
+    expect(calculatorMetas).toHaveLength(76)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 75 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(75)
+  it('builds calculatorComponents map for all 76 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(76)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -269,15 +272,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 74 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(74)
+  it('discovers all 75 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(75)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 74 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(74)
+  it('discovers all 75 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(75)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -302,10 +305,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 75 calculators with no duplicates', () => {
+  it('groups contain all 76 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(75)
-    expect(new Set(allKeys).size).toBe(75)
+    expect(allKeys).toHaveLength(76)
+    expect(new Set(allKeys).size).toBe(76)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -332,7 +335,7 @@ describe('calculator groups', () => {
 
   it('pregnancy group has correct calculators in order', () => {
     expect(calculatorGroups[3].calculators).toEqual([
-      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'pregnancyBMI', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
+      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'fertilityWindow', 'pregnancyBMI', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
       'babyMilestones', 'babyFeedingAmount', 'newbornBilirubin',
     ])
   })
@@ -375,8 +378,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 414 routes', () => {
-    expect(routes).toHaveLength(414)
+  it('generates exactly 419 routes', () => {
+    expect(routes).toHaveLength(419)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/fertilityWindow.test.js
+++ b/src/__tests__/fertilityWindow.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import {
+  addDays,
+  calcOvulationDay,
+  calcFertilityWindow,
+  getDayLabel,
+  daysBetween,
+  conceptionProbability,
+} from '../utils/fertilityWindow.js'
+
+function d(s) {
+  return new Date(s + 'T00:00:00')
+}
+
+describe('addDays', () => {
+  it('adds positive days correctly', () => {
+    expect(addDays(d('2026-03-01'), 14)).toEqual(d('2026-03-15'))
+  })
+
+  it('handles month boundary', () => {
+    expect(addDays(d('2026-02-25'), 7)).toEqual(d('2026-03-04'))
+  })
+
+  it('handles negative days', () => {
+    expect(addDays(d('2026-03-15'), -5)).toEqual(d('2026-03-10'))
+  })
+
+  it('returns null for invalid input', () => {
+    expect(addDays(null, 5)).toBeNull()
+    expect(addDays('not a date', 5)).toBeNull()
+  })
+})
+
+describe('calcOvulationDay', () => {
+  it('28-day cycle → ovulation on day 14 after LMP', () => {
+    // LMP 2026-03-01, cycle 28 → ovulation = 2026-03-01 + 14 = 2026-03-15
+    expect(calcOvulationDay(d('2026-03-01'), 28)).toEqual(d('2026-03-15'))
+  })
+
+  it('32-day cycle → ovulation on day 18 after LMP', () => {
+    // 32 - 14 = 18
+    expect(calcOvulationDay(d('2026-03-01'), 32)).toEqual(d('2026-03-19'))
+  })
+
+  it('21-day cycle → ovulation on day 7 after LMP', () => {
+    expect(calcOvulationDay(d('2026-03-01'), 21)).toEqual(d('2026-03-08'))
+  })
+
+  it('returns null for cycle out of range', () => {
+    expect(calcOvulationDay(d('2026-03-01'), 20)).toBeNull()
+    expect(calcOvulationDay(d('2026-03-01'), 46)).toBeNull()
+  })
+
+  it('returns null for invalid LMP', () => {
+    expect(calcOvulationDay(null, 28)).toBeNull()
+    expect(calcOvulationDay(d('invalid'), 28)).toBeNull()
+  })
+})
+
+describe('calcFertilityWindow', () => {
+  it('28-day cycle starting 2026-03-01 → ovulation 2026-03-15', () => {
+    const w = calcFertilityWindow(d('2026-03-01'), 28)
+    expect(w.ovulation).toEqual(d('2026-03-15'))
+  })
+
+  it('expanded window is 10 days wide (O-7 to O+2)', () => {
+    const w = calcFertilityWindow(d('2026-03-01'), 28)
+    expect(w.expandedStart).toEqual(d('2026-03-08'))
+    expect(w.expandedEnd).toEqual(d('2026-03-17'))
+  })
+
+  it('core window is 7 days (O-5 to O+1)', () => {
+    const w = calcFertilityWindow(d('2026-03-01'), 28)
+    expect(w.coreStart).toEqual(d('2026-03-10'))
+    expect(w.coreEnd).toEqual(d('2026-03-16'))
+  })
+
+  it('peak fertility is 3 days (O-2 to O)', () => {
+    const w = calcFertilityWindow(d('2026-03-01'), 28)
+    expect(w.peakStart).toEqual(d('2026-03-13'))
+    expect(w.peakEnd).toEqual(d('2026-03-15'))
+  })
+
+  it('LH surge runs from O-1 to ovulation', () => {
+    const w = calcFertilityWindow(d('2026-03-01'), 28)
+    expect(w.lhSurgeStart).toEqual(d('2026-03-14'))
+    expect(w.lhSurgeEnd).toEqual(d('2026-03-15'))
+  })
+
+  it('predicts next period start', () => {
+    const w = calcFertilityWindow(d('2026-03-01'), 28)
+    expect(w.nextPeriod).toEqual(d('2026-03-29'))
+  })
+
+  it('returns null for invalid inputs', () => {
+    expect(calcFertilityWindow(null, 28)).toBeNull()
+    expect(calcFertilityWindow(d('2026-03-01'), 200)).toBeNull()
+  })
+})
+
+describe('getDayLabel', () => {
+  const w = calcFertilityWindow(d('2026-03-01'), 28) // ovulation = 2026-03-15
+
+  it('labels ovulation day', () => {
+    expect(getDayLabel(d('2026-03-15'), w)).toBe('ovulation')
+  })
+
+  it('labels peak fertility days', () => {
+    expect(getDayLabel(d('2026-03-13'), w)).toBe('peak')
+    expect(getDayLabel(d('2026-03-14'), w)).toBe('lhSurge')
+  })
+
+  it('labels core window days', () => {
+    expect(getDayLabel(d('2026-03-11'), w)).toBe('core')
+    expect(getDayLabel(d('2026-03-16'), w)).toBe('core')
+  })
+
+  it('labels expanded window edges', () => {
+    expect(getDayLabel(d('2026-03-08'), w)).toBe('expanded')
+    expect(getDayLabel(d('2026-03-17'), w)).toBe('expanded')
+  })
+
+  it('returns null for non-fertile days', () => {
+    expect(getDayLabel(d('2026-03-01'), w)).toBeNull()
+    expect(getDayLabel(d('2026-03-25'), w)).toBeNull()
+  })
+})
+
+describe('daysBetween', () => {
+  it('counts forward days', () => {
+    expect(daysBetween(d('2026-03-01'), d('2026-03-15'))).toBe(14)
+  })
+
+  it('counts backward days as negative', () => {
+    expect(daysBetween(d('2026-03-15'), d('2026-03-01'))).toBe(-14)
+  })
+
+  it('zero for same day', () => {
+    expect(daysBetween(d('2026-03-15'), d('2026-03-15'))).toBe(0)
+  })
+
+  it('returns null for invalid input', () => {
+    expect(daysBetween(null, d('2026-03-15'))).toBeNull()
+  })
+})
+
+describe('conceptionProbability', () => {
+  it('peaks on ovulation day (~33%)', () => {
+    expect(conceptionProbability(0)).toBeCloseTo(0.33, 2)
+  })
+
+  it('day -1 is high (~31%)', () => {
+    expect(conceptionProbability(-1)).toBeCloseTo(0.31, 2)
+  })
+
+  it('day -2 is high (~27%)', () => {
+    expect(conceptionProbability(-2)).toBeCloseTo(0.27, 2)
+  })
+
+  it('drops sharply after ovulation', () => {
+    expect(conceptionProbability(1)).toBeCloseTo(0.10, 2)
+    expect(conceptionProbability(2)).toBe(0)
+  })
+
+  it('zero outside fertile window', () => {
+    expect(conceptionProbability(-7)).toBe(0)
+    expect(conceptionProbability(5)).toBe(0)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 298 links (75 calcs × 2 locales + 74 blogs × 2 locales)', () => {
+  it('generates 302 links (76 calcs × 2 locales + 75 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(298)
+    expect(links).toHaveLength(302)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -19,7 +19,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
-  'pregnancyBMI',
+  'pregnancyBMI', 'fertilityWindow',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -84,6 +84,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-blutdruck-perzentile',
   'vitamin-d-mangel',
   'bmi-schwangerschaft-berechnen',
+  'fruchtbares-fenster-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -148,12 +149,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pediatric-blood-pressure-guide',
   'vitamin-d-deficiency',
   'pregnancy-bmi-guide',
+  'fertility-window-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 75 calculator meta files', () => {
+  it('discovers all 76 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(75)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(76)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -191,19 +193,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 74 DE blog slugs', () => {
+  it('returns all 75 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(74)
+    expect(de).toHaveLength(75)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 74 EN blog slugs', () => {
+  it('returns all 75 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(74)
+    expect(en).toHaveLength(75)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -271,9 +273,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 150 calcs + 2 blog index + 148 blog articles = 302)', () => {
+  it('generates correct total URL count (2 home + 152 calcs + 2 blog index + 150 blog articles = 306)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(302)
+    expect(urlCount).toBe(306)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -665,6 +665,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'pregnancyBMI',
     related: ['pregnancy-weight-gain-guide', 'calculate-bmi', 'calculate-due-date'],
   },
+  {
+    slug: 'fertility-window-guide',
+    title: 'Fertility Window Calculator: 10 Days, LH Surge & Peak Days',
+    description: 'Calculate your fertility window — 10-day expanded window, LH surge, daily conception probability from Wilcox 1995. Practical tips for trying to conceive.',
+    date: '2026-05-10',
+    readTime: '8 min',
+    calculatorKey: 'fertilityWindow',
+    related: ['calculate-ovulation', 'period-calculator-guide', 'calculate-due-date'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -665,6 +665,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'pregnancyBMI',
     related: ['gewichtszunahme-schwangerschaft-berechnen', 'bmi-berechnen', 'geburtstermin-berechnen'],
   },
+  {
+    slug: 'fruchtbares-fenster-berechnen',
+    title: 'Fruchtbares Fenster berechnen: 10 Tage, LH-Anstieg & Spitzentage',
+    description: 'Fruchtbares Fenster berechnen — 10-Tage-Fenster, LH-Anstieg, tägliche Empfängniswahrscheinlichkeit nach Wilcox 1995. Tipps für den Kinderwunsch.',
+    date: '2026-05-10',
+    readTime: '8 min',
+    calculatorKey: 'fertilityWindow',
+    related: ['eisprung-berechnen', 'zyklusrechner-guide', 'geburtstermin-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/fertilityWindow.json
+++ b/src/locales/calculators/de/fertilityWindow.json
@@ -1,0 +1,75 @@
+{
+  "home": {
+    "calculators": {
+      "fertilityWindow": {
+        "name": "Fruchtbares Fenster Rechner",
+        "description": "Berechne dein erweitertes fruchtbares Fenster mit LH-Anstieg und Spitzentagen."
+      }
+    }
+  },
+  "fertilityWindow": {
+    "meta": {
+      "title": "Fruchtbares Fenster Rechner — Erweitertes Fenster mit LH-Anstieg",
+      "description": "Berechne dein fruchtbares Fenster mit LH-Anstieg und Empfängniswahrscheinlichkeit pro Tag. 10-Tage-Fenster, Spitzenfruchtbarkeit und Tipps für den Kinderwunsch. Kostenlos, ohne Anmeldung."
+    },
+    "title": "Fruchtbares Fenster Rechner",
+    "description": "Ermittle dein erweitertes 10-Tage-Fenster mit LH-Anstieg, Spitzentagen und Empfängniswahrscheinlichkeit.",
+    "lmp": "Erster Tag deiner letzten Periode",
+    "cycleLength": "Zykluslänge (Tage)",
+    "ovulationDay": "Eisprung",
+    "expandedWindow": "Erweitertes Fenster (10 Tage)",
+    "coreWindow": "Klassisches Fenster (7 Tage)",
+    "peakFertility": "Spitzenfruchtbarkeit (3 Tage)",
+    "lhSurge": "LH-Anstieg",
+    "nextPeriod": "Nächste Periode",
+    "eggViable": "Eizelle befruchtungsfähig",
+    "dailyForecast": "Tägliche Empfängniswahrscheinlichkeit",
+    "day": "Tag",
+    "date": "Datum",
+    "phase": "Phase",
+    "probability": "Wahrscheinlichkeit",
+    "phaseOvulation": "Eisprung",
+    "phaseLhSurge": "LH-Anstieg",
+    "phasePeak": "Spitzenfruchtbarkeit",
+    "phaseCore": "Fruchtbar",
+    "phaseExpanded": "Erweitert fruchtbar",
+    "phaseNone": "Nicht fruchtbar",
+    "highest": "Höchste",
+    "high": "Hoch",
+    "moderate": "Moderat",
+    "low": "Niedrig",
+    "veryLow": "Sehr niedrig",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner schätzt deinen Eisprung mit der Formel LMP + Zykluslänge − 14. Da Spermien bis zu 5 Tage überleben und die Eizelle 12–24 Stunden befruchtungsfähig bleibt, ergibt sich ein erweitertes fruchtbares Fenster von 10 Tagen (7 Tage vor bis 2 Tage nach Eisprung). Die LH-Welle steigt 24–36 Stunden vor dem Eisprung an. Tägliche Empfängniswahrscheinlichkeiten basieren auf Wilcox et al. 1995.",
+    "linkOvulation": "Eisprungrechner",
+    "linkPeriod": "Zyklusrechner",
+    "linkPregnancy": "Geburtstermin-Rechner",
+    "source": "Quelle: Wilcox AJ et al., NEJM 1995 — Timing of Sexual Intercourse in Relation to Ovulation",
+    "faq": [
+      {
+        "q": "Was ist das erweiterte fruchtbare Fenster?",
+        "a": "Während das klassische Fenster 6 Tage umfasst (5 vor Eisprung + Eisprungtag), erweitert dieser Rechner es auf 10 Tage. Spermien können selten 6–7 Tage überleben, und der Eisprungzeitpunkt schwankt. Das erweiterte Fenster gibt mehr Sicherheit beim Kinderwunsch."
+      },
+      {
+        "q": "Was bedeutet der LH-Anstieg?",
+        "a": "Das luteinisierende Hormon (LH) steigt 24–36 Stunden vor dem Eisprung sprunghaft an. LH-Tests aus der Apotheke erkennen diesen Anstieg im Urin und sind die zuverlässigste Methode zur Vorhersage."
+      },
+      {
+        "q": "An welchem Tag ist die Empfängniswahrscheinlichkeit am höchsten?",
+        "a": "Am Eisprungtag selbst (~33 %) und am Tag davor (~31 %). Geschlechtsverkehr alle 1–2 Tage während der Spitzenfruchtbarkeit (Tag −2 bis Eisprungtag) maximiert die Chance."
+      },
+      {
+        "q": "Wie genau ist die Berechnung?",
+        "a": "Bei regelmäßigem Zyklus (Schwankung ≤ 2 Tage) trifft die Schätzung in ~80 % der Fälle. Bei unregelmäßigem Zyklus, PCOS oder Stillzeit ist die Genauigkeit niedriger — kombiniere dann mit LH-Tests und Basaltemperatur."
+      },
+      {
+        "q": "Was, wenn mein Zyklus länger oder kürzer als 28 Tage ist?",
+        "a": "Die Lutealphase (nach Eisprung) bleibt fast immer 14 Tage konstant. Bei einem 35-Tage-Zyklus erfolgt der Eisprung an Tag 21, bei einem 24-Tage-Zyklus an Tag 10. Der Rechner berücksichtigt das automatisch."
+      },
+      {
+        "q": "Kann ich das fruchtbare Fenster zur Verhütung nutzen?",
+        "a": "Nein. Symptothermale Methoden (NFP) brauchen zusätzlich Basaltemperatur und Zervixschleim. Kalenderbasierte Berechnungen alleine haben einen Pearl-Index von 9–40 und sind nicht zur Verhütung geeignet."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/fertilityWindow.json
+++ b/src/locales/calculators/en/fertilityWindow.json
@@ -1,0 +1,75 @@
+{
+  "home": {
+    "calculators": {
+      "fertilityWindow": {
+        "name": "Fertility Window Calculator",
+        "description": "Calculate your expanded fertility window with LH surge and daily conception probability."
+      }
+    }
+  },
+  "fertilityWindow": {
+    "meta": {
+      "title": "Fertility Window Calculator — Expanded Window with LH Surge",
+      "description": "Calculate your fertility window with LH surge and daily conception probabilities. 10-day expanded window, peak days, and tips for trying to conceive. Free, no signup."
+    },
+    "title": "Fertility Window Calculator",
+    "description": "Find your expanded 10-day fertility window with LH surge, peak days, and conception probability.",
+    "lmp": "First day of last period",
+    "cycleLength": "Cycle length (days)",
+    "ovulationDay": "Ovulation",
+    "expandedWindow": "Expanded window (10 days)",
+    "coreWindow": "Classic window (7 days)",
+    "peakFertility": "Peak fertility (3 days)",
+    "lhSurge": "LH surge",
+    "nextPeriod": "Next period",
+    "eggViable": "Egg viable",
+    "dailyForecast": "Daily conception probability",
+    "day": "Day",
+    "date": "Date",
+    "phase": "Phase",
+    "probability": "Probability",
+    "phaseOvulation": "Ovulation",
+    "phaseLhSurge": "LH surge",
+    "phasePeak": "Peak fertility",
+    "phaseCore": "Fertile",
+    "phaseExpanded": "Extended fertile",
+    "phaseNone": "Not fertile",
+    "highest": "Highest",
+    "high": "High",
+    "moderate": "Moderate",
+    "low": "Low",
+    "veryLow": "Very low",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator estimates ovulation as LMP + cycle length − 14. Because sperm survive up to 5 days and the egg stays viable 12–24 hours, the expanded fertility window covers 10 days (7 days before to 2 days after ovulation). The LH surge starts 24–36 hours before ovulation. Daily conception probabilities are based on Wilcox et al. 1995.",
+    "linkOvulation": "Ovulation calculator",
+    "linkPeriod": "Period calculator",
+    "linkPregnancy": "Due date calculator",
+    "source": "Source: Wilcox AJ et al., NEJM 1995 — Timing of Sexual Intercourse in Relation to Ovulation",
+    "faq": [
+      {
+        "q": "What is the expanded fertility window?",
+        "a": "The classic window covers 6 days (5 before ovulation + the ovulation day). This calculator extends it to 10 days. Sperm occasionally survive 6–7 days, and ovulation timing varies. The expanded window gives more confidence when trying to conceive."
+      },
+      {
+        "q": "What does the LH surge mean?",
+        "a": "Luteinizing hormone (LH) spikes 24–36 hours before ovulation. Over-the-counter LH urine tests detect this surge and are the most reliable predictor of imminent ovulation."
+      },
+      {
+        "q": "Which day has the highest conception probability?",
+        "a": "Ovulation day (~33 %) and the day before (~31 %). Intercourse every 1–2 days during the peak window (day −2 to ovulation day) maximizes your chance."
+      },
+      {
+        "q": "How accurate is the prediction?",
+        "a": "For regular cycles (variation ≤ 2 days) the estimate hits in roughly 80 % of cases. For irregular cycles, PCOS, or breastfeeding, accuracy drops — combine with LH tests and basal body temperature."
+      },
+      {
+        "q": "What if my cycle is longer or shorter than 28 days?",
+        "a": "The luteal phase (post-ovulation) is almost always 14 days. In a 35-day cycle ovulation is on day 21; in a 24-day cycle it is on day 10. The calculator adjusts automatically."
+      },
+      {
+        "q": "Can I use this for contraception?",
+        "a": "No. Sympto-thermal methods (NFP) require basal body temperature and cervical mucus on top of calendar tracking. Calendar-only predictions have a Pearl Index of 9–40 and are not safe contraception."
+      }
+    ]
+  }
+}

--- a/src/pages/FertilityWindowCalculator.vue
+++ b/src/pages/FertilityWindowCalculator.vue
@@ -1,0 +1,198 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  addDays,
+  calcFertilityWindow,
+  getDayLabel,
+  conceptionProbability,
+} from '../utils/fertilityWindow.js'
+
+const { t, locale, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('fertilityWindow.faq') || [])
+
+useHead(() => ({
+  title: t('fertilityWindow.meta.title'),
+  description: t('fertilityWindow.meta.description'),
+  routeKey: 'fertilityWindow',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalWebPage',
+    name: 'Fertility Window Calculator',
+    url: 'https://healthcalculator.app/en/fertility-window-calculator',
+    about: { '@type': 'MedicalCondition', name: 'Fertility' },
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const lmp = ref('')
+const cycleLength = ref(28)
+
+const lmpDate = computed(() => lmp.value ? new Date(lmp.value + 'T00:00:00') : null)
+const window = computed(() => calcFertilityWindow(lmpDate.value, cycleLength.value))
+
+function formatDate(date) {
+  if (!date) return ''
+  return date.toLocaleDateString(locale.value === 'de' ? 'de-DE' : 'en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+function formatShort(date) {
+  if (!date) return ''
+  return date.toLocaleDateString(locale.value === 'de' ? 'de-DE' : 'en-US', { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+const dailyForecast = computed(() => {
+  if (!window.value) return []
+  const ov = window.value.ovulation
+  const days = []
+  for (let offset = -7; offset <= 2; offset++) {
+    const date = addDays(ov, offset)
+    const phase = getDayLabel(date, window.value)
+    const probability = conceptionProbability(offset)
+    days.push({ offset, date, phase, probability })
+  }
+  return days
+})
+
+function phaseStyle(phase) {
+  switch (phase) {
+    case 'ovulation': return 'bg-rose-600 text-white'
+    case 'lhSurge': return 'bg-rose-500 text-white'
+    case 'peak': return 'bg-rose-400 text-white'
+    case 'core': return 'bg-rose-200 text-rose-900'
+    case 'expanded': return 'bg-rose-50 text-rose-700'
+    default: return 'bg-stone-50 text-stone-500'
+  }
+}
+
+function probabilityLabel(p) {
+  if (p >= 0.30) return t('fertilityWindow.highest')
+  if (p >= 0.20) return t('fertilityWindow.high')
+  if (p >= 0.13) return t('fertilityWindow.moderate')
+  if (p > 0) return t('fertilityWindow.low')
+  return t('fertilityWindow.veryLow')
+}
+
+const hasResults = computed(() => !!window.value)
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('fertilityWindow.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('fertilityWindow.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid gap-6 sm:grid-cols-2">
+      <div>
+        <label for="lmp" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('fertilityWindow.lmp') }}</label>
+        <input id="lmp" v-model="lmp" type="date" data-testid="lmp"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label for="cycle" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('fertilityWindow.cycleLength') }}</label>
+        <input id="cycle" v-model.number="cycleLength" type="number" min="21" max="45" data-testid="cycle-length"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="hasResults" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-6">
+      <div class="rounded-xl border border-rose-200 bg-rose-50 p-5 text-center">
+        <div class="text-xs font-semibold text-rose-600 uppercase tracking-widest mb-1">{{ t('fertilityWindow.ovulationDay') }}</div>
+        <div class="text-xl font-bold text-stone-900" data-testid="ovulation-date">{{ formatDate(window.ovulation) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('fertilityWindow.peakFertility') }}</div>
+        <div class="text-sm font-bold text-stone-900" data-testid="peak-window">{{ formatShort(window.peakStart) }} – {{ formatShort(window.peakEnd) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('fertilityWindow.expandedWindow') }}</div>
+        <div class="text-sm font-bold text-stone-900" data-testid="expanded-window">{{ formatShort(window.expandedStart) }} – {{ formatShort(window.expandedEnd) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('fertilityWindow.lhSurge') }}</div>
+        <div class="text-sm font-bold text-stone-900" data-testid="lh-surge">{{ formatShort(window.lhSurgeStart) }} – {{ formatShort(window.lhSurgeEnd) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('fertilityWindow.coreWindow') }}</div>
+        <div class="text-sm font-bold text-stone-900" data-testid="core-window">{{ formatShort(window.coreStart) }} – {{ formatShort(window.coreEnd) }}</div>
+      </div>
+      <div class="rounded-xl border border-stone-200 p-5 text-center">
+        <div class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-1">{{ t('fertilityWindow.nextPeriod') }}</div>
+        <div class="text-sm font-bold text-stone-900" data-testid="next-period">{{ formatShort(window.nextPeriod) }}</div>
+      </div>
+    </div>
+
+    <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('fertilityWindow.dailyForecast') }}</h2>
+    <div class="overflow-hidden rounded-lg border border-stone-200">
+      <table class="w-full text-sm" data-testid="forecast-table">
+        <thead>
+          <tr class="bg-stone-50 border-b border-stone-200">
+            <th class="text-left px-4 py-3 font-semibold text-stone-700">{{ t('fertilityWindow.day') }}</th>
+            <th class="text-left px-4 py-3 font-semibold text-stone-700">{{ t('fertilityWindow.date') }}</th>
+            <th class="text-left px-4 py-3 font-semibold text-stone-700">{{ t('fertilityWindow.phase') }}</th>
+            <th class="text-left px-4 py-3 font-semibold text-stone-700">{{ t('fertilityWindow.probability') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-stone-100">
+          <tr v-for="row in dailyForecast" :key="row.offset" data-testid="forecast-row">
+            <td class="px-4 py-3 text-stone-700 font-medium tabular-nums">
+              <span v-if="row.offset === 0">0</span>
+              <span v-else-if="row.offset > 0">+{{ row.offset }}</span>
+              <span v-else>{{ row.offset }}</span>
+            </td>
+            <td class="px-4 py-3 text-stone-700 tabular-nums">{{ formatShort(row.date) }}</td>
+            <td class="px-4 py-3">
+              <span :class="phaseStyle(row.phase)" class="inline-block rounded px-2 py-1 text-xs font-semibold">
+                {{ t('fertilityWindow.phase' + (row.phase ? row.phase.charAt(0).toUpperCase() + row.phase.slice(1) : 'None')) }}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-stone-700 tabular-nums">
+              <span v-if="row.probability > 0">{{ (row.probability * 100).toFixed(0) }} %</span>
+              <span v-else class="text-stone-400">—</span>
+              <span class="text-xs text-stone-400 ml-2">{{ probabilityLabel(row.probability) }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="text-xs text-stone-400 mt-4">{{ t('fertilityWindow.source') }}</p>
+  </div>
+
+  <div class="flex flex-wrap gap-3 mb-6 text-sm">
+    <router-link :to="localePath('ovulation')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('fertilityWindow.linkOvulation') }}
+    </router-link>
+    <span class="text-stone-300">&middot;</span>
+    <router-link :to="localePath('period')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('fertilityWindow.linkPeriod') }}
+    </router-link>
+    <span class="text-stone-300">&middot;</span>
+    <router-link :to="localePath('dueDate')" class="text-stone-500 hover:text-stone-800 underline underline-offset-2 transition-colors">
+      {{ t('fertilityWindow.linkPregnancy') }}
+    </router-link>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('fertilityWindow.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('fertilityWindow.howItWorksText') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="fertilityWindow" />
+</template>

--- a/src/pages/blog/FruchtbaresFensterBerechnen.vue
+++ b/src/pages/blog/FruchtbaresFensterBerechnen.vue
@@ -1,0 +1,208 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Fruchtbares Fenster berechnen: 10 Tage, LH-Anstieg & Spitzentage | Health Calculators',
+  description: 'Fruchtbares Fenster berechnen — 10-Tage-Fenster, LH-Anstieg, tägliche Empfängniswahrscheinlichkeit nach Wilcox 1995. Tipps für den Kinderwunsch.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: 'Fruchtbares Fenster berechnen: 10 Tage, LH-Anstieg & Spitzentage',
+    description: 'Fruchtbares Fenster berechnen — 10-Tage-Fenster, LH-Anstieg, tägliche Empfängniswahrscheinlichkeit nach Wilcox 1995.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-10',
+    dateModified: '2026-05-10',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/fruchtbares-fenster-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">
+        &larr; Blog
+      </router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">
+        Fruchtbares Fenster berechnen: 10 Tage, LH-Anstieg &amp; Spitzentage
+      </h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">10. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das <strong>fruchtbare Fenster</strong> ist die Zeit im Zyklus, in der eine Empfängnis möglich ist. Die meisten Rechner zeigen 6 Tage — biologisch sinnvoll sind aber bis zu 10.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Guide erfährst du, wie das erweiterte Fenster, der LH-Anstieg und die Spitzentage zusammenhängen — und wann die Empfängniswahrscheinlichkeit am höchsten ist.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Klassisches vs. erweitertes fruchtbares Fenster</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das <strong>klassische Fenster</strong> umfasst 6 Tage: 5 Tage vor dem Eisprung plus den Eisprungtag selbst. Die Logik: Spermien überleben bis zu 5 Tage im Zervixschleim, die Eizelle bleibt 12–24 Stunden befruchtungsfähig.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das <strong>erweiterte Fenster</strong> spannt sich über 10 Tage — von Tag −7 bis Tag +2 relativ zum Eisprung. Es trägt Schwankungen im Eisprungzeitpunkt und seltener Spermienlangzeit-Überleben Rechnung.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+          <p class="text-base font-semibold text-stone-900 mb-2">Warum 10 Tage?</p>
+          <p class="text-sm text-stone-500 leading-relaxed">
+            Studien zeigen: Der tatsächliche Eisprungtag streut bei „regelmäßigen" Frauen um ±2 Tage. Wer das Fenster auf 10 Tage erweitert, verpasst auch bei abweichendem Zyklus keinen fruchtbaren Tag.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Der LH-Anstieg — der zuverlässigste Marker</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das <strong>luteinisierende Hormon</strong> (LH) steigt 24–36 Stunden vor dem Eisprung sprunghaft an. Dieser <em>LH-Surge</em> löst den Eisprung aus.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          LH-Tests aus der Apotheke (auch „Ovulationstests") messen das Hormon im Urin. Ein positiver Test bedeutet: Der Eisprung kommt innerhalb der nächsten 1–2 Tage.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+          <p class="text-base font-semibold text-stone-900 mb-2">Tipp</p>
+          <p class="text-sm text-stone-500 leading-relaxed">
+            Ab 3–4 Tagen vor dem berechneten Eisprung täglich testen — am besten am späten Vormittag oder frühen Nachmittag. Morgen-Urin kann den Anstieg verfälschen.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Empfängniswahrscheinlichkeit pro Tag</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Klassikstudie von <strong>Wilcox et al. 1995</strong> (NEJM) hat erstmals tägliche Empfängniswahrscheinlichkeiten bestimmt. Die Daten:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Tag</th>
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Wahrscheinlichkeit</th>
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Bewertung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-4 py-2 tabular-nums">−5</td><td class="px-4 py-2 tabular-nums">10 %</td><td class="px-4 py-2 text-stone-600">Niedrig</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−4</td><td class="px-4 py-2 tabular-nums">16 %</td><td class="px-4 py-2 text-stone-600">Moderat</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−3</td><td class="px-4 py-2 tabular-nums">14 %</td><td class="px-4 py-2 text-stone-600">Moderat</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−2</td><td class="px-4 py-2 tabular-nums">27 %</td><td class="px-4 py-2 text-rose-700 font-semibold">Hoch</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−1</td><td class="px-4 py-2 tabular-nums">31 %</td><td class="px-4 py-2 text-rose-700 font-semibold">Sehr hoch</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">0 (Eisprung)</td><td class="px-4 py-2 tabular-nums">33 %</td><td class="px-4 py-2 text-rose-700 font-semibold">Höchste</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">+1</td><td class="px-4 py-2 tabular-nums">10 %</td><td class="px-4 py-2 text-stone-600">Niedrig</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die <strong>Spitzentage</strong> (Tag −2 bis Eisprungtag) bringen ~90 % aller Schwangerschaften zustande. Wer plant, sollte hier den Schwerpunkt setzen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">So nutzt du das fruchtbare Fenster richtig</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">1. Zykluslänge bestimmen</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Tracke deinen Zyklus mindestens 3 Monate. Der erste Tag der Periode = Tag 1. Bilde den Mittelwert.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">2. Fenster mit Rechner ermitteln</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Trage letzten Periodenbeginn und Zykluslänge in den Rechner ein. Du bekommst dein 10-Tage-Fenster mit Tagesprognose.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">3. LH-Tests in der zweiten Wochenhälfte</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Ab Tag −4 täglich testen, bis der Test positiv wird. Der Eisprung folgt in 24–36 Stunden.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">4. Geschlechtsverkehr alle 1–2 Tage</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Während der Spitzentage (Tag −2 bis Tag 0). Tägliches Timing bringt keinen Vorteil — Spermienqualität bleibt bei 1–2 Tagen Abstand optimal.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was, wenn der Zyklus unregelmäßig ist?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei Schwankungen &gt; 7 Tagen oder Zyklen außerhalb von 21–35 Tagen ist die Kalendermethode ungenau. Hier helfen:
+        </p>
+        <ul class="list-disc pl-6 space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>LH-Tests</strong> — direkt am Anstieg orientieren</li>
+          <li><strong>Basaltemperatur</strong> — bestätigt Eisprung im Nachhinein (Anstieg um 0,2–0,5 °C)</li>
+          <li><strong>Zervixschleim</strong> — klar und spinnbar zur Spitzenfruchtbarkeit</li>
+          <li><strong>Ovulationsmonitore</strong> — kombinieren mehrere Hormone (LH + Estradiol)</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei PCOS, sehr unregelmäßigen Zyklen oder fehlendem Eisprung sollte ein Frauenarzt zu Rate gezogen werden.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Fruchtbares Fenster jetzt berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">10-Tage-Fenster mit LH-Anstieg und Tages-Wahrscheinlichkeit — kostenlos.</p>
+        <router-link
+          :to="localePath('fertilityWindow')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >
+          Jetzt kostenlos berechnen &rarr;
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <router-link :to="localePath('ovulation')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Eisprungrechner</p>
+            <p class="text-sm text-stone-500">Berechne nur den Eisprungtag</p>
+          </router-link>
+          <router-link :to="localePath('period')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Zyklusrechner</p>
+            <p class="text-sm text-stone-500">Periode &amp; Zyklusphasen</p>
+          </router-link>
+          <router-link :to="localePath('dueDate')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Geburtstermin-Rechner</p>
+            <p class="text-sm text-stone-500">Wann ist die Geburt?</p>
+          </router-link>
+        </div>
+      </div>
+
+      <!-- Conclusion -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das fruchtbare Fenster ist mehr als 6 Tage — biologisch sinnvoll sind 10. Kombiniere Kalenderberechnung mit LH-Tests, um die Spitzentage zuverlässig zu treffen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Hinweis: Kein Rechner ersetzt eine medizinische Beratung. Bei länger als 12 Monaten erfolgloser Schwangerschaftsplanung (oder 6 Monaten bei Frauen über 35) sprich mit einem Reproduktionsmediziner.
+        </p>
+      </div>
+
+      <RelatedArticles slug="fruchtbares-fenster-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/FertilityWindowGuide.vue
+++ b/src/pages/blog/en/FertilityWindowGuide.vue
@@ -1,0 +1,208 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Fertility Window Calculator: 10 Days, LH Surge & Peak Days | Health Calculators',
+  description: 'Calculate your fertility window — 10-day expanded window, LH surge, daily conception probability from Wilcox 1995. Practical tips for trying to conceive.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: 'Fertility Window Calculator: 10 Days, LH Surge & Peak Days',
+    description: 'Calculate your fertility window — 10-day expanded window, LH surge, daily conception probability from Wilcox 1995.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-10',
+    dateModified: '2026-05-10',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/fertility-window-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">
+        &larr; Blog
+      </router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">
+        Fertility Window Calculator: 10 Days, LH Surge &amp; Peak Days
+      </h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 10, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>fertility window</strong> is the time in your cycle when conception is possible. Most calculators show six days — biologically, ten makes more sense.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how the expanded window, the LH surge, and the peak days fit together — and when conception probability is highest.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Classic vs. expanded fertility window</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>classic window</strong> covers six days: five days before ovulation plus ovulation day itself. The logic: sperm survive up to five days in cervical mucus, while the egg is fertilizable for only 12–24 hours.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>expanded window</strong> covers ten days — from day −7 to day +2 relative to ovulation. It accounts for variability in ovulation timing and occasional long sperm survival.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+          <p class="text-base font-semibold text-stone-900 mb-2">Why ten days?</p>
+          <p class="text-sm text-stone-500 leading-relaxed">
+            Research shows actual ovulation day varies by ±2 days even in "regular" cycles. A ten-day window catches every fertile day, even when ovulation drifts.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The LH surge — the most reliable marker</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Luteinizing hormone</strong> (LH) spikes 24–36 hours before ovulation. This <em>LH surge</em> triggers ovulation itself.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Over-the-counter LH tests (also called "ovulation tests") detect the hormone in urine. A positive test means ovulation will occur within the next 1–2 days.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+          <p class="text-base font-semibold text-stone-900 mb-2">Tip</p>
+          <p class="text-sm text-stone-500 leading-relaxed">
+            Start testing 3–4 days before predicted ovulation. Late morning or early afternoon urine is best — first-morning urine can distort the result.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Daily conception probability</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The landmark <strong>Wilcox et al. 1995</strong> NEJM study first quantified daily conception probabilities:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Day</th>
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Probability</th>
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Rating</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-4 py-2 tabular-nums">−5</td><td class="px-4 py-2 tabular-nums">10 %</td><td class="px-4 py-2 text-stone-600">Low</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−4</td><td class="px-4 py-2 tabular-nums">16 %</td><td class="px-4 py-2 text-stone-600">Moderate</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−3</td><td class="px-4 py-2 tabular-nums">14 %</td><td class="px-4 py-2 text-stone-600">Moderate</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−2</td><td class="px-4 py-2 tabular-nums">27 %</td><td class="px-4 py-2 text-rose-700 font-semibold">High</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">−1</td><td class="px-4 py-2 tabular-nums">31 %</td><td class="px-4 py-2 text-rose-700 font-semibold">Very high</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">0 (ovulation)</td><td class="px-4 py-2 tabular-nums">33 %</td><td class="px-4 py-2 text-rose-700 font-semibold">Highest</td></tr>
+              <tr><td class="px-4 py-2 tabular-nums">+1</td><td class="px-4 py-2 tabular-nums">10 %</td><td class="px-4 py-2 text-stone-600">Low</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The <strong>peak days</strong> (day −2 through ovulation day) account for roughly 90 % of pregnancies in the data. If you are trying to conceive, this is where to focus.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How to use the fertility window</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">1. Track your cycle length</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Track at least three months. Day 1 = first day of your period. Take the average.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">2. Calculate your window</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Enter your last period start and cycle length. The calculator returns a 10-day window with daily probabilities.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">3. Use LH tests in the second half</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              From day −4 onward test daily until positive. Ovulation follows 24–36 hours later.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">4. Intercourse every 1–2 days</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              During peak days (day −2 to day 0). Daily intercourse gives no benefit — sperm quality is best with 1–2 day spacing.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What if my cycle is irregular?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          If your cycle varies by more than 7 days or falls outside 21–35 days, calendar prediction is unreliable. Better tools:
+        </p>
+        <ul class="list-disc pl-6 space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>LH tests</strong> — track the surge directly</li>
+          <li><strong>Basal body temperature</strong> — confirms ovulation retrospectively (0.2–0.5 °C rise)</li>
+          <li><strong>Cervical mucus</strong> — clear and stretchy at peak fertility</li>
+          <li><strong>Fertility monitors</strong> — combine LH + estradiol detection</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For PCOS, very irregular cycles, or absent ovulation, see a gynecologist.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your fertility window</h3>
+        <p class="text-stone-300 text-sm mb-5">10-day window with LH surge and daily probability — free.</p>
+        <router-link
+          :to="localePath('fertilityWindow')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >
+          Calculate now &rarr;
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <router-link :to="localePath('ovulation')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Ovulation calculator</p>
+            <p class="text-sm text-stone-500">Just the ovulation day</p>
+          </router-link>
+          <router-link :to="localePath('period')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Period calculator</p>
+            <p class="text-sm text-stone-500">Periods &amp; cycle phases</p>
+          </router-link>
+          <router-link :to="localePath('dueDate')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Due date calculator</p>
+            <p class="text-sm text-stone-500">Estimate your due date</p>
+          </router-link>
+        </div>
+      </div>
+
+      <!-- Conclusion -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Your fertility window is more than six days — ten makes biological sense. Combine calendar tracking with LH tests to hit the peak days reliably.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Note: no calculator replaces medical advice. If you have been trying for 12 months (or 6 months if over 35) without success, see a reproductive specialist.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="fertility-window-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/fertilityWindow.meta.js
+++ b/src/pages/fertilityWindow.meta.js
@@ -1,0 +1,16 @@
+import Component from './FertilityWindowCalculator.vue'
+import BlogDe from './blog/FruchtbaresFensterBerechnen.vue'
+import BlogEn from './blog/en/FertilityWindowGuide.vue'
+
+export default {
+  key: 'fertilityWindow',
+  component: Component,
+  slugs: { de: 'fruchtbares-fenster-rechner', en: 'fertility-window-calculator' },
+  group: 'pregnancy',
+  groupOrder: 3,
+  order: 1.1,
+  blog: {
+    de: { slug: 'fruchtbares-fenster-berechnen', component: BlogDe },
+    en: { slug: 'fertility-window-guide', component: BlogEn },
+  },
+}

--- a/src/utils/fertilityWindow.js
+++ b/src/utils/fertilityWindow.js
@@ -1,0 +1,86 @@
+// Fertility Window — expanded fertility window with LH surge and peak fertility.
+// Based on LMP (last menstrual period) + cycle length.
+//
+// Sperm survive up to 5 days in cervical mucus. Egg viable ~12–24 h after ovulation.
+// LH surge occurs 24–36 h before ovulation.
+//
+// Phases (relative to estimated ovulation day O):
+//   - expanded fertility window: O-7 … O+2 (10 days, conservative)
+//   - core fertility window:     O-5 … O+1 (7 days, classic 6-day window + safety buffer)
+//   - peak fertility:            O-2 … O   (3 days, highest conception probability)
+//   - LH surge:                  O-1 … O   (24–36 h before ovulation)
+//   - egg viable:                O    … O+1
+//   - ovulation day:             O = LMP + cycleLength - 14
+//
+// Pure date math — no side effects.
+
+export function addDays(date, days) {
+  if (!(date instanceof Date) || isNaN(date)) return null
+  const d = new Date(date)
+  d.setDate(d.getDate() + days)
+  return d
+}
+
+export function calcOvulationDay(lmpDate, cycleLength) {
+  if (!(lmpDate instanceof Date) || isNaN(lmpDate)) return null
+  if (!cycleLength || cycleLength < 21 || cycleLength > 45) return null
+  return addDays(lmpDate, cycleLength - 14)
+}
+
+export function calcFertilityWindow(lmpDate, cycleLength) {
+  const ovulation = calcOvulationDay(lmpDate, cycleLength)
+  if (!ovulation) return null
+  return {
+    ovulation,
+    expandedStart: addDays(ovulation, -7),
+    expandedEnd: addDays(ovulation, 2),
+    coreStart: addDays(ovulation, -5),
+    coreEnd: addDays(ovulation, 1),
+    peakStart: addDays(ovulation, -2),
+    peakEnd: ovulation,
+    lhSurgeStart: addDays(ovulation, -1),
+    lhSurgeEnd: ovulation,
+    eggViableStart: ovulation,
+    eggViableEnd: addDays(ovulation, 1),
+    nextPeriod: addDays(lmpDate, cycleLength),
+  }
+}
+
+export function getDayLabel(date, window) {
+  if (!date || !window) return null
+  const t = startOfDay(date).getTime()
+  const ov = startOfDay(window.ovulation).getTime()
+  if (t === ov) return 'ovulation'
+  if (t >= startOfDay(window.lhSurgeStart).getTime() && t <= startOfDay(window.lhSurgeEnd).getTime()) return 'lhSurge'
+  if (t >= startOfDay(window.peakStart).getTime() && t <= startOfDay(window.peakEnd).getTime()) return 'peak'
+  if (t >= startOfDay(window.coreStart).getTime() && t <= startOfDay(window.coreEnd).getTime()) return 'core'
+  if (t >= startOfDay(window.expandedStart).getTime() && t <= startOfDay(window.expandedEnd).getTime()) return 'expanded'
+  return null
+}
+
+function startOfDay(date) {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+export function daysBetween(a, b) {
+  if (!a || !b) return null
+  const ms = startOfDay(b).getTime() - startOfDay(a).getTime()
+  return Math.round(ms / 86400000)
+}
+
+export function conceptionProbability(daysBeforeOvulation) {
+  // Approximate per-cycle conception probability by timing of intercourse
+  // relative to ovulation (Wilcox et al. 1995, simplified).
+  const table = {
+    [-5]: 0.10,
+    [-4]: 0.16,
+    [-3]: 0.14,
+    [-2]: 0.27,
+    [-1]: 0.31,
+    [0]: 0.33,
+    [1]: 0.10,
+  }
+  return table[daysBeforeOvulation] ?? 0
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-136-fertility-window
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-136-fertility-window-20260510-220030`
**Cost:** $8.190651250000002

Closes jenslaufer/health-calculators#136

### Prompt
> Implement the Fertility Window Calculator as described in issue #136.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Expanded fertility window with LH surge
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.


## PARTIAL-COMMIT GUARD (MANDATORY — added 2026-05-07 after FK #270 + HC #231 partial; validated 3-of-3 on FK #280 + HC #232 + HC #233, 4-of-3 on FK #281)
Before `git push`, run:
  git diff --name-only main..HEAD | sort

Output MUST contain ALL of these paths (substitute <DeBlogPascal> + <EnBlogPascal> with your chosen blog Vue component names):
  e2e/fertilityWindow.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/fertilityWindow.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/fertilityWindow.json
  src/locales/calculators/en/fertilityWindow.json
  src/pages/FertilityWindowCalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/fertilityWindow.meta.js
  src/utils/fertilityWindow.js

If ANY path is missing → DO NOT push. Stage + commit the missing files first.
Counter check: `git diff --name-only main..HEAD | wc -l` MUST be >= 14.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/fertilityWindow.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/fertilityWindow.test.js` with 6+ test cases covering edge cases. Run `npm test -- fertilityWindow` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/FertilityWindowCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/fertilityWindow.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/fertilityWindow.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'fertilityWindow'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/fertilityWindow.json` + `src/locales/calculators/en/fertilityWindow.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/fertilityWindow.js (or shared util — verify pattern in repo first)`
- `src/__tests__/fertilityWindow.test.js`
- `src/pages/FertilityWindowCalculator.vue`
- `src/pages/fertilityWindow.meta.js`
- `src/locales/calculators/de/fertilityWindow.json`
- `src/locales/calculators/en/fertilityWindow.json`
- `e2e/fertilityWindow.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'fertilityWindow',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks