### PR TITLE
fix(seo): resolve title cannibalization between protein and proteinNeed calculators (#243)

### DIFF
--- a/src/__tests__/seo-title-uniqueness.test.js
+++ b/src/__tests__/seo-title-uniqueness.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import deProtein from '../locales/calculators/de/protein.json'
+import deProteinNeed from '../locales/calculators/de/proteinNeed.json'
+import enProtein from '../locales/calculators/en/protein.json'
+import enProteinNeed from '../locales/calculators/en/proteinNeed.json'
+
+describe('SEO title uniqueness', () => {
+  it('de protein and proteinNeed meta titles are distinct', () => {
+    expect(deProtein.protein.meta.title).not.toBe(deProteinNeed.proteinNeed.meta.title)
+  })
+
+  it('en protein and proteinNeed meta titles are distinct', () => {
+    expect(enProtein.protein.meta.title).not.toBe(enProteinNeed.proteinNeed.meta.title)
+  })
+})

--- a/src/locales/calculators/de/protein.json
+++ b/src/locales/calculators/de/protein.json
@@ -9,10 +9,10 @@
   },
   "protein": {
     "meta": {
-      "title": "Protein-Rechner — Täglichen Proteinbedarf berechnen",
-      "description": "Berechne deinen täglichen Proteinbedarf basierend auf Gewicht, Aktivität, Ziel und Ernährungsform. Individuelle Empfehlungen mit Lebensmittelquellen."
+      "title": "Protein-Rechner — Tagesbedarf nach Diet & Mahlzeiten verteilen",
+      "description": "Berechne deinen Proteinbedarf inkl. veganer/vegetarischer Lebensmittelquellen und optimaler Verteilung über 3-6 Mahlzeiten."
     },
-    "title": "Protein-Rechner",
+    "title": "Protein-Rechner — Verteilung pro Mahlzeit",
     "description": "Berechne dein tägliches Proteinziel basierend auf Gewicht, Aktivität, Ziel und Ernährung.",
     "sedentary": "Sitzend",
     "light": "Leicht aktiv",

--- a/src/locales/calculators/de/proteinNeed.json
+++ b/src/locales/calculators/de/proteinNeed.json
@@ -9,10 +9,10 @@
   },
   "proteinNeed": {
     "meta": {
-      "title": "Eiweißbedarfs-Rechner — Täglichen Proteinbedarf berechnen",
-      "description": "Berechne deinen täglichen Eiweißbedarf basierend auf Aktivitätslevel, Ziel, Alter und Geschlecht. Mit Mahlzeiten-Aufteilung und Lebensmittelbeispielen."
+      "title": "Eiweißbedarf — Tagesbedarf nach Alter, Aktivität & Ziel berechnen",
+      "description": "Wie viel Eiweiß pro Tag? Bedarfsbereich nach Aktivitätsstufe (sedentary–athlete), Lebensphase und Ziel mit Altersanpassung."
     },
-    "title": "Eiweißbedarfs-Rechner",
+    "title": "Eiweißbedarfs-Rechner — Tagesbedarf nach Alter & Aktivität",
     "description": "Berechne deinen individuellen täglichen Eiweißbedarf — angepasst an Aktivität, Ziel und Alter.",
     "sedentary": "Sitzend",
     "moderate": "Moderat aktiv",

--- a/src/locales/calculators/en/protein.json
+++ b/src/locales/calculators/en/protein.json
@@ -9,8 +9,8 @@
   },
   "protein": {
     "meta": {
-      "title": "Protein Calculator — Daily Protein Intake Calculator",
-      "description": "Calculate your daily protein intake based on weight, activity level, goal, and diet type. Personalized recommendations with food sources."
+      "title": "Protein Calculator — Distribute Daily Intake by Meal & Diet",
+      "description": "Calculate your daily protein need with food sources for omnivore, vegetarian, and vegan diets. Distribute across 3-6 meals."
     },
     "title": "Protein Calculator",
     "description": "Calculate your daily protein target based on your weight, activity, goal, and diet.",

--- a/src/locales/calculators/en/proteinNeed.json
+++ b/src/locales/calculators/en/proteinNeed.json
@@ -9,8 +9,8 @@
   },
   "proteinNeed": {
     "meta": {
-      "title": "Protein Need Calculator — Daily Protein Requirement",
-      "description": "Calculate your daily protein requirement based on activity level, goal, age, and gender. With per-meal breakdown and food examples."
+      "title": "Protein Need Calculator — Daily Requirements by Age & Activity",
+      "description": "Determine your daily protein requirement based on activity level, age, and goal. Range-based recommendations with meal breakdown."
     },
     "title": "Protein Need Calculator",
     "description": "Calculate your individual daily protein requirement — adjusted for activity, goal, and age.",


### PR DESCRIPTION
## Summary

Closes #243.

- **`protein`**: retitled to meal-distribution / diet-type keyword target ("Distribute Daily Intake by Meal & Diet")
- **`proteinNeed`**: retitled to age & activity requirement keyword target ("Daily Requirements by Age & Activity")
- No deletions — Option B (differentiate, keep both)

## Changed files

| File | Change |
|------|--------|
| `de/protein.json` | `title`, `meta.title`, `meta.description` |
| `en/protein.json` | `meta.title`, `meta.description` |
| `de/proteinNeed.json` | `title`, `meta.title`, `meta.description` |
| `en/proteinNeed.json` | `meta.title`, `meta.description` |
| `src/__tests__/seo-title-uniqueness.test.js` | new test asserting de+en titles stay distinct |

## Test plan

- [x] `npm test` — 76 test files, 2080 tests, all GREEN
- [x] Partial-commit guard: exactly 5 paths changed vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)