### PR TITLE
Add FFMI-Rechner (Fettfreie-Masse-Index calculator)

### DIFF
--- a/e2e/ffmiRechner.spec.js
+++ b/e2e/ffmiRechner.spec.js
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/ffmi-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/FFMI-Rechner/)
+})
+
+test('male 80 kg, 180 cm, 15% body fat → FFMI ~20.99 (aboveAverage)', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('180')
+  await page.getByTestId('bodyFat').fill('15')
+
+  const result = page.getByTestId('ffmi-result')
+  await expect(result).toBeVisible()
+  const ffmi = parseFloat(await result.textContent())
+  expect(ffmi).toBeGreaterThan(20.8)
+  expect(ffmi).toBeLessThan(21.2)
+
+  await expect(page.getByTestId('result-status')).toHaveText('Überdurchschnittlich')
+})
+
+test('female 60 kg, 165 cm, 25% body fat → FFMI 16.5 (aboveAverage)', async ({ page }) => {
+  await page.getByTestId('sex-female').click()
+  await page.getByTestId('weight').fill('60')
+  await page.getByTestId('height').fill('165')
+  await page.getByTestId('bodyFat').fill('25')
+
+  const result = page.getByTestId('ffmi-result')
+  await expect(result).toBeVisible()
+  const ffmi = parseFloat(await result.textContent())
+  expect(ffmi).toBeGreaterThan(16.3)
+  expect(ffmi).toBeLessThan(16.7)
+})
+
+test('fat-free mass output appears', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('180')
+  await page.getByTestId('bodyFat').fill('15')
+
+  await expect(page.getByTestId('ffm-result')).toBeVisible()
+  await expect(page.getByTestId('ffm-result')).toContainText('68')
+})
+
+test('normalized FFMI output appears', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('80')
+  await page.getByTestId('height').fill('180')
+  await page.getByTestId('bodyFat').fill('15')
+
+  await expect(page.getByTestId('normalized-ffmi')).toBeVisible()
+})
+
+test('extreme FFMI > 28 male → physiologically unlikely', async ({ page }) => {
+  await page.getByTestId('sex-male').click()
+  await page.getByTestId('weight').fill('120')
+  await page.getByTestId('height').fill('175')
+  await page.getByTestId('bodyFat').fill('5')
+
+  await expect(page.getByTestId('result-status')).toHaveText('Physiologisch unwahrscheinlich')
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -26,7 +26,7 @@ const EXPECTED_KEYS = [
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
-  'ironDeficiency',
+  'ironDeficiency', 'ffmiRechner',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention']
@@ -111,6 +111,7 @@ const EXPECTED_ROUTE_MAP = {
   menopauseSymptom: { de: 'menopause-symptome-rechner', en: 'menopause-symptom-calculator' },
   pearlIndexRechner: { de: 'pearl-index-rechner', en: 'pearl-index-calculator' },
   ironDeficiency: { de: 'eisenmangel-rechner', en: 'iron-deficiency-calculator' },
+  ffmiRechner: { de: 'ffmi-rechner', en: 'ffmi-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -183,6 +184,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'diabetes-typ-2-vorbeugen',
   'pearl-index-berechnen',
   'eisenmangel-berechnen',
+  'ffmi-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -255,11 +257,12 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'prevent-type-2-diabetes',
   'pearl-index-calculator-guide',
   'iron-deficiency-calculator-guide',
+  'ffmi-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
   it('discovers all 81 calculators', () => {
-    expect(calculatorMetas).toHaveLength(81)
+    expect(calculatorMetas).toHaveLength(82)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
@@ -267,7 +270,7 @@ describe('calculator discovery', () => {
   })
 
   it('builds calculatorComponents map for all 81 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(81)
+    expect(Object.keys(calculatorComponents)).toHaveLength(82)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -291,14 +294,14 @@ describe('calculator discovery', () => {
 
 describe('blog component discovery', () => {
   it('discovers all 81 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(81)
+    expect(Object.keys(blogComponentsDe)).toHaveLength(82)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
   it('discovers all 81 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(81)
+    expect(Object.keys(blogComponentsEn)).toHaveLength(82)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -325,8 +328,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 81 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(81)
-    expect(new Set(allKeys).size).toBe(81)
+    expect(allKeys).toHaveLength(82)
+    expect(new Set(allKeys).size).toBe(82)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -334,7 +337,7 @@ describe('calculator groups', () => {
 
   it('bodyComposition group has correct calculators in order', () => {
     expect(calculatorGroups[0].calculators).toEqual([
-      'bmi', 'bodyFat', 'idealWeight', 'waistHipRatio', 'whtrRechner', 'leanBodyMass', 'bsa', 'bodyType', 'bmiFrauen', 'bmiMaenner',
+      'bmi', 'bodyFat', 'idealWeight', 'waistHipRatio', 'whtrRechner', 'leanBodyMass', 'ffmiRechner', 'bsa', 'bodyType', 'bmiFrauen', 'bmiMaenner',
     ])
   })
 
@@ -397,7 +400,7 @@ describe('i18n completeness', () => {
 
 describe('SSG routes', () => {
   it('generates exactly 447 routes', () => {
-    expect(routes).toHaveLength(447)
+    expect(routes).toHaveLength(452)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/ffmiRechner.test.js
+++ b/src/__tests__/ffmiRechner.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcFFM,
+  calcFFMI,
+  calcNormalizedFFMI,
+  classifyFFMI,
+  calcFFMIResult,
+} from '../utils/ffmiRechner.js'
+
+// FFMI = Fettfreie-Masse-Index (Fat-Free Mass Index).
+//   FFM (kg)  = weight × (1 - bodyFat% / 100)
+//   FFMI      = FFM / heightM²
+//   normFFMI  = FFMI + 6.1 × (1.80 - heightM)        (Kouri et al., 1995)
+// Classification thresholds by sex (Kouri 1995, normalized FFMI), 5 buckets:
+//   Male:   <18 belowAverage, 18–20 average, 20–25 aboveAverage, 25–28 top1, >28 unlikelyNatural
+//   Female: <13 belowAverage, 13–15 average, 15–19 aboveAverage, 19–22 top1, >22 unlikelyNatural
+
+describe('calcFFM (fat-free mass in kg)', () => {
+  it('80 kg at 15% body fat → 68 kg', () => {
+    expect(calcFFM(80, 15)).toBeCloseTo(68, 5)
+  })
+  it('60 kg at 25% body fat → 45 kg', () => {
+    expect(calcFFM(60, 25)).toBeCloseTo(45, 5)
+  })
+  it('returns null for invalid inputs', () => {
+    expect(calcFFM(null, 15)).toBeNull()
+    expect(calcFFM(80, null)).toBeNull()
+    expect(calcFFM(0, 15)).toBeNull()
+    expect(calcFFM(80, -5)).toBeNull()
+    expect(calcFFM(80, 100)).toBeNull()
+  })
+})
+
+describe('calcFFMI', () => {
+  it('80 kg, 180 cm, 15% body fat → 20.99', () => {
+    // FFM = 68, height = 1.80 → 68 / 3.24 = 20.99
+    expect(calcFFMI(80, 180, 15)).toBeCloseTo(20.99, 1)
+  })
+  it('60 kg, 165 cm, 25% body fat → 16.53', () => {
+    // FFM = 45, h = 1.65 → 45 / 2.7225 = 16.53
+    expect(calcFFMI(60, 165, 25)).toBeCloseTo(16.53, 1)
+  })
+  it('100 kg, 190 cm, 10% body fat → 24.93', () => {
+    // FFM = 90, h = 1.90 → 90 / 3.61 = 24.93
+    expect(calcFFMI(100, 190, 10)).toBeCloseTo(24.93, 1)
+  })
+  it('returns null for invalid inputs', () => {
+    expect(calcFFMI(null, 180, 15)).toBeNull()
+    expect(calcFFMI(80, null, 15)).toBeNull()
+    expect(calcFFMI(80, 180, null)).toBeNull()
+    expect(calcFFMI(80, 0, 15)).toBeNull()
+  })
+})
+
+describe('calcNormalizedFFMI', () => {
+  it('unchanged at exactly 1.80 m height', () => {
+    // FFMI 20.99 at 180 cm → normalized = 20.99
+    const ffmi = calcFFMI(80, 180, 15)
+    const norm = calcNormalizedFFMI(ffmi, 180)
+    expect(norm).toBeCloseTo(ffmi, 5)
+  })
+  it('adjusts upward for shorter person', () => {
+    // 1.65 m: norm = ffmi + 6.1*(1.80 - 1.65) = ffmi + 0.915
+    const ffmi = 18
+    expect(calcNormalizedFFMI(ffmi, 165)).toBeCloseTo(18.915, 3)
+  })
+  it('adjusts downward for taller person', () => {
+    // 1.90 m: norm = ffmi + 6.1*(1.80 - 1.90) = ffmi - 0.61
+    const ffmi = 24
+    expect(calcNormalizedFFMI(ffmi, 190)).toBeCloseTo(23.39, 3)
+  })
+  it('returns null for invalid', () => {
+    expect(calcNormalizedFFMI(null, 180)).toBeNull()
+    expect(calcNormalizedFFMI(20, null)).toBeNull()
+    expect(calcNormalizedFFMI(20, 0)).toBeNull()
+  })
+})
+
+describe('classifyFFMI — male thresholds', () => {
+  it('17 → belowAverage', () => {
+    expect(classifyFFMI(17, 'male')).toBe('belowAverage')
+  })
+  it('19 → average', () => {
+    expect(classifyFFMI(19, 'male')).toBe('average')
+  })
+  it('21 → aboveAverage', () => {
+    expect(classifyFFMI(21, 'male')).toBe('aboveAverage')
+  })
+  it('23 → aboveAverage', () => {
+    expect(classifyFFMI(23, 'male')).toBe('aboveAverage')
+  })
+  it('26 → top1', () => {
+    expect(classifyFFMI(26, 'male')).toBe('top1')
+  })
+  it('30 → unlikelyNatural', () => {
+    expect(classifyFFMI(30, 'male')).toBe('unlikelyNatural')
+  })
+})
+
+describe('classifyFFMI — female thresholds', () => {
+  it('12 → belowAverage', () => {
+    expect(classifyFFMI(12, 'female')).toBe('belowAverage')
+  })
+  it('14 → average', () => {
+    expect(classifyFFMI(14, 'female')).toBe('average')
+  })
+  it('16 → aboveAverage', () => {
+    expect(classifyFFMI(16, 'female')).toBe('aboveAverage')
+  })
+  it('18 → aboveAverage', () => {
+    expect(classifyFFMI(18, 'female')).toBe('aboveAverage')
+  })
+  it('20 → top1', () => {
+    expect(classifyFFMI(20, 'female')).toBe('top1')
+  })
+  it('24 → unlikelyNatural', () => {
+    expect(classifyFFMI(24, 'female')).toBe('unlikelyNatural')
+  })
+  it('returns null for unknown sex', () => {
+    expect(classifyFFMI(20, 'other')).toBeNull()
+  })
+})
+
+describe('calcFFMIResult integration', () => {
+  it('80 kg, 180 cm, 15% BF, male → average', () => {
+    const r = calcFFMIResult({ weightKg: 80, heightCm: 180, bodyFatPct: 15, sex: 'male' })
+    expect(r.ffm).toBeCloseTo(68, 1)
+    expect(r.ffmi).toBeCloseTo(20.99, 1)
+    expect(r.normalizedFFMI).toBeCloseTo(20.99, 1)
+    // 20.99 falls in 20–25 (aboveAverage) bucket for male
+    expect(r.category).toBe('aboveAverage')
+  })
+  it('returns null when sex missing', () => {
+    expect(calcFFMIResult({ weightKg: 80, heightCm: 180, bodyFatPct: 15 })).toBeNull()
+  })
+  it('returns null when inputs missing', () => {
+    expect(calcFFMIResult({ heightCm: 180, bodyFatPct: 15, sex: 'male' })).toBeNull()
+  })
+  it('classifies on normalized FFMI, not raw FFMI', () => {
+    // Short person: raw FFMI 17, height 1.65 → norm 17.915 (still belowAverage for male)
+    // Tall person same FFM:
+    const tall = calcFFMIResult({ weightKg: 75, heightCm: 195, bodyFatPct: 15, sex: 'male' })
+    // FFM = 63.75, h = 1.95 → ffmi = 16.77, norm = 16.77 + 6.1*(-0.15) = 15.85
+    expect(tall.ffmi).toBeGreaterThan(tall.normalizedFFMI)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 324 links (81 calcs × 2 locales + 81 blogs × 2 locales)', () => {
+  it('generates 328 links (82 calcs × 2 locales + 82 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(324)
+    expect(links).toHaveLength(328)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -20,7 +20,7 @@ const EXPECTED_KEYS = [
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
-  'ironDeficiency',
+  'ironDeficiency', 'ffmiRechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -92,6 +92,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'diabetes-typ-2-vorbeugen',
   'pearl-index-berechnen',
   'eisenmangel-berechnen',
+  'ffmi-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -163,12 +164,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'prevent-type-2-diabetes',
   'pearl-index-calculator-guide',
   'iron-deficiency-calculator-guide',
+  'ffmi-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 81 calculator meta files', () => {
+  it('discovers all 82 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(81)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(82)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -206,19 +208,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 81 DE blog slugs', () => {
+  it('returns all 82 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(81)
+    expect(de).toHaveLength(82)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 81 EN blog slugs', () => {
+  it('returns all 82 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(81)
+    expect(en).toHaveLength(82)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -286,9 +288,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 162 calcs + 2 blog index + 162 blog articles = 328)', () => {
+  it('generates correct total URL count (2 home + 164 calcs + 2 blog index + 164 blog articles = 332)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(328)
+    expect(urlCount).toBe(332)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -728,6 +728,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'ironDeficiency',
     related: ['anemia-risk-calculator-guide', 'thyroid-function-calculator', 'calculate-bmr'],
   },
+  {
+    slug: 'ffmi-calculator-guide',
+    title: 'FFMI Calculator: How to Read Your Fat-Free Mass Index',
+    description: 'Calculate FFMI from weight, height and body fat. Normalized FFMI by Kouri, natural-athlete cutoffs, BMI comparison and training recommendations.',
+    date: '2026-05-13',
+    readTime: '8 min',
+    calculatorKey: 'ffmiRechner',
+    related: ['calculate-lean-body-mass', 'calculate-body-fat', 'calculate-bmi'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -728,6 +728,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'ironDeficiency',
     related: ['anaemie-risiko-berechnen', 'schilddruesenfunktion-berechnen', 'grundumsatz-berechnen'],
   },
+  {
+    slug: 'ffmi-berechnen',
+    title: 'FFMI berechnen: Fettfreie-Masse-Index richtig deuten',
+    description: 'FFMI berechnen mit Gewicht, Größe und Körperfett. Normalisierter FFMI nach Kouri, Grenzwerte für natürliche Athleten, BMI-Vergleich und Trainingsempfehlungen.',
+    date: '2026-05-13',
+    readTime: '8 min',
+    calculatorKey: 'ffmiRechner',
+    related: ['magermasse-berechnen', 'koerperfett-berechnen', 'bmi-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/ffmiRechner.json
+++ b/src/locales/calculators/de/ffmiRechner.json
@@ -1,0 +1,78 @@
+{
+  "home": {
+    "calculators": {
+      "ffmiRechner": {
+        "name": "FFMI-Rechner",
+        "description": "Fettfreie-Masse-Index berechnen — Muskelmasse relativ zur Körpergröße einordnen."
+      }
+    }
+  },
+  "ffmiRechner": {
+    "meta": {
+      "title": "FFMI-Rechner — Fettfreie-Masse-Index berechnen",
+      "description": "Berechne deinen FFMI (Fettfreie-Masse-Index) aus Gewicht, Größe und Körperfett. Mit normalisiertem FFMI nach Kouri und Klassifikation für natürliche Athleten. Kostenlos, sofort."
+    },
+    "title": "FFMI-Rechner",
+    "description": "Bestimme deinen Fettfreie-Masse-Index — die aussagekräftigste Kennzahl für Muskelmasse relativ zur Körpergröße. Mit normalisierter Variante und Einordnung für natürliche Athleten.",
+    "sexLabel": "Geschlecht",
+    "sexMale": "Männlich",
+    "sexFemale": "Weiblich",
+    "weightLabel": "Gewicht (kg)",
+    "heightLabel": "Größe (cm)",
+    "bodyFatLabel": "Körperfett (%)",
+    "bodyFatHint": "Körperfettanteil aus Caliper, Bioimpedanz oder DEXA-Messung",
+    "resultsLabel": "Dein FFMI",
+    "ffmLabel": "Fettfreie Masse",
+    "ffmiLabel": "FFMI",
+    "normalizedFFMILabel": "Normalisierter FFMI",
+    "normalizedFFMIHint": "auf 1,80 m Körpergröße angepasst (Kouri 1995)",
+    "categoryLabel": "Einordnung",
+    "category_belowAverage": "Unterdurchschnittlich",
+    "category_average": "Durchschnittlich",
+    "category_aboveAverage": "Überdurchschnittlich",
+    "category_top1": "Top 1 % (natürliches Limit)",
+    "category_unlikelyNatural": "Physiologisch unwahrscheinlich",
+    "advice_belowAverage": "Dein FFMI liegt unter dem Durchschnitt. Mit gezieltem Krafttraining (3–4× pro Woche, progressive Überlastung) und ausreichend Protein (1,6–2,2 g/kg Körpergewicht) lässt sich der Wert deutlich steigern.",
+    "advice_average": "Dein FFMI liegt im Normalbereich für Untrainierte. Wer Muskelmasse aufbauen will, profitiert von strukturiertem Hypertrophie-Training und einem leichten Kalorienüberschuss.",
+    "advice_aboveAverage": "Sehr guter FFMI — typisch für Hobbysportler mit konsequentem Krafttraining. Weiter so. Mit gezielter Periodisierung lässt sich die Marke 23 (M) bzw. 17 (F) erreichen.",
+    "advice_top1": "Außergewöhnlicher FFMI im Bereich natürlicher Spitzenathleten. Dieses Niveau ist nur mit jahrelangem, optimiertem Training und genetischer Veranlagung erreichbar.",
+    "advice_unlikelyNatural": "Dieser FFMI gilt als physiologisch unwahrscheinlich für natürliches Training. Kouri et al. (1995) fanden bei über 200 Natural-Bodybuildern keinen Wert > 25 (M) bzw. > 22 (F).",
+    "refTitle": "FFMI-Klassifikation (normalisiert)",
+    "refMale": "Männer",
+    "refFemale": "Frauen",
+    "refRange": "Bereich",
+    "exampleTitle": "Rechenbeispiel",
+    "exampleText": "Ein Mann mit 80 kg Gewicht, 180 cm Größe und 15 % Körperfett: FFM = 80 × (1 − 0,15) = 68 kg. FFMI = 68 / 1,80² = 68 / 3,24 = 20,99. Da Größe exakt 1,80 m ist, bleibt der normalisierte FFMI bei 20,99 — überdurchschnittlich, typisch für ambitionierte Hobbyathleten.",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der FFMI wurde 1995 von Kouri et al. an der Harvard Medical School entwickelt, um Muskelmasse zwischen verschiedenen Körpergrößen vergleichbar zu machen. Die fettfreie Masse (Knochen, Organe, Muskeln, Wasser) wird ins Verhältnis zum Quadrat der Körpergröße gesetzt — analog zum BMI, aber ohne Verfälschung durch Fettmasse. Der normalisierte FFMI addiert 6,1 × (1,80 m − tatsächliche Größe), damit kleine und große Athleten dieselbe Skala teilen. Werte > 25 (Männer) oder > 22 (Frauen) gelten als unerreichbar ohne anabole Substanzen.",
+    "uniqueContent": "Warum der FFMI dem BMI überlegen ist — und wo seine Grenzen liegen",
+    "uniqueContentText": "Der Body Mass Index behandelt einen kräftigen Bodybuilder mit 100 kg bei 185 cm rechnerisch identisch mit einem übergewichtigen Bürohocker derselben Maße: BMI 29,2 — beide formal „Übergewicht\". Das ist offensichtlich Unsinn. Der FFMI löst dieses Problem, indem er nur die fettfreie Masse (Muskeln, Knochen, Organe, Wasser) zählt. Voraussetzung ist eine möglichst exakte Körperfettmessung. Caliper-Messungen taugen für Trends, sind aber abhängig vom Tester. Bioimpedanz-Waagen schwanken je nach Hydratationszustand um 2–5 Prozentpunkte. Die zuverlässigsten Methoden sind DEXA und Hydrostatic Weighing — beide in deutschen Sportkliniken verfügbar. Der zweite Trick ist die Normalisierung auf 1,80 m Körpergröße. Ohne sie wären kleine Athleten systematisch im Nachteil: Bei gleicher Muskelmasse-zu-Skelett-Ratio ergibt sich rechnerisch ein niedrigerer FFMI. Kouri et al. korrigierten das empirisch mit dem Faktor 6,1. Was der FFMI nicht kann: Er sagt nichts über Kraft oder Funktion. Ein FFMI von 23 mit reinem Volumentraining ist nicht dasselbe wie ein FFMI von 23 mit Olympic-Lifting-Hintergrund. Und der „natürliche Cutoff\" bei 25 (Männer) ist eine statistische Aussage — Einzelfälle mit besonders günstiger Genetik (lange Muskelbäuche, geringer Knochenanteil) können auch ohne Doping höhere Werte erreichen. Trotzdem bleibt der FFMI das beste Werkzeug für realistische Selbsteinschätzung: Wer in fünf Jahren von 18 auf 21 kommt, hat respektable 12 kg Muskelmasse aufgebaut. Wer von 21 auf 24 will, sollte sich auf weitere drei Jahre Geduld einstellen.",
+    "disclaimer": "Der FFMI hängt entscheidend von der Genauigkeit der Körperfettmessung ab. Caliper-Werte sind nur so zuverlässig wie der Tester, Bioimpedanz schwankt mit der Tageshydratation. Für medizinisch relevante Aussagen sind DEXA oder Hydrostatic Weighing der Goldstandard. Der Rechner ersetzt keine sportmedizinische Beratung.",
+    "faq": [
+      {
+        "q": "Was sagt der FFMI aus, was der BMI nicht kann?",
+        "a": "Der BMI behandelt einen muskulösen Athleten und einen übergewichtigen Untrainierten gleich, wenn Gewicht und Größe identisch sind. Der FFMI ignoriert die Fettmasse und misst nur die fettfreie Masse — er ist deshalb die bessere Kennzahl für Trainierte und Bodybuilder."
+      },
+      {
+        "q": "Was ist der normalisierte FFMI?",
+        "a": "Eine Korrektur, die kleine und große Athleten vergleichbar macht. Kouri et al. addieren 6,1 × (1,80 m − tatsächliche Größe) zum FFMI. Bei 1,80 m bleibt der Wert unverändert; ein 1,65 m großer Athlet bekommt etwa +0,92 dazu, ein 1,90 m großer −0,61."
+      },
+      {
+        "q": "Ab welchem FFMI gilt man als „muskulös\"?",
+        "a": "Bei Männern liegt der Durchschnitt Untrainierter bei 18–20. Hobbysportler erreichen 20–22, fortgeschrittene Athleten 22–24, natürliche Spitzenathleten 24–25. Frauen liegen jeweils 5 Punkte tiefer."
+      },
+      {
+        "q": "Stimmt es, dass FFMI > 25 nur mit Doping erreichbar ist?",
+        "a": "Kouri et al. (1995) untersuchten 157 Natural-Bodybuilder und 83 Steroidnutzer. Bei den Naturals lag der Maximalwert bei 25,0; bei den Steroidnutzern reichte er bis 32,2. Einzelfälle mit extremer Genetik können über 25 kommen, aber die statistische Regel gilt: > 25 normalisiert ist physiologisch unwahrscheinlich ohne anabole Substanzen."
+      },
+      {
+        "q": "Wie genau muss die Körperfettmessung sein?",
+        "a": "Sehr genau — ein Fehler von 3 % Körperfett verändert den FFMI um etwa 0,6 Punkte. DEXA gilt als Goldstandard (±1–2 %). Caliper-Messungen schwanken stärker (±3–5 %), Bioimpedanz-Waagen je nach Modell und Hydratation ±3–8 %."
+      },
+      {
+        "q": "Wie kann ich meinen FFMI verbessern?",
+        "a": "Progressives Krafttraining (3–4× pro Woche), 1,6–2,2 g Protein pro kg Körpergewicht, leichter Kalorienüberschuss (200–500 kcal), Schlaf 7–9 Stunden. Realistisch sind 4–8 kg Muskelaufbau im ersten Jahr — danach 1–3 kg pro Jahr."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/ffmiRechner.json
+++ b/src/locales/calculators/en/ffmiRechner.json
@@ -1,0 +1,78 @@
+{
+  "home": {
+    "calculators": {
+      "ffmiRechner": {
+        "name": "FFMI Calculator",
+        "description": "Calculate Fat-Free Mass Index — gauge your muscle mass relative to height."
+      }
+    }
+  },
+  "ffmiRechner": {
+    "meta": {
+      "title": "FFMI Calculator — Fat-Free Mass Index",
+      "description": "Calculate your FFMI (Fat-Free Mass Index) from weight, height and body fat. With normalized FFMI by Kouri and natural-athlete classification. Free and instant."
+    },
+    "title": "FFMI Calculator",
+    "description": "Determine your Fat-Free Mass Index — the most meaningful number for muscle mass relative to height. With normalized variant and natural-athlete benchmarks.",
+    "sexLabel": "Sex",
+    "sexMale": "Male",
+    "sexFemale": "Female",
+    "weightLabel": "Weight (kg)",
+    "heightLabel": "Height (cm)",
+    "bodyFatLabel": "Body fat (%)",
+    "bodyFatHint": "Body fat percentage from caliper, bioimpedance or DEXA",
+    "resultsLabel": "Your FFMI",
+    "ffmLabel": "Fat-free mass",
+    "ffmiLabel": "FFMI",
+    "normalizedFFMILabel": "Normalized FFMI",
+    "normalizedFFMIHint": "adjusted to 1.80 m height (Kouri 1995)",
+    "categoryLabel": "Classification",
+    "category_belowAverage": "Below average",
+    "category_average": "Average",
+    "category_aboveAverage": "Above average",
+    "category_top1": "Top 1 % (natural limit)",
+    "category_unlikelyNatural": "Physiologically unlikely",
+    "advice_belowAverage": "Your FFMI is below average. Targeted strength training (3–4× per week, progressive overload) and adequate protein (1.6–2.2 g/kg bodyweight) will move this number significantly.",
+    "advice_average": "Your FFMI sits in the normal range for untrained adults. To add muscle, follow a structured hypertrophy program with a small caloric surplus.",
+    "advice_aboveAverage": "Strong FFMI — typical for recreational lifters with consistent training. Keep going. With smart periodization you can push toward 23 (M) or 17 (F).",
+    "advice_top1": "Exceptional FFMI in the range of elite natural athletes. This level requires years of optimized training and favorable genetics.",
+    "advice_unlikelyNatural": "This FFMI is considered physiologically unlikely to reach naturally. Kouri et al. (1995) found no natural bodybuilder exceeding 25 (M) or 22 (F) in their landmark study.",
+    "refTitle": "FFMI classification (normalized)",
+    "refMale": "Male",
+    "refFemale": "Female",
+    "refRange": "Range",
+    "exampleTitle": "Worked example",
+    "exampleText": "A man weighing 80 kg, height 180 cm, 15 % body fat: FFM = 80 × (1 − 0.15) = 68 kg. FFMI = 68 / 1.80² = 68 / 3.24 = 20.99. Since height is exactly 1.80 m, normalized FFMI stays at 20.99 — above average, typical for committed recreational athletes.",
+    "howItWorks": "How it works",
+    "howItWorksText": "FFMI was developed in 1995 by Kouri et al. at Harvard Medical School to make muscle mass comparable across heights. Fat-free mass (bone, organs, muscle, water) is divided by height squared — analogous to BMI, but unaffected by fat. Normalized FFMI adds 6.1 × (1.80 m − actual height) so that short and tall athletes share the same scale. Values > 25 (men) or > 22 (women) are considered unreachable without anabolic substances.",
+    "uniqueContent": "Why FFMI beats BMI — and where it falls short",
+    "uniqueContentText": "Body Mass Index treats a 100 kg muscular bodybuilder at 185 cm identically to an overweight office worker of the same proportions: BMI 29.2 — both flagged as „overweight\". That makes no sense. FFMI fixes this by counting only fat-free mass (muscle, bone, organs, water). It depends on an accurate body fat measurement. Calipers track trends but vary with the operator. Bioimpedance scales drift by 2–5 percentage points with hydration. The gold-standard methods are DEXA and hydrostatic weighing — both available at most sports clinics. The second trick is normalization to 1.80 m height. Without it, short athletes would be systematically penalized: with the same muscle-to-frame ratio, their raw FFMI comes out lower. Kouri et al. corrected this empirically with the 6.1 factor. What FFMI cannot do: it says nothing about strength or function. An FFMI of 23 from pure bodybuilding work is not the same as 23 backed by Olympic lifting. And the „natural cutoff\" at 25 is a statistical statement — outliers with favorable genetics (long muscle bellies, light bones) can edge above it without drugs. Still, FFMI remains the best tool for honest self-assessment. Going from 18 to 21 in five years means roughly 12 kg of real muscle. Moving from 21 to 24 is a three-to-five year project for most lifters, and the closer you get to 25, the harder every kilogram becomes.",
+    "disclaimer": "FFMI accuracy depends heavily on body fat measurement quality. Calipers are only as good as the operator; bioimpedance varies with daily hydration. For clinically relevant numbers, use DEXA or hydrostatic weighing. This calculator does not replace sports medicine advice.",
+    "faq": [
+      {
+        "q": "What does FFMI tell you that BMI doesn't?",
+        "a": "BMI treats a muscular athlete and an overweight untrained person the same when weight and height match. FFMI ignores fat mass and counts only fat-free mass, making it the better number for trained adults and bodybuilders."
+      },
+      {
+        "q": "What is normalized FFMI?",
+        "a": "A correction that makes short and tall athletes comparable. Kouri et al. add 6.1 × (1.80 m − actual height) to FFMI. At 1.80 m, the number is unchanged; a 1.65 m athlete gains about +0.92, a 1.90 m athlete loses 0.61."
+      },
+      {
+        "q": "At what FFMI do you count as „muscular\"?",
+        "a": "For men, untrained adults average 18–20. Recreational lifters reach 20–22, advanced athletes 22–24, natural elite 24–25. Women sit roughly 5 points lower across all bands."
+      },
+      {
+        "q": "Is it true that FFMI > 25 requires steroids?",
+        "a": "Kouri et al. (1995) examined 157 natural bodybuilders and 83 steroid users. The natural cohort topped out at 25.0; steroid users reached 32.2. Rare outliers may cross 25 with elite genetics, but the statistical rule holds: > 25 normalized is unlikely without anabolic drugs."
+      },
+      {
+        "q": "How accurate must my body fat measurement be?",
+        "a": "Very accurate — a 3 % body fat error shifts FFMI by about 0.6 points. DEXA is the gold standard (±1–2 %). Calipers vary more (±3–5 %), bioimpedance scales by ±3–8 % depending on model and hydration."
+      },
+      {
+        "q": "How do I improve my FFMI?",
+        "a": "Progressive strength training (3–4× per week), 1.6–2.2 g protein per kg bodyweight, a small caloric surplus (200–500 kcal), 7–9 hours of sleep. Realistic gains are 4–8 kg of muscle in year one, then 1–3 kg per year."
+      }
+    ]
+  }
+}

--- a/src/pages/FfmiRechnerCalculator.vue
+++ b/src/pages/FfmiRechnerCalculator.vue
@@ -1,0 +1,209 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcFFMIResult } from '../utils/ffmiRechner.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('ffmiRechner.faq') || [])
+
+useHead(() => ({
+  title: t('ffmiRechner.meta.title'),
+  description: t('ffmiRechner.meta.description'),
+  routeKey: 'ffmiRechner',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'FFMI Calculator',
+    url: 'https://healthcalculator.app/en/ffmi-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const sex = ref('male')
+const weight = ref(null)
+const height = ref(null)
+const bodyFat = ref(null)
+
+const result = computed(() => calcFFMIResult({
+  weightKg: weight.value,
+  heightCm: height.value,
+  bodyFatPct: bodyFat.value,
+  sex: sex.value,
+}))
+
+const categoryStyle = computed(() => {
+  if (!result.value) return { color: '', bg: '' }
+  switch (result.value.category) {
+    case 'belowAverage': return { color: 'text-yellow-600', bg: 'bg-yellow-50 border-yellow-200 text-yellow-900' }
+    case 'average': return { color: 'text-stone-700', bg: 'bg-stone-50 border-stone-200 text-stone-900' }
+    case 'aboveAverage': return { color: 'text-green-600', bg: 'bg-green-50 border-green-200 text-green-900' }
+    case 'top1': return { color: 'text-blue-600', bg: 'bg-blue-50 border-blue-200 text-blue-900' }
+    case 'unlikelyNatural': return { color: 'text-red-700', bg: 'bg-red-100 border-red-300 text-red-900' }
+    default: return { color: '', bg: '' }
+  }
+})
+
+const categoryLevel = computed(() => {
+  if (!result.value) return 0
+  return { belowAverage: 0, average: 1, aboveAverage: 2, top1: 3, unlikelyNatural: 4 }[result.value.category] ?? 0
+})
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('ffmiRechner.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('ffmiRechner.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('ffmiRechner.sexLabel') }}</label>
+        <div class="flex gap-2">
+          <button @click="sex = 'male'" data-testid="sex-male"
+            :class="sex === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('ffmiRechner.sexMale') }}</button>
+          <button @click="sex = 'female'" data-testid="sex-female"
+            :class="sex === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('ffmiRechner.sexFemale') }}</button>
+        </div>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('ffmiRechner.weightLabel') }}</label>
+        <input v-model.number="weight" type="number" step="0.1" min="0" placeholder="80" data-testid="weight"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-2">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('ffmiRechner.heightLabel') }}</label>
+        <input v-model.number="height" type="number" step="0.1" min="0" placeholder="180" data-testid="height"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('ffmiRechner.bodyFatLabel') }}</label>
+        <input v-model.number="bodyFat" type="number" step="0.1" min="0" max="99" placeholder="15" data-testid="bodyFat"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+      </div>
+    </div>
+    <p class="text-xs text-stone-400 leading-relaxed">{{ t('ffmiRechner.bodyFatHint') }}</p>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">{{ t('ffmiRechner.resultsLabel') }}</p>
+
+    <div class="flex items-baseline gap-3 mb-2">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="ffmi-result">{{ result.ffmi.toFixed(2) }}</span>
+      <span class="text-lg text-stone-400">FFMI</span>
+    </div>
+    <p class="text-sm font-semibold mb-6" :class="categoryStyle.color" data-testid="result-status">
+      {{ t('ffmiRechner.category_' + result.category) }}
+    </p>
+
+    <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+      <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-yellow-500 via-green-500 via-blue-500 to-red-700 rounded-full" style="width: 100%"></div>
+      <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (categoryLevel / 4 * 100) + '%' }"></div>
+    </div>
+
+    <div class="grid grid-cols-3 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="ffm-result">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ffmiRechner.ffmLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.ffm.toFixed(1) }} <span class="text-base text-stone-400 font-medium">kg</span></p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ffmiRechner.ffmiLabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.ffmi.toFixed(2) }}</p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4" data-testid="normalized-ffmi">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ffmiRechner.normalizedFFMILabel') }}</p>
+        <p class="text-2xl font-bold text-stone-900 tabular-nums">{{ result.normalizedFFMI.toFixed(2) }}</p>
+        <p class="text-xs text-stone-400 mt-1">{{ t('ffmiRechner.normalizedFFMIHint') }}</p>
+      </div>
+    </div>
+
+    <div class="rounded-lg p-4 text-sm font-medium border" :class="categoryStyle.bg" data-testid="advice">
+      {{ t('ffmiRechner.advice_' + result.category) }}
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <div class="px-6 py-4 border-b border-stone-200 bg-stone-50">
+      <h2 class="text-base font-semibold text-stone-900">{{ t('ffmiRechner.refTitle') }}</h2>
+    </div>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ffmiRechner.refRange') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ffmiRechner.refMale') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('ffmiRechner.refFemale') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ffmiRechner.category_belowAverage') }}</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 18</td>
+          <td class="px-6 py-3 text-stone-600">&lt; 13</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ffmiRechner.category_average') }}</td>
+          <td class="px-6 py-3 text-stone-600">18–20</td>
+          <td class="px-6 py-3 text-stone-600">13–15</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ffmiRechner.category_aboveAverage') }}</td>
+          <td class="px-6 py-3 text-stone-600">20–25</td>
+          <td class="px-6 py-3 text-stone-600">15–19</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ffmiRechner.category_top1') }}</td>
+          <td class="px-6 py-3 text-stone-600">25–28</td>
+          <td class="px-6 py-3 text-stone-600">19–22</td>
+        </tr>
+        <tr>
+          <td class="px-6 py-3 text-stone-900 font-medium">{{ t('ffmiRechner.category_unlikelyNatural') }}</td>
+          <td class="px-6 py-3 text-stone-600">&gt; 28</td>
+          <td class="px-6 py-3 text-stone-600">&gt; 22</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('ffmiRechner.exampleTitle') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('ffmiRechner.exampleText') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('ffmiRechner.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('ffmiRechner.howItWorksText') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('ffmiRechner.uniqueContent') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('ffmiRechner.uniqueContentText') }}</p>
+  </div>
+
+  <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-6">
+    <p class="text-sm text-amber-900 leading-relaxed">{{ t('ffmiRechner.disclaimer') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="ffmiRechner" />
+</template>

--- a/src/pages/blog/FfmiBerechnen.vue
+++ b/src/pages/blog/FfmiBerechnen.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'FFMI berechnen: Fettfreie-Masse-Index richtig deuten | Health Calculators',
+  description: 'FFMI berechnen mit Gewicht, Größe und Körperfett. Normalisierter FFMI nach Kouri, Grenzwerte für natürliche Athleten, BMI-Vergleich und Trainingsempfehlungen.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'FFMI berechnen: Fettfreie-Masse-Index richtig deuten',
+    description: 'FFMI berechnen mit Gewicht, Größe und Körperfett. Normalisierter FFMI nach Kouri, Grenzwerte für natürliche Athleten, BMI-Vergleich und Trainingsempfehlungen.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-13',
+    dateModified: '2026-05-13',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/ffmi-berechnen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">FFMI berechnen: Fettfreie-Masse-Index richtig deuten</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">13. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <strong>Fettfreie-Masse-Index (FFMI)</strong> ist die ehrlichste Antwort auf die Frage „bin ich muskulös?" Wo der BMI muskulöse Athleten zu Unrecht als „übergewichtig" abstempelt, bezieht der FFMI nur die fettfreie Masse — Muskeln, Knochen, Organe, Wasser — auf die Körpergröße. Das Ergebnis: eine Zahl, die Bodybuilder, Kraftsportler und Hobbyathleten quer durch alle Größenklassen vergleichbar macht.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Ratgeber erklärt die Formel, die Normalisierung nach Kouri und warum der Wert 25 als statistische Obergrenze für natürliches Training gilt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel in drei Schritten</h2>
+        <ol class="list-decimal pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Fettfreie Masse berechnen:</strong> FFM (kg) = Körpergewicht × (1 − Körperfett% / 100). Beispiel: 80 kg bei 15 % Körperfett ergibt 68 kg FFM.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>FFMI berechnen:</strong> FFMI = FFM / Körpergröße in Metern². Bei 1,80 m: 68 / 3,24 = 20,99.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Auf 1,80 m normalisieren:</strong> normFFMI = FFMI + 6,1 × (1,80 − Größe_in_m). So werden 1,65-m-Athleten und 1,95-m-Athleten direkt vergleichbar.</li>
+        </ol>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">FFMI-Klassifikation für Männer und Frauen</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bereich</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Männer</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Frauen</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Typische Athleten</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Unterdurchschnittlich</td><td class="px-6 py-3 text-stone-600">&lt; 18</td><td class="px-6 py-3 text-stone-600">&lt; 13</td><td class="px-6 py-3 text-stone-600">Untrainiert, schmaler Körperbau</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Durchschnittlich</td><td class="px-6 py-3 text-stone-600">18–20</td><td class="px-6 py-3 text-stone-600">13–15</td><td class="px-6 py-3 text-stone-600">Untrainierter Normalbereich</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Überdurchschnittlich</td><td class="px-6 py-3 text-stone-600">20–25</td><td class="px-6 py-3 text-stone-600">15–19</td><td class="px-6 py-3 text-stone-600">Hobby- und Wettkampfsportler</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Top 1 %</td><td class="px-6 py-3 text-stone-600">25–28</td><td class="px-6 py-3 text-stone-600">19–22</td><td class="px-6 py-3 text-stone-600">Natürliche Spitzenathleten</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Physiologisch unwahrscheinlich</td><td class="px-6 py-3 text-stone-600">&gt; 28</td><td class="px-6 py-3 text-stone-600">&gt; 22</td><td class="px-6 py-3 text-stone-600">Statistisch nur mit Anabolika</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Quelle:</strong> Kouri EM, Pope HG Jr, Katz DL, Oliva P. „Fat-free mass index in users and nonusers of anabolic-androgenic steroids." Clin J Sport Med 1995. Die Studie untersuchte 157 Natural-Bodybuilder und 83 Steroidnutzer — der höchste natürliche FFMI lag bei 25,0.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt FFMI berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Gewicht, Größe, Körperfett — sofort siehst du deinen FFMI, den normalisierten Wert und die Einordnung gegen natürliche Athleten.</p>
+        <router-link
+          :to="localePath('ffmiRechner')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">FFMI vs. BMI — der zentrale Unterschied</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> macht keinen Unterschied zwischen Fett- und Muskelmasse. Ein Bodybuilder mit 100 kg bei 1,85 m hat BMI 29,2 — formal „übergewichtig", obwohl er möglicherweise unter 10 % Körperfett trägt. Der FFMI löst das, indem er die Fettmasse rausrechnet. Wer wirklich wissen will, wie er körperlich dasteht, kombiniert <router-link :to="localeBlogPath('koerperfett-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Körperfettanteil</router-link> und <router-link :to="localeBlogPath('magermasse-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Magermasse</router-link> zum FFMI.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wie genau muss die Körperfettmessung sein?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Sehr genau. Ein Fehler von 3 Prozentpunkten Körperfett verschiebt den FFMI um rund 0,6 Punkte — genug, um in eine andere Kategorie zu rutschen. Die Methoden im Vergleich:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>DEXA-Scan:</strong> Goldstandard, Genauigkeit ±1–2 %. In deutschen Sportkliniken und Radiologie-Praxen ab etwa 100 €.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Hydrostatic Weighing:</strong> Klassischer Goldstandard, Unterwasserwiegung, ±1–2 % — selten verfügbar.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Caliper (Hautfaltenmessung):</strong> 3- oder 7-Punkte-Methode, ±3–5 %, stark vom Tester abhängig.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Bioimpedanz-Waagen:</strong> ±3–8 %, schwanken mit Hydratation und Mahlzeiten. Immer gleiche Tageszeit messen.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">FFMI im Trainingsplan einsetzen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der FFMI ist ein <strong>Trend-Marker</strong> — er zeigt über Monate und Jahre, ob das Training Muskelmasse generiert. Für Hypertrophie sind drei Hebel entscheidend: progressive Überlastung (mehr Gewicht oder mehr Wiederholungen), 1,6–2,2 g Protein pro kg Körpergewicht und ein moderater Kalorienüberschuss. Wer den <router-link :to="localePath('tdee')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Kalorienbedarf</router-link> kennt, kann gezielt 200–500 kcal darüber essen — genug für Muskelwachstum, ohne dass die Fettmasse explodiert.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Realistische Erwartung: Anfänger steigern den FFMI im ersten Jahr um 1,5–2,5 Punkte. Fortgeschrittene um 0,3–0,8 Punkte pro Jahr. Wer von FFMI 21 auf 24 will, sollte mindestens drei Jahre einplanen — und je näher man an 25 kommt, desto härter wird jedes zusätzliche Kilo Muskel.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der FFMI ist nur eine Kennzahl im Körperkomposition-Puzzle. Wer ihn berechnet hat, ergänzt sinnvoll mit dem
+          <router-link :to="localeBlogPath('magermasse-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Magermasse-Rechner</router-link>
+          (alternative Schätzformel, falls keine Körperfettmessung vorliegt), dem
+          <router-link :to="localeBlogPath('koerperfett-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Körperfett-Rechner</router-link>
+          (U.S. Navy-Methode aus Umfangsmaßen), dem klassischen
+          <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner</router-link>
+          als Kontrast und dem
+          <router-link :to="localeBlogPath('tdee-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Kalorienbedarf-Rechner</router-link>,
+          um den passenden Energieumsatz für deinen Muskelaufbau zu finden.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der FFMI ist die beste Einzelzahl, um Muskelmasse über die Zeit zu tracken — fairer als BMI, anschaulicher als reine Gewichtsangaben. Mit unserem
+          <router-link :to="localePath('ffmiRechner')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">FFMI-Rechner</router-link>
+          dauert die Auswertung 30 Sekunden. Wichtig: Die Aussagekraft hängt an der Körperfettmessung — DEXA oder gut geführter Caliper sind Pflicht, wenn der Wert mehr als grobe Orientierung sein soll.
+        </p>
+      </div>
+
+      <RelatedArticles slug="ffmi-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/FfmiCalculatorGuide.vue
+++ b/src/pages/blog/en/FfmiCalculatorGuide.vue
@@ -1,0 +1,156 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'FFMI Calculator: How to Read Your Fat-Free Mass Index | Health Calculators',
+  description: 'Calculate FFMI from weight, height and body fat. Normalized FFMI by Kouri, natural-athlete cutoffs, BMI comparison and training recommendations.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'FFMI Calculator: How to Read Your Fat-Free Mass Index',
+    description: 'Calculate FFMI from weight, height and body fat. Normalized FFMI by Kouri, natural-athlete cutoffs, BMI comparison and training recommendations.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-05-13',
+    dateModified: '2026-05-13',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/ffmi-calculator-guide',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">FFMI Calculator: How to Read Your Fat-Free Mass Index</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 13, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>Fat-Free Mass Index (FFMI)</strong> is the most honest answer to „am I muscular?". Where BMI wrongly labels muscular athletes as „overweight", FFMI only counts fat-free mass — muscle, bone, organs, water — relative to height. The result is a number that makes bodybuilders, strength athletes and recreational lifters comparable across every height class.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains the formula, the Kouri normalization, and why 25 is treated as the statistical ceiling for natural training.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula in three steps</h2>
+        <ol class="list-decimal pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Fat-free mass:</strong> FFM (kg) = body weight × (1 − body fat % / 100). Example: 80 kg at 15 % body fat → 68 kg FFM.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>FFMI:</strong> FFMI = FFM / height in meters². At 1.80 m: 68 / 3.24 = 20.99.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Normalize to 1.80 m:</strong> normFFMI = FFMI + 6.1 × (1.80 − height_in_m). Short and tall athletes now share one scale.</li>
+        </ol>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">FFMI classification for men and women</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Range</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Men</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Women</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Typical profile</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Below average</td><td class="px-6 py-3 text-stone-600">&lt; 18</td><td class="px-6 py-3 text-stone-600">&lt; 13</td><td class="px-6 py-3 text-stone-600">Untrained, slim build</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Average</td><td class="px-6 py-3 text-stone-600">18–20</td><td class="px-6 py-3 text-stone-600">13–15</td><td class="px-6 py-3 text-stone-600">Untrained normal range</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Above average</td><td class="px-6 py-3 text-stone-600">20–25</td><td class="px-6 py-3 text-stone-600">15–19</td><td class="px-6 py-3 text-stone-600">Recreational + competitive athletes</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Top 1 %</td><td class="px-6 py-3 text-stone-600">25–28</td><td class="px-6 py-3 text-stone-600">19–22</td><td class="px-6 py-3 text-stone-600">Natural elite athletes</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Physiologically unlikely</td><td class="px-6 py-3 text-stone-600">&gt; 28</td><td class="px-6 py-3 text-stone-600">&gt; 22</td><td class="px-6 py-3 text-stone-600">Statistically only with anabolics</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Source:</strong> Kouri EM, Pope HG Jr, Katz DL, Oliva P. „Fat-free mass index in users and nonusers of anabolic-androgenic steroids." Clin J Sport Med 1995. The study examined 157 natural bodybuilders and 83 steroid users — the highest natural FFMI was 25.0.
+        </p>
+      </div>
+
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your FFMI now</h3>
+        <p class="text-stone-300 text-sm mb-5">Weight, height, body fat — instant FFMI, normalized value and classification against natural athletes.</p>
+        <router-link
+          :to="localePath('ffmiRechner')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">FFMI vs. BMI — the key difference</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <router-link :to="localeBlogPath('calculate-bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI</router-link> makes no distinction between fat and muscle. A bodybuilder weighing 100 kg at 1.85 m has BMI 29.2 — flagged as „overweight" even at under 10 % body fat. FFMI solves this by removing fat mass from the equation. For a complete picture, combine
+          <router-link :to="localeBlogPath('calculate-body-fat')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">body fat percentage</router-link> and
+          <router-link :to="localeBlogPath('calculate-lean-body-mass')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">lean body mass</router-link> with your FFMI.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How accurate must body fat measurement be?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Very accurate. A 3-percentage-point error shifts FFMI by about 0.6 — enough to move you across a category line. The methods compared:
+        </p>
+        <ul class="list-disc pl-6 mb-4 space-y-2">
+          <li class="text-base text-stone-600 leading-relaxed"><strong>DEXA scan:</strong> Gold standard, accuracy ±1–2 %. Available at sports clinics and radiology practices from around $100.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Hydrostatic weighing:</strong> Classic gold standard, underwater weighing, ±1–2 % — rarely available outside research labs.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Calipers (skinfold):</strong> 3- or 7-site method, ±3–5 %, operator-dependent.</li>
+          <li class="text-base text-stone-600 leading-relaxed"><strong>Bioimpedance scales:</strong> ±3–8 %, drift with hydration and meals. Measure at the same time of day.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Using FFMI in your training plan</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          FFMI is a <strong>trend marker</strong> — it shows over months and years whether your training is building real muscle. Three hypertrophy levers matter most: progressive overload (more weight or reps), 1.6–2.2 g of protein per kg bodyweight, and a moderate caloric surplus. With your
+          <router-link :to="localePath('tdee')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">daily energy needs</router-link>
+          known, eating 200–500 kcal over maintenance keeps fat gain in check while muscle grows.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Realistic expectations: beginners add 1.5–2.5 FFMI points in year one. Advanced lifters add 0.3–0.8 per year. Going from FFMI 21 to 24 is at least a three-year project — and every step closer to 25 gets exponentially harder.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          FFMI is one piece of the body composition puzzle. After running it, dig deeper with the
+          <router-link :to="localeBlogPath('calculate-lean-body-mass')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Lean Body Mass calculator</router-link>
+          (alternative estimate if no body fat measurement is available), the
+          <router-link :to="localeBlogPath('calculate-body-fat')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Body Fat calculator</router-link>
+          (U.S. Navy method from circumference measurements), the classic
+          <router-link :to="localeBlogPath('calculate-bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI calculator</router-link>
+          for contrast, and the
+          <router-link :to="localeBlogPath('calculate-tdee')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">TDEE calculator</router-link>
+          to lock in the right energy intake for muscle gain.
+        </p>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          FFMI is the single best number for tracking muscle mass over time — fairer than BMI, more telling than scale weight. With our
+          <router-link :to="localePath('ffmiRechner')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">FFMI calculator</router-link>
+          the math takes 30 seconds. The caveat: it is only as good as your body fat measurement — DEXA or a well-trained caliper operator are required if you want more than rough orientation.
+        </p>
+      </div>
+
+      <RelatedArticles slug="ffmi-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/ffmiRechner.meta.js
+++ b/src/pages/ffmiRechner.meta.js
@@ -1,0 +1,16 @@
+import Component from './FfmiRechnerCalculator.vue'
+import BlogDe from './blog/FfmiBerechnen.vue'
+import BlogEn from './blog/en/FfmiCalculatorGuide.vue'
+
+export default {
+  key: 'ffmiRechner',
+  component: Component,
+  slugs: { de: 'ffmi-rechner', en: 'ffmi-calculator' },
+  group: 'bodyComposition',
+  groupOrder: 0,
+  order: 4.5,
+  blog: {
+    de: { slug: 'ffmi-berechnen', component: BlogDe },
+    en: { slug: 'ffmi-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/ffmiRechner.js
+++ b/src/utils/ffmiRechner.js
@@ -1,0 +1,65 @@
+// FFMI — Fettfreie-Masse-Index (Fat-Free Mass Index).
+// Reference: Kouri EM, Pope HG Jr, Katz DL, Oliva P. "Fat-free mass index in
+// users and nonusers of anabolic-androgenic steroids." Clin J Sport Med 1995.
+//
+//   FFM (kg)   = weight × (1 − bodyFat% / 100)
+//   FFMI       = FFM / heightM²
+//   normFFMI   = FFMI + 6.1 × (1.80 − heightM)
+//
+// Classification on normalized FFMI, 5 buckets per sex:
+//   Male:   <18 belowAverage, 18–20 average, 20–25 aboveAverage, 25–28 top1, >28 unlikelyNatural
+//   Female: <13 belowAverage, 13–15 average, 15–19 aboveAverage, 19–22 top1, >22 unlikelyNatural
+
+const THRESHOLDS = {
+  male: { average: 18, aboveAverage: 20, top1: 25, unlikelyNatural: 28 },
+  female: { average: 13, aboveAverage: 15, top1: 19, unlikelyNatural: 22 },
+}
+
+function isPositiveNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0
+}
+
+export function calcFFM(weightKg, bodyFatPct) {
+  if (!isPositiveNumber(weightKg)) return null
+  if (typeof bodyFatPct !== 'number' || !Number.isFinite(bodyFatPct)) return null
+  if (bodyFatPct < 0 || bodyFatPct >= 100) return null
+  return weightKg * (1 - bodyFatPct / 100)
+}
+
+export function calcFFMI(weightKg, heightCm, bodyFatPct) {
+  const ffm = calcFFM(weightKg, bodyFatPct)
+  if (ffm == null || !isPositiveNumber(heightCm)) return null
+  const heightM = heightCm / 100
+  return ffm / (heightM * heightM)
+}
+
+export function calcNormalizedFFMI(ffmi, heightCm) {
+  if (typeof ffmi !== 'number' || !Number.isFinite(ffmi)) return null
+  if (!isPositiveNumber(heightCm)) return null
+  const heightM = heightCm / 100
+  return ffmi + 6.1 * (1.80 - heightM)
+}
+
+export function classifyFFMI(normalizedFFMI, sex) {
+  if (typeof normalizedFFMI !== 'number' || !Number.isFinite(normalizedFFMI)) return null
+  const t = THRESHOLDS[sex]
+  if (!t) return null
+  if (normalizedFFMI < t.average) return 'belowAverage'
+  if (normalizedFFMI < t.aboveAverage) return 'average'
+  if (normalizedFFMI < t.top1) return 'aboveAverage'
+  if (normalizedFFMI < t.unlikelyNatural) return 'top1'
+  return 'unlikelyNatural'
+}
+
+export function calcFFMIResult({ weightKg, heightCm, bodyFatPct, sex } = {}) {
+  if (sex !== 'male' && sex !== 'female') return null
+  const ffm = calcFFM(weightKg, bodyFatPct)
+  if (ffm == null) return null
+  const ffmi = calcFFMI(weightKg, heightCm, bodyFatPct)
+  if (ffmi == null) return null
+  const normalizedFFMI = calcNormalizedFFMI(ffmi, heightCm)
+  const category = classifyFFMI(normalizedFFMI, sex)
+  return { ffm, ffmi, normalizedFFMI, category }
+}
+
+export const FFMI_CATEGORIES = ['belowAverage', 'average', 'aboveAverage', 'top1', 'unlikelyNatural']


### PR DESCRIPTION
## Summary
- New SSR calculator at `/de/ffmi-rechner` + `/en/ffmi-calculator` computing FFMI, normalized FFMI (Kouri 1995) and a 5-bucket sex-specific classification (unterdurchschnittlich / durchschnittlich / überdurchschnittlich / top 1 % / physiologisch unwahrscheinlich).
- Worked example + classification table + unique 300+ word content block + DE/EN blog articles cross-linking to Magermasse, Körperfett, BMI and Kalorienbedarf.
- Pure calc util (`src/utils/ffmiRechner.js`) with red-first unit tests (28 cases), Playwright spec (7 cases, all green) and auto-discovery / sitemap / llms-txt bumps from 81 → 82 calculators.

## Test plan
- [x] `npm test` — 2267 passing (all unit + integration tests)
- [x] `npm run build` — 332 sitemap URLs, 328 llms.txt links
- [x] `npx playwright test ffmiRechner` — 7 passing
- [x] `npx playwright test` (full suite) — 1116 passing
- [x] Manual verification: `/de/ffmi-rechner` resolves with FFMI 20.99 for the 80 kg / 180 cm / 15 % example

Closes jenslaufer/health-calculators#193

🤖 Generated with [Claude Code](https://claude.com/claude-code)