### PR TITLE
hc-140-iron-deficiency: Implement the Iron Deficiency Calculator as described in iss

### DIFF
--- a/e2e/ironDeficiency.spec.js
+++ b/e2e/ironDeficiency.spec.js
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/eisenmangel-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Eisenmangel-Rechner/)
+})
+
+test('healthy adult: ferritin 120 + TSAT 28 + no symptoms → no risk', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('ferritin').fill('120')
+  await page.getByTestId('tsat').fill('28')
+  await page.getByTestId('hemoglobin').fill('13.5')
+  await expect(page.getByTestId('result-status')).toHaveText('Kein Risiko')
+})
+
+test('latent iron deficiency: ferritin 20 → moderate via ferritin', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('ferritin').fill('20')
+  await page.getByTestId('tsat').fill('22')
+  await page.getByTestId('hemoglobin').fill('13')
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+})
+
+test('severe: ferritin 10 + low Hb → severe', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('ferritin').fill('10')
+  await page.getByTestId('tsat').fill('12')
+  await page.getByTestId('hemoglobin').fill('10')
+  await expect(page.getByTestId('result-status')).toHaveText('Schwer')
+})
+
+test('low TSAT alone → mild', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('male')
+  await page.getByTestId('ferritin').fill('120')
+  await page.getByTestId('tsat').fill('18')
+  await page.getByTestId('hemoglobin').fill('14')
+  await expect(page.getByTestId('result-status')).toHaveText('Leicht')
+})
+
+test('symptom-only screening: 5 symptom points → moderate', async ({ page }) => {
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('ferritin').fill('120')
+  await page.getByTestId('tsat').fill('25')
+  await page.getByTestId('hemoglobin').fill('13')
+  await page.getByTestId('checkbox-fatigue').check()
+  await page.getByTestId('checkbox-restlessLegs').check()
+  await page.getByTestId('checkbox-pica').check()
+  await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+  await expect(page.getByTestId('symptom-score')).toContainText('5')
+})
+
+test('imperial unit toggle (g/L for Hb) works', async ({ page }) => {
+  await page.getByRole('button', { name: 'µg/L · g/L', exact: true }).click()
+  await page.getByTestId('sex').selectOption('female')
+  await page.getByTestId('ferritin').fill('120')
+  await page.getByTestId('tsat').fill('28')
+  await page.getByTestId('hemoglobin').fill('135') // 13.5 g/dL
+  await expect(page.getByTestId('result-status')).toHaveText('Kein Risiko')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -26,6 +26,7 @@ const EXPECTED_KEYS = [
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
+  'ironDeficiency',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention']
@@ -109,6 +110,7 @@ const EXPECTED_ROUTE_MAP = {
   breastMilkAlcohol: { de: 'alkohol-stillen-rechner', en: 'breast-milk-alcohol-calculator' },
   menopauseSymptom: { de: 'menopause-symptome-rechner', en: 'menopause-symptom-calculator' },
   pearlIndexRechner: { de: 'pearl-index-rechner', en: 'pearl-index-calculator' },
+  ironDeficiency: { de: 'eisenmangel-rechner', en: 'iron-deficiency-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -180,6 +182,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'menopause-symptome-bewerten',
   'diabetes-typ-2-vorbeugen',
   'pearl-index-berechnen',
+  'eisenmangel-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -251,19 +254,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'menopause-symptom-calculator-guide',
   'prevent-type-2-diabetes',
   'pearl-index-calculator-guide',
+  'iron-deficiency-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 80 calculators', () => {
-    expect(calculatorMetas).toHaveLength(80)
+  it('discovers all 81 calculators', () => {
+    expect(calculatorMetas).toHaveLength(81)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 80 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(80)
+  it('builds calculatorComponents map for all 81 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(81)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -286,15 +290,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 80 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(80)
+  it('discovers all 81 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(81)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 80 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(80)
+  it('discovers all 81 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(81)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -319,10 +323,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 80 calculators with no duplicates', () => {
+  it('groups contain all 81 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(80)
-    expect(new Set(allKeys).size).toBe(80)
+    expect(allKeys).toHaveLength(81)
+    expect(new Set(allKeys).size).toBe(81)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -343,7 +347,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency',
     ])
   })
 
@@ -392,8 +396,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 442 routes', () => {
-    expect(routes).toHaveLength(442)
+  it('generates exactly 447 routes', () => {
+    expect(routes).toHaveLength(447)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/ironDeficiency.test.js
+++ b/src/__tests__/ironDeficiency.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyFerritin,
+  classifyTsat,
+  classifyHemoglobin,
+  calcSymptomScore,
+  symptomBand,
+  calcIronDeficiency,
+  TOTAL_SYMPTOM_POINTS,
+} from '../utils/ironDeficiency.js'
+
+// Iron deficiency screening combines four signals:
+//   1) Ferritin (ng/mL): <15 severe, <30 moderate, <100 mild, else none
+//   2) TSAT (%):         <16 moderate, <20 mild, else none
+//   3) Hemoglobin (g/dL) WHO cutoffs by sex (women 12/11/8, men 13/11/8)
+//   4) Symptom score (10 weighted symptoms, max 13 points)
+// Final category = max(ferritin, tsat, hb, symptom).
+
+describe('classifyFerritin', () => {
+  it('150 ng/mL → none', () => {
+    expect(classifyFerritin(150)).toBe('none')
+  })
+  it('60 ng/mL → mild', () => {
+    expect(classifyFerritin(60)).toBe('mild')
+  })
+  it('20 ng/mL → moderate', () => {
+    expect(classifyFerritin(20)).toBe('moderate')
+  })
+  it('10 ng/mL → severe', () => {
+    expect(classifyFerritin(10)).toBe('severe')
+  })
+  it('returns null for invalid input', () => {
+    expect(classifyFerritin(null)).toBeNull()
+    expect(classifyFerritin(0)).toBeNull()
+    expect(classifyFerritin(-5)).toBeNull()
+    expect(classifyFerritin('abc')).toBeNull()
+  })
+})
+
+describe('classifyTsat', () => {
+  it('25% → none', () => {
+    expect(classifyTsat(25)).toBe('none')
+  })
+  it('18% → mild', () => {
+    expect(classifyTsat(18)).toBe('mild')
+  })
+  it('10% → moderate', () => {
+    expect(classifyTsat(10)).toBe('moderate')
+  })
+  it('returns null for invalid', () => {
+    expect(classifyTsat(null)).toBeNull()
+    expect(classifyTsat(-1)).toBeNull()
+  })
+  it('0% → moderate (legal lower bound)', () => {
+    expect(classifyTsat(0)).toBe('moderate')
+  })
+})
+
+describe('classifyHemoglobin', () => {
+  it('woman 13 → none', () => {
+    expect(classifyHemoglobin(13, 'female')).toBe('none')
+  })
+  it('woman 11.5 → mild', () => {
+    expect(classifyHemoglobin(11.5, 'female')).toBe('mild')
+  })
+  it('man 12.5 → mild (below male 13 cutoff)', () => {
+    expect(classifyHemoglobin(12.5, 'male')).toBe('mild')
+  })
+  it('woman 9 → moderate', () => {
+    expect(classifyHemoglobin(9, 'female')).toBe('moderate')
+  })
+  it('woman 7 → severe', () => {
+    expect(classifyHemoglobin(7, 'female')).toBe('severe')
+  })
+  it('returns null for invalid Hb', () => {
+    expect(classifyHemoglobin(null, 'female')).toBeNull()
+    expect(classifyHemoglobin(13, 'other')).toBeNull()
+  })
+})
+
+describe('Symptom score', () => {
+  it('no symptoms → 0', () => {
+    expect(calcSymptomScore({})).toBe(0)
+  })
+  it('fatigue → 1', () => {
+    expect(calcSymptomScore({ fatigue: true })).toBe(1)
+  })
+  it('restless legs → 2', () => {
+    expect(calcSymptomScore({ restlessLegs: true })).toBe(2)
+  })
+  it('pica → 2', () => {
+    expect(calcSymptomScore({ pica: true })).toBe(2)
+  })
+  it('shortness of breath → 2', () => {
+    expect(calcSymptomScore({ shortnessOfBreath: true })).toBe(2)
+  })
+  it('all symptoms → 13', () => {
+    const all = {
+      fatigue: true, pallor: true, shortnessOfBreath: true, hairLoss: true,
+      brittleNails: true, restlessLegs: true, pica: true, coldHandsFeet: true,
+      headache: true, poorConcentration: true,
+    }
+    expect(calcSymptomScore(all)).toBe(13)
+    expect(TOTAL_SYMPTOM_POINTS).toBe(13)
+  })
+  it('ignores unknown flags', () => {
+    expect(calcSymptomScore({ fatigue: true, unknown: true })).toBe(1)
+  })
+})
+
+describe('symptomBand', () => {
+  it('0 → none', () => {
+    expect(symptomBand(0)).toBe('none')
+  })
+  it('2 → mild', () => {
+    expect(symptomBand(2)).toBe('mild')
+  })
+  it('5 → moderate', () => {
+    expect(symptomBand(5)).toBe('moderate')
+  })
+  it('8 → severe', () => {
+    expect(symptomBand(8)).toBe('severe')
+  })
+})
+
+describe('calcIronDeficiency integration', () => {
+  it('returns null without sex', () => {
+    expect(calcIronDeficiency({ ferritin: 50, sex: null })).toBeNull()
+  })
+
+  it('healthy adult: ferritin 120, tsat 30, no symptoms → none', () => {
+    const r = calcIronDeficiency({
+      ferritin: 120, tsat: 30, hemoglobin: 14, sex: 'female', symptoms: {},
+    })
+    expect(r.category).toBe('none')
+    expect(r.ferritinCategory).toBe('none')
+    expect(r.tsatCategory).toBe('none')
+    expect(r.hbCategory).toBe('none')
+    expect(r.symptomScore).toBe(0)
+  })
+
+  it('latent iron deficiency: ferritin 20, normal Hb → moderate via ferritin', () => {
+    const r = calcIronDeficiency({
+      ferritin: 20, tsat: 22, hemoglobin: 13, sex: 'female', symptoms: {},
+    })
+    expect(r.ferritinCategory).toBe('moderate')
+    expect(r.category).toBe('moderate')
+  })
+
+  it('iron-deficiency anemia: ferritin 10, Hb 10 → severe (ferritin drives)', () => {
+    const r = calcIronDeficiency({
+      ferritin: 10, tsat: 12, hemoglobin: 10, sex: 'female',
+      symptoms: { fatigue: true, pallor: true },
+    })
+    expect(r.ferritinCategory).toBe('severe')
+    expect(r.category).toBe('severe')
+  })
+
+  it('symptom-only screening: 4 symptoms → moderate via symptoms', () => {
+    const r = calcIronDeficiency({
+      ferritin: 120, tsat: 30, sex: 'female',
+      symptoms: { fatigue: true, restlessLegs: true, pica: true },
+    })
+    // 1 + 2 + 2 = 5 → moderate
+    expect(r.symptomScore).toBe(5)
+    expect(r.symptomCategory).toBe('moderate')
+    expect(r.category).toBe('moderate')
+  })
+
+  it('low TSAT with normal ferritin → mild via tsat', () => {
+    const r = calcIronDeficiency({
+      ferritin: 120, tsat: 18, sex: 'male', symptoms: {},
+    })
+    expect(r.tsatCategory).toBe('mild')
+    expect(r.category).toBe('mild')
+  })
+
+  it('omitted markers fall back to remaining signals', () => {
+    const r = calcIronDeficiency({
+      sex: 'female',
+      symptoms: { restlessLegs: true, pica: true, fatigue: true, shortnessOfBreath: true },
+    })
+    // 2 + 2 + 1 + 2 = 7 → severe by symptoms alone
+    expect(r.ferritinCategory).toBeNull()
+    expect(r.tsatCategory).toBeNull()
+    expect(r.hbCategory).toBeNull()
+    expect(r.symptomScore).toBe(7)
+    expect(r.category).toBe('severe')
+  })
+
+  it('any one severe signal wins', () => {
+    const r = calcIronDeficiency({
+      ferritin: 150, tsat: 30, hemoglobin: 7, sex: 'male', symptoms: {},
+    })
+    expect(r.hbCategory).toBe('severe')
+    expect(r.category).toBe('severe')
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 320 links (80 calcs × 2 locales + 80 blogs × 2 locales)', () => {
+  it('generates 324 links (81 calcs × 2 locales + 81 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(320)
+    expect(links).toHaveLength(324)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -20,6 +20,7 @@ const EXPECTED_KEYS = [
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
+  'ironDeficiency',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -90,6 +91,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'menopause-symptome-bewerten',
   'diabetes-typ-2-vorbeugen',
   'pearl-index-berechnen',
+  'eisenmangel-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -160,12 +162,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'menopause-symptom-calculator-guide',
   'prevent-type-2-diabetes',
   'pearl-index-calculator-guide',
+  'iron-deficiency-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 80 calculator meta files', () => {
+  it('discovers all 81 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(80)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(81)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -203,19 +206,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 80 DE blog slugs', () => {
+  it('returns all 81 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(80)
+    expect(de).toHaveLength(81)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 80 EN blog slugs', () => {
+  it('returns all 81 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(80)
+    expect(en).toHaveLength(81)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -283,9 +286,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 160 calcs + 2 blog index + 160 blog articles = 324)', () => {
+  it('generates correct total URL count (2 home + 162 calcs + 2 blog index + 162 blog articles = 328)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(324)
+    expect(urlCount).toBe(328)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -719,6 +719,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'pearlIndexRechner',
     related: ['calculate-ovulation', 'period-calculator-guide', 'fertility-window-guide'],
   },
+  {
+    slug: 'iron-deficiency-calculator-guide',
+    title: 'Iron Deficiency Calculator: Read Ferritin, TSAT and Symptoms Correctly',
+    description: 'Screen for iron deficiency from ferritin, transferrin saturation, hemoglobin and 10 clinical signs. Cutoffs, latent deficiency, treatment, and diet — explained.',
+    date: '2026-05-12',
+    readTime: '9 min',
+    calculatorKey: 'ironDeficiency',
+    related: ['anemia-risk-calculator-guide', 'thyroid-function-calculator', 'calculate-bmr'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -719,6 +719,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'pearlIndexRechner',
     related: ['eisprung-berechnen', 'zyklusrechner-guide', 'fruchtbares-fenster-berechnen'],
   },
+  {
+    slug: 'eisenmangel-berechnen',
+    title: 'Eisenmangel berechnen: Ferritin, TSAT und Symptome richtig einordnen',
+    description: 'Eisenmangel mit Ferritin, Transferrin-Sättigung, Hämoglobin und 10 klinischen Zeichen einschätzen. Grenzwerte, latenter Eisenmangel, Therapie und Ernährung — kompakt erklärt.',
+    date: '2026-05-12',
+    readTime: '9 min',
+    calculatorKey: 'ironDeficiency',
+    related: ['anaemie-risiko-berechnen', 'schilddruesenfunktion-berechnen', 'grundumsatz-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/ironDeficiency.json
+++ b/src/locales/calculators/de/ironDeficiency.json
@@ -1,0 +1,95 @@
+{
+  "home": {
+    "calculators": {
+      "ironDeficiency": {
+        "name": "Eisenmangel-Rechner",
+        "description": "Eisenmangel-Risiko aus Ferritin, Transferrin-Sättigung, Hämoglobin und Symptomen einschätzen."
+      }
+    }
+  },
+  "ironDeficiency": {
+    "meta": {
+      "title": "Eisenmangel-Rechner — Ferritin, TSAT & Symptome bewerten",
+      "description": "Schätze dein Eisenmangel-Risiko aus Ferritin, Transferrin-Sättigung, Hämoglobin und 10 typischen Symptomen. Mit Grenzwerten, Schweregrad und ärztlichen Hinweisen. Kostenlos, sofort."
+    },
+    "title": "Eisenmangel-Rechner",
+    "description": "Bestimme dein Eisenmangel-Risiko aus Laborwerten und Symptomen — mit Ferritin- und TSAT-Grenzwerten, WHO-Hb-Cutoffs und gewichtetem Symptom-Score.",
+    "unitMetric": "ng/mL · g/dL",
+    "unitSi": "µg/L · g/L",
+    "sexLabel": "Geschlecht",
+    "sexFemale": "Weiblich",
+    "sexMale": "Männlich",
+    "ferritinLabel": "Ferritin ({unit})",
+    "tsatLabel": "Transferrin-Sättigung (%)",
+    "hbLabel": "Hämoglobin ({unit})",
+    "symptomsLabel": "Symptome (alle zutreffenden ankreuzen)",
+    "symptom_fatigue": "Müdigkeit / Erschöpfung",
+    "symptom_fatigue_desc": "Anhaltende Schwäche trotz ausreichend Schlaf",
+    "symptom_pallor": "Blasse Haut / Schleimhäute",
+    "symptom_pallor_desc": "Blasses Gesicht, blasse Nagelbetten oder Augenlider innen",
+    "symptom_shortnessOfBreath": "Atemnot bei Belastung",
+    "symptom_shortnessOfBreath_desc": "Kurzatmigkeit beim Treppensteigen oder leichter Anstrengung",
+    "symptom_hairLoss": "Haarausfall",
+    "symptom_hairLoss_desc": "Vermehrter Haarverlust, dünner werdendes Haar",
+    "symptom_brittleNails": "Brüchige Nägel",
+    "symptom_brittleNails_desc": "Längsrillen, Löffelnägel oder splitternde Nägel",
+    "symptom_restlessLegs": "Restless-Legs / Kribbeln",
+    "symptom_restlessLegs_desc": "Unruhige Beine abends — hochspezifisches Eisenmangel-Zeichen",
+    "symptom_pica": "Pica / ungewöhnliches Verlangen",
+    "symptom_pica_desc": "Drang Eis zu kauen, Erde oder Stärke zu essen — Alarmzeichen",
+    "symptom_coldHandsFeet": "Kalte Hände und Füße",
+    "symptom_coldHandsFeet_desc": "Reduzierte periphere Durchblutung trotz warmer Umgebung",
+    "symptom_headache": "Kopfschmerzen",
+    "symptom_headache_desc": "Häufige dumpfe Kopfschmerzen, oft morgens",
+    "symptom_poorConcentration": "Konzentrationsstörungen",
+    "symptom_poorConcentration_desc": "Brain-Fog, Vergesslichkeit, reduzierte Leistungsfähigkeit",
+    "resultsLabel": "Dein Eisenmangel-Risiko",
+    "ferritinCategoryLabel": "Ferritin",
+    "tsatCategoryLabel": "TSAT",
+    "hbCategoryLabel": "Hämoglobin",
+    "symptomScoreLabel": "Symptom-Score",
+    "category_none": "Kein Risiko",
+    "category_mild": "Leicht",
+    "category_moderate": "Moderat",
+    "category_severe": "Schwer",
+    "advice_none": "Deine Eisenparameter und Symptome sprechen aktuell nicht für einen Eisenmangel. Bei anhaltender Müdigkeit dennoch Ferritin und Blutbild kontrollieren lassen.",
+    "advice_mild": "Hinweise auf einen latenten Eisenmangel (entleerte Speicher, noch normales Hämoglobin). Hausarzt-Termin für vollständigen Eisenstatus (Ferritin, TSAT, CRP) und ggf. orale Eisensubstitution.",
+    "advice_moderate": "Deutlicher Eisenmangel wahrscheinlich. Ärztliche Abklärung der Ursache (Menstruation, Ernährung, gastrointestinaler Blutverlust) und gezielte Eisensubstitution oral oder intravenös empfohlen.",
+    "advice_severe": "Schwerer Eisenmangel mit hoher Wahrscheinlichkeit für Eisenmangelanämie. Zeitnahe ärztliche Vorstellung — Blutbild, Eisenstatus und Ursachensuche notwendig. Bei Atemnot in Ruhe, Brustschmerz oder Synkope sofort Notarzt rufen.",
+    "refTitle": "Grenzwerte (allgemeine Erwachsene)",
+    "refMarker": "Marker",
+    "refFerritin": "Ferritin (ng/mL)",
+    "refTsat": "TSAT (%)",
+    "refHbWomen": "Hb Frauen (g/dL)",
+    "refHbMen": "Hb Männer (g/dL)",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner kombiniert vier Signale: (1) Ferritin spiegelt den Eisenspeicher wider — Werte unter 30 ng/mL gelten als Eisenmangel, unter 15 ng/mL als entleerte Speicher. (2) Die Transferrin-Sättigung (TSAT) zeigt das zirkulierende Eisen — < 20 % ist auffällig, < 16 % deutet auf eingeschränkte Erythropoese. (3) Hämoglobin wird mit den WHO-Grenzwerten verglichen — niedrige Werte zeigen bereits eine Eisenmangelanämie. (4) Ein gewichteter Symptom-Score (max. 13 Punkte) berücksichtigt typische Beschwerden wie Müdigkeit, Restless-Legs und Pica. Maßgeblich ist der höchste der vier Schweregrade.",
+    "disclaimer": "Dieser Rechner dient zur Selbsteinschätzung gesunder Erwachsener und ersetzt keine ärztliche Untersuchung. Bei Schwangerschaft, chronischen Entzündungen, Niereninsuffizienz oder Tumorerkrankungen gelten abweichende Ferritin-Grenzwerte (Akute-Phase-Reaktion). Bei Atemnot in Ruhe, Brustschmerz, Synkope oder schwarzem Stuhl sofort medizinische Hilfe in Anspruch nehmen.",
+    "faq": [
+      {
+        "q": "Ab welchem Ferritinwert spricht man von Eisenmangel?",
+        "a": "Ein Ferritin unter 30 ng/mL gilt allgemein als Eisenmangel, Werte unter 15 ng/mL bedeuten entleerte Eisenspeicher. Bei chronischen Entzündungen oder Lebererkrankungen kann Ferritin falsch hoch sein — dann wird auch ein Wert bis 100 ng/mL als Mangel gewertet."
+      },
+      {
+        "q": "Was ist Transferrin-Sättigung (TSAT)?",
+        "a": "Die TSAT zeigt an, wie viel Eisen aktuell auf dem Transportprotein Transferrin gebunden ist. Werte unter 20 % deuten auf eine eingeschränkte Eisenzufuhr zu den eisenverbrauchenden Geweben hin, unter 16 % gelten als klar pathologisch."
+      },
+      {
+        "q": "Eisenmangel ohne Anämie — gibt es das?",
+        "a": "Ja, der sogenannte latente Eisenmangel: Ferritin ist erniedrigt, aber das Hämoglobin liegt noch im Normbereich. Diese Phase kann monate- bis jahrelang bestehen — Symptome wie Müdigkeit, Restless-Legs und Haarausfall treten oft schon dann auf."
+      },
+      {
+        "q": "Wer ist besonders gefährdet?",
+        "a": "Frauen im gebärfähigen Alter (Menstruation, Schwangerschaft), Veganer und Vegetarier, Spitzensportler, Kinder im Wachstum, Patienten mit chronischen Magen-Darm-Erkrankungen oder Blutverlust, häufige Blutspender."
+      },
+      {
+        "q": "Wie wird Eisenmangel behandelt?",
+        "a": "Bei mildem bis mittlerem Mangel: orale Eisenpräparate (60–120 mg elementares Eisen pro Tag, idealerweise nüchtern mit Vitamin C, ohne Kaffee/Tee) über mindestens 3 Monate. Bei Unverträglichkeit, schwerem Mangel oder gleichzeitiger chronischer Entzündung: intravenöse Eisengabe."
+      },
+      {
+        "q": "Welche Ernährung deckt den Eisenbedarf?",
+        "a": "Hämeisen aus rotem Fleisch, Fisch und Geflügel wird am besten resorbiert. Pflanzliches Nicht-Hämeisen aus Hülsenfrüchten, Vollkorn, Nüssen und dunklem Blattgemüse profitiert von Vitamin C zur Aufnahme. Kaffee, schwarzer Tee, Milchprodukte und Calcium hemmen die Eisenresorption — am besten Abstand halten."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/ironDeficiency.json
+++ b/src/locales/calculators/en/ironDeficiency.json
@@ -1,0 +1,95 @@
+{
+  "home": {
+    "calculators": {
+      "ironDeficiency": {
+        "name": "Iron Deficiency Calculator",
+        "description": "Screen for iron deficiency from ferritin, transferrin saturation, hemoglobin and symptoms."
+      }
+    }
+  },
+  "ironDeficiency": {
+    "meta": {
+      "title": "Iron Deficiency Calculator — Ferritin, TSAT & Symptoms",
+      "description": "Estimate your iron deficiency risk from ferritin, transferrin saturation, hemoglobin and 10 typical symptoms. Cutoffs, severity grading, clinical guidance. Free, instant."
+    },
+    "title": "Iron Deficiency Calculator",
+    "description": "Grade your iron deficiency risk from lab values and symptoms — using ferritin and TSAT cutoffs, WHO hemoglobin thresholds and a weighted symptom score.",
+    "unitMetric": "ng/mL · g/dL",
+    "unitSi": "µg/L · g/L",
+    "sexLabel": "Sex",
+    "sexFemale": "Female",
+    "sexMale": "Male",
+    "ferritinLabel": "Ferritin ({unit})",
+    "tsatLabel": "Transferrin saturation (%)",
+    "hbLabel": "Hemoglobin ({unit})",
+    "symptomsLabel": "Symptoms (check all that apply)",
+    "symptom_fatigue": "Fatigue / low energy",
+    "symptom_fatigue_desc": "Persistent tiredness despite adequate sleep",
+    "symptom_pallor": "Pale skin / mucous membranes",
+    "symptom_pallor_desc": "Pale face, nail beds or inner eyelids",
+    "symptom_shortnessOfBreath": "Shortness of breath on exertion",
+    "symptom_shortnessOfBreath_desc": "Breathlessness climbing stairs or with light effort",
+    "symptom_hairLoss": "Hair loss",
+    "symptom_hairLoss_desc": "Increased shedding, thinning hair",
+    "symptom_brittleNails": "Brittle nails",
+    "symptom_brittleNails_desc": "Ridges, spoon-shaped nails or splitting tips",
+    "symptom_restlessLegs": "Restless legs / leg tingling",
+    "symptom_restlessLegs_desc": "Urge to move legs in the evening — highly specific iron-deficiency sign",
+    "symptom_pica": "Pica / unusual cravings",
+    "symptom_pica_desc": "Craving ice, dirt or starch — red-flag for iron deficiency",
+    "symptom_coldHandsFeet": "Cold hands and feet",
+    "symptom_coldHandsFeet_desc": "Reduced peripheral perfusion in a warm room",
+    "symptom_headache": "Headache",
+    "symptom_headache_desc": "Frequent dull headaches, often in the morning",
+    "symptom_poorConcentration": "Poor concentration",
+    "symptom_poorConcentration_desc": "Brain fog, forgetfulness, reduced performance",
+    "resultsLabel": "Your iron deficiency risk",
+    "ferritinCategoryLabel": "Ferritin",
+    "tsatCategoryLabel": "TSAT",
+    "hbCategoryLabel": "Hemoglobin",
+    "symptomScoreLabel": "Symptom score",
+    "category_none": "No risk",
+    "category_mild": "Mild",
+    "category_moderate": "Moderate",
+    "category_severe": "Severe",
+    "advice_none": "Your iron parameters and symptoms do not currently suggest iron deficiency. If fatigue persists, ask your GP for a ferritin test and a complete blood count anyway.",
+    "advice_mild": "Signs of latent iron deficiency (depleted stores, hemoglobin still normal). Book a GP visit for a full iron panel (ferritin, TSAT, CRP) and consider oral iron supplementation.",
+    "advice_moderate": "Clear iron deficiency likely. See a clinician to identify the cause (menstruation, diet, gastrointestinal blood loss) and start targeted oral or IV iron replacement.",
+    "advice_severe": "Severe iron deficiency with a high probability of iron-deficiency anemia. Seek timely medical care — full blood count, iron panel and cause workup are required. With breathlessness at rest, chest pain or fainting, call emergency services immediately.",
+    "refTitle": "Cutoffs (general adults)",
+    "refMarker": "Marker",
+    "refFerritin": "Ferritin (ng/mL)",
+    "refTsat": "TSAT (%)",
+    "refHbWomen": "Hb women (g/dL)",
+    "refHbMen": "Hb men (g/dL)",
+    "howItWorks": "How it works",
+    "howItWorksText": "The calculator combines four signals: (1) Ferritin reflects iron stores — values below 30 ng/mL indicate iron deficiency, below 15 ng/mL signal depleted stores. (2) Transferrin saturation (TSAT) reflects circulating iron — < 20 % is suspicious, < 16 % suggests iron-restricted erythropoiesis. (3) Hemoglobin is compared with WHO cutoffs — low values already indicate iron-deficiency anemia. (4) A weighted symptom score (max. 13 points) covers typical complaints like fatigue, restless legs and pica. The final severity equals the highest of the four estimates.",
+    "disclaimer": "This calculator is intended for self-assessment in healthy adults and does not replace clinical evaluation. In pregnancy, chronic inflammation, kidney disease or cancer different ferritin cutoffs apply (acute-phase reactant). With breathlessness at rest, chest pain, syncope or black stools seek medical care immediately.",
+    "faq": [
+      {
+        "q": "What ferritin value counts as iron deficiency?",
+        "a": "Ferritin below 30 ng/mL is generally considered iron deficiency, below 15 ng/mL signals depleted iron stores. In chronic inflammation or liver disease ferritin can be falsely elevated — a value up to 100 ng/mL may then still indicate deficiency."
+      },
+      {
+        "q": "What is transferrin saturation (TSAT)?",
+        "a": "TSAT shows how much iron is currently bound to the transport protein transferrin. Values below 20 % indicate restricted iron supply to iron-using tissues, below 16 % is considered clearly pathological."
+      },
+      {
+        "q": "Can iron deficiency exist without anemia?",
+        "a": "Yes, called latent iron deficiency: ferritin is low but hemoglobin still normal. This stage can last months to years — symptoms like fatigue, restless legs and hair loss often appear long before anemia."
+      },
+      {
+        "q": "Who is most at risk?",
+        "a": "Women of reproductive age (menstruation, pregnancy), vegans and vegetarians, endurance athletes, growing children, patients with chronic gastrointestinal disease or blood loss, and frequent blood donors."
+      },
+      {
+        "q": "How is iron deficiency treated?",
+        "a": "Mild to moderate cases: oral iron supplements (60–120 mg elemental iron per day, ideally fasting with vitamin C, away from coffee or tea) for at least 3 months. With intolerance, severe deficiency or concurrent chronic inflammation: intravenous iron."
+      },
+      {
+        "q": "Which foods cover iron requirements?",
+        "a": "Heme iron from red meat, fish and poultry is absorbed best. Plant-based non-heme iron from legumes, whole grains, nuts and dark leafy greens benefits from vitamin C for uptake. Coffee, black tea, dairy products and calcium inhibit iron absorption — space them apart."
+      }
+    ]
+  }
+}

--- a/src/pages/IronDeficiencyCalculator.vue
+++ b/src/pages/IronDeficiencyCalculator.vue
@@ -1,0 +1,313 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcIronDeficiency, TOTAL_SYMPTOM_POINTS } from '../utils/ironDeficiency.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('ironDeficiency.faq') || [])
+
+useHead(() => ({
+  title: t('ironDeficiency.meta.title'),
+  description: t('ironDeficiency.meta.description'),
+  routeKey: 'ironDeficiency',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Iron Deficiency Calculator',
+    url: 'https://healthcalculator.app/iron-deficiency-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const unit = ref('metric') // metric: Hb g/dL + ferritin ng/mL ; si: Hb g/L + ferritin µg/L (same number)
+const sex = ref('female')
+const ferritin = ref(null)
+const tsat = ref(null)
+const hemoglobin = ref(null)
+
+const symptoms = ref({
+  fatigue: false,
+  pallor: false,
+  shortnessOfBreath: false,
+  hairLoss: false,
+  brittleNails: false,
+  restlessLegs: false,
+  pica: false,
+  coldHandsFeet: false,
+  headache: false,
+  poorConcentration: false,
+})
+
+const symptomList = [
+  { key: 'fatigue', points: 1 },
+  { key: 'pallor', points: 1 },
+  { key: 'shortnessOfBreath', points: 2 },
+  { key: 'hairLoss', points: 1 },
+  { key: 'brittleNails', points: 1 },
+  { key: 'restlessLegs', points: 2 },
+  { key: 'pica', points: 2 },
+  { key: 'coldHandsFeet', points: 1 },
+  { key: 'headache', points: 1 },
+  { key: 'poorConcentration', points: 1 },
+]
+
+// In "si" mode the user types Hb as g/L (multiply input by 10). Ferritin ng/mL == µg/L numerically.
+const hemoglobinGdL = computed(() => {
+  if (hemoglobin.value == null) return null
+  return unit.value === 'si' ? hemoglobin.value / 10 : hemoglobin.value
+})
+
+const result = computed(() => calcIronDeficiency({
+  ferritin: ferritin.value,
+  tsat: tsat.value,
+  hemoglobin: hemoglobinGdL.value,
+  sex: sex.value,
+  symptoms: symptoms.value,
+}))
+
+const categoryStyle = computed(() => {
+  if (!result.value) return { color: '', bg: '' }
+  switch (result.value.category) {
+    case 'none': return { color: 'text-green-600', bg: 'bg-green-50 border-green-200 text-green-900' }
+    case 'mild': return { color: 'text-yellow-600', bg: 'bg-yellow-50 border-yellow-200 text-yellow-900' }
+    case 'moderate': return { color: 'text-orange-500', bg: 'bg-orange-50 border-orange-200 text-orange-900' }
+    case 'severe': return { color: 'text-red-700', bg: 'bg-red-100 border-red-300 text-red-900' }
+    default: return { color: '', bg: '' }
+  }
+})
+
+const categoryLevel = computed(() => {
+  if (!result.value) return 0
+  return { none: 0, mild: 1, moderate: 2, severe: 3 }[result.value.category] ?? 0
+})
+
+const hbUnit = computed(() => unit.value === 'si' ? 'g/L' : 'g/dL')
+const ferritinUnit = computed(() => unit.value === 'si' ? 'µg/L' : 'ng/mL')
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('ironDeficiency.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('ironDeficiency.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="unit = 'metric'"
+        :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('ironDeficiency.unitMetric') }}</button>
+      <button
+        @click="unit = 'si'"
+        :class="unit === 'si' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+        class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+      >{{ t('ironDeficiency.unitSi') }}</button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('ironDeficiency.sexLabel') }}
+        </label>
+        <select
+          v-model="sex"
+          data-testid="sex"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        >
+          <option value="female">{{ t('ironDeficiency.sexFemale') }}</option>
+          <option value="male">{{ t('ironDeficiency.sexMale') }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('ironDeficiency.ferritinLabel', { unit: ferritinUnit }) }}
+        </label>
+        <input
+          v-model.number="ferritin"
+          type="number"
+          step="0.1"
+          min="0"
+          placeholder="30"
+          data-testid="ferritin"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('ironDeficiency.tsatLabel') }}
+        </label>
+        <input
+          v-model.number="tsat"
+          type="number"
+          step="0.1"
+          min="0"
+          max="100"
+          placeholder="25"
+          data-testid="tsat"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('ironDeficiency.hbLabel', { unit: hbUnit }) }}
+        </label>
+        <input
+          v-model.number="hemoglobin"
+          type="number"
+          step="0.1"
+          min="0"
+          :placeholder="unit === 'metric' ? '13.5' : '135'"
+          data-testid="hemoglobin"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('ironDeficiency.symptomsLabel') }}</p>
+    <div class="space-y-3">
+      <label
+        v-for="s in symptomList"
+        :key="s.key"
+        :data-testid="'symptom-' + s.key"
+        :class="symptoms[s.key] ? 'border-stone-900 bg-stone-50' : 'border-stone-200 hover:border-stone-300'"
+        class="flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-colors duration-150"
+      >
+        <input
+          v-model="symptoms[s.key]"
+          type="checkbox"
+          :data-testid="'checkbox-' + s.key"
+          class="mt-1 h-5 w-5 rounded border-stone-300 text-stone-900 focus:ring-stone-600"
+        />
+        <div class="flex-1 min-w-0">
+          <div class="flex items-baseline justify-between gap-3">
+            <p class="text-sm font-semibold text-stone-900">{{ t('ironDeficiency.symptom_' + s.key) }}</p>
+            <span class="text-xs font-semibold text-stone-400 tabular-nums">+{{ s.points }}</span>
+          </div>
+          <p class="text-xs text-stone-500 leading-relaxed mt-1">{{ t('ironDeficiency.symptom_' + s.key + '_desc') }}</p>
+        </div>
+      </label>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('ironDeficiency.resultsLabel') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold tabular-nums tracking-tight leading-none" :class="categoryStyle.color" data-testid="result-status">{{ t('ironDeficiency.category_' + result.category) }}</span>
+    </div>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-500 via-yellow-500 via-orange-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (categoryLevel / 3 * 100) + '%' }"></div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="ferritin-category">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ironDeficiency.ferritinCategoryLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900">
+          <span v-if="result.ferritinCategory">{{ t('ironDeficiency.category_' + result.ferritinCategory) }}</span>
+          <span v-else class="text-stone-400 text-lg">—</span>
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="tsat-category">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ironDeficiency.tsatCategoryLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900">
+          <span v-if="result.tsatCategory">{{ t('ironDeficiency.category_' + result.tsatCategory) }}</span>
+          <span v-else class="text-stone-400 text-lg">—</span>
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="hb-category">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ironDeficiency.hbCategoryLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900">
+          <span v-if="result.hbCategory">{{ t('ironDeficiency.category_' + result.hbCategory) }}</span>
+          <span v-else class="text-stone-400 text-lg">—</span>
+        </p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="symptom-score">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ironDeficiency.symptomScoreLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.symptomScore }}<span class="text-lg text-stone-400 font-medium"> / {{ TOTAL_SYMPTOM_POINTS }}</span></p>
+      </div>
+    </div>
+
+    <div class="rounded-lg p-4 text-sm font-medium border" :class="categoryStyle.bg" data-testid="advice">
+      {{ t('ironDeficiency.advice_' + result.category) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('ironDeficiency.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ironDeficiency.refMarker') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ironDeficiency.category_none') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ironDeficiency.category_mild') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ironDeficiency.category_moderate') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ironDeficiency.category_severe') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ironDeficiency.refFerritin') }}</td>
+          <td class="px-6 py-3 text-stone-600">≥ 100</td>
+          <td class="px-6 py-3 text-stone-600">30–99</td>
+          <td class="px-6 py-3 text-stone-600">15–29</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 15</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ironDeficiency.refTsat') }}</td>
+          <td class="px-6 py-3 text-stone-600">≥ 20 %</td>
+          <td class="px-6 py-3 text-stone-600">16–19 %</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 16 %</td>
+          <td class="px-6 py-3 text-stone-600">—</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ironDeficiency.refHbWomen') }}</td>
+          <td class="px-6 py-3 text-stone-600">≥ 12.0</td>
+          <td class="px-6 py-3 text-stone-600">11.0–11.9</td>
+          <td class="px-6 py-3 text-stone-600">8.0–10.9</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 8.0</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ironDeficiency.refHbMen') }}</td>
+          <td class="px-6 py-3 text-stone-600">≥ 13.0</td>
+          <td class="px-6 py-3 text-stone-600">11.0–12.9</td>
+          <td class="px-6 py-3 text-stone-600">8.0–10.9</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 8.0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('ironDeficiency.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('ironDeficiency.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('ironDeficiency.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="ironDeficiency" />
+</template>

--- a/src/pages/blog/EisenmangelBerechnen.vue
+++ b/src/pages/blog/EisenmangelBerechnen.vue
@@ -1,0 +1,173 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Eisenmangel berechnen: Ferritin, TSAT und Symptome richtig einordnen | Health Calculators',
+  description: 'Eisenmangel mit Ferritin, Transferrin-Sättigung, Hämoglobin und 10 klinischen Zeichen einschätzen. Grenzwerte, latenter Eisenmangel, Therapie und Ernährung — kompakt erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Eisenmangel berechnen: Ferritin, TSAT und Symptome richtig einordnen',
+    description: 'Eisenmangel mit Ferritin, Transferrin-Sättigung, Hämoglobin und 10 klinischen Zeichen einschätzen. Grenzwerte, latenter Eisenmangel, Therapie und Ernährung — kompakt erklärt.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-12',
+    dateModified: '2026-05-12',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/eisenmangel-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Eisenmangel berechnen: Ferritin, TSAT und Symptome richtig einordnen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">12. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eisenmangel ist der <strong>häufigste Mikronährstoffmangel weltweit</strong>. Schätzungsweise zwei Milliarden Menschen sind betroffen — Frauen im gebärfähigen Alter, Veganer, Sportler und Kinder am stärksten. Oft beginnt der Mangel schleichend mit leerer werdenden Eisenspeichern, während das Hämoglobin noch normal aussieht.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Ratgeber zeigt, wie du dein Eisenmangel-Risiko quantitativ einschätzen kannst — mit den drei wichtigsten Labormarkern (Ferritin, Transferrin-Sättigung und Hämoglobin) plus einem gewichteten Symptom-Score.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die drei Stufen des Eisenmangels</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eisenmangel entwickelt sich nicht plötzlich. Klinisch unterscheidet man drei Stadien — wer sie kennt, kann gezielt früh handeln:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>1. Speicherdepletion (latenter Eisenmangel):</strong> Ferritin sinkt, Hämoglobin und TSAT noch normal. Erste Symptome wie Müdigkeit, Haarausfall oder Restless-Legs treten auf.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>2. Eisendefizitäre Erythropoese:</strong> Auch die Transferrin-Sättigung sinkt unter 20 %. Die roten Blutkörperchen werden kleiner und blasser, Hämoglobin ist noch grenzwertig normal.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>3. Eisenmangelanämie:</strong> Hämoglobin fällt unter die WHO-Grenze (Frauen 12,0 g/dL, Männer 13,0 g/dL). Klassische Anämie-Symptome wie Atemnot, Tachykardie und blasse Haut treten in den Vordergrund.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Grenzwerte für Erwachsene</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Marker</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Normal</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Auffällig</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Eisenmangel</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Schwer</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Ferritin (ng/mL)</td><td class="px-6 py-3 text-stone-600">≥ 100</td><td class="px-6 py-3 text-stone-600">30–99</td><td class="px-6 py-3 text-stone-600">15–29</td><td class="px-6 py-3 text-stone-600">&lt; 15</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">TSAT (%)</td><td class="px-6 py-3 text-stone-600">≥ 20</td><td class="px-6 py-3 text-stone-600">16–19</td><td class="px-6 py-3 text-stone-600">&lt; 16</td><td class="px-6 py-3 text-stone-600">—</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hb Frauen (g/dL)</td><td class="px-6 py-3 text-stone-600">≥ 12,0</td><td class="px-6 py-3 text-stone-600">11,0–11,9</td><td class="px-6 py-3 text-stone-600">8,0–10,9</td><td class="px-6 py-3 text-stone-600">&lt; 8,0</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hb Männer (g/dL)</td><td class="px-6 py-3 text-stone-600">≥ 13,0</td><td class="px-6 py-3 text-stone-600">11,0–12,9</td><td class="px-6 py-3 text-stone-600">8,0–10,9</td><td class="px-6 py-3 text-stone-600">&lt; 8,0</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Wichtig:</strong> Bei chronischer Entzündung, Niereninsuffizienz oder Tumorerkrankungen ist Ferritin als Akute-Phase-Reaktant oft falsch hoch. Dann gelten Ferritin-Werte bis 100 ng/mL noch als Mangel — und die TSAT wird zum entscheidenden Marker.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Typische Symptome im Score</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Unser Rechner gewichtet zehn typische Eisenmangel-Zeichen — manche unspezifisch (Müdigkeit), andere hochspezifisch (Pica, Restless-Legs):
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptom</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Punkte</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Hinweis</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Müdigkeit</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Häufigstes, aber unspezifisches Zeichen</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Blasse Haut</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Augenlider innen, Lippen, Nagelbett</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Atemnot bei Belastung</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Reduzierte O₂-Transportkapazität</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Haarausfall</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Diffuser Verlust, häufig bei Ferritin &lt; 30</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Brüchige Nägel</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Längsrillen, Löffelnägel (Koilonychie)</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Restless-Legs</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Hochspezifisch für Eisenmangel</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Pica (Eis, Erde)</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Alarmsignal — fast immer Eisenmangel</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Kalte Hände/Füße</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Periphere Vasokonstriktion</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Kopfschmerzen</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Hypoxie der Hirnrinde</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Konzentrationsstörungen</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">"Brain-Fog", verlangsamtes Denken</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt Eisenmangel-Risiko berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Ferritin, Transferrin-Sättigung, Hämoglobin und 10 klinische Symptome — sofortiges Ergebnis mit Schweregrad und Empfehlung. Anonym und kostenlos.</p>
+        <router-link
+          :to="localePath('ironDeficiency')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Ursachen für Eisenmangel</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Erhöhter Bedarf:</strong> Menstruation (besonders Hypermenorrhö), Schwangerschaft, Wachstum, intensiver Ausdauersport.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Verminderte Aufnahme:</strong> Vegane oder vegetarische Ernährung, Magen-OPs, Zöliakie, atrophische Gastritis, häufiger Säureblocker-Einsatz.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Blutverlust:</strong> Magengeschwüre, Hämorrhoiden, Darmtumoren, häufige Blutspenden, NSAR-bedingte Mikroblutungen.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Chronische Erkrankungen:</strong> Niereninsuffizienz, Herzinsuffizienz, entzündliche Darmerkrankungen — funktioneller Eisenmangel trotz normaler Speicher.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">So wird Eisenmangel behandelt</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Orale Therapie:</strong> 60–120 mg elementares Eisen pro Tag, idealerweise nüchtern mit Vitamin C, ohne Kaffee, Tee oder Calcium. Neuere Studien zeigen, dass eine Dosis jeden zweiten Tag besser resorbiert wird als zweimal täglich.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Intravenöse Eisengabe:</strong> Bei oraler Unverträglichkeit, schwerem Mangel, chronisch entzündlichen Darmerkrankungen oder Herz-/Niereninsuffizienz. Vorteil: schnelle Speicherauffüllung, oft mit nur ein bis zwei Infusionen.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Ursachensuche zwingend:</strong> Vor allem bei Männern und postmenopausalen Frauen muss eine Blutungsquelle (Magen, Darm) ausgeschlossen werden — eine Eisengabe ohne Diagnose kann eine Tumorblutung verschleiern.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eisenmangel und Anämie hängen eng zusammen, aber nicht jeder Eisenmangel führt sofort zur Anämie. Wer wissen will, ob bereits eine Blutarmut vorliegt, nutzt unseren
+          <router-link :to="localeBlogPath('anaemie-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Anämie-Risiko-Rechner</router-link>.
+          Da Müdigkeit und Belastungsdyspnoe auch durch eine geschwächte Schilddrüse entstehen, lohnt ein Blick auf die
+          <router-link :to="localeBlogPath('schilddruesenfunktion-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Schilddrüsenfunktion</router-link>.
+          Beim niedrigen Energieumsatz hilft zusätzlich der
+          <router-link :to="localeBlogPath('grundumsatz-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Grundumsatz-Rechner</router-link>,
+          um ernährungs- von erkrankungsbedingter Müdigkeit zu trennen.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Eisenmangel ist häufig, gut behandelbar — und beginnt lange vor der Anämie. Mit unserem
+          <router-link :to="localePath('ironDeficiency')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Eisenmangel-Rechner</router-link>
+          siehst du in Sekunden, ob deine Werte und Symptome auffällig sind. Bei Ferritin unter 30 ng/mL, TSAT unter 20 % oder mehreren typischen Symptomen lohnt sich der Termin beim Hausarzt — meist genügt ein einfaches Blutbild für die Diagnose.
+        </p>
+      </div>
+
+      <RelatedArticles slug="eisenmangel-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/IronDeficiencyCalculatorGuide.vue
+++ b/src/pages/blog/en/IronDeficiencyCalculatorGuide.vue
@@ -1,0 +1,173 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Iron Deficiency Calculator: Read Ferritin, TSAT and Symptoms Correctly | Health Calculators',
+  description: 'Screen for iron deficiency from ferritin, transferrin saturation, hemoglobin and 10 clinical signs. Cutoffs, latent deficiency, treatment, and diet — explained.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Iron Deficiency Calculator: Read Ferritin, TSAT and Symptoms Correctly',
+    description: 'Screen for iron deficiency from ferritin, transferrin saturation, hemoglobin and 10 clinical signs. Cutoffs, latent deficiency, treatment, and diet — explained.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-12',
+    dateModified: '2026-05-12',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/iron-deficiency-calculator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Iron Deficiency Calculator: Read Ferritin, TSAT and Symptoms Correctly</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 12, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Iron deficiency is the <strong>most common micronutrient deficiency worldwide</strong>. An estimated two billion people are affected — women of reproductive age, vegans, endurance athletes and growing children most of all. It often starts silently, with shrinking iron stores while hemoglobin still looks normal.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide shows how to quantify your iron deficiency risk — using the three key lab markers (ferritin, transferrin saturation and hemoglobin) plus a weighted symptom score.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The three stages of iron deficiency</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Iron deficiency does not appear overnight. Clinically it unfolds in three stages — knowing them lets you act early:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>1. Storage depletion (latent iron deficiency):</strong> Ferritin falls, hemoglobin and TSAT still normal. Early symptoms — fatigue, hair loss, restless legs — already appear.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>2. Iron-deficient erythropoiesis:</strong> Transferrin saturation drops below 20 %. Red blood cells turn smaller and paler; hemoglobin is borderline normal.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>3. Iron-deficiency anemia:</strong> Hemoglobin falls below the WHO cutoff (women 12.0 g/dL, men 13.0 g/dL). Classic anemia signs — breathlessness, tachycardia, pallor — come to the front.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Adult cutoffs</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Marker</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Normal</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Suggestive</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Deficient</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Severe</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Ferritin (ng/mL)</td><td class="px-6 py-3 text-stone-600">≥ 100</td><td class="px-6 py-3 text-stone-600">30–99</td><td class="px-6 py-3 text-stone-600">15–29</td><td class="px-6 py-3 text-stone-600">&lt; 15</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">TSAT (%)</td><td class="px-6 py-3 text-stone-600">≥ 20</td><td class="px-6 py-3 text-stone-600">16–19</td><td class="px-6 py-3 text-stone-600">&lt; 16</td><td class="px-6 py-3 text-stone-600">—</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hb women (g/dL)</td><td class="px-6 py-3 text-stone-600">≥ 12.0</td><td class="px-6 py-3 text-stone-600">11.0–11.9</td><td class="px-6 py-3 text-stone-600">8.0–10.9</td><td class="px-6 py-3 text-stone-600">&lt; 8.0</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hb men (g/dL)</td><td class="px-6 py-3 text-stone-600">≥ 13.0</td><td class="px-6 py-3 text-stone-600">11.0–12.9</td><td class="px-6 py-3 text-stone-600">8.0–10.9</td><td class="px-6 py-3 text-stone-600">&lt; 8.0</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Important:</strong> Ferritin is an acute-phase reactant. In chronic inflammation, kidney disease or cancer ferritin is falsely elevated. There a value up to 100 ng/mL still counts as deficiency — and TSAT becomes the decisive marker.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Typical symptoms in the score</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The calculator weights ten typical iron-deficiency signs — some nonspecific (fatigue), others highly specific (pica, restless legs):
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Symptom</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Points</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Note</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Fatigue</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Most common, but nonspecific</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Pale skin</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Inner eyelids, lips, nail beds</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Shortness of breath</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Reduced O₂-carrying capacity</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Hair loss</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Diffuse shedding, often with ferritin &lt; 30</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Brittle nails</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Ridges, spoon-shaped nails (koilonychia)</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Restless legs</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Highly specific for iron deficiency</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Pica (ice, dirt)</td><td class="px-6 py-3 text-stone-600">2</td><td class="px-6 py-3 text-stone-600">Red flag — almost always iron deficiency</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Cold hands/feet</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Peripheral vasoconstriction</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Headache</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Cortical hypoxia</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Poor concentration</td><td class="px-6 py-3 text-stone-600">1</td><td class="px-6 py-3 text-stone-600">Brain fog, slowed thinking</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Run the iron deficiency calculator</h3>
+        <p class="text-stone-300 text-sm mb-5">Ferritin, TSAT, hemoglobin and 10 clinical symptoms — instant result with severity and guidance. Anonymous and free.</p>
+        <router-link
+          :to="localePath('ironDeficiency')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Common causes of iron deficiency</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Increased demand:</strong> Menstruation (especially heavy periods), pregnancy, growth, intensive endurance training.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Reduced absorption:</strong> Vegan or vegetarian diet, gastric surgery, celiac disease, atrophic gastritis, frequent acid-blocker use.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Blood loss:</strong> Peptic ulcer, hemorrhoids, colon cancer, frequent blood donations, NSAID-induced microbleeding.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Chronic disease:</strong> Kidney failure, heart failure, inflammatory bowel disease — functional iron deficiency despite normal stores.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How iron deficiency is treated</h2>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Oral therapy:</strong> 60–120 mg elemental iron per day, ideally fasting with vitamin C, away from coffee, tea or calcium. Newer trials show that dosing every other day is absorbed better than twice a day.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Intravenous iron:</strong> For oral intolerance, severe deficiency, inflammatory bowel disease, or heart/kidney failure. Advantage: stores refill fast, often after one or two infusions.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Cause workup is mandatory:</strong> In men and postmenopausal women a bleeding source (stomach, colon) must be ruled out — supplementing iron without diagnosing the cause can mask a malignancy.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Iron deficiency and anemia are closely linked, but not every iron deficiency leads straight to anemia. To check whether you are already anemic, run our
+          <router-link :to="localeBlogPath('anemia-risk-calculator-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Anemia Risk Calculator</router-link>.
+          Because fatigue and dyspnea on exertion can also stem from a weak thyroid, take a look at the
+          <router-link :to="localeBlogPath('thyroid-function-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Thyroid Function Calculator</router-link>.
+          If your energy budget feels low overall, the
+          <router-link :to="localeBlogPath('calculate-bmr')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMR calculator</router-link>
+          helps separate diet-related from disease-related fatigue.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Iron deficiency is common, treatable — and starts long before anemia. With our
+          <router-link :to="localePath('ironDeficiency')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Iron Deficiency Calculator</router-link>
+          you see in seconds whether your numbers and symptoms are off. With ferritin under 30 ng/mL, TSAT under 20 % or several typical symptoms, book a GP visit — usually a simple blood test is enough for diagnosis.
+        </p>
+      </div>
+
+      <RelatedArticles slug="iron-deficiency-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/ironDeficiency.meta.js
+++ b/src/pages/ironDeficiency.meta.js
@@ -1,0 +1,16 @@
+import Component from './IronDeficiencyCalculator.vue'
+import BlogDe from './blog/EisenmangelBerechnen.vue'
+import BlogEn from './blog/en/IronDeficiencyCalculatorGuide.vue'
+
+export default {
+  key: 'ironDeficiency',
+  component: Component,
+  slugs: { de: 'eisenmangel-rechner', en: 'iron-deficiency-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 104,
+  blog: {
+    de: { slug: 'eisenmangel-berechnen', component: BlogDe },
+    en: { slug: 'iron-deficiency-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/ironDeficiency.js
+++ b/src/utils/ironDeficiency.js
@@ -1,0 +1,118 @@
+// Iron deficiency risk screening.
+//
+// Combines four signals into a single severity category:
+//   1) Serum ferritin (ng/mL) — first depleted iron store.
+//        < 15  → severe (depleted stores)
+//        < 30  → moderate (clear iron deficiency)
+//        < 100 → mild (suggestive, especially with inflammation)
+//        ≥ 100 → none
+//   2) Transferrin saturation TSAT (%) — circulating iron supply.
+//        < 16  → moderate
+//        < 20  → mild
+//        ≥ 20  → none
+//   3) Hemoglobin (g/dL, optional) — late marker, defines iron-deficiency anemia.
+//        WHO cutoffs by sex:
+//          Women: < 8 severe, < 11 moderate, < 12 mild, ≥ 12 none
+//          Men:   < 8 severe, < 11 moderate, < 13 mild, ≥ 13 none
+//   4) Symptom score (0–13) — typical clinical signs:
+//        fatigue (1), pallor (1), shortnessOfBreath (2), hairLoss (1),
+//        brittleNails (1), restlessLegs (2), pica (2), coldHandsFeet (1),
+//        headache (1), poorConcentration (1)
+//        score 0 → none, 1–3 → mild, 4–6 → moderate, ≥ 7 → severe
+//
+// Final category = max(ferritin, tsat, hb, symptom) so any one severe signal wins.
+
+const SYMPTOM_POINTS = {
+  fatigue: 1,
+  pallor: 1,
+  shortnessOfBreath: 2,
+  hairLoss: 1,
+  brittleNails: 1,
+  restlessLegs: 2,
+  pica: 2,
+  coldHandsFeet: 1,
+  headache: 1,
+  poorConcentration: 1,
+}
+
+const HB_CUTOFFS = {
+  female: { mild: 12.0, moderate: 11.0, severe: 8.0 },
+  male: { mild: 13.0, moderate: 11.0, severe: 8.0 },
+}
+
+const LEVELS = ['none', 'mild', 'moderate', 'severe']
+
+function isPositiveNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0
+}
+
+export function classifyFerritin(ferritin) {
+  if (!isPositiveNumber(ferritin)) return null
+  if (ferritin < 15) return 'severe'
+  if (ferritin < 30) return 'moderate'
+  if (ferritin < 100) return 'mild'
+  return 'none'
+}
+
+export function classifyTsat(tsat) {
+  if (tsat == null || !Number.isFinite(tsat) || tsat < 0) return null
+  if (tsat < 16) return 'moderate'
+  if (tsat < 20) return 'mild'
+  return 'none'
+}
+
+export function classifyHemoglobin(hb, sex) {
+  if (!isPositiveNumber(hb)) return null
+  const cutoffs = HB_CUTOFFS[sex]
+  if (!cutoffs) return null
+  if (hb < cutoffs.severe) return 'severe'
+  if (hb < cutoffs.moderate) return 'moderate'
+  if (hb < cutoffs.mild) return 'mild'
+  return 'none'
+}
+
+export function calcSymptomScore(symptoms) {
+  if (!symptoms || typeof symptoms !== 'object') return 0
+  let score = 0
+  for (const [key, points] of Object.entries(SYMPTOM_POINTS)) {
+    if (symptoms[key]) score += points
+  }
+  return score
+}
+
+export function symptomBand(score) {
+  if (score >= 7) return 'severe'
+  if (score >= 4) return 'moderate'
+  if (score >= 1) return 'mild'
+  return 'none'
+}
+
+function maxLevel(...levels) {
+  let idx = 0
+  for (const lvl of levels) {
+    if (lvl == null) continue
+    const i = LEVELS.indexOf(lvl)
+    if (i > idx) idx = i
+  }
+  return LEVELS[idx]
+}
+
+export function calcIronDeficiency({ ferritin, tsat, hemoglobin, sex, symptoms } = {}) {
+  if (sex !== 'male' && sex !== 'female') return null
+  const ferritinCategory = classifyFerritin(ferritin)
+  const tsatCategory = classifyTsat(tsat)
+  const hbCategory = classifyHemoglobin(hemoglobin, sex)
+  const symptomScore = calcSymptomScore(symptoms)
+  const symptomCategory = symptomBand(symptomScore)
+  const category = maxLevel(ferritinCategory, tsatCategory, hbCategory, symptomCategory)
+  return {
+    category,
+    ferritinCategory,
+    tsatCategory,
+    hbCategory,
+    symptomScore,
+    symptomCategory,
+  }
+}
+
+export const TOTAL_SYMPTOM_POINTS = Object.values(SYMPTOM_POINTS).reduce((a, b) => a + b, 0)


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-140-iron-deficiency
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-140-iron-deficiency-20260512-220030`
**Cost:** $8.506109000000002

Closes jenslaufer/health-calculators#140

### Prompt
> Implement the Iron Deficiency Calculator as described in issue #140.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Iron deficiency risk from symptoms + labs
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.


## PARTIAL-COMMIT GUARD (MANDATORY — added 2026-05-07 after FK #270 + HC #231 partial; validated 3-of-3 on FK #280 + HC #232 + HC #233, 4-of-3 on FK #281)
Before `git push`, run:
  git diff --name-only main..HEAD | sort

Output MUST contain ALL of these paths (substitute <DeBlogPascal> + <EnBlogPascal> with your chosen blog Vue component names):
  e2e/ironDeficiency.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/ironDeficiency.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/ironDeficiency.json
  src/locales/calculators/en/ironDeficiency.json
  src/pages/IronDeficiencyCalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/ironDeficiency.meta.js
  src/utils/ironDeficiency.js

If ANY path is missing → DO NOT push. Stage + commit the missing files first.
Counter check: `git diff --name-only main..HEAD | wc -l` MUST be >= 14.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/ironDeficiency.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/ironDeficiency.test.js` with 6+ test cases covering edge cases. Run `npm test -- ironDeficiency` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/IronDeficiencyCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/ironDeficiency.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/ironDeficiency.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'ironDeficiency'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/ironDeficiency.json` + `src/locales/calculators/en/ironDeficiency.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/ironDeficiency.js (or shared util — verify pattern in repo first)`
- `src/__tests__/ironDeficiency.test.js`
- `src/pages/IronDeficiencyCalculator.vue`
- `src/pages/ironDeficiency.meta.js`
- `src/locales/calculators/de/ironDeficiency.json`
- `src/locales/calculators/en/ironDeficiency.json`
- `e2e/ironDeficiency.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'ironDeficiency',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks