### PR TITLE
add Menopause Symptom Calculator with MRS score and Heinemann 2003 cutoffs

### DIFF
--- a/e2e/menopauseSymptom.spec.js
+++ b/e2e/menopauseSymptom.spec.js
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/menopause-symptome-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Menopause-Symptome/)
+})
+
+test('no symptoms scored → no result card visible', async ({ page }) => {
+  await expect(page.getByTestId('result-total')).toHaveCount(0)
+})
+
+test('one mild symptom → mild category', async ({ page }) => {
+  await page.getByTestId('hotFlushes-2').click()
+  await page.getByTestId('sleepProblems-2').click()
+  await page.getByTestId('depressiveMood-2').click()
+  await expect(page.getByTestId('result-total')).toBeVisible()
+  await expect(page.getByTestId('result-total')).toHaveText('6')
+  await expect(page.getByTestId('result-category')).toHaveText('leicht')
+})
+
+test('severe symptoms → severe category and evaluation recommended', async ({ page }) => {
+  await page.getByTestId('hotFlushes-4').click()
+  await page.getByTestId('sleepProblems-4').click()
+  await page.getByTestId('depressiveMood-4').click()
+  await page.getByTestId('anxiety-4').click()
+  await page.getByTestId('exhaustion-1').click()
+  await expect(page.getByTestId('result-total')).toHaveText('17')
+  await expect(page.getByTestId('result-category')).toHaveText('schwer')
+  const status = page.getByTestId('evaluation-status')
+  await expect(status).toBeVisible()
+  await expect(status).toContainText(/Abklärung empfohlen/i)
+})
+
+test('subscale scores update independently', async ({ page }) => {
+  await page.getByTestId('hotFlushes-3').click()
+  await page.getByTestId('sleepProblems-3').click()
+  await page.getByTestId('depressiveMood-2').click()
+  await page.getByTestId('vaginalDryness-2').click()
+  await expect(page.getByTestId('somatic-score')).toContainText('6')
+  await expect(page.getByTestId('psychological-score')).toContainText('2')
+  await expect(page.getByTestId('urogenital-score')).toContainText('2')
+})
+
+test('changing a score replaces the previous value', async ({ page }) => {
+  await page.getByTestId('hotFlushes-4').click()
+  await expect(page.getByTestId('result-total')).toHaveText('4')
+  await page.getByTestId('hotFlushes-1').click()
+  await expect(page.getByTestId('result-total')).toHaveText('1')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -25,7 +25,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
-  'pregnancyBMI', 'fertilityWindow',
+  'pregnancyBMI', 'fertilityWindow', 'menopauseSymptom',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency']
@@ -105,6 +105,7 @@ const EXPECTED_ROUTE_MAP = {
   pediatricBloodPressure: { de: 'kinder-blutdruck-rechner', en: 'pediatric-blood-pressure-calculator' },
   pregnancyBMI: { de: 'bmi-schwangerschaft-rechner', en: 'pregnancy-bmi-calculator' },
   fertilityWindow: { de: 'fruchtbares-fenster-rechner', en: 'fertility-window-calculator' },
+  menopauseSymptom: { de: 'menopause-symptome-rechner', en: 'menopause-symptom-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -171,6 +172,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'vitamin-d-mangel',
   'bmi-schwangerschaft-berechnen',
   'fruchtbares-fenster-berechnen',
+  'menopause-symptome-bewerten',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -237,19 +239,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'vitamin-d-deficiency',
   'pregnancy-bmi-guide',
   'fertility-window-guide',
+  'menopause-symptom-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 76 calculators', () => {
-    expect(calculatorMetas).toHaveLength(76)
+  it('discovers all 77 calculators', () => {
+    expect(calculatorMetas).toHaveLength(77)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 76 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(76)
+  it('builds calculatorComponents map for all 77 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(77)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -272,15 +275,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 75 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(75)
+  it('discovers all 76 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 75 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(75)
+  it('discovers all 76 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -305,10 +308,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 76 calculators with no duplicates', () => {
+  it('groups contain all 77 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(76)
-    expect(new Set(allKeys).size).toBe(76)
+    expect(allKeys).toHaveLength(77)
+    expect(new Set(allKeys).size).toBe(77)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -336,7 +339,7 @@ describe('calculator groups', () => {
   it('pregnancy group has correct calculators in order', () => {
     expect(calculatorGroups[3].calculators).toEqual([
       'pregnancy', 'ovulation', 'pregnancyWeightGain', 'fertilityWindow', 'pregnancyBMI', 'period', 'dueDate', 'pcosSymptoms', 'apgarScore',
-      'babyMilestones', 'babyFeedingAmount', 'newbornBilirubin',
+      'babyMilestones', 'babyFeedingAmount', 'newbornBilirubin', 'menopauseSymptom',
     ])
   })
 })
@@ -378,8 +381,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 419 routes', () => {
-    expect(routes).toHaveLength(419)
+  it('generates exactly 424 routes', () => {
+    expect(routes).toHaveLength(424)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 302 links (76 calcs × 2 locales + 75 blogs × 2 locales)', () => {
+  it('generates 306 links (77 calcs × 2 locales + 76 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(302)
+    expect(links).toHaveLength(306)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/menopauseSymptom.test.js
+++ b/src/__tests__/menopauseSymptom.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { calcMenopauseSymptom, MRS_ITEMS } from '../utils/menopauseSymptom.js'
+
+// MRS — Menopause Rating Scale (Heinemann et al. 2003).
+// 11 items × 0–4 → total 0–44; subscales somatic (4 items), psychological (4),
+// urogenital (3). Severity cutoffs validated in BMC Health Qual Life Outcomes 2004.
+
+describe('calcMenopauseSymptom', () => {
+  it('returns total 0 and category none when no symptoms', () => {
+    const r = calcMenopauseSymptom({})
+    expect(r.total).toBe(0)
+    expect(r.somatic).toBe(0)
+    expect(r.psychological).toBe(0)
+    expect(r.urogenital).toBe(0)
+    expect(r.category).toBe('none')
+    expect(r.evaluationRecommended).toBe(false)
+  })
+
+  it('sums all 11 items into total score', () => {
+    const r = calcMenopauseSymptom({
+      hotFlushes: 4, heartDiscomfort: 4, sleepProblems: 4, jointMuscleDiscomfort: 4,
+      depressiveMood: 4, irritability: 4, anxiety: 4, exhaustion: 4,
+      sexualProblems: 4, bladderProblems: 4, vaginalDryness: 4,
+    })
+    expect(r.total).toBe(44)
+    expect(r.somatic).toBe(16)
+    expect(r.psychological).toBe(16)
+    expect(r.urogenital).toBe(12)
+    expect(r.category).toBe('severe')
+    expect(r.evaluationRecommended).toBe(true)
+  })
+
+  it('classifies total 5–8 as mild', () => {
+    const r = calcMenopauseSymptom({ hotFlushes: 2, sleepProblems: 2, depressiveMood: 2 })
+    expect(r.total).toBe(6)
+    expect(r.category).toBe('mild')
+    expect(r.evaluationRecommended).toBe(false)
+  })
+
+  it('classifies total 9–16 as moderate', () => {
+    const r = calcMenopauseSymptom({
+      hotFlushes: 3, sleepProblems: 3, depressiveMood: 3, anxiety: 3,
+    })
+    expect(r.total).toBe(12)
+    expect(r.category).toBe('moderate')
+    expect(r.evaluationRecommended).toBe(false)
+  })
+
+  it('classifies total ≥17 as severe and recommends evaluation', () => {
+    const r = calcMenopauseSymptom({
+      hotFlushes: 4, sleepProblems: 4, depressiveMood: 4, anxiety: 4, exhaustion: 1,
+    })
+    expect(r.total).toBe(17)
+    expect(r.category).toBe('severe')
+    expect(r.evaluationRecommended).toBe(true)
+  })
+
+  it('classifies somatic subscale per Heinemann cutoffs', () => {
+    expect(calcMenopauseSymptom({ hotFlushes: 2 }).somaticCategory).toBe('none')
+    expect(calcMenopauseSymptom({ hotFlushes: 3 }).somaticCategory).toBe('mild')
+    expect(calcMenopauseSymptom({ hotFlushes: 4, sleepProblems: 3 }).somaticCategory).toBe('moderate')
+    expect(calcMenopauseSymptom({ hotFlushes: 4, sleepProblems: 3, jointMuscleDiscomfort: 2 }).somaticCategory).toBe('severe')
+  })
+
+  it('classifies psychological subscale per Heinemann cutoffs', () => {
+    expect(calcMenopauseSymptom({ depressiveMood: 1 }).psychologicalCategory).toBe('none')
+    expect(calcMenopauseSymptom({ depressiveMood: 2 }).psychologicalCategory).toBe('mild')
+    expect(calcMenopauseSymptom({ depressiveMood: 3, irritability: 2 }).psychologicalCategory).toBe('moderate')
+    expect(calcMenopauseSymptom({ depressiveMood: 4, irritability: 3 }).psychologicalCategory).toBe('severe')
+  })
+
+  it('classifies urogenital subscale per Heinemann cutoffs', () => {
+    expect(calcMenopauseSymptom({}).urogenitalCategory).toBe('none')
+    expect(calcMenopauseSymptom({ vaginalDryness: 1 }).urogenitalCategory).toBe('mild')
+    expect(calcMenopauseSymptom({ vaginalDryness: 2 }).urogenitalCategory).toBe('moderate')
+    expect(calcMenopauseSymptom({ vaginalDryness: 2, bladderProblems: 2 }).urogenitalCategory).toBe('severe')
+  })
+
+  it('clamps inputs to 0–4 range and floors fractional values', () => {
+    const r = calcMenopauseSymptom({ hotFlushes: 9, sleepProblems: -3, depressiveMood: 2.6 })
+    expect(r.scores.hotFlushes).toBe(4)
+    expect(r.scores.sleepProblems).toBe(0)
+    expect(r.scores.depressiveMood).toBe(3)
+  })
+
+  it('ignores unknown keys and treats missing values as 0', () => {
+    const r = calcMenopauseSymptom({ unknownKey: 4, hotFlushes: 2 })
+    expect(r.total).toBe(2)
+    expect(r.scores.hotFlushes).toBe(2)
+  })
+
+  it('exposes 11 MRS_ITEMS with subscale tags', () => {
+    expect(MRS_ITEMS).toHaveLength(11)
+    expect(MRS_ITEMS.filter(i => i.subscale === 'somatic')).toHaveLength(4)
+    expect(MRS_ITEMS.filter(i => i.subscale === 'psychological')).toHaveLength(4)
+    expect(MRS_ITEMS.filter(i => i.subscale === 'urogenital')).toHaveLength(3)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -19,7 +19,7 @@ const EXPECTED_KEYS = [
   'heartFailureRisk', 'dehydrationRisk', 'thyroidFunction', 'anemiaRisk',
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
-  'pregnancyBMI', 'fertilityWindow',
+  'pregnancyBMI', 'fertilityWindow', 'menopauseSymptom',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -85,6 +85,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'vitamin-d-mangel',
   'bmi-schwangerschaft-berechnen',
   'fruchtbares-fenster-berechnen',
+  'menopause-symptome-bewerten',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -150,12 +151,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'vitamin-d-deficiency',
   'pregnancy-bmi-guide',
   'fertility-window-guide',
+  'menopause-symptom-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 76 calculator meta files', () => {
+  it('discovers all 77 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(76)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(77)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -193,19 +195,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 75 DE blog slugs', () => {
+  it('returns all 76 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(75)
+    expect(de).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 75 EN blog slugs', () => {
+  it('returns all 76 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(75)
+    expect(en).toHaveLength(76)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -273,9 +275,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 152 calcs + 2 blog index + 150 blog articles = 306)', () => {
+  it('generates correct total URL count (2 home + 154 calcs + 2 blog index + 152 blog articles = 310)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(306)
+    expect(urlCount).toBe(310)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -674,6 +674,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'fertilityWindow',
     related: ['calculate-ovulation', 'period-calculator-guide', 'calculate-due-date'],
   },
+  {
+    slug: 'menopause-symptom-calculator-guide',
+    title: 'Menopause Symptom Calculator: MRS Score, Severity Bands and Treatment',
+    description: 'Score menopause symptoms with the Menopause Rating Scale (MRS) — 11 items, 3 domains, Heinemann 2003 cutoffs. With calculator, severity bands and treatment overview.',
+    date: '2026-05-11',
+    readTime: '8 min',
+    calculatorKey: 'menopauseSymptom',
+    related: ['osteoporosis-risk-calculator-guide', 'pcos-symptom-checker', 'biological-age-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -674,6 +674,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'fertilityWindow',
     related: ['eisprung-berechnen', 'zyklusrechner-guide', 'geburtstermin-berechnen'],
   },
+  {
+    slug: 'menopause-symptome-bewerten',
+    title: 'Menopause-Symptome bewerten: MRS-Score, Schweregrade und Therapie',
+    description: 'Wechseljahresbeschwerden mit dem Menopause Rating Scale (MRS) bewerten — 11 Symptome, 3 Bereiche, Schweregradgrenzen nach Heinemann 2003. Mit Rechner und Therapie-Übersicht.',
+    date: '2026-05-11',
+    readTime: '8 min',
+    calculatorKey: 'menopauseSymptom',
+    related: ['osteoporose-risiko-berechnen', 'pcos-symptome-erkennen', 'biologisches-alter-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/menopauseSymptom.json
+++ b/src/locales/calculators/de/menopauseSymptom.json
@@ -1,0 +1,86 @@
+{
+  "home": {
+    "calculators": {
+      "menopauseSymptom": {
+        "name": "Menopause-Symptome-Rechner",
+        "description": "Schweregrad deiner Wechseljahresbeschwerden mit dem Menopause Rating Scale (MRS) bestimmen."
+      }
+    }
+  },
+  "menopauseSymptom": {
+    "meta": {
+      "title": "Menopause-Symptome-Rechner — MRS-Score online berechnen",
+      "description": "Wechseljahresbeschwerden mit dem Menopause Rating Scale (MRS) bewerten: Hitzewallungen, Schlafprobleme, Stimmung, urogenitale Symptome. Schnell, kostenlos, ohne Anmeldung."
+    },
+    "title": "Menopause-Symptome-Rechner",
+    "description": "Bewerte deine Wechseljahresbeschwerden mit dem klinisch validierten Menopause Rating Scale (MRS) — 11 Symptome, 3 Bereiche, klare Empfehlung.",
+    "intro": "Bitte bewerte für jedes der folgenden Symptome, wie stark du es aktuell empfindest:",
+    "somaticSection": "Somatisch-vegetativ",
+    "psychologicalSection": "Psychisch",
+    "urogenitalSection": "Urogenital",
+    "hotFlushes": "Hitzewallungen, Schwitzen",
+    "heartDiscomfort": "Herzbeschwerden (Herzklopfen, Stolpern, Beklemmung)",
+    "sleepProblems": "Schlafstörungen (Einschlafen, Durchschlafen, früh wach)",
+    "jointMuscleDiscomfort": "Gelenk- und Muskelbeschwerden",
+    "depressiveMood": "Depressive Verstimmung (Traurigkeit, Antriebslosigkeit, Weinen)",
+    "irritability": "Reizbarkeit (nervös, innere Anspannung, aggressiv)",
+    "anxiety": "Ängstlichkeit (innere Unruhe, Panik)",
+    "exhaustion": "Körperliche und geistige Erschöpfung (Leistungsknick, Vergesslichkeit)",
+    "sexualProblems": "Sexuelle Probleme (Lust, sexuelle Aktivität, Befriedigung)",
+    "bladderProblems": "Harnwegsbeschwerden (Drang, häufiges Wasserlassen, Inkontinenz)",
+    "vaginalDryness": "Trockenheit der Scheide (Brennen, Probleme beim Verkehr)",
+    "severity_0": "keine",
+    "severity_1": "leicht",
+    "severity_2": "mittel",
+    "severity_3": "stark",
+    "severity_4": "sehr stark",
+    "results": "MRS-Auswertung",
+    "totalScore": "Gesamtscore",
+    "subscaleScores": "Bereiche",
+    "category_none": "keine / sehr leicht",
+    "category_mild": "leicht",
+    "category_moderate": "moderat",
+    "category_severe": "schwer",
+    "interpretation_none": "Aktuell zeigen sich keine relevanten Wechseljahresbeschwerden. Beobachte deine Symptome und prüfe bei Veränderungen erneut.",
+    "interpretation_mild": "Leichte Wechseljahresbeschwerden. Lebensstilmaßnahmen (Schlafhygiene, Bewegung, Ernährung, Stressabbau) helfen oft schon spürbar.",
+    "interpretation_moderate": "Moderate Beschwerden, die deinen Alltag beeinträchtigen können. Ein Gespräch mit der Gynäkologin über Therapieoptionen ist sinnvoll.",
+    "interpretation_severe": "Schwere Beschwerden mit deutlicher Beeinträchtigung der Lebensqualität. Eine fachärztliche Abklärung mit Therapieplan (z. B. Hormonersatz, lokale Östrogene, Phytotherapie) ist klar empfohlen.",
+    "evaluationRecommended": "Fachärztliche Abklärung empfohlen — vereinbare einen Termin in der Gynäkologie.",
+    "evaluationNotRecommended": "Aktuell keine fachärztliche Abklärung dringend nötig. Bei Verschlechterung erneut prüfen.",
+    "mrsTitle": "Was ist das Menopause Rating Scale?",
+    "mrsText": "Das MRS ist der international meistgenutzte Fragebogen zur Erfassung von Wechseljahresbeschwerden (Heinemann et al. 2003). Es erfasst 11 typische Symptome in 3 Dimensionen — somatisch-vegetativ, psychisch und urogenital — und liefert einen Gesamtscore von 0 bis 44 sowie Subscores je Bereich.",
+    "subscalesTitle": "Die drei MRS-Dimensionen",
+    "somaticDescription": "Hitzewallungen, Herzbeschwerden, Schlafstörungen, Gelenk-/Muskelbeschwerden",
+    "psychologicalDescription": "Depressive Verstimmung, Reizbarkeit, Ängstlichkeit, Erschöpfung",
+    "urogenitalDescription": "Sexuelle Probleme, Harnwegsbeschwerden, vaginale Trockenheit",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Bewerte jedes der 11 Symptome auf einer Skala von 0 (keine) bis 4 (sehr stark). Der Rechner addiert deine Antworten zu einem Gesamtscore (0–44) und gibt einen Schweregrad je Dimension zurück. Die Cutoff-Werte entsprechen der Originalvalidierung (Heinemann 2003, Schneider 2000) und werden weltweit in Forschung und Praxis verwendet.",
+    "disclaimer": "Dieser Rechner ist ein Selbst-Screening, kein Diagnoseinstrument. Therapieentscheidungen (z. B. Hormonersatz) gehören immer in die Hand einer Gynäkologin oder eines Gynäkologen.",
+    "faq": [
+      {
+        "q": "Was ist die Menopause Rating Scale (MRS)?",
+        "a": "Die MRS ist ein 1996 entwickelter, klinisch validierter Fragebogen mit 11 Items zur Bewertung von Wechseljahresbeschwerden. Sie wird weltweit eingesetzt und ist in über 25 Sprachen übersetzt. Heinemann et al. 2003 haben die heutigen Cutoff-Werte etabliert."
+      },
+      {
+        "q": "Welche Symptome erfasst die MRS?",
+        "a": "11 typische Symptome in 3 Bereichen: somatisch (Hitzewallungen, Herzbeschwerden, Schlaf, Gelenke), psychisch (Stimmung, Reizbarkeit, Ängste, Erschöpfung) und urogenital (Sexualität, Blase, Scheidentrockenheit)."
+      },
+      {
+        "q": "Was bedeutet mein Gesamtscore?",
+        "a": "0–4: keine bis sehr leichte Beschwerden. 5–8: leichte Beschwerden. 9–16: moderate Beschwerden — Beratung sinnvoll. 17+: schwere Beschwerden — Therapie meist klar indiziert."
+      },
+      {
+        "q": "Wann sollte ich zur Gynäkologin?",
+        "a": "Ab moderaten Beschwerden (Score 9+) oder wenn ein einzelner Bereich (z. B. urogenital) auffällig ist. Bei schweren Symptomen (17+) oder Blutungsstörungen ist eine Abklärung dringend empfohlen — auch um andere Ursachen auszuschließen."
+      },
+      {
+        "q": "Welche Therapien gibt es bei Wechseljahresbeschwerden?",
+        "a": "Lebensstil (Bewegung, Schlafhygiene, kühle Räume, Gewicht), Hormonersatztherapie (HRT) systemisch oder lokal, nicht-hormonelle Optionen (SSRI/SNRI, Gabapentin, Clonidin), pflanzliche Mittel (Traubensilberkerze, Soja-Isoflavone) und Kognitive Verhaltenstherapie gegen Hitzewallungen."
+      },
+      {
+        "q": "Wie lange dauern die Wechseljahre?",
+        "a": "Im Mittel beginnt die Perimenopause Mitte 40 und dauert 4–8 Jahre. Vasomotorische Symptome (Hitzewallungen) bestehen median 7,4 Jahre — bei einigen Frauen mehr als 14 Jahre. Urogenitale Symptome bleiben oft lebenslang ohne lokale Therapie."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/menopauseSymptom.json
+++ b/src/locales/calculators/en/menopauseSymptom.json
@@ -1,0 +1,86 @@
+{
+  "home": {
+    "calculators": {
+      "menopauseSymptom": {
+        "name": "Menopause Symptom Calculator",
+        "description": "Score your menopause symptoms with the Menopause Rating Scale (MRS) — hot flushes, mood, urogenital signs."
+      }
+    }
+  },
+  "menopauseSymptom": {
+    "meta": {
+      "title": "Menopause Symptom Calculator — MRS Score Online",
+      "description": "Score your menopause symptoms with the validated Menopause Rating Scale (MRS): hot flushes, sleep, mood, urogenital signs. Fast, free, no sign-up."
+    },
+    "title": "Menopause Symptom Calculator",
+    "description": "Score your menopause symptoms using the clinically validated Menopause Rating Scale (MRS) — 11 symptoms, 3 domains, clear next steps.",
+    "intro": "Rate how strongly you currently experience each of the following symptoms:",
+    "somaticSection": "Somato-vegetative",
+    "psychologicalSection": "Psychological",
+    "urogenitalSection": "Urogenital",
+    "hotFlushes": "Hot flushes, sweating",
+    "heartDiscomfort": "Heart discomfort (palpitations, racing, tightness)",
+    "sleepProblems": "Sleep problems (falling asleep, staying asleep, early waking)",
+    "jointMuscleDiscomfort": "Joint and muscle discomfort",
+    "depressiveMood": "Depressive mood (sadness, low drive, tearfulness)",
+    "irritability": "Irritability (nervous, tense, aggressive)",
+    "anxiety": "Anxiety (inner restlessness, panic)",
+    "exhaustion": "Physical and mental exhaustion (performance drop, forgetfulness)",
+    "sexualProblems": "Sexual problems (desire, activity, satisfaction)",
+    "bladderProblems": "Bladder problems (urgency, frequency, incontinence)",
+    "vaginalDryness": "Vaginal dryness (burning, discomfort during sex)",
+    "severity_0": "none",
+    "severity_1": "mild",
+    "severity_2": "moderate",
+    "severity_3": "severe",
+    "severity_4": "very severe",
+    "results": "MRS assessment",
+    "totalScore": "Total score",
+    "subscaleScores": "Subscales",
+    "category_none": "none / very mild",
+    "category_mild": "mild",
+    "category_moderate": "moderate",
+    "category_severe": "severe",
+    "interpretation_none": "No relevant menopause symptoms right now. Track changes and re-check if your experience shifts.",
+    "interpretation_mild": "Mild menopause symptoms. Lifestyle measures (sleep hygiene, exercise, nutrition, stress reduction) often help noticeably.",
+    "interpretation_moderate": "Moderate symptoms that may affect daily life. A focused gynecology consultation about treatment options is reasonable.",
+    "interpretation_severe": "Severe symptoms with clear quality-of-life impact. A specialist work-up with a structured treatment plan (e.g. hormone therapy, local estrogen, phytotherapy) is clearly recommended.",
+    "evaluationRecommended": "Specialist evaluation recommended — book a gynecology appointment.",
+    "evaluationNotRecommended": "No urgent specialist evaluation indicated. Re-check if symptoms worsen.",
+    "mrsTitle": "What is the Menopause Rating Scale?",
+    "mrsText": "The MRS is the most widely used international questionnaire for assessing menopause symptoms (Heinemann et al. 2003). It captures 11 typical symptoms across 3 dimensions — somato-vegetative, psychological and urogenital — yielding a total score 0–44 plus subscale scores.",
+    "subscalesTitle": "The three MRS dimensions",
+    "somaticDescription": "Hot flushes, heart discomfort, sleep problems, joint/muscle complaints",
+    "psychologicalDescription": "Depressive mood, irritability, anxiety, exhaustion",
+    "urogenitalDescription": "Sexual problems, bladder symptoms, vaginal dryness",
+    "howItWorks": "How it works",
+    "howItWorksText": "Rate each of the 11 symptoms on a 0 (none) to 4 (very severe) scale. The calculator sums your answers into a total score (0–44) and reports a severity band per dimension. Cutoffs follow the original validation (Heinemann 2003, Schneider 2000) and are used worldwide in research and practice.",
+    "disclaimer": "This calculator is a self-screening tool, not a diagnostic instrument. Treatment decisions (e.g. hormone therapy) always belong with your gynecologist.",
+    "faq": [
+      {
+        "q": "What is the Menopause Rating Scale (MRS)?",
+        "a": "The MRS is an internationally validated 11-item questionnaire developed in 1996 to score menopause symptoms. It is translated into 25+ languages. Heinemann et al. 2003 established the severity cutoffs in use today."
+      },
+      {
+        "q": "Which symptoms does the MRS capture?",
+        "a": "11 typical symptoms across 3 domains: somato-vegetative (hot flushes, heart, sleep, joints), psychological (mood, irritability, anxiety, exhaustion) and urogenital (sexuality, bladder, vaginal dryness)."
+      },
+      {
+        "q": "What does my total score mean?",
+        "a": "0–4: none to very mild. 5–8: mild. 9–16: moderate — consult your gynecologist. 17+: severe — therapy is usually clearly indicated."
+      },
+      {
+        "q": "When should I see a gynecologist?",
+        "a": "Once symptoms are moderate (score 9+) or if a single domain (e.g. urogenital) stands out. With severe symptoms (17+) or bleeding changes a work-up is clearly indicated — also to rule out other causes."
+      },
+      {
+        "q": "What treatments exist for menopause symptoms?",
+        "a": "Lifestyle (exercise, sleep hygiene, cool rooms, weight), hormone therapy (HT) systemic or local, non-hormonal options (SSRI/SNRI, gabapentin, clonidine), phytotherapy (black cohosh, soy isoflavones) and cognitive behavioral therapy for hot flushes."
+      },
+      {
+        "q": "How long do menopause symptoms last?",
+        "a": "Perimenopause typically begins in the mid-40s and lasts 4–8 years. Vasomotor symptoms (hot flushes) persist a median of 7.4 years — for some women more than 14 years. Urogenital symptoms often remain lifelong without local treatment."
+      }
+    ]
+  }
+}

--- a/src/pages/MenopauseSymptomCalculator.vue
+++ b/src/pages/MenopauseSymptomCalculator.vue
@@ -1,0 +1,228 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcMenopauseSymptom, MRS_ITEMS } from '../utils/menopauseSymptom.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('menopauseSymptom.faq') || [])
+
+useHead(() => ({
+  title: t('menopauseSymptom.meta.title'),
+  description: t('menopauseSymptom.meta.description'),
+  routeKey: 'menopauseSymptom',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Menopause Symptom Calculator',
+    url: 'https://healthcalculator.app/en/menopause-symptom-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const scores = ref(Object.fromEntries(MRS_ITEMS.map(i => [i.key, 0])))
+
+function setScore(key, value) {
+  scores.value[key] = value
+}
+
+const somaticItems = MRS_ITEMS.filter(i => i.subscale === 'somatic')
+const psychologicalItems = MRS_ITEMS.filter(i => i.subscale === 'psychological')
+const urogenitalItems = MRS_ITEMS.filter(i => i.subscale === 'urogenital')
+
+const result = computed(() => calcMenopauseSymptom(scores.value))
+
+const hasInput = computed(() => Object.values(scores.value).some(v => v > 0))
+
+const categoryColor = computed(() => {
+  if (!result.value) return ''
+  switch (result.value.category) {
+    case 'none': return 'text-green-600'
+    case 'mild': return 'text-lime-600'
+    case 'moderate': return 'text-yellow-600'
+    case 'severe': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+})
+
+const categoryBg = computed(() => {
+  if (!result.value) return 'bg-stone-300'
+  switch (result.value.category) {
+    case 'none': return 'bg-green-500'
+    case 'mild': return 'bg-lime-500'
+    case 'moderate': return 'bg-yellow-500'
+    case 'severe': return 'bg-red-600'
+    default: return 'bg-stone-300'
+  }
+})
+
+const subscaleColor = (cat) => {
+  switch (cat) {
+    case 'none': return 'text-green-600'
+    case 'mild': return 'text-lime-600'
+    case 'moderate': return 'text-yellow-600'
+    case 'severe': return 'text-red-600'
+    default: return 'text-stone-600'
+  }
+}
+
+const severityLevels = [0, 1, 2, 3, 4]
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('menopauseSymptom.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('menopauseSymptom.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-sm text-stone-600 mb-6">{{ t('menopauseSymptom.intro') }}</p>
+
+    <div class="mb-8">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('menopauseSymptom.somaticSection') }}</h2>
+      <div class="space-y-4">
+        <div v-for="item in somaticItems" :key="item.key">
+          <p class="text-sm text-stone-700 mb-2">{{ t('menopauseSymptom.' + item.key) }}</p>
+          <div class="grid grid-cols-5 gap-2">
+            <button
+              v-for="level in severityLevels"
+              :key="level"
+              @click="setScore(item.key, level)"
+              :data-testid="item.key + '-' + level"
+              :class="scores[item.key] === level ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-2 py-2 rounded-lg text-xs font-medium transition-colors duration-150"
+            >{{ t('menopauseSymptom.severity_' + level) }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mb-8 pt-6 border-t border-stone-100">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('menopauseSymptom.psychologicalSection') }}</h2>
+      <div class="space-y-4">
+        <div v-for="item in psychologicalItems" :key="item.key">
+          <p class="text-sm text-stone-700 mb-2">{{ t('menopauseSymptom.' + item.key) }}</p>
+          <div class="grid grid-cols-5 gap-2">
+            <button
+              v-for="level in severityLevels"
+              :key="level"
+              @click="setScore(item.key, level)"
+              :data-testid="item.key + '-' + level"
+              :class="scores[item.key] === level ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-2 py-2 rounded-lg text-xs font-medium transition-colors duration-150"
+            >{{ t('menopauseSymptom.severity_' + level) }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="pt-6 border-t border-stone-100">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('menopauseSymptom.urogenitalSection') }}</h2>
+      <div class="space-y-4">
+        <div v-for="item in urogenitalItems" :key="item.key">
+          <p class="text-sm text-stone-700 mb-2">{{ t('menopauseSymptom.' + item.key) }}</p>
+          <div class="grid grid-cols-5 gap-2">
+            <button
+              v-for="level in severityLevels"
+              :key="level"
+              @click="setScore(item.key, level)"
+              :data-testid="item.key + '-' + level"
+              :class="scores[item.key] === level ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+              class="px-2 py-2 rounded-lg text-xs font-medium transition-colors duration-150"
+            >{{ t('menopauseSymptom.severity_' + level) }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="hasInput && result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('menopauseSymptom.results') }}</p>
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="result-total">{{ result.total }}</span>
+      <span class="text-lg text-stone-400">/ 44</span>
+      <span :class="categoryColor" class="text-lg font-semibold" data-testid="result-category">{{ t('menopauseSymptom.category_' + result.category) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div :class="categoryBg" class="absolute inset-y-0 left-0 transition-all duration-300" :style="{ width: (result.total / 44 * 100) + '%' }"></div>
+    </div>
+
+    <div class="bg-stone-50 rounded-lg p-4 mb-4" data-testid="interpretation">
+      <p class="text-sm text-stone-700 leading-relaxed">{{ t('menopauseSymptom.interpretation_' + result.category) }}</p>
+    </div>
+
+    <div class="grid grid-cols-3 gap-3 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('menopauseSymptom.somaticSection') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="somatic-score">{{ result.somatic }} <span class="text-sm text-stone-400">/ 16</span></p>
+        <p :class="subscaleColor(result.somaticCategory)" class="text-xs font-semibold mt-1" data-testid="somatic-category">{{ t('menopauseSymptom.category_' + result.somaticCategory) }}</p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('menopauseSymptom.psychologicalSection') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="psychological-score">{{ result.psychological }} <span class="text-sm text-stone-400">/ 16</span></p>
+        <p :class="subscaleColor(result.psychologicalCategory)" class="text-xs font-semibold mt-1" data-testid="psychological-category">{{ t('menopauseSymptom.category_' + result.psychologicalCategory) }}</p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('menopauseSymptom.urogenitalSection') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums" data-testid="urogenital-score">{{ result.urogenital }} <span class="text-sm text-stone-400">/ 12</span></p>
+        <p :class="subscaleColor(result.urogenitalCategory)" class="text-xs font-semibold mt-1" data-testid="urogenital-category">{{ t('menopauseSymptom.category_' + result.urogenitalCategory) }}</p>
+      </div>
+    </div>
+
+    <div
+      class="rounded-lg p-4 text-sm font-medium"
+      :class="result.evaluationRecommended ? 'bg-red-50 text-red-900 border border-red-200' : 'bg-green-50 text-green-900 border border-green-200'"
+      data-testid="evaluation-status"
+    >
+      {{ result.evaluationRecommended ? t('menopauseSymptom.evaluationRecommended') : t('menopauseSymptom.evaluationNotRecommended') }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('menopauseSymptom.subscalesTitle') }}</h2>
+    </div>
+    <ul class="divide-y divide-stone-100">
+      <li class="px-6 py-3">
+        <p class="text-sm font-semibold text-stone-900">{{ t('menopauseSymptom.somaticSection') }}</p>
+        <p class="text-xs text-stone-500 mt-1">{{ t('menopauseSymptom.somaticDescription') }}</p>
+      </li>
+      <li class="px-6 py-3">
+        <p class="text-sm font-semibold text-stone-900">{{ t('menopauseSymptom.psychologicalSection') }}</p>
+        <p class="text-xs text-stone-500 mt-1">{{ t('menopauseSymptom.psychologicalDescription') }}</p>
+      </li>
+      <li class="px-6 py-3">
+        <p class="text-sm font-semibold text-stone-900">{{ t('menopauseSymptom.urogenitalSection') }}</p>
+        <p class="text-xs text-stone-500 mt-1">{{ t('menopauseSymptom.urogenitalDescription') }}</p>
+      </li>
+    </ul>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('menopauseSymptom.mrsTitle') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed mb-4">{{ t('menopauseSymptom.mrsText') }}</p>
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('menopauseSymptom.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('menopauseSymptom.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('menopauseSymptom.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="menopauseSymptom" />
+</template>

--- a/src/pages/blog/MenopauseSymptomeBewerten.vue
+++ b/src/pages/blog/MenopauseSymptomeBewerten.vue
@@ -1,0 +1,204 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Was ist das Menopause Rating Scale (MRS)?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Die MRS ist ein international validierter Fragebogen mit 11 Items zur Bewertung von Wechseljahresbeschwerden in 3 Dimensionen (somatisch, psychisch, urogenital). Heinemann et al. 2003 haben die heute genutzten Schweregradgrenzen etabliert.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Was bedeutet mein MRS-Gesamtscore?',
+      acceptedAnswer: { '@type': 'Answer', text: '0–4 Punkte: keine bis sehr leichte Beschwerden. 5–8: leicht. 9–16: moderat. 17+: schwer — Therapie meist klar indiziert.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Wie lange dauern Wechseljahresbeschwerden?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Vasomotorische Symptome bestehen median 7,4 Jahre. Urogenitale Symptome bleiben oft lebenslang ohne lokale Therapie.' },
+    },
+  ],
+}
+
+useHead({
+  title: 'Menopause-Symptome bewerten: MRS-Score, Schweregrade und Therapieoptionen | Health Calculators',
+  description: 'Wechseljahresbeschwerden mit dem Menopause Rating Scale (MRS) bewerten — 11 Symptome, 3 Bereiche, Schweregradgrenzen nach Heinemann 2003. Mit Rechner und Therapie-Übersicht.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Menopause-Symptome bewerten: MRS-Score, Schweregrade und der Weg zur Therapie',
+      description: 'Wechseljahresbeschwerden mit dem Menopause Rating Scale (MRS) bewerten — 11 Symptome, 3 Bereiche, Schweregradgrenzen nach Heinemann 2003. Mit Rechner und Therapie-Übersicht.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-11',
+      dateModified: '2026-05-11',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/menopause-symptome-bewerten',
+      },
+    },
+    faqJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Menopause-Symptome bewerten: MRS-Score, Schweregrade und der Weg zur Therapie</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">11. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>Wechseljahre</strong> sind keine Krankheit — aber sie können den Alltag massiv beeinträchtigen. Hitzewallungen, Schlafstörungen, Stimmungsschwankungen und urogenitale Beschwerden treten in unterschiedlicher Intensität auf, oft über viele Jahre hinweg.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das <strong>Menopause Rating Scale (MRS)</strong> ist der internationale Goldstandard zur Erfassung dieser Beschwerden. Es liefert einen klaren Schweregrad pro Bereich — und damit eine fundierte Grundlage für das Gespräch mit der Gynäkologin.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist das Menopause Rating Scale?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die MRS wurde 1996 in Deutschland entwickelt (Schneider, Heinemann) und ist heute in über 25 Sprachen übersetzt. Sie erfasst <strong>11 typische Wechseljahressymptome</strong> auf einer 5-stufigen Skala (0 = keine, 4 = sehr stark) — gruppiert in 3 klinisch sinnvolle Dimensionen:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Dimension</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptome</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Range</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Somatisch-vegetativ</td><td class="px-6 py-3 text-stone-600">Hitzewallungen, Herzbeschwerden, Schlaf, Gelenke</td><td class="px-6 py-3 text-stone-600 tabular-nums">0–16</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Psychisch</td><td class="px-6 py-3 text-stone-600">Stimmung, Reizbarkeit, Ängste, Erschöpfung</td><td class="px-6 py-3 text-stone-600 tabular-nums">0–16</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Urogenital</td><td class="px-6 py-3 text-stone-600">Sexualität, Blase, Scheidentrockenheit</td><td class="px-6 py-3 text-stone-600 tabular-nums">0–12</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der Gesamtscore reicht von <strong>0 bis 44</strong>. Die Schweregradgrenzen (Heinemann et al. 2003) sind in zehntausenden Patientinnen validiert und werden weltweit in Studien und Praxis genutzt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">MRS-Schweregrade — was bedeutet dein Score?</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Gesamtscore</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Schweregrad</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Empfehlung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0–4</td><td class="px-6 py-3 text-stone-600">keine / sehr leicht</td><td class="px-6 py-3 text-stone-600">Beobachten</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5–8</td><td class="px-6 py-3 text-stone-600">leicht</td><td class="px-6 py-3 text-stone-600">Lebensstil-Maßnahmen meist ausreichend</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">9–16</td><td class="px-6 py-3 text-stone-600">moderat</td><td class="px-6 py-3 text-stone-600">Gynäkologische Beratung sinnvoll</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">≥ 17</td><td class="px-6 py-3 text-stone-600">schwer</td><td class="px-6 py-3 text-stone-600">Fachärztliche Therapie klar empfohlen</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deinen MRS-Score berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">11 Symptome, 3 Bereiche, klare Schweregrad-Auswertung nach Heinemann 2003. Kostenlos, sofort, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('menopauseSymptom')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >MRS-Score berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die wichtigsten Symptome im Detail</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Hitzewallungen (vasomotorische Symptome)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Häufigstes Symptom (≈ 80 % aller Frauen). Mediane Dauer: 7,4 Jahre — bei Frauen mit frühem Beginn sogar &gt; 14 Jahre. Auslöser: Schwankungen der Östrogene mit Sensibilisierung des hypothalamischen Thermoregulationszentrums.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Schlafstörungen</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Bei ≈ 40–60 % der Frauen. Teils durch nächtliches Schwitzen, teils unabhängig — Östrogenmangel verändert REM-Phasen und Stimmung. Schlafhygiene und Therapie der Hitzewallungen helfen beide.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Stimmungsänderungen</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Reizbarkeit, depressive Verstimmung und Ängste treten in der Perimenopause 2–4× häufiger auf als zuvor. Wichtiger Differentialcheck: echte Depression (PHQ-9) abgrenzen — beides ist behandelbar.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Urogenitale Beschwerden (GSM)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Scheidentrockenheit, Brennen, Drangsymptomatik, Inkontinenz — zusammengefasst als „Genitourinäres Menopause-Syndrom". Bessert sich oft <em>nicht</em> spontan und sollte aktiv behandelt werden (lokale Östrogene sind sehr wirksam und sicher).</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Therapie — was wirklich hilft</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lebensstil</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Kühle Schlafräume, regelmäßige Bewegung (3–5× pro Woche), Gewichtskontrolle, Alkohol- und Koffein-Begrenzung — alles mit moderaten, aber realen Effekten.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Hormonersatztherapie (HRT)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Goldstandard für moderate bis schwere Beschwerden. Senkt MRS-Score klinisch deutlich, schützt vor Osteoporose, hat klar definiertes Risikoprofil. Frühstart (&lt; 60 J., &lt; 10 J. seit Menopause) verbessert Nutzen-Risiko-Bilanz erheblich.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Nicht-hormonell</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">SSRI/SNRI (Venlafaxin, Paroxetin), Gabapentin, Clonidin, neu: Fezolinetant (NK3-Antagonist). Kognitive Verhaltenstherapie reduziert Hitzewallungen messbar.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lokale Östrogene</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Für urogenitale Beschwerden sehr wirksam und systemisch nahezu wirkungslos — auch nach Mammakarzinom oft vertretbar (individuelle Abwägung).</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wechseljahre, Knochen und Stoffwechsel</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Östrogenmangel beschleunigt den <strong>Knochenabbau</strong> messbar — in den ersten 5 Jahren nach Menopause verlieren Frauen 1–3 % Knochenmasse pro Jahr. Prüfe daher dein
+          <router-link :to="localeBlogPath('osteoporose-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Osteoporose-Risiko</router-link>
+          parallel zum MRS — Knochendichte-Messung wird ab 65 Jahren oder bei Risikofaktoren empfohlen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wechseljahre verändern auch Stoffwechsel und Hormone insgesamt. Wenn du Zyklusunregelmäßigkeiten oder typische androgene Zeichen hast, schau zusätzlich den
+          <router-link :to="localeBlogPath('pcos-symptome-erkennen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">PCOS-Symptom-Check</router-link>
+          an. Für ein Gesamtbild deiner Alterungsbiologie lohnt sich das
+          <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biologische Alter</router-link>
+          — ein ehrlicher Blick auf den eigenen Status.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wechseljahresbeschwerden sind häufig, oft jahrelang — und meist gut behandelbar. Die MRS gibt dir einen klaren, vergleichbaren Wert für die Schwere deiner Symptome und einen sinnvollen Ausgangspunkt für die nächste Sprechstunde. Starte mit dem
+          <router-link :to="localePath('menopauseSymptom')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">MRS-Rechner</router-link> und nimm das Ergebnis mit ins Gespräch mit deiner Gynäkologin.
+        </p>
+      </div>
+
+      <RelatedArticles slug="menopause-symptome-bewerten" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/MenopauseSymptomCalculatorGuide.vue
+++ b/src/pages/blog/en/MenopauseSymptomCalculatorGuide.vue
@@ -1,0 +1,204 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is the Menopause Rating Scale (MRS)?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The MRS is an internationally validated 11-item questionnaire that scores menopause symptoms across three domains — somato-vegetative, psychological and urogenital. Heinemann et al. 2003 established the severity cutoffs in use today.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'What does my MRS total score mean?',
+      acceptedAnswer: { '@type': 'Answer', text: '0–4: none to very mild. 5–8: mild. 9–16: moderate. 17+: severe — therapy is usually clearly indicated.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'How long do menopause symptoms last?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Vasomotor symptoms persist a median of 7.4 years. Urogenital symptoms often remain lifelong without local treatment.' },
+    },
+  ],
+}
+
+useHead({
+  title: 'Menopause Symptom Calculator: MRS Score, Severity Bands and Treatment Options | Health Calculators',
+  description: 'Score menopause symptoms with the Menopause Rating Scale (MRS) — 11 items, 3 domains, Heinemann 2003 cutoffs. With calculator, severity bands and treatment overview.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Menopause Symptom Calculator: MRS Score, Severity Bands and the Path to Treatment',
+      description: 'Score menopause symptoms with the Menopause Rating Scale (MRS) — 11 items, 3 domains, Heinemann 2003 cutoffs. With calculator, severity bands and treatment overview.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-11',
+      dateModified: '2026-05-11',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/menopause-symptom-calculator-guide',
+      },
+    },
+    faqJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Menopause Symptom Calculator: MRS Score, Severity Bands and the Path to Treatment</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 11, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Menopause</strong> is not a disease — but it can disrupt daily life substantially. Hot flushes, sleep problems, mood swings and urogenital symptoms appear with varying intensity, often persisting for years.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The <strong>Menopause Rating Scale (MRS)</strong> is the international gold standard for assessing these symptoms. It produces a clear severity band per domain — a solid foundation for the conversation with your gynecologist.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is the Menopause Rating Scale?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Developed in Germany in 1996 (Schneider, Heinemann), the MRS is now translated into 25+ languages. It captures <strong>11 typical menopause symptoms</strong> on a 5-point scale (0 = none, 4 = very severe) — grouped into three clinically meaningful domains:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Domain</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptoms</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Range</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Somato-vegetative</td><td class="px-6 py-3 text-stone-600">Hot flushes, heart discomfort, sleep, joints</td><td class="px-6 py-3 text-stone-600 tabular-nums">0–16</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Psychological</td><td class="px-6 py-3 text-stone-600">Mood, irritability, anxiety, exhaustion</td><td class="px-6 py-3 text-stone-600 tabular-nums">0–16</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Urogenital</td><td class="px-6 py-3 text-stone-600">Sexuality, bladder, vaginal dryness</td><td class="px-6 py-3 text-stone-600 tabular-nums">0–12</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The total score ranges from <strong>0 to 44</strong>. The severity cutoffs (Heinemann et al. 2003) have been validated in tens of thousands of women and are used worldwide in research and routine care.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">MRS severity bands — what does your score mean?</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Total score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Severity</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Recommendation</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0–4</td><td class="px-6 py-3 text-stone-600">none / very mild</td><td class="px-6 py-3 text-stone-600">Watchful waiting</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5–8</td><td class="px-6 py-3 text-stone-600">mild</td><td class="px-6 py-3 text-stone-600">Lifestyle measures usually sufficient</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">9–16</td><td class="px-6 py-3 text-stone-600">moderate</td><td class="px-6 py-3 text-stone-600">Gynecology consult reasonable</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium tabular-nums">≥ 17</td><td class="px-6 py-3 text-stone-600">severe</td><td class="px-6 py-3 text-stone-600">Specialist treatment clearly indicated</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your MRS score now</h3>
+        <p class="text-stone-300 text-sm mb-5">11 symptoms, 3 domains, clear severity output per Heinemann 2003. Free, instant, no sign-up.</p>
+        <router-link
+          :to="localePath('menopauseSymptom')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate MRS score &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The key symptoms in detail</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Hot flushes (vasomotor symptoms)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">The most common symptom (≈ 80 % of women). Median duration: 7.4 years — for early-onset women &gt; 14 years. Driven by fluctuating estrogen and a sensitized hypothalamic thermoregulation centre.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Sleep problems</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Affect ≈ 40–60 % of women. Partly from night sweats, partly independent — estrogen withdrawal alters REM and mood. Sleep hygiene plus treating vasomotor symptoms both help.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Mood changes</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Irritability, depressive mood and anxiety occur 2–4× more often during perimenopause. Differential check: rule out major depression (PHQ-9) — both are treatable.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Genitourinary symptoms (GSM)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Vaginal dryness, burning, urgency, incontinence — collectively termed "genitourinary syndrome of menopause". Often does <em>not</em> resolve spontaneously and should be treated actively (local estrogen is highly effective and safe).</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Treatment — what actually works</h2>
+        <div class="space-y-3">
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Lifestyle</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Cool sleep rooms, regular exercise (3–5× per week), weight management, limited alcohol and caffeine — all with modest but real effects.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Hormone therapy (HT)</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Gold standard for moderate-to-severe symptoms. Reduces MRS score substantially, protects against osteoporosis, has a well-defined risk profile. Early start (&lt; age 60, &lt; 10 years post-menopause) markedly improves the benefit-risk ratio.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Non-hormonal</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">SSRI/SNRI (venlafaxine, paroxetine), gabapentin, clonidine, newer: fezolinetant (NK3 antagonist). Cognitive behavioral therapy measurably reduces hot flushes.</p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Local estrogen</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Highly effective for urogenital symptoms with virtually no systemic absorption — often acceptable even after breast cancer (individualized decision).</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Menopause, bone and metabolism</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Estrogen loss measurably accelerates <strong>bone loss</strong> — in the first 5 years post-menopause women lose 1–3 % of bone mass per year. Check your
+          <router-link :to="localeBlogPath('osteoporosis-risk-calculator-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">osteoporosis risk</router-link>
+          alongside your MRS — bone density (DEXA) is recommended from age 65 or earlier with risk factors.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Menopause shifts metabolism and hormones overall. If you have cycle irregularities or androgenic signs, also run the
+          <router-link :to="localeBlogPath('pcos-symptom-checker')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">PCOS symptom check</router-link>.
+          For an overall picture of your aging biology the
+          <router-link :to="localeBlogPath('biological-age-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biological age calculator</router-link>
+          is an honest reality check.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Menopause symptoms are common, often long-lasting — and usually highly treatable. The MRS gives you a clear, comparable severity score and a solid starting point for your next consultation. Start with the
+          <router-link :to="localePath('menopauseSymptom')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">MRS calculator</router-link> and bring the result into your conversation with your gynecologist.
+        </p>
+      </div>
+
+      <RelatedArticles slug="menopause-symptom-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/menopauseSymptom.meta.js
+++ b/src/pages/menopauseSymptom.meta.js
@@ -1,0 +1,16 @@
+import Component from './MenopauseSymptomCalculator.vue'
+import BlogDe from './blog/MenopauseSymptomeBewerten.vue'
+import BlogEn from './blog/en/MenopauseSymptomCalculatorGuide.vue'
+
+export default {
+  key: 'menopauseSymptom',
+  component: Component,
+  slugs: { de: 'menopause-symptome-rechner', en: 'menopause-symptom-calculator' },
+  group: 'pregnancy',
+  groupOrder: 4,
+  order: 200,
+  blog: {
+    de: { slug: 'menopause-symptome-bewerten', component: BlogDe },
+    en: { slug: 'menopause-symptom-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/menopauseSymptom.js
+++ b/src/utils/menopauseSymptom.js
@@ -1,0 +1,91 @@
+// Menopause Rating Scale (MRS) — Heinemann et al. 2003.
+// 11 items, each rated 0–4 (none/mild/moderate/severe/very severe).
+// Grouped into 3 subscales: somato-vegetative, psychological, urogenital.
+//
+// Total score = sum of 11 items, range 0–44.
+// Severity (total): 0–4 none/very mild · 5–8 mild · 9–16 moderate · ≥17 severe.
+// Subscale cutoffs (Heinemann 2003):
+//   somatic:        0–2 none · 3–4 mild · 5–8 moderate · ≥9 severe
+//   psychological:  0–1 none · 2–3 mild · 4–6 moderate · ≥7 severe
+//   urogenital:     0   none · 1   mild · 2–3 moderate · ≥4 severe
+
+export const MRS_ITEMS = [
+  { key: 'hotFlushes', subscale: 'somatic' },
+  { key: 'heartDiscomfort', subscale: 'somatic' },
+  { key: 'sleepProblems', subscale: 'somatic' },
+  { key: 'jointMuscleDiscomfort', subscale: 'somatic' },
+  { key: 'depressiveMood', subscale: 'psychological' },
+  { key: 'irritability', subscale: 'psychological' },
+  { key: 'anxiety', subscale: 'psychological' },
+  { key: 'exhaustion', subscale: 'psychological' },
+  { key: 'sexualProblems', subscale: 'urogenital' },
+  { key: 'bladderProblems', subscale: 'urogenital' },
+  { key: 'vaginalDryness', subscale: 'urogenital' },
+]
+
+function clamp(n) {
+  const v = Math.round(Number(n) || 0)
+  if (v < 0) return 0
+  if (v > 4) return 4
+  return v
+}
+
+function totalCategory(score) {
+  if (score <= 4) return 'none'
+  if (score <= 8) return 'mild'
+  if (score <= 16) return 'moderate'
+  return 'severe'
+}
+
+function somaticCategory(score) {
+  if (score <= 2) return 'none'
+  if (score <= 4) return 'mild'
+  if (score <= 8) return 'moderate'
+  return 'severe'
+}
+
+function psychologicalCategory(score) {
+  if (score <= 1) return 'none'
+  if (score <= 3) return 'mild'
+  if (score <= 6) return 'moderate'
+  return 'severe'
+}
+
+function urogenitalCategory(score) {
+  if (score === 0) return 'none'
+  if (score === 1) return 'mild'
+  if (score <= 3) return 'moderate'
+  return 'severe'
+}
+
+export function calcMenopauseSymptom(values = {}) {
+  const scores = {}
+  for (const item of MRS_ITEMS) {
+    scores[item.key] = clamp(values[item.key])
+  }
+
+  const somatic = MRS_ITEMS
+    .filter(i => i.subscale === 'somatic')
+    .reduce((s, i) => s + scores[i.key], 0)
+  const psychological = MRS_ITEMS
+    .filter(i => i.subscale === 'psychological')
+    .reduce((s, i) => s + scores[i.key], 0)
+  const urogenital = MRS_ITEMS
+    .filter(i => i.subscale === 'urogenital')
+    .reduce((s, i) => s + scores[i.key], 0)
+
+  const total = somatic + psychological + urogenital
+
+  return {
+    scores,
+    somatic,
+    psychological,
+    urogenital,
+    total,
+    category: totalCategory(total),
+    somaticCategory: somaticCategory(somatic),
+    psychologicalCategory: psychologicalCategory(psychological),
+    urogenitalCategory: urogenitalCategory(urogenital),
+    evaluationRecommended: total >= 17,
+  }
+}


### PR DESCRIPTION
## Summary
- Implements the Menopause Rating Scale (MRS) — 11 items, 3 domains (somato-vegetative, psychological, urogenital), total 0–44 with Heinemann 2003 severity bands
- New calculator at `/de/menopause-symptome-rechner` + `/en/menopause-symptom-calculator`, with DE + EN blog articles and full FAQ
- Internal linking from blog → osteoporosis, PCOS, biological-age calculators (existing routes verified)

## Test plan
- [x] 11 unit tests for `calcMenopauseSymptom` (subscale cutoffs, clamping, total severity)
- [x] 7 Playwright E2E tests (page load, mild/severe categories, subscale isolation, score replacement, back link)
- [x] Full vitest run (76 files, 2094 tests) green
- [x] `npm run build` succeeds → 310 sitemap URLs, 306 llms.txt links, SSG pre-rendering for new routes

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)