### PR TITLE
Pearl-Index Rechner — contraceptive method effectiveness

### DIFF
--- a/e2e/pearlIndexRechner.spec.js
+++ b/e2e/pearlIndexRechner.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/pearl-index-rechner/')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Pearl-Index Rechner/)
+})
+
+test('renders mandatory medical disclaimer', async ({ page }) => {
+  const disclaimer = page.getByTestId('medical-disclaimer')
+  await expect(disclaimer).toBeVisible()
+  await expect(disclaimer).toContainText('ärztliche Verhütungsberatung')
+})
+
+test('shows H1 with calculator title', async ({ page }) => {
+  await expect(page.getByRole('heading', { level: 1, name: 'Pearl-Index Rechner' })).toBeVisible()
+})
+
+test('default values 100 women / 12 months / 1 pregnancy → PI 1,00', async ({ page }) => {
+  await page.getByTestId('women').fill('100')
+  await page.getByTestId('months').fill('12')
+  await page.getByTestId('pregnancies').fill('1')
+
+  const result = page.getByTestId('pearl-index-result')
+  await expect(result).toBeVisible()
+  await expect(result).toHaveText('1,00')
+})
+
+test('3 pregnancies / 100 women / 12 months → PI 3,00', async ({ page }) => {
+  await page.getByTestId('women').fill('100')
+  await page.getByTestId('months').fill('12')
+  await page.getByTestId('pregnancies').fill('3')
+
+  const result = page.getByTestId('pearl-index-result')
+  await expect(result).toHaveText('3,00')
+
+  const category = page.getByTestId('pearl-index-category')
+  await expect(category).toHaveText('Sicher')
+})
+
+test('0 pregnancies → PI 0,00 sehr sicher', async ({ page }) => {
+  await page.getByTestId('women').fill('100')
+  await page.getByTestId('months').fill('12')
+  await page.getByTestId('pregnancies').fill('0')
+
+  const result = page.getByTestId('pearl-index-result')
+  await expect(result).toHaveText('0,00')
+
+  await expect(page.getByTestId('pearl-index-category')).toHaveText('Sehr sicher')
+})
+
+test('reference table renders all methods', async ({ page }) => {
+  const table = page.getByTestId('reference-table')
+  await expect(table).toBeVisible()
+  const rows = page.getByTestId('reference-row')
+  await expect(rows).toHaveCount(17)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -25,7 +25,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
-  'pregnancyBMI', 'fertilityWindow',
+  'pregnancyBMI', 'fertilityWindow', 'pearlIndexRechner',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency']
@@ -105,6 +105,7 @@ const EXPECTED_ROUTE_MAP = {
   pediatricBloodPressure: { de: 'kinder-blutdruck-rechner', en: 'pediatric-blood-pressure-calculator' },
   pregnancyBMI: { de: 'bmi-schwangerschaft-rechner', en: 'pregnancy-bmi-calculator' },
   fertilityWindow: { de: 'fruchtbares-fenster-rechner', en: 'fertility-window-calculator' },
+  pearlIndexRechner: { de: 'pearl-index-rechner', en: 'pearl-index-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -171,6 +172,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'vitamin-d-mangel',
   'bmi-schwangerschaft-berechnen',
   'fruchtbares-fenster-berechnen',
+  'pearl-index-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -237,19 +239,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'vitamin-d-deficiency',
   'pregnancy-bmi-guide',
   'fertility-window-guide',
+  'pearl-index-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 76 calculators', () => {
-    expect(calculatorMetas).toHaveLength(76)
+  it('discovers all 77 calculators', () => {
+    expect(calculatorMetas).toHaveLength(77)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 76 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(76)
+  it('builds calculatorComponents map for all 77 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(77)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -272,15 +275,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 75 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(75)
+  it('discovers all 76 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 75 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(75)
+  it('discovers all 76 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -305,10 +308,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 76 calculators with no duplicates', () => {
+  it('groups contain all 77 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(76)
-    expect(new Set(allKeys).size).toBe(76)
+    expect(allKeys).toHaveLength(77)
+    expect(new Set(allKeys).size).toBe(77)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -335,7 +338,7 @@ describe('calculator groups', () => {
 
   it('pregnancy group has correct calculators in order', () => {
     expect(calculatorGroups[3].calculators).toEqual([
-      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'fertilityWindow', 'pregnancyBMI', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
+      'pregnancy', 'ovulation', 'pregnancyWeightGain', 'fertilityWindow', 'pregnancyBMI', 'pearlIndexRechner', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
       'babyMilestones', 'babyFeedingAmount', 'newbornBilirubin',
     ])
   })
@@ -378,8 +381,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 419 routes', () => {
-    expect(routes).toHaveLength(419)
+  it('generates exactly 424 routes', () => {
+    expect(routes).toHaveLength(424)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 302 links (76 calcs × 2 locales + 75 blogs × 2 locales)', () => {
+  it('generates 306 links (77 calcs × 2 locales + 76 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(302)
+    expect(links).toHaveLength(306)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/pearlIndexRechner.test.js
+++ b/src/__tests__/pearlIndexRechner.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { calcPearlIndex, classifyPearlIndex, referenceMethods } from '../utils/pearlIndexRechner.js'
+
+describe('calcPearlIndex', () => {
+  it('1 pregnancy / 100 women / 12 months = 1.0', () => {
+    expect(calcPearlIndex(1, 100, 12)).toBeCloseTo(1.0, 5)
+  })
+
+  it('0 pregnancies → 0', () => {
+    expect(calcPearlIndex(0, 100, 12)).toBe(0)
+  })
+
+  it('3 pregnancies / 50 women / 24 months = 3.0', () => {
+    // (3 × 1200) / (50 × 24) = 3600 / 1200 = 3
+    expect(calcPearlIndex(3, 50, 24)).toBeCloseTo(3.0, 5)
+  })
+
+  it('2 pregnancies / 200 women / 6 months = 2.0', () => {
+    // (2 × 1200) / (200 × 6) = 2400 / 1200 = 2
+    expect(calcPearlIndex(2, 200, 6)).toBeCloseTo(2.0, 5)
+  })
+
+  it('matches Pille typical PI: 9 pregnancies / 100 women / 12 months = 9', () => {
+    expect(calcPearlIndex(9, 100, 12)).toBeCloseTo(9, 5)
+  })
+
+  it('returns null for invalid women count', () => {
+    expect(calcPearlIndex(1, 0, 12)).toBeNull()
+    expect(calcPearlIndex(1, -10, 12)).toBeNull()
+  })
+
+  it('returns null for invalid months', () => {
+    expect(calcPearlIndex(1, 100, 0)).toBeNull()
+    expect(calcPearlIndex(1, 100, -3)).toBeNull()
+  })
+
+  it('returns null for negative pregnancies', () => {
+    expect(calcPearlIndex(-1, 100, 12)).toBeNull()
+  })
+
+  it('returns null for null inputs', () => {
+    expect(calcPearlIndex(null, 100, 12)).toBeNull()
+    expect(calcPearlIndex(1, null, 12)).toBeNull()
+    expect(calcPearlIndex(1, 100, null)).toBeNull()
+  })
+
+  it('returns null for NaN', () => {
+    expect(calcPearlIndex(NaN, 100, 12)).toBeNull()
+  })
+})
+
+describe('classifyPearlIndex', () => {
+  it('PI < 1 → verySafe', () => {
+    expect(classifyPearlIndex(0.1)).toBe('verySafe')
+    expect(classifyPearlIndex(0.9)).toBe('verySafe')
+  })
+
+  it('1 ≤ PI < 5 → safe', () => {
+    expect(classifyPearlIndex(1)).toBe('safe')
+    expect(classifyPearlIndex(4.9)).toBe('safe')
+  })
+
+  it('5 ≤ PI < 10 → moderate', () => {
+    expect(classifyPearlIndex(5)).toBe('moderate')
+    expect(classifyPearlIndex(9)).toBe('moderate')
+  })
+
+  it('10 ≤ PI < 25 → lowSafety', () => {
+    expect(classifyPearlIndex(10)).toBe('lowSafety')
+    expect(classifyPearlIndex(24)).toBe('lowSafety')
+  })
+
+  it('PI ≥ 25 → unsafe', () => {
+    expect(classifyPearlIndex(25)).toBe('unsafe')
+    expect(classifyPearlIndex(85)).toBe('unsafe')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(classifyPearlIndex(null)).toBeNull()
+    expect(classifyPearlIndex(NaN)).toBeNull()
+  })
+})
+
+describe('referenceMethods', () => {
+  it('contains key contraceptive methods', () => {
+    const keys = referenceMethods.map(m => m.key)
+    expect(keys).toContain('pillCombined')
+    expect(keys).toContain('condomMale')
+    expect(keys).toContain('iudCopper')
+    expect(keys).toContain('iudHormonal')
+    expect(keys).toContain('diaphragm')
+    expect(keys).toContain('nfpSymptothermal')
+  })
+
+  it('every entry has perfect and typical values', () => {
+    for (const m of referenceMethods) {
+      expect(typeof m.perfect).toBe('number')
+      expect(typeof m.typical).toBe('number')
+      expect(m.typical).toBeGreaterThanOrEqual(m.perfect)
+    }
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -19,7 +19,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
-  'pregnancyBMI', 'fertilityWindow',
+  'pregnancyBMI', 'fertilityWindow', 'pearlIndexRechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -85,6 +85,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'vitamin-d-mangel',
   'bmi-schwangerschaft-berechnen',
   'fruchtbares-fenster-berechnen',
+  'pearl-index-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -150,12 +151,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'vitamin-d-deficiency',
   'pregnancy-bmi-guide',
   'fertility-window-guide',
+  'pearl-index-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 76 calculator meta files', () => {
+  it('discovers all 77 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(76)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(77)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -193,19 +195,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 75 DE blog slugs', () => {
+  it('returns all 76 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(75)
+    expect(de).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 75 EN blog slugs', () => {
+  it('returns all 76 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(75)
+    expect(en).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -273,9 +275,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 152 calcs + 2 blog index + 150 blog articles = 306)', () => {
+  it('generates correct total URL count (2 home + 154 calcs + 2 blog index + 152 blog articles = 310)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(306)
+    expect(urlCount).toBe(310)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -674,6 +674,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'fertilityWindow',
     related: ['calculate-ovulation', 'period-calculator-guide', 'calculate-due-date'],
   },
+  {
+    slug: 'pearl-index-calculator-guide',
+    title: 'Pearl Index Calculator: Contraceptive Method Effectiveness',
+    description: 'Pearl Index explained — formula, perfect vs typical use, reference values for the pill, condoms, IUDs, NFP. Sources: BZgA, Trussell.',
+    date: '2026-05-11',
+    readTime: '8 min',
+    calculatorKey: 'pearlIndexRechner',
+    related: ['calculate-ovulation', 'period-calculator-guide', 'fertility-window-guide'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -674,6 +674,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'fertilityWindow',
     related: ['eisprung-berechnen', 'zyklusrechner-guide', 'geburtstermin-berechnen'],
   },
+  {
+    slug: 'pearl-index-berechnen',
+    title: 'Pearl-Index berechnen: Verhütungsmethoden im Vergleich',
+    description: 'Pearl-Index verstehen und berechnen — Formel, perfekte vs. typische Anwendung, Referenzwerte für Pille, Kondom, Spirale, NFP. Quellen: BZgA, Trussell.',
+    date: '2026-05-11',
+    readTime: '8 min',
+    calculatorKey: 'pearlIndexRechner',
+    related: ['eisprung-berechnen', 'zyklusrechner-guide', 'fruchtbares-fenster-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/pearlIndexRechner.json
+++ b/src/locales/calculators/de/pearlIndexRechner.json
@@ -1,0 +1,99 @@
+{
+  "home": {
+    "calculators": {
+      "pearlIndexRechner": {
+        "name": "Pearl-Index Rechner",
+        "description": "Berechne den Pearl-Index aus Studiendaten und vergleiche Verhütungsmethoden."
+      }
+    }
+  },
+  "pearlIndexRechner": {
+    "meta": {
+      "title": "Pearl-Index Rechner — Verhütungssicherheit berechnen & vergleichen",
+      "description": "Pearl-Index berechnen aus Studiendaten: PI = (Schwangerschaften × 1200) / (Frauen × Monate). Referenztabelle mit Pille, Kondom, Spirale, NFP & mehr. Quellen: BZgA, Trussell."
+    },
+    "title": "Pearl-Index Rechner",
+    "description": "Berechne den Pearl-Index aus Studiendaten und vergleiche Verhütungsmethoden anhand validierter Referenzwerte.",
+    "disclaimer": "Hinweis: Dieser Rechner dient ausschließlich der Information und Bildung. Er ist kein Ersatz für eine ärztliche Verhütungsberatung. Sprich für die Wahl der passenden Verhütungsmethode mit deiner Frauenärztin oder deinem Frauenarzt.",
+    "inputsTitle": "Studiendaten eingeben",
+    "women": "Anzahl der Frauen",
+    "womenHint": "z.B. 100",
+    "months": "Beobachtungszeit (Monate)",
+    "monthsHint": "z.B. 12 für ein Jahr",
+    "pregnancies": "Anzahl ungewollter Schwangerschaften",
+    "pregnanciesHint": "Im Beobachtungszeitraum aufgetretene Schwangerschaften",
+    "result": "Pearl-Index",
+    "resultUnit": "Schwangerschaften pro 100 Frauenjahre",
+    "resultExplain": "Bei {women} Frauen über {months} Monate entspricht der Pearl-Index {pi} Schwangerschaften pro 100 Frauenjahre.",
+    "verySafe": "Sehr sicher",
+    "safe": "Sicher",
+    "moderate": "Mäßig sicher",
+    "lowSafety": "Geringe Sicherheit",
+    "unsafe": "Unsicher",
+    "categoryHelp": "Klassifikation orientiert an WHO/BZgA: < 1 sehr sicher, 1–4 sicher, 5–9 mäßig, 10–24 gering, ≥ 25 unsicher.",
+    "exampleTitle": "Rechenbeispiel",
+    "exampleText": "100 Frauen verhüten 12 Monate lang mit einer Methode. In dieser Zeit treten 3 ungewollte Schwangerschaften auf. Pearl-Index = (3 × 1200) / (100 × 12) = 3,0. Das heißt: 3 von 100 Frauen werden bei einjähriger Anwendung schwanger.",
+    "referenceTitle": "Pearl-Index nach Verhütungsmethode",
+    "referenceIntro": "Typische Pearl-Indices etablierter Methoden bei perfekter und durchschnittlicher Anwendung. Quellen: BZgA, Deutsche Gesellschaft für Gynäkologie und Geburtshilfe (DGGG), Trussell 2011.",
+    "method": "Methode",
+    "perfectUse": "Perfekte Anwendung",
+    "typicalUse": "Typische Anwendung",
+    "methods": {
+      "pillCombined": "Kombinationspille",
+      "pillMini": "Minipille (Gestagen)",
+      "iudHormonal": "Hormonspirale (LNG-IUS)",
+      "iudCopper": "Kupferspirale",
+      "implant": "Hormonimplantat (Stäbchen)",
+      "depot": "Drei-Monats-Spritze",
+      "patch": "Verhütungspflaster",
+      "ring": "Vaginalring",
+      "condomMale": "Kondom (männlich)",
+      "condomFemale": "Femidom (Frauenkondom)",
+      "diaphragm": "Diaphragma + Spermizid",
+      "nfpSymptothermal": "NFP symptothermal (korrekt)",
+      "nfpCalendar": "Kalendermethode allein",
+      "withdrawal": "Coitus interruptus",
+      "sterilizationFemale": "Tubenligatur (Sterilisation Frau)",
+      "sterilizationMale": "Vasektomie (Sterilisation Mann)",
+      "noMethod": "Keine Verhütung"
+    },
+    "contentTitle": "Was sagt der Pearl-Index aus?",
+    "contentP1": "Der Pearl-Index ist das Standardmaß für die Sicherheit einer Verhütungsmethode. Er gibt an, wie viele von 100 Frauen schwanger werden, wenn sie ein Jahr lang ausschließlich diese Methode anwenden. Ein Pearl-Index von 1 bedeutet: eine von hundert Frauen wird trotz korrekter Anwendung pro Jahr schwanger.",
+    "contentP2": "Wichtig ist die Unterscheidung zwischen perfekter und typischer Anwendung. Die Pille hat bei korrekter Einnahme einen Pearl-Index von 0,1–0,9. Bei realer Anwendung — vergessene Tabletten, Wechselwirkungen, Erbrechen — steigt er auf 6–9. Hormonspirale, Implantat und Sterilisation sind nahezu anwendungsfehlerunabhängig und schneiden deshalb auch im Alltag konstant unter 1 ab.",
+    "contentP3": "Methodische Grenzen: Der Pearl-Index ist kein perfektes Maß. Längere Studiendauern senken den Wert künstlich, da besonders fertile Paare früh ausscheiden. Lebensphase, Alter, Häufigkeit des Geschlechtsverkehrs und Begleitfaktoren wie Antibiotika beeinflussen das individuelle Risiko zusätzlich. Genauer ist die Lebenstabellenanalyse, die den Pearl-Index in der Forschung zunehmend ergänzt.",
+    "contentP4": "Für die Praxis heißt das: Vergleiche Methoden anhand der typischen, nicht der perfekten Anwendung. Wer Anwendungsfehler ausschließen will, profitiert von Long-Acting Reversible Contraceptives (LARC) wie Hormonspirale oder Implantat. Hormonfreie Alternativen mit niedrigem Pearl-Index sind die Kupferspirale und korrekt durchgeführte symptothermale NFP. Welche Methode persönlich am besten passt, hängt von Gesundheit, Lebensphase und Vorlieben ab — und gehört in die Hand einer Frauenärztin oder eines Frauenarztes.",
+    "internalLinksTitle": "Passende Rechner für Zyklus und Schwangerschaft",
+    "linkOvulation": "Eisprungrechner",
+    "linkPeriod": "Zyklusrechner",
+    "linkPregnancy": "Schwangerschafts-Rechner",
+    "linkFertility": "Fruchtbares Fenster Rechner",
+    "sourcesTitle": "Quellen",
+    "sourcesText": "Bundeszentrale für gesundheitliche Aufklärung (BZgA): Sichergehen.de — Verhütungsmethoden im Vergleich. Deutsche Gesellschaft für Gynäkologie und Geburtshilfe (DGGG): S3-Leitlinie Hormonelle Empfängnisverhütung. Trussell J. Contraceptive failure in the United States. Contraception 2011;83(5):397–404. Frank-Herrmann P et al. The effectiveness of a fertility awareness based method to avoid pregnancy. Hum Reprod 2007.",
+    "faq": [
+      {
+        "q": "Wie wird der Pearl-Index berechnet?",
+        "a": "Pearl-Index = (Schwangerschaften × 1200) / (Frauen × Monate). Der Faktor 1200 = 100 Frauen × 12 Monate stellt den Bezug auf 100 Frauenjahre her. Der Wert sagt: so viele von 100 Frauen werden bei einjähriger Anwendung schwanger."
+      },
+      {
+        "q": "Was ist der Unterschied zwischen perfekter und typischer Anwendung?",
+        "a": "Perfekt = Methode wird immer korrekt angewendet (Pille pünktlich, Kondom richtig). Typisch = reale Anwendung mit Fehlern. Beim Kondom liegt die Differenz bei Faktor 7 (PI 2 vs. 15), bei der Pille bei Faktor 10 (0,9 vs. 9). Bei Hormonspirale und Implantat gibt es kaum Unterschied."
+      },
+      {
+        "q": "Welche Verhütungsmethode hat den niedrigsten Pearl-Index?",
+        "a": "Hormonimplantat (PI ~0,05), Hormonspirale (PI ~0,2) und Sterilisation (PI 0,15–0,5). Diese Long-Acting Reversible Contraceptives (LARC) sind anwendungsfehlerunabhängig und in der typischen Anwendung am sichersten."
+      },
+      {
+        "q": "Ist NFP eine sichere Verhütungsmethode?",
+        "a": "Symptothermale NFP nach Sensiplan, korrekt erlernt und konsequent angewendet, erreicht laut Frank-Herrmann et al. 2007 einen Pearl-Index von 0,4. Reine Kalendermethoden ohne Temperatur und Zervixschleim haben dagegen 9–40 und sind nicht sicher genug."
+      },
+      {
+        "q": "Warum ist der Pearl-Index nicht perfekt als Maß?",
+        "a": "Längere Studien verzerren den Wert nach unten, weil besonders fertile Paare früh ausscheiden. Der PI berücksichtigt zudem nicht die individuelle Häufigkeit des Geschlechtsverkehrs. Die Lebenstabellenanalyse ist methodisch genauer, der Pearl-Index aber etabliert und gut vergleichbar."
+      },
+      {
+        "q": "Ersetzt dieser Rechner eine ärztliche Beratung?",
+        "a": "Nein. Die Wahl der Verhütungsmethode hängt von Alter, Gesundheit, Vorerkrankungen, Lebensphase und persönlichen Vorlieben ab. Sprich für eine fundierte Entscheidung mit deiner Frauenärztin oder deinem Frauenarzt."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/pearlIndexRechner.json
+++ b/src/locales/calculators/en/pearlIndexRechner.json
@@ -1,0 +1,99 @@
+{
+  "home": {
+    "calculators": {
+      "pearlIndexRechner": {
+        "name": "Pearl Index Calculator",
+        "description": "Calculate the Pearl Index from study data and compare contraceptive methods."
+      }
+    }
+  },
+  "pearlIndexRechner": {
+    "meta": {
+      "title": "Pearl Index Calculator — Contraceptive Method Effectiveness",
+      "description": "Calculate the Pearl Index from study data: PI = (pregnancies × 1200) / (women × months). Reference table for the pill, condoms, IUDs, NFP and more. Sources: BZgA, Trussell."
+    },
+    "title": "Pearl Index Calculator",
+    "description": "Calculate the Pearl Index from study data and compare contraceptive methods using validated reference values.",
+    "disclaimer": "Note: This calculator is for information and education only. It does not replace medical contraceptive counseling. Talk to your gynaecologist before choosing a contraceptive method.",
+    "inputsTitle": "Enter study data",
+    "women": "Number of women",
+    "womenHint": "e.g. 100",
+    "months": "Observation period (months)",
+    "monthsHint": "e.g. 12 for one year",
+    "pregnancies": "Number of unintended pregnancies",
+    "pregnanciesHint": "Pregnancies that occurred during the observation period",
+    "result": "Pearl Index",
+    "resultUnit": "pregnancies per 100 woman-years",
+    "resultExplain": "With {women} women over {months} months the Pearl Index is {pi} pregnancies per 100 woman-years.",
+    "verySafe": "Very safe",
+    "safe": "Safe",
+    "moderate": "Moderately safe",
+    "lowSafety": "Low safety",
+    "unsafe": "Unsafe",
+    "categoryHelp": "Classification per WHO/BZgA: < 1 very safe, 1–4 safe, 5–9 moderate, 10–24 low, ≥ 25 unsafe.",
+    "exampleTitle": "Worked example",
+    "exampleText": "100 women use a method for 12 months. During that time 3 unintended pregnancies occur. Pearl Index = (3 × 1200) / (100 × 12) = 3.0. Meaning: 3 of 100 women become pregnant after one year of use.",
+    "referenceTitle": "Pearl Index by contraceptive method",
+    "referenceIntro": "Typical Pearl Indices for established methods, both perfect and typical use. Sources: BZgA, German Society for Gynaecology and Obstetrics (DGGG), Trussell 2011.",
+    "method": "Method",
+    "perfectUse": "Perfect use",
+    "typicalUse": "Typical use",
+    "methods": {
+      "pillCombined": "Combined pill",
+      "pillMini": "Progestin-only pill",
+      "iudHormonal": "Hormonal IUD (LNG-IUS)",
+      "iudCopper": "Copper IUD",
+      "implant": "Hormonal implant",
+      "depot": "Depot injection (3-month)",
+      "patch": "Contraceptive patch",
+      "ring": "Vaginal ring",
+      "condomMale": "Male condom",
+      "condomFemale": "Female condom",
+      "diaphragm": "Diaphragm + spermicide",
+      "nfpSymptothermal": "NFP sympto-thermal (correct)",
+      "nfpCalendar": "Calendar method only",
+      "withdrawal": "Withdrawal",
+      "sterilizationFemale": "Tubal ligation (female)",
+      "sterilizationMale": "Vasectomy (male)",
+      "noMethod": "No contraception"
+    },
+    "contentTitle": "What does the Pearl Index tell you?",
+    "contentP1": "The Pearl Index is the standard measure of contraceptive effectiveness. It expresses how many out of 100 women become pregnant after one year of using the method exclusively. A Pearl Index of 1 means: one in a hundred women becomes pregnant per year despite correct use.",
+    "contentP2": "The crucial distinction is between perfect and typical use. The pill scores 0.1–0.9 with perfect use. Real-world use — missed pills, drug interactions, vomiting — pushes that to 6–9. Hormonal IUDs, implants, and sterilisation are largely independent of user error and stay below 1 even in everyday use.",
+    "contentP3": "Methodological limits: the Pearl Index is not perfect. Longer studies push the value down because highly fertile couples drop out early. Age, life stage, intercourse frequency, and concomitant factors such as antibiotics also affect individual risk. Life-table analysis is more accurate and increasingly complements the Pearl Index in research.",
+    "contentP4": "Practical takeaway: compare methods by typical, not perfect use. To rule out user error, choose long-acting reversible contraceptives (LARCs) such as the hormonal IUD or implant. Hormone-free options with a low Pearl Index are the copper IUD and correctly performed sympto-thermal NFP. Which method fits you depends on health, life stage, and preference — and belongs in the hands of a gynaecologist.",
+    "internalLinksTitle": "Related cycle and pregnancy calculators",
+    "linkOvulation": "Ovulation calculator",
+    "linkPeriod": "Period calculator",
+    "linkPregnancy": "Pregnancy calculator",
+    "linkFertility": "Fertility window calculator",
+    "sourcesTitle": "Sources",
+    "sourcesText": "German Federal Centre for Health Education (BZgA): Sichergehen.de — Comparison of contraceptive methods. German Society for Gynaecology and Obstetrics (DGGG): S3 Guideline on Hormonal Contraception. Trussell J. Contraceptive failure in the United States. Contraception 2011;83(5):397–404. Frank-Herrmann P et al. The effectiveness of a fertility awareness based method to avoid pregnancy. Hum Reprod 2007.",
+    "faq": [
+      {
+        "q": "How is the Pearl Index calculated?",
+        "a": "Pearl Index = (pregnancies × 1200) / (women × months). The factor 1200 = 100 women × 12 months scales the result to 100 woman-years. The value tells you how many of 100 women become pregnant after one year of use."
+      },
+      {
+        "q": "What is the difference between perfect and typical use?",
+        "a": "Perfect = the method is always used correctly (pill on time, condom applied properly). Typical = real-world use with mistakes. Condoms differ by a factor of 7 (PI 2 vs 15), the pill by 10 (0.9 vs 9). Hormonal IUDs and implants barely differ between perfect and typical use."
+      },
+      {
+        "q": "Which contraceptive method has the lowest Pearl Index?",
+        "a": "Hormonal implant (PI ~0.05), hormonal IUD (PI ~0.2), and sterilisation (PI 0.15–0.5). These long-acting reversible contraceptives (LARCs) are independent of user error and the safest in typical use."
+      },
+      {
+        "q": "Is NFP a safe contraceptive method?",
+        "a": "Sympto-thermal NFP per Sensiplan, correctly learned and consistently used, achieves a Pearl Index of 0.4 according to Frank-Herrmann et al. 2007. Calendar-only methods without basal body temperature and cervical mucus score 9–40 and are not safe enough."
+      },
+      {
+        "q": "Why is the Pearl Index imperfect as a metric?",
+        "a": "Longer studies bias the value downward because highly fertile couples drop out early. The PI also ignores intercourse frequency. Life-table analysis is methodologically more precise, but the Pearl Index is well established and easy to compare."
+      },
+      {
+        "q": "Does this calculator replace medical advice?",
+        "a": "No. The right contraceptive method depends on age, health, pre-existing conditions, life stage, and personal preference. Discuss your choice with a gynaecologist."
+      }
+    ]
+  }
+}

--- a/src/pages/PearlIndexRechnerCalculator.vue
+++ b/src/pages/PearlIndexRechnerCalculator.vue
@@ -1,0 +1,184 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcPearlIndex, classifyPearlIndex, referenceMethods } from '../utils/pearlIndexRechner.js'
+
+const { t, tm, locale } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('pearlIndexRechner.faq') || [])
+
+useHead(() => ({
+  title: t('pearlIndexRechner.meta.title'),
+  description: t('pearlIndexRechner.meta.description'),
+  routeKey: 'pearlIndexRechner',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: t('pearlIndexRechner.title'),
+    url: locale.value === 'de'
+      ? 'https://healthcalculator.app/de/pearl-index-rechner'
+      : 'https://healthcalculator.app/en/pearl-index-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const women = ref(100)
+const months = ref(12)
+const pregnancies = ref(null)
+
+const pearlIndex = computed(() => calcPearlIndex(pregnancies.value, women.value, months.value))
+const category = computed(() => classifyPearlIndex(pearlIndex.value))
+
+const formattedPi = computed(() => {
+  if (pearlIndex.value === null) return null
+  return locale.value === 'de'
+    ? pearlIndex.value.toFixed(2).replace('.', ',')
+    : pearlIndex.value.toFixed(2)
+})
+
+const categoryStyle = computed(() => {
+  switch (category.value) {
+    case 'verySafe': return { color: 'text-green-700', bg: 'bg-green-50', border: 'border-green-200' }
+    case 'safe': return { color: 'text-green-600', bg: 'bg-green-50', border: 'border-green-200' }
+    case 'moderate': return { color: 'text-yellow-600', bg: 'bg-yellow-50', border: 'border-yellow-200' }
+    case 'lowSafety': return { color: 'text-orange-600', bg: 'bg-orange-50', border: 'border-orange-200' }
+    case 'unsafe': return { color: 'text-red-700', bg: 'bg-red-50', border: 'border-red-200' }
+    default: return { color: 'text-stone-600', bg: 'bg-stone-50', border: 'border-stone-200' }
+  }
+})
+
+function formatPi(value) {
+  if (value === null || value === undefined) return ''
+  const fixed = value < 1 ? value.toFixed(2) : value.toFixed(1)
+  return locale.value === 'de' ? fixed.replace('.', ',') : fixed
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('pearlIndexRechner.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('pearlIndexRechner.description') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-6" data-testid="medical-disclaimer">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('pearlIndexRechner.disclaimer') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-4">{{ t('pearlIndexRechner.inputsTitle') }}</h2>
+    <div class="grid gap-6 sm:grid-cols-3">
+      <div>
+        <label for="women" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pearlIndexRechner.women') }}</label>
+        <input id="women" v-model.number="women" type="number" min="1" step="1" :placeholder="t('pearlIndexRechner.womenHint')" data-testid="women"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        <p class="text-xs text-stone-400 mt-1">{{ t('pearlIndexRechner.womenHint') }}</p>
+      </div>
+      <div>
+        <label for="months" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pearlIndexRechner.months') }}</label>
+        <input id="months" v-model.number="months" type="number" min="1" step="1" :placeholder="t('pearlIndexRechner.monthsHint')" data-testid="months"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        <p class="text-xs text-stone-400 mt-1">{{ t('pearlIndexRechner.monthsHint') }}</p>
+      </div>
+      <div>
+        <label for="pregnancies" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pearlIndexRechner.pregnancies') }}</label>
+        <input id="pregnancies" v-model.number="pregnancies" type="number" min="0" step="1" placeholder="0" data-testid="pregnancies"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        <p class="text-xs text-stone-400 mt-1">{{ t('pearlIndexRechner.pregnanciesHint') }}</p>
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="pearlIndex !== null" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6" data-testid="result-card">
+    <div class="flex items-baseline gap-3 mb-2">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="pearl-index-result">{{ formattedPi }}</span>
+      <span v-if="category" :class="categoryStyle.color" class="text-lg font-semibold" data-testid="pearl-index-category">{{ t('pearlIndexRechner.' + category) }}</span>
+    </div>
+    <p class="text-sm text-stone-500 mb-4">{{ t('pearlIndexRechner.resultUnit') }}</p>
+    <div :class="[categoryStyle.bg, categoryStyle.border]" class="border rounded-lg p-4">
+      <p :class="categoryStyle.color" class="text-sm font-medium">
+        {{ t('pearlIndexRechner.resultExplain', { women, months, pi: formattedPi }) }}
+      </p>
+      <p class="text-xs text-stone-500 mt-2">{{ t('pearlIndexRechner.categoryHelp') }}</p>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('pearlIndexRechner.exampleTitle') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('pearlIndexRechner.exampleText') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6" data-testid="reference-table-wrap">
+    <div class="px-6 py-5 border-b border-stone-200">
+      <h2 class="text-base font-semibold text-stone-900 mb-1">{{ t('pearlIndexRechner.referenceTitle') }}</h2>
+      <p class="text-sm text-stone-500">{{ t('pearlIndexRechner.referenceIntro') }}</p>
+    </div>
+    <table class="w-full text-sm" data-testid="reference-table">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('pearlIndexRechner.method') }}</th>
+          <th class="text-right px-6 py-3 font-semibold text-stone-700">{{ t('pearlIndexRechner.perfectUse') }}</th>
+          <th class="text-right px-6 py-3 font-semibold text-stone-700">{{ t('pearlIndexRechner.typicalUse') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr v-for="m in referenceMethods" :key="m.key" data-testid="reference-row">
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('pearlIndexRechner.methods.' + m.key) }}</td>
+          <td class="px-6 py-3 text-stone-700 text-right tabular-nums">{{ formatPi(m.perfect) }}</td>
+          <td class="px-6 py-3 text-stone-700 text-right tabular-nums">{{ formatPi(m.typical) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('pearlIndexRechner.contentTitle') }}</h2>
+    <div class="space-y-3 text-sm text-stone-600 leading-relaxed">
+      <p>{{ t('pearlIndexRechner.contentP1') }}</p>
+      <p>{{ t('pearlIndexRechner.contentP2') }}</p>
+      <p>{{ t('pearlIndexRechner.contentP3') }}</p>
+      <p>{{ t('pearlIndexRechner.contentP4') }}</p>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('pearlIndexRechner.internalLinksTitle') }}</h2>
+    <div class="flex flex-wrap gap-3 text-sm">
+      <router-link :to="localePath('ovulation')" class="text-stone-600 hover:text-stone-900 underline underline-offset-2 transition-colors">
+        {{ t('pearlIndexRechner.linkOvulation') }}
+      </router-link>
+      <span class="text-stone-300">&middot;</span>
+      <router-link :to="localePath('period')" class="text-stone-600 hover:text-stone-900 underline underline-offset-2 transition-colors">
+        {{ t('pearlIndexRechner.linkPeriod') }}
+      </router-link>
+      <span class="text-stone-300">&middot;</span>
+      <router-link :to="localePath('pregnancy')" class="text-stone-600 hover:text-stone-900 underline underline-offset-2 transition-colors">
+        {{ t('pearlIndexRechner.linkPregnancy') }}
+      </router-link>
+      <span class="text-stone-300">&middot;</span>
+      <router-link :to="localePath('fertilityWindow')" class="text-stone-600 hover:text-stone-900 underline underline-offset-2 transition-colors">
+        {{ t('pearlIndexRechner.linkFertility') }}
+      </router-link>
+    </div>
+  </div>
+
+  <div class="bg-stone-50 rounded-xl border border-stone-200 p-6 mb-6">
+    <h3 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pearlIndexRechner.sourcesTitle') }}</h3>
+    <p class="text-xs text-stone-500 leading-relaxed">{{ t('pearlIndexRechner.sourcesText') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="pearlIndexRechner" />
+</template>

--- a/src/pages/blog/PearlIndexBerechnen.vue
+++ b/src/pages/blog/PearlIndexBerechnen.vue
@@ -1,0 +1,224 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Pearl-Index berechnen: Verhütungsmethoden im Vergleich | Health Calculators',
+  description: 'Pearl-Index verstehen und berechnen — Formel, perfekte vs. typische Anwendung, Referenzwerte für Pille, Kondom, Spirale, NFP. Quellen: BZgA, Trussell.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: 'Pearl-Index berechnen: Verhütungsmethoden im Vergleich',
+    description: 'Pearl-Index verstehen und berechnen — Formel, perfekte vs. typische Anwendung, Referenzwerte für Pille, Kondom, Spirale, NFP.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-11',
+    dateModified: '2026-05-11',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/pearl-index-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">
+        &larr; Blog
+      </router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">
+        Pearl-Index berechnen: Verhütungsmethoden im Vergleich
+      </h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">11. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          Hinweis: Dieser Artikel dient ausschließlich der Information. Er ist kein Ersatz für eine ärztliche Verhütungsberatung. Sprich für die Wahl der passenden Verhütungsmethode mit deiner Frauenärztin oder deinem Frauenarzt.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <strong>Pearl-Index</strong> ist seit fast 100 Jahren die Standardgröße, wenn es um die Sicherheit von Verhütungsmethoden geht. Er sagt: <em>So viele von 100 Frauen werden bei einjähriger Anwendung schwanger.</em>
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Was der Pearl-Index leistet, wo seine Grenzen liegen — und welche Methoden im realen Alltag wirklich sicher sind.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eingeführt 1933 von dem amerikanischen Statistiker Raymond Pearl. Die Berechnung ist denkbar einfach:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-4 text-center">
+          <p class="text-lg font-semibold text-stone-900 tabular-nums">
+            Pearl-Index = (Schwangerschaften &times; 1200) / (Frauen &times; Monate)
+          </p>
+          <p class="text-sm text-stone-500 mt-2">
+            Der Faktor 1200 = 100 Frauen &times; 12 Monate normiert auf 100 Frauenjahre.
+          </p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beispiel: 100 Frauen verhüten 12 Monate mit der Pille. 6 werden schwanger. Pearl-Index = (6 &times; 1200) / (100 &times; 12) = <strong>6,0</strong>. Sechs von hundert Anwenderinnen werden in einem Jahr schwanger.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Perfekte vs. typische Anwendung</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der wichtigste Punkt beim Pearl-Index: Es gibt fast immer zwei Werte. <strong>Perfekt</strong> meint die Methode unter Idealbedingungen — Pille immer pünktlich, Kondom immer korrekt. <strong>Typisch</strong> meint die reale Welt: vergessene Tabletten, gerissene Kondome, Antibiotika-Wechselwirkungen.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Methode</th>
+                <th class="text-right px-4 py-3 font-semibold text-stone-700">Perfekt</th>
+                <th class="text-right px-4 py-3 font-semibold text-stone-700">Typisch</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-4 py-2">Hormonimplantat</td><td class="px-4 py-2 text-right tabular-nums">0,05</td><td class="px-4 py-2 text-right tabular-nums">0,05</td></tr>
+              <tr><td class="px-4 py-2">Hormonspirale (LNG-IUS)</td><td class="px-4 py-2 text-right tabular-nums">0,2</td><td class="px-4 py-2 text-right tabular-nums">0,2</td></tr>
+              <tr><td class="px-4 py-2">Kupferspirale</td><td class="px-4 py-2 text-right tabular-nums">0,6</td><td class="px-4 py-2 text-right tabular-nums">0,8</td></tr>
+              <tr><td class="px-4 py-2">Kombinationspille</td><td class="px-4 py-2 text-right tabular-nums">0,3</td><td class="px-4 py-2 text-right tabular-nums">9</td></tr>
+              <tr><td class="px-4 py-2">Kondom (männlich)</td><td class="px-4 py-2 text-right tabular-nums">2</td><td class="px-4 py-2 text-right tabular-nums">15</td></tr>
+              <tr><td class="px-4 py-2">NFP symptothermal</td><td class="px-4 py-2 text-right tabular-nums">0,4</td><td class="px-4 py-2 text-right tabular-nums">2,3</td></tr>
+              <tr><td class="px-4 py-2">Kalendermethode allein</td><td class="px-4 py-2 text-right tabular-nums">5</td><td class="px-4 py-2 text-right tabular-nums">24</td></tr>
+              <tr><td class="px-4 py-2">Coitus interruptus</td><td class="px-4 py-2 text-right tabular-nums">4</td><td class="px-4 py-2 text-right tabular-nums">22</td></tr>
+              <tr><td class="px-4 py-2">Keine Verhütung</td><td class="px-4 py-2 text-right tabular-nums">85</td><td class="px-4 py-2 text-right tabular-nums">85</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Quellen: BZgA Sichergehen.de, DGGG-Leitlinie Hormonelle Empfängnisverhütung, Trussell 2011, Frank-Herrmann et al. 2007.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was die Zahlen wirklich bedeuten</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI &lt; 1 — Sehr sicher</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Hormonimplantat, Hormonspirale, Kupferspirale, Sterilisation. Diese Long-Acting Reversible Contraceptives (LARC) sind anwendungsfehlerunabhängig.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI 1–4 — Sicher</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Pille bei perfekter Anwendung, NFP symptothermal nach Sensiplan. Erfordert Disziplin und Lernkurve.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI 5–9 — Mäßig sicher</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Pille bei typischer Anwendung. Anwendungsfehler werden statistisch sichtbar.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI 10–24 — Geringe Sicherheit</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Kondom typisch, Diaphragma. Geeignet bei Kombination mit anderen Methoden oder akzeptiertem Restrisiko.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI &ge; 25 — Unsicher</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Kalendermethode allein, Coitus interruptus. Nicht zur Verhütung empfohlen, wenn Schwangerschaft sicher vermieden werden soll.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Grenzen des Pearl-Index</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Pearl-Index ist nicht perfekt. Drei methodische Probleme:
+        </p>
+        <ul class="list-disc pl-6 space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>Studiendauer verzerrt.</strong> Je länger die Studie, desto niedriger der PI — weil die fertilsten Paare am schnellsten ausscheiden.</li>
+          <li><strong>Häufigkeit ignoriert.</strong> Ein Paar mit täglichem Geschlechtsverkehr hat ein höheres Schwangerschaftsrisiko als eines mit wöchentlichem.</li>
+          <li><strong>Keine Subgruppen.</strong> Alter, Begleitmedikation, Lebensphase werden nicht differenziert.</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Moderne Studien ergänzen den Pearl-Index zunehmend mit der <strong>Lebenstabellenanalyse</strong>, die Versagensraten kumulativ über die Zeit darstellt.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Pearl-Index jetzt selbst berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Trage Studiendaten ein und vergleiche mit Referenzwerten — kostenlos.</p>
+        <router-link
+          :to="localePath('pearlIndexRechner')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >
+          Jetzt zum Rechner &rarr;
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was bedeutet das für dich?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Drei praktische Empfehlungen aus der Datenlage:
+        </p>
+        <ol class="list-decimal pl-6 space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>Vergleiche typische, nicht perfekte Werte.</strong> Im Alltag zählt, wie sicher eine Methode bei realer Nutzung ist.</li>
+          <li><strong>Wer Anwendungsfehler ausschließen will, wählt LARC.</strong> Hormonimplantat, Hormon- oder Kupferspirale halten 3–10 Jahre.</li>
+          <li><strong>Hormonfreie Sicherheit gibt es.</strong> Kupferspirale (PI 0,8) und korrekt erlernte symptothermale NFP nach Sensiplan (PI 0,4) sind valide Alternativen.</li>
+        </ol>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Welche Methode für dich passt, hängt von deiner Gesundheit, Vorerkrankungen, Lebensphase und persönlichen Vorlieben ab.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <router-link :to="localePath('ovulation')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Eisprungrechner</p>
+            <p class="text-sm text-stone-500">Wann ist der Eisprung?</p>
+          </router-link>
+          <router-link :to="localePath('period')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Zyklusrechner</p>
+            <p class="text-sm text-stone-500">Periode &amp; Zyklusphasen</p>
+          </router-link>
+          <router-link :to="localePath('fertilityWindow')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Fruchtbares Fenster Rechner</p>
+            <p class="text-sm text-stone-500">10-Tage-Fenster mit LH-Anstieg</p>
+          </router-link>
+          <router-link :to="localePath('pregnancy')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Schwangerschafts-Rechner</p>
+            <p class="text-sm text-stone-500">Schwangerschaftswoche bestimmen</p>
+          </router-link>
+        </div>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Pearl-Index ist die etablierte Sprache der Verhütungssicherheit — wenn man sie richtig liest. Achte auf die typische Anwendung, nicht nur auf die perfekten Studienzahlen. Methoden mit niedrigem Anwendungsfehler-Risiko (LARC) sind im Alltag fast immer sicherer als jene, die tägliche Disziplin verlangen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Hinweis: Dieser Artikel ist kein Ersatz für ärztliche Verhütungsberatung. Welche Methode zu deiner Lebenssituation passt, klärst du am besten mit deiner Frauenärztin oder deinem Frauenarzt.
+        </p>
+      </div>
+
+      <RelatedArticles slug="pearl-index-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/PearlIndexCalculatorGuide.vue
+++ b/src/pages/blog/en/PearlIndexCalculatorGuide.vue
@@ -1,0 +1,224 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Pearl Index Calculator: Contraceptive Method Effectiveness | Health Calculators',
+  description: 'Pearl Index explained — formula, perfect vs typical use, reference values for the pill, condoms, IUDs, NFP. Sources: BZgA, Trussell.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: 'Pearl Index Calculator: Contraceptive Method Effectiveness',
+    description: 'Pearl Index explained — formula, perfect vs typical use, reference values for the pill, condoms, IUDs, NFP.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-11',
+    dateModified: '2026-05-11',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/pearl-index-calculator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">
+        &larr; Blog
+      </router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">
+        Pearl Index Calculator: Contraceptive Method Effectiveness
+      </h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 11, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          Note: This article is for information only. It does not replace medical contraceptive counseling. Talk to your gynaecologist before choosing a contraceptive method.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>Pearl Index</strong> has been the standard way to express contraceptive effectiveness for almost a century. It tells you: <em>how many of 100 women become pregnant after one year of using the method.</em>
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Here is what the Pearl Index does well, where it falls short — and which methods are actually safe in everyday life.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Introduced in 1933 by US statistician Raymond Pearl. The math is simple:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-4 text-center">
+          <p class="text-lg font-semibold text-stone-900 tabular-nums">
+            Pearl Index = (pregnancies &times; 1200) / (women &times; months)
+          </p>
+          <p class="text-sm text-stone-500 mt-2">
+            The factor 1200 = 100 women &times; 12 months scales to 100 woman-years.
+          </p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Example: 100 women take the pill for 12 months. 6 become pregnant. Pearl Index = (6 &times; 1200) / (100 &times; 12) = <strong>6.0</strong>. Six in a hundred users become pregnant in one year.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Perfect vs. typical use</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The most important point about the Pearl Index: there are almost always two values. <strong>Perfect</strong> means the method under ideal conditions — pill always on time, condom always correctly applied. <strong>Typical</strong> means the real world: missed pills, broken condoms, antibiotic interactions.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-4 py-3 font-semibold text-stone-700">Method</th>
+                <th class="text-right px-4 py-3 font-semibold text-stone-700">Perfect</th>
+                <th class="text-right px-4 py-3 font-semibold text-stone-700">Typical</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-4 py-2">Hormonal implant</td><td class="px-4 py-2 text-right tabular-nums">0.05</td><td class="px-4 py-2 text-right tabular-nums">0.05</td></tr>
+              <tr><td class="px-4 py-2">Hormonal IUD (LNG-IUS)</td><td class="px-4 py-2 text-right tabular-nums">0.2</td><td class="px-4 py-2 text-right tabular-nums">0.2</td></tr>
+              <tr><td class="px-4 py-2">Copper IUD</td><td class="px-4 py-2 text-right tabular-nums">0.6</td><td class="px-4 py-2 text-right tabular-nums">0.8</td></tr>
+              <tr><td class="px-4 py-2">Combined pill</td><td class="px-4 py-2 text-right tabular-nums">0.3</td><td class="px-4 py-2 text-right tabular-nums">9</td></tr>
+              <tr><td class="px-4 py-2">Male condom</td><td class="px-4 py-2 text-right tabular-nums">2</td><td class="px-4 py-2 text-right tabular-nums">15</td></tr>
+              <tr><td class="px-4 py-2">NFP sympto-thermal</td><td class="px-4 py-2 text-right tabular-nums">0.4</td><td class="px-4 py-2 text-right tabular-nums">2.3</td></tr>
+              <tr><td class="px-4 py-2">Calendar method only</td><td class="px-4 py-2 text-right tabular-nums">5</td><td class="px-4 py-2 text-right tabular-nums">24</td></tr>
+              <tr><td class="px-4 py-2">Withdrawal</td><td class="px-4 py-2 text-right tabular-nums">4</td><td class="px-4 py-2 text-right tabular-nums">22</td></tr>
+              <tr><td class="px-4 py-2">No contraception</td><td class="px-4 py-2 text-right tabular-nums">85</td><td class="px-4 py-2 text-right tabular-nums">85</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Sources: BZgA Sichergehen.de, DGGG Guideline on Hormonal Contraception, Trussell 2011, Frank-Herrmann et al. 2007.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What the numbers really mean</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI &lt; 1 — Very safe</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Hormonal implant, hormonal IUD, copper IUD, sterilisation. These long-acting reversible contraceptives (LARCs) do not depend on user behavior.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI 1–4 — Safe</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Pill under perfect use, sympto-thermal NFP per Sensiplan. Requires discipline and a learning curve.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI 5–9 — Moderately safe</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Pill under typical use. User error becomes statistically visible.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI 10–24 — Low safety</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Condom typical, diaphragm. Suitable when combined with other methods or with accepted residual risk.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">PI &ge; 25 — Unsafe</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Calendar method only, withdrawal. Not recommended if pregnancy must be reliably avoided.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Limits of the Pearl Index</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The Pearl Index is not perfect. Three methodological problems:
+        </p>
+        <ul class="list-disc pl-6 space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>Study duration biases it.</strong> The longer the study, the lower the PI — because the most fertile couples drop out first.</li>
+          <li><strong>Frequency ignored.</strong> A couple having sex daily faces a higher pregnancy risk than one having sex weekly.</li>
+          <li><strong>No subgroups.</strong> Age, comedication, and life stage are not differentiated.</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Modern studies increasingly complement the Pearl Index with <strong>life-table analysis</strong>, which shows cumulative failure rates over time.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate the Pearl Index now</h3>
+        <p class="text-stone-300 text-sm mb-5">Enter study data and compare against reference values — free.</p>
+        <router-link
+          :to="localePath('pearlIndexRechner')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >
+          Open the calculator &rarr;
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What does this mean for you?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Three practical takeaways from the data:
+        </p>
+        <ol class="list-decimal pl-6 space-y-2 text-base text-stone-600 leading-relaxed mb-4">
+          <li><strong>Compare typical, not perfect values.</strong> What matters in everyday life is how the method holds up under real use.</li>
+          <li><strong>To rule out user error, choose a LARC.</strong> Hormonal implant, hormonal IUD, or copper IUD last 3–10 years.</li>
+          <li><strong>Hormone-free safety exists.</strong> Copper IUD (PI 0.8) and correctly learned sympto-thermal NFP per Sensiplan (PI 0.4) are valid alternatives.</li>
+        </ol>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Which method fits you depends on your health, pre-existing conditions, life stage, and personal preference.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <router-link :to="localePath('ovulation')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Ovulation calculator</p>
+            <p class="text-sm text-stone-500">When is ovulation?</p>
+          </router-link>
+          <router-link :to="localePath('period')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Period calculator</p>
+            <p class="text-sm text-stone-500">Period &amp; cycle phases</p>
+          </router-link>
+          <router-link :to="localePath('fertilityWindow')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Fertility window calculator</p>
+            <p class="text-sm text-stone-500">10-day window with LH surge</p>
+          </router-link>
+          <router-link :to="localePath('pregnancy')" class="block bg-white border border-stone-200 rounded-xl p-4 hover:border-stone-400 transition-colors">
+            <p class="text-base font-semibold text-stone-900">Pregnancy calculator</p>
+            <p class="text-sm text-stone-500">Determine pregnancy week</p>
+          </router-link>
+        </div>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The Pearl Index is the established language of contraceptive safety — when read correctly. Look at typical use, not just perfect-use study numbers. Methods with low user-error potential (LARCs) are almost always safer in everyday life than those that demand daily discipline.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Note: This article does not replace medical contraceptive counseling. Which method fits your life is best discussed with your gynaecologist.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="pearl-index-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/pearlIndexRechner.meta.js
+++ b/src/pages/pearlIndexRechner.meta.js
@@ -1,0 +1,16 @@
+import Component from './PearlIndexRechnerCalculator.vue'
+import BlogDe from './blog/PearlIndexBerechnen.vue'
+import BlogEn from './blog/en/PearlIndexCalculatorGuide.vue'
+
+export default {
+  key: 'pearlIndexRechner',
+  component: Component,
+  slugs: { de: 'pearl-index-rechner', en: 'pearl-index-calculator' },
+  group: 'pregnancy',
+  groupOrder: 3,
+  order: 1.6,
+  blog: {
+    de: { slug: 'pearl-index-berechnen', component: BlogDe },
+    en: { slug: 'pearl-index-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/pearlIndexRechner.js
+++ b/src/utils/pearlIndexRechner.js
@@ -1,0 +1,48 @@
+// Pearl Index — contraceptive method effectiveness measure.
+// Formula: PI = (unintended pregnancies × 1200) / (women × months)
+// 1200 = 100 women × 12 months (one woman-year basis).
+//
+// Sources for reference values:
+//   - Pille (kombinierte orale Kontrazeptiva): 0,1–0,9 (perfect) / 6–9 (typical) — BZgA
+//   - Kondom: 2 (perfect) / 12–15 (typical) — Trussell 2011 / BZgA
+//   - Hormonspirale (LNG-IUS): 0,16 — Trussell / DGGG
+//   - Kupferspirale (Cu-IUD): 0,3–0,8 — Trussell / DGGG
+//   - Diaphragma mit Spermizid: 1–20 — BZgA
+//   - NFP (symptothermal, korrekt angewendet): 0,4–2,3 — Frank-Herrmann et al. 2007
+//   - Kalendermethode allein: 9–40 — BZgA / Trussell
+//   - Coitus interruptus: 4–28 — BZgA
+
+export function calcPearlIndex(pregnancies, women, months) {
+  if (!Number.isFinite(pregnancies) || !Number.isFinite(women) || !Number.isFinite(months)) return null
+  if (pregnancies < 0 || women <= 0 || months <= 0) return null
+  return (pregnancies * 1200) / (women * months)
+}
+
+export const referenceMethods = [
+  { key: 'pillCombined', perfect: 0.3, typical: 9 },
+  { key: 'pillMini', perfect: 0.3, typical: 9 },
+  { key: 'iudHormonal', perfect: 0.2, typical: 0.2 },
+  { key: 'iudCopper', perfect: 0.6, typical: 0.8 },
+  { key: 'implant', perfect: 0.05, typical: 0.05 },
+  { key: 'depot', perfect: 0.2, typical: 6 },
+  { key: 'patch', perfect: 0.3, typical: 9 },
+  { key: 'ring', perfect: 0.3, typical: 9 },
+  { key: 'condomMale', perfect: 2, typical: 15 },
+  { key: 'condomFemale', perfect: 5, typical: 21 },
+  { key: 'diaphragm', perfect: 6, typical: 12 },
+  { key: 'nfpSymptothermal', perfect: 0.4, typical: 2.3 },
+  { key: 'nfpCalendar', perfect: 5, typical: 24 },
+  { key: 'withdrawal', perfect: 4, typical: 22 },
+  { key: 'sterilizationFemale', perfect: 0.5, typical: 0.5 },
+  { key: 'sterilizationMale', perfect: 0.15, typical: 0.15 },
+  { key: 'noMethod', perfect: 85, typical: 85 },
+]
+
+export function classifyPearlIndex(pi) {
+  if (pi === null || pi === undefined || !Number.isFinite(pi)) return null
+  if (pi < 1) return 'verySafe'
+  if (pi < 5) return 'safe'
+  if (pi < 10) return 'moderate'
+  if (pi < 25) return 'lowSafety'
+  return 'unsafe'
+}


### PR DESCRIPTION
## Summary
- New SSR pages `/de/pearl-index-rechner` and `/en/pearl-index-calculator`.
- Pearl-Index formula PI = (pregnancies × 1200) / (women × months) with WHO/BZgA-style classification.
- Reference table for 17 contraceptive methods (perfect & typical use), sourced from BZgA, DGGG, Trussell 2011, Frank-Herrmann 2007.
- Mandatory medical disclaimer ("kein Ersatz für ärztliche Verhütungsberatung") at the top.
- DE + EN blog guides explain perfect vs. typical use, methodological limits.
- Internal links to Eisprung-, Zyklus-, Fruchtbares-Fenster-, and Schwangerschafts-Rechner.

## Test plan
- [x] `npm test` — 2101 passed
- [x] `npm run build` — SSG + sitemap (310 URLs) + llms.txt (306 links)
- [x] `npx playwright test pearlIndexRechner` — 8 passed
- [x] Disclaimer rendered prominently (E2E asserted)
- [x] Trailing-slash canonical `/de/pearl-index-rechner/` resolves

Closes jenslaufer/health-calculators#191