### PR TITLE
hc-177-menopause: Implement the blog article from issue #177: "Menopause — N

### DIFF
--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -29,7 +29,7 @@ const EXPECTED_KEYS = [
   'ironDeficiency', 'ffmiRechner',
 ]
 
-const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention']
+const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
 
 const EXPECTED_ROUTE_MAP = {
   bmi: { de: 'bmi-rechner', en: 'bmi-calculator' },
@@ -185,6 +185,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'pearl-index-berechnen',
   'eisenmangel-berechnen',
   'ffmi-berechnen',
+  'menopause-natuerlich-begleiten',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -258,6 +259,7 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pearl-index-calculator-guide',
   'iron-deficiency-calculator-guide',
   'ffmi-calculator-guide',
+  'menopause-natural-relief',
 ]
 
 describe('calculator discovery', () => {
@@ -294,14 +296,14 @@ describe('calculator discovery', () => {
 
 describe('blog component discovery', () => {
   it('discovers all 81 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(82)
+    expect(Object.keys(blogComponentsDe)).toHaveLength(83)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
   it('discovers all 81 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(82)
+    expect(Object.keys(blogComponentsEn)).toHaveLength(83)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -400,7 +402,7 @@ describe('i18n completeness', () => {
 
 describe('SSG routes', () => {
   it('generates exactly 447 routes', () => {
-    expect(routes).toHaveLength(452)
+    expect(routes).toHaveLength(455)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -67,7 +67,7 @@ describe('generateLlmsTxt', () => {
 
   it('generates 328 links (82 calcs × 2 locales + 82 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(328)
+    expect(links).toHaveLength(330)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/menopauseNatural.test.js
+++ b/src/__tests__/menopauseNatural.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { articles } from '../data/articles.js'
+import { articlesEn } from '../data/articles-en.js'
+import { blogComponentsDe, blogComponentsEn, calculatorMetas } from '../discovery.js'
+import routes from '../routes.js'
+
+const DE_BLOG = resolve(__dirname, '../pages/blog/MenopauseNatuerlich.vue')
+const EN_BLOG = resolve(__dirname, '../pages/blog/en/MenopauseNaturalRelief.vue')
+
+const deSrc = readFileSync(DE_BLOG, 'utf8')
+const enSrc = readFileSync(EN_BLOG, 'utf8')
+
+describe('Menopause natural relief blog — DE content', () => {
+  it('contains the required structural sections', () => {
+    expect(deSrc).toMatch(/Menopause natürlich begleiten: Symptomlinderung und wann zum Arzt/)
+    expect(deSrc).toMatch(/Perimenopause, Menopause, Postmenopause/)
+    expect(deSrc).toMatch(/Die häufigsten Symptome/)
+    expect(deSrc).toMatch(/Natürliche Linderung/)
+    expect(deSrc).toMatch(/Ernährung: Phytoöstrogene/)
+    expect(deSrc).toMatch(/Bewegung: Krafttraining/)
+    expect(deSrc).toMatch(/Schlafhygiene/)
+    expect(deSrc).toMatch(/Stressreduktion und Atemtechnik/)
+    expect(deSrc).toMatch(/Warnzeichen — wann zur Ärztin oder zum Arzt/)
+    expect(deSrc).toMatch(/HRT — die Hormontherapie im Überblick/)
+    expect(deSrc).toMatch(/Langzeitrisiken — Knochen und Herz/)
+  })
+
+  it('opens with a medical disclaimer above the intro', () => {
+    const disclaimerIdx = deSrc.indexOf('Medizinischer Hinweis')
+    const introIdx = deSrc.indexOf('hormoneller Übergang')
+    expect(disclaimerIdx).toBeGreaterThan(-1)
+    expect(introIdx).toBeGreaterThan(-1)
+    expect(disclaimerIdx).toBeLessThan(introIdx)
+  })
+
+  it('declares Article, MedicalWebPage and FAQPage structured data', () => {
+    expect(deSrc).toMatch(/'@type':\s*'Article'/)
+    expect(deSrc).toMatch(/'@type':\s*'MedicalWebPage'/)
+    expect(deSrc).toMatch(/'@type':\s*'FAQPage'/)
+  })
+
+  it('links to the existing menopause, BMI, osteoporosis and cardiovascular calculators', () => {
+    expect(deSrc).toMatch(/localePath\('menopauseSymptom'\)/)
+    expect(deSrc).toMatch(/localePath\('bmi'\)/)
+    expect(deSrc).toMatch(/localePath\('osteoporosisRisk'\)/)
+    expect(deSrc).toMatch(/localePath\('cardiovascularRisk'\)/)
+  })
+})
+
+describe('Menopause natural relief blog — EN content', () => {
+  it('contains the required structural sections', () => {
+    expect(enSrc).toMatch(/Menopause — Natural Symptom Relief and When to See a Doctor/)
+    expect(enSrc).toMatch(/Perimenopause, menopause, postmenopause/)
+    expect(enSrc).toMatch(/The most common symptoms/)
+    expect(enSrc).toMatch(/Natural relief/)
+    expect(enSrc).toMatch(/Diet: phytoestrogens/)
+    expect(enSrc).toMatch(/Exercise: strength training/)
+    expect(enSrc).toMatch(/Sleep hygiene/)
+    expect(enSrc).toMatch(/Stress reduction and breathing/)
+    expect(enSrc).toMatch(/Red flags — when to see a doctor/)
+    expect(enSrc).toMatch(/HRT — hormone therapy in brief/)
+    expect(enSrc).toMatch(/Long-term risks — bone and heart/)
+  })
+
+  it('opens with a medical disclaimer above the intro', () => {
+    const disclaimerIdx = enSrc.indexOf('Medical disclaimer')
+    const introIdx = enSrc.indexOf('hormonal transition')
+    expect(disclaimerIdx).toBeGreaterThan(-1)
+    expect(introIdx).toBeGreaterThan(-1)
+    expect(disclaimerIdx).toBeLessThan(introIdx)
+  })
+
+  it('declares Article, MedicalWebPage and FAQPage structured data', () => {
+    expect(enSrc).toMatch(/'@type':\s*'Article'/)
+    expect(enSrc).toMatch(/'@type':\s*'MedicalWebPage'/)
+    expect(enSrc).toMatch(/'@type':\s*'FAQPage'/)
+  })
+
+  it('links to the existing menopause, BMI, osteoporosis and cardiovascular calculators', () => {
+    expect(enSrc).toMatch(/localePath\('menopauseSymptom'\)/)
+    expect(enSrc).toMatch(/localePath\('bmi'\)/)
+    expect(enSrc).toMatch(/localePath\('osteoporosisRisk'\)/)
+    expect(enSrc).toMatch(/localePath\('cardiovascularRisk'\)/)
+  })
+})
+
+describe('Menopause natural relief blog — registration', () => {
+  it('is registered in articles.js with calculatorKey menopauseNatural and existing related slugs', () => {
+    const article = articles.find(a => a.slug === 'menopause-natuerlich-begleiten')
+    expect(article).toBeTruthy()
+    expect(article.calculatorKey).toBe('menopauseNatural')
+    for (const related of article.related) {
+      expect(articles.find(a => a.slug === related), `related not found in articles.js: ${related}`).toBeTruthy()
+    }
+  })
+
+  it('is registered in articles-en.js with calculatorKey menopauseNatural and existing related slugs', () => {
+    const article = articlesEn.find(a => a.slug === 'menopause-natural-relief')
+    expect(article).toBeTruthy()
+    expect(article.calculatorKey).toBe('menopauseNatural')
+    for (const related of article.related) {
+      expect(articlesEn.find(a => a.slug === related), `related not found in articles-en.js: ${related}`).toBeTruthy()
+    }
+  })
+
+  it('is registered in blog discovery for both locales', () => {
+    expect(blogComponentsDe['menopause-natuerlich-begleiten']).toBeDefined()
+    expect(blogComponentsEn['menopause-natural-relief']).toBeDefined()
+  })
+
+  it('menopauseNatural does not appear as a calculator', () => {
+    const calcKeys = calculatorMetas.map(m => m.key)
+    expect(calcKeys).not.toContain('menopauseNatural')
+  })
+
+  it('exposes blog routes for both locales and a DE old-blog redirect', () => {
+    expect(routes.find(r => r.path === '/de/blog/menopause-natuerlich-begleiten')).toBeDefined()
+    expect(routes.find(r => r.path === '/en/blog/menopause-natural-relief')).toBeDefined()
+    expect(routes.find(r => r.path === '/blog/menopause-natuerlich-begleiten')?.redirect).toBe('/de/blog/menopause-natuerlich-begleiten')
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -93,6 +93,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'pearl-index-berechnen',
   'eisenmangel-berechnen',
   'ffmi-berechnen',
+  'menopause-natuerlich-begleiten',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -165,6 +166,7 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pearl-index-calculator-guide',
   'iron-deficiency-calculator-guide',
   'ffmi-calculator-guide',
+  'menopause-natural-relief',
 ]
 
 describe('discoverMetas', () => {
@@ -211,7 +213,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 82 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(82)
+    expect(de).toHaveLength(83)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
@@ -220,7 +222,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 82 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(82)
+    expect(en).toHaveLength(83)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -288,9 +290,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 164 calcs + 2 blog index + 164 blog articles = 332)', () => {
+  it('generates correct total URL count (2 home + 164 calcs + 2 blog index + 166 blog articles = 334)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(332)
+    expect(urlCount).toBe(334)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -737,6 +737,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'ffmiRechner',
     related: ['calculate-lean-body-mass', 'calculate-body-fat', 'calculate-bmi'],
   },
+  {
+    slug: 'menopause-natural-relief',
+    title: 'Menopause — Natural Symptom Relief and When to See a Doctor',
+    description: 'Menopause explained — perimenopause vs menopause, common symptoms, natural relief through diet, exercise, phytoestrogens, sleep and stress. Plus red flags, HRT overview and long-term bone and heart risks.',
+    date: '2026-05-13',
+    readTime: '14 min',
+    calculatorKey: 'menopauseNatural',
+    related: ['menopause-symptom-calculator-guide', 'osteoporosis-risk-calculator-guide', 'cardiovascular-risk-framingham'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -737,6 +737,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'ffmiRechner',
     related: ['magermasse-berechnen', 'koerperfett-berechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'menopause-natuerlich-begleiten',
+    title: 'Menopause natürlich begleiten: Symptomlinderung und wann zum Arzt',
+    description: 'Wechseljahre verstehen — Perimenopause vs. Menopause, häufige Symptome, natürliche Linderung über Ernährung, Bewegung, Phytoöstrogene, Schlaf und Stress. Plus Warnzeichen, HRT-Überblick und Langzeitrisiken.',
+    date: '2026-05-13',
+    readTime: '14 min',
+    calculatorKey: 'menopauseNatural',
+    related: ['menopause-symptome-bewerten', 'osteoporose-risiko-berechnen', 'herz-kreislauf-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/pages/blog/MenopauseNatuerlich.vue
+++ b/src/pages/blog/MenopauseNatuerlich.vue
@@ -1,0 +1,517 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Menopause natürlich begleiten: Symptomlinderung und wann zum Arzt | Health Calculators',
+  description: 'Wechseljahre verstehen — Perimenopause vs. Menopause, häufige Symptome, natürliche Linderung über Ernährung, Bewegung, Phytoöstrogene, Schlaf und Stress. Plus Warnzeichen, HRT-Überblick und Langzeitrisiken für Knochen und Herz.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Menopause natürlich begleiten: Symptomlinderung und wann zum Arzt',
+      description: 'Wechseljahre verstehen — Perimenopause vs. Menopause, häufige Symptome, natürliche Linderung, Warnzeichen, HRT-Überblick und Langzeitrisiken für Knochen und Herz.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-13',
+      dateModified: '2026-05-13',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/menopause-natuerlich-begleiten',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'MedicalWebPage',
+      name: 'Menopause natürlich begleiten — Symptome und Therapie',
+      about: { '@type': 'MedicalCondition', name: 'Menopause' },
+      audience: { '@type': 'PeopleAudience', audienceType: 'Frauen 40–65' },
+      lastReviewed: '2026-05-13',
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist der Unterschied zwischen Perimenopause und Menopause?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Perimenopause ist die Übergangsphase mit schwankenden Hormonspiegeln, beginnt meist Mitte 40 und dauert 4–10 Jahre. Menopause ist der Zeitpunkt 12 Monate nach der letzten Regelblutung — im Mittel mit 51. Danach spricht man von Postmenopause.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welche natürlichen Mittel helfen gegen Hitzewallungen?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Gut belegt sind regelmäßige Bewegung, Gewichtsreduktion bei BMI > 25, Vermeidung von Triggern wie Koffein, Alkohol und scharfen Speisen, Atemtechniken (Paced Breathing) sowie Phytoöstrogene aus Soja und Leinsamen. Die Wirkung ist individuell und meist moderat.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wann sollte ich wegen Wechseljahresbeschwerden zum Arzt?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Bei starken Blutungen, Blutungen nach 12-monatiger Pause, einseitigem Brustknoten, anhaltenden Depressionen, Herzrasen, ungeklärtem Gewichtsverlust oder Beschwerden, die den Alltag dominieren. Auch wer eine HRT (Hormontherapie) erwägt, braucht eine fundierte ärztliche Beratung.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Erhöht die Menopause das Risiko für Osteoporose und Herzinfarkt?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Ja. Der Östrogenabfall beschleunigt den Knochenabbau (bis zu 2 % pro Jahr in den ersten 5–10 Jahren) und verschlechtert das Lipidprofil. Postmenopausale Frauen haben ein deutlich erhöhtes Risiko für Osteoporose und Herz-Kreislauf-Erkrankungen — Prävention beginnt früh.',
+          },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Menopause natürlich begleiten: Symptomlinderung und wann zum Arzt</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">13. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">14 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Medical disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          <strong>Medizinischer Hinweis:</strong> Dieser Artikel ersetzt keine ärztliche Beratung, Diagnose oder Behandlung. Wechseljahresbeschwerden sind individuell, und einige Symptome können auf andere Erkrankungen hindeuten (Schilddrüse, Anämie, Depression). Bei starken Beschwerden, ungewöhnlichen Blutungen oder Fragen zur Hormontherapie bitte mit einer Ärztin oder einem Arzt sprechen.
+        </p>
+      </div>
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>Menopause</strong> ist keine Krankheit, sondern ein hormoneller Übergang, der jede Frau betrifft. Im Mittel tritt sie mit 51 Jahren ein — bei manchen Frauen früher (Prämature Ovarialinsuffizienz vor dem 40. Lebensjahr), bei anderen später. Davor liegt die <strong>Perimenopause</strong>, die schon Mitte 40 mit unregelmäßigen Zyklen, Stimmungsschwankungen oder Schlafstörungen beginnen kann und im Schnitt 4–10 Jahre andauert.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel sortiert die Phasen, beschreibt die häufigsten Symptome, fasst zusammen, was bei natürlicher Linderung wirklich hilft, und benennt klar, wann ärztliche Abklärung Pflicht ist. Außerdem: HRT (Hormontherapie) im Überblick und die unterschätzten Langzeitfolgen für Knochen und Herz.
+        </p>
+      </div>
+
+      <!-- Perimenopause vs Menopause -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Perimenopause, Menopause, Postmenopause — was ist was?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Wechseljahre sind kein Punkt, sondern ein Prozess. Drei Phasen lassen sich klar trennen, auch wenn die Übergänge fließend sind:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Phase</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Typischer Beginn</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Merkmal</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Perimenopause</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~ 45 Jahre</td>
+                <td class="px-6 py-3 text-stone-900">Zykluslänge schwankt, FSH steigt phasenweise, erste Symptome treten auf</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Menopause</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~ 51 Jahre</td>
+                <td class="px-6 py-3 text-stone-900">Letzte Regelblutung — diagnostiziert rückblickend nach 12 Monaten Amenorrhö</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Postmenopause</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">danach</td>
+                <td class="px-6 py-3 text-stone-900">Östrogen dauerhaft niedrig, Symptome klingen meist ab, Langzeitrisiken steigen</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hormonell sinkt zuerst Progesteron, weil Eisprünge seltener werden. Östrogen schwankt anfangs stark — mit hohen Spitzen und tiefen Tälern — und fällt erst spät dauerhaft ab. Diese Schwankungen erklären, warum die Perimenopause oft beschwerdereicher ist als die Postmenopause selbst.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wer wissen will, wie ausgeprägt die eigenen Beschwerden objektiv sind, kann mit dem
+          <router-link :to="localePath('menopauseSymptom')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Menopause-Symptom-Rechner</router-link>
+          den MRS-Score bestimmen — eine validierte Skala mit 11 Symptomen und drei Bereichen.
+        </p>
+      </div>
+
+      <!-- Common symptoms -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die häufigsten Symptome</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Rund 80 % aller Frauen erleben Wechseljahresbeschwerden. Etwa ein Viertel davon empfindet sie als stark belastend. Die Symptome sind vielfältig — drei Gruppen dominieren:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Vasomotorische Symptome</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Hitzewallungen und nächtliche Schweißausbrüche sind das klassische Bild. Eine Hitzewallung dauert typischerweise 1–5 Minuten, beginnt im Brustbereich und steigt zum Kopf auf, oft gefolgt von Schüttelfrost. Bei manchen Frauen treten sie zehnmal am Tag auf, bei anderen kaum. Im Mittel halten sie 7–10 Jahre an — manchmal auch deutlich länger.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Psychische und kognitive Symptome</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Reizbarkeit, Stimmungstiefs, Ängstlichkeit, Konzentrationsprobleme, „Brain Fog“ — alles häufige Begleiter. Frauen mit prämenstruellem Syndrom oder postpartaler Depression in der Vorgeschichte sind anfälliger. Schlafmangel verstärkt diese Symptome zusätzlich.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Urogenitale Symptome</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Vaginale Trockenheit, Brennen, Schmerzen beim Geschlechtsverkehr, häufige Harnwegsinfekte, Drang- und Belastungsinkontinenz. Diese „genitourinary syndrome of menopause“ (GSM) trifft etwa 50 % der Frauen, oft erst spät — und bleibt unbehandelt häufig dauerhaft.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Schlafstörungen</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Ein- und Durchschlafprobleme treffen 40–60 % der Frauen in den Wechseljahren — teils direkt hormonell bedingt, teils Folge nächtlicher Schweißausbrüche. Chronischer Schlafmangel verstärkt fast alle anderen Symptome und ist ein eigenständiger Risikofaktor für Herz-Kreislauf-Erkrankungen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Gelenk- und Muskelbeschwerden</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Östrogen wirkt anti-entzündlich und schützt Knorpel. Mit dem Abfall klagen viele Frauen über Morgensteifigkeit, Gelenkschmerzen (besonders Hände und Knie) und Muskelschmerzen. Diese „menopausale Arthralgie“ wird oft unterschätzt und mit Rheuma verwechselt.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Natural relief intro -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Natürliche Linderung — was wirklich hilft</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          „Natürlich" heißt nicht automatisch wirkungslos — und auch nicht automatisch sicher. Die folgenden Maßnahmen haben in Studien gezeigt, dass sie Symptome messbar lindern. Realistisch ist eine Reduktion von 30–50 % bei mehreren Beschwerden, kombiniert. Wer eine vollständige Symptomfreiheit erwartet, wird enttäuscht.
+        </p>
+      </div>
+
+      <!-- Diet -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">1. Ernährung: Phytoöstrogene und mediterrane Kost</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Phytoöstrogene</strong> sind pflanzliche Verbindungen, die schwach an Östrogenrezeptoren binden. Sojaisoflavone (Genistein, Daidzein) sind die am besten untersuchten. Meta-Analysen zeigen eine moderate Wirkung gegen Hitzewallungen — typischerweise eine Reduktion um 20–25 % gegenüber Placebo. Erforderlich sind 40–80 mg Isoflavone pro Tag (entspricht 200–400 ml Sojadrink oder 100 g Tofu).
+        </p>
+        <div class="space-y-3 mb-4">
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Soja:</strong> Tofu, Tempeh, Edamame, Sojadrink, fermentierte Produkte (Miso, Natto) liefern besonders gut verfügbares Daidzein.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Leinsamen:</strong> Frisch geschrotet 1–2 EL/Tag. Liefert Lignane mit phytoöstrogener Wirkung plus Omega-3.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Hülsenfrüchte:</strong> Kichererbsen, Linsen, Bohnen — moderate Mengen Isoflavone, dazu Ballaststoffe und pflanzliches Protein.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Mediterrane Kost:</strong> Olivenöl, Gemüse, Fisch, Nüsse — senkt Entzündungsmarker, schützt Herz und Gefäße in der Postmenopause.</p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Was meiden?</strong> Alkohol, Koffein und scharfe Speisen sind klassische Trigger für Hitzewallungen. Ein Versuch von 2–4 Wochen ohne Alkohol und mit reduziertem Koffein (max. 1 Tasse Kaffee morgens) zeigt schnell, ob diese Faktoren bei dir relevant sind.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wer in der Postmenopause an Gewicht zulegt — ein häufiges Phänomen durch den sinkenden Grundumsatz — kann mit dem
+          <router-link :to="localePath('bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner</router-link>
+          eine erste Orientierung gewinnen. Gewichtsverlust bei BMI über 25 reduziert Hitzewallungen messbar.
+        </p>
+      </div>
+
+      <!-- Exercise -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">2. Bewegung: Krafttraining wird zur Pflicht</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Vor der Menopause ist Bewegung eine Empfehlung. Danach wird sie zur medizinischen Notwendigkeit. Mit dem Östrogenabfall beschleunigt sich der Verlust von Muskelmasse und Knochendichte. Dagegen hilft nur Belastung.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Trainingsart</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Frequenz</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Wirkung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Krafttraining</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">2–3 ×/Woche</td>
+                <td class="px-6 py-3 text-stone-900">Muskel- und Knochenaufbau, Stoffwechsel, Stimmung</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Ausdauer (moderat)</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">150 min/Woche</td>
+                <td class="px-6 py-3 text-stone-900">Herz-Kreislauf, Schlaf, weniger Hitzewallungen</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Stoßbelastung (Hüpfen, Springen)</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">2 ×/Woche</td>
+                <td class="px-6 py-3 text-stone-900">Knochendichte (vor allem Hüfte und Wirbelsäule)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Yoga, Tai Chi</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">2–3 ×/Woche</td>
+                <td class="px-6 py-3 text-stone-900">Stress, Schlaf, Gleichgewicht, Sturzprävention</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Eine kontrollierte Studie an Frauen 50–65 mit zwei Krafttrainingseinheiten pro Woche zeigte nach einem Jahr einen Erhalt der Knochendichte an Wirbelsäule und Hüfte — während die Kontrollgruppe 1–2 % verlor. Wer sein individuelles Frakturrisiko einordnen will, kann das
+          <router-link :to="localePath('osteoporosisRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Osteoporose-Risiko berechnen</router-link>.
+        </p>
+      </div>
+
+      <!-- Sleep hygiene -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">3. Schlafhygiene</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Schlafstörungen sind oft die belastendste Folge der Menopause — und einer der wenigen Hebel, bei dem Verhaltensänderungen viel bewirken. Die Maßnahmen sind banal, aber wirksam, wenn sie konsequent umgesetzt werden:
+        </p>
+        <div class="space-y-3 mb-4">
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Schlafzimmer kühl halten:</strong> 16–18 °C, atmungsaktive Bettwäsche, mehrere dünne Lagen statt einer dicken Decke.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Regelmäßige Zeiten:</strong> Immer um die gleiche Zeit ins Bett und aufstehen — auch am Wochenende. Der zirkadiane Rhythmus reagiert empfindlich auf Unregelmäßigkeit.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Kein Alkohol abends:</strong> Erleichtert zwar das Einschlafen, fragmentiert aber die zweite Nachthälfte massiv.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Kein Koffein nach 14 Uhr:</strong> Die Halbwertszeit von Koffein steigt mit dem Alter — abends ist Mittagskaffee noch wirksam.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Bildschirme dimmen:</strong> Mindestens 60 Minuten vor dem Schlafen kein helles Licht direkt vor den Augen.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Bei Schweißausbrüchen:</strong> Wasser griffbereit, dünne Schichten zum Wegstreifen, Ventilator. Wer trotz allem länger als 4 Wochen unter 6 Stunden Schlaf bleibt, sollte ärztlich abklären lassen.</p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          CBT-I (kognitive Verhaltenstherapie bei Insomnie) ist die wirksamste nicht-medikamentöse Behandlung für Schlafstörungen — auch in den Wechseljahren. Online-Programme sind verfügbar und werden von einigen Krankenkassen erstattet.
+        </p>
+      </div>
+
+      <!-- Stress -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">4. Stressreduktion und Atemtechnik</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Stress ist ein Verstärker fast aller Wechseljahrssymptome. Chronisch erhöhtes Cortisol verschlechtert Schlaf, Stimmung und Hitzewallungen. Zwei Verfahren sind besonders gut belegt:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Paced Breathing</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Langsames Bauchatmen mit 6 Atemzügen pro Minute (5 Sekunden ein, 5 Sekunden aus). Zweimal täglich 15 Minuten — und zusätzlich beim ersten Anzeichen einer Hitzewallung. Eine randomisierte Studie zeigte nach 9 Wochen eine Reduktion der Hitzewallungen um etwa 30–40 %.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Achtsamkeit (MBSR)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Mindfulness-Based Stress Reduction reduziert nicht primär die Häufigkeit der Hitzewallungen, aber das subjektive Erleben — wie belastend sie wahrgenommen werden. Auch Stimmung und Schlaf bessern sich in den meisten Studien.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Soziale Unterstützung</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Frauen, die offen über ihre Wechseljahre sprechen — mit Partner, Freundinnen oder in Gruppen — berichten weniger Belastung. Die Phase ist normal und vorübergehend; Tabuisierung verschlimmert sie unnötig.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Phytoöstrogene und Pflanzliche Mittel -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">5. Pflanzliche Präparate — die ehrliche Einordnung</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Apotheken und Drogerien sind voll von Wechseljahresmitteln. Die Studienlage ist gemischt — manche Präparate wirken in Studien wie Placebo, andere zeigen moderate Effekte. Wichtig: „pflanzlich" bedeutet nicht „nebenwirkungsfrei".
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Präparat</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Evidenz</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Zu beachten</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Traubensilberkerze (Cimicifuga)</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Moderat bei Hitzewallungen</td>
+                <td class="px-6 py-3 text-stone-900">Selten Leberbelastung — bei Leberproblemen meiden</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Soja-Isoflavone (Standardisiert)</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Moderat (20–25 % Reduktion)</td>
+                <td class="px-6 py-3 text-stone-900">Bei Brustkrebs-Vorgeschichte mit Ärztin besprechen</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Rotklee</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Gemischt</td>
+                <td class="px-6 py-3 text-stone-900">Phytoöstrogene Wirkung — gleiche Vorsicht wie Soja</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Johanniskraut</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Gut bei leichten Depressionen</td>
+                <td class="px-6 py-3 text-stone-900">Wechselwirkungen mit vielen Medikamenten (Pille, Antikoagulantien)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Salbei</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Schwach, bei Schweißausbrüchen</td>
+                <td class="px-6 py-3 text-stone-900">Hochdosierter Tee oder Extrakt — keine Dauereinnahme</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Nachtkerzenöl</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Schwach</td>
+                <td class="px-6 py-3 text-stone-900">Wirkung kaum besser als Placebo</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beginne mit einem Präparat, gib ihm 8–12 Wochen, dokumentiere die Symptome (gerne mit dem MRS-Score), und entscheide dann. Mehrere pflanzliche Wirkstoffe gleichzeitig zu kombinieren erhöht das Risiko von Wechselwirkungen — ohne dass die Wirkung sicher steigt.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Wie ausgeprägt sind deine Beschwerden?</h3>
+        <p class="text-stone-300 text-sm mb-5">Der validierte MRS-Score bewertet 11 Symptome in 3 Bereichen — in 2 Minuten.</p>
+        <router-link
+          :to="localePath('menopauseSymptom')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Zum Menopause-Symptom-Rechner &rarr;</router-link>
+      </div>
+
+      <!-- Red flags -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warnzeichen — wann zur Ärztin oder zum Arzt</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die meisten Wechseljahrssymptome sind belastend, aber harmlos. Einige Beschwerden gehören aber zeitnah ärztlich abgeklärt, weil sie auf andere Erkrankungen hindeuten können:
+        </p>
+        <div class="bg-rose-50 border border-rose-200 rounded-xl p-6 mb-4">
+          <ul class="space-y-3 text-sm text-rose-900 leading-relaxed">
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Blutung nach 12 Monaten Pause:</strong> Postmenopausale Blutung muss immer abgeklärt werden (Endometriumkarzinom-Risiko).</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Sehr starke oder verlängerte Blutungen:</strong> Häufige starke Blutungen in der Perimenopause können Myome, Polypen oder Hyperplasien anzeigen.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Einseitiger Brustknoten oder Hautveränderungen:</strong> Sofortige Mammographie/Sonographie.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Anhaltende Depression, Suizidgedanken:</strong> Psychotherapie, ggf. Antidepressivum — auch in der Perimenopause behandelbar.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Herzrasen, Brustschmerzen, Atemnot:</strong> Frauen erleben Herzinfarkte oft mit atypischen Symptomen — nicht abwarten.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Ungeklärter Gewichtsverlust, anhaltende Müdigkeit:</strong> Schilddrüse, Anämie, Diabetes ausschließen — nicht alles ist „Wechseljahre".</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Schwere Hitzewallungen vor dem 40. Lebensjahr:</strong> Prämature Ovarialinsuffizienz (POI) — eigene Diagnostik nötig.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Beschwerden, die den Alltag dominieren:</strong> Schlaf unter 5 Stunden, Arbeitsunfähigkeit, soziale Rückzug — es gibt wirksame Hilfe.</span></li>
+          </ul>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Vor der ersten Konsultation lohnt es sich, ein Symptomtagebuch zu führen: Häufigkeit der Hitzewallungen, Schlafdauer, Stimmung, Zykluslänge. Das spart Zeit und führt zu besseren Therapieentscheidungen.
+        </p>
+      </div>
+
+      <!-- HRT overview -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">HRT — die Hormontherapie im Überblick</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hormontherapie (HRT, früher HET genannt) ersetzt Östrogen — und bei Frauen mit Gebärmutter auch Progesteron, um die Gebärmutterschleimhaut zu schützen. Sie ist die wirksamste Behandlung gegen Hitzewallungen, urogenitale Symptome und den Knochenabbau in den ersten Jahren.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Nach der WHI-Studie (2002) galt HRT lange als riskant. Differenzierte Auswertungen seit etwa 2015 zeigen: <strong>Bei gesunden Frauen unter 60 Jahren und innerhalb von 10 Jahren nach der letzten Regel</strong> überwiegt der Nutzen in vielen Fällen die Risiken. Das nennt man das „Window of Opportunity".
+        </p>
+        <div class="space-y-3 mb-4">
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Transdermal (Pflaster, Gel):</strong> Geringeres Thromboserisiko als Tabletten — heute Standard bei systemischer Therapie.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Mikronisiertes Progesteron:</strong> Bevorzugt gegenüber synthetischen Gestagenen — günstigeres Brustkrebsprofil.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Lokale Östrogene (Vaginalcreme, Tablette, Ring):</strong> Wirken gegen Trockenheit, Inkontinenz, Schmerzen — kaum systemische Wirkung, sehr sicher, auch langfristig.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Kontraindikationen:</strong> Aktuell oder zurückliegend Brustkrebs, Endometriumkarzinom, akute Thromboembolie, schwere Lebererkrankung, ungeklärte vaginale Blutung.</p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eine ehrliche Risikoabwägung gehört zu jedem HRT-Gespräch: Brustkrebs-Risiko steigt nach 5 Jahren kombinierter HRT geringfügig (etwa 1 zusätzlicher Fall pro 1000 Frauen pro Jahr), Thromboserisiko verdoppelt sich bei oraler Therapie. Wer das individuelle
+          <router-link :to="localePath('cardiovascularRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Herz-Kreislauf-Risiko</router-link>
+          kennt, kann das Gespräch fokussierter führen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Nicht-hormonelle Medikamente sind eine Alternative: SSRI/SNRI (Paroxetin, Venlafaxin), Gabapentin oder der neuere NK3-Rezeptorantagonist Fezolinetant — alle verschreibungspflichtig und mit eigenen Nebenwirkungsprofilen.
+        </p>
+      </div>
+
+      <!-- Long-term risks -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Langzeitrisiken — Knochen und Herz</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Wechseljahre sind nicht nur eine Phase mit Symptomen, sondern ein gesundheitlicher Wendepunkt. Zwei langfristige Risiken werden oft unterschätzt:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Osteoporose</h3>
+            <p class="text-sm text-stone-500 leading-relaxed mb-2">
+              In den ersten 5–10 Jahren nach der letzten Regel verlieren Frauen bis zu 2 % der Knochendichte pro Jahr. Eine von zwei Frauen über 50 erleidet im Leben eine osteoporosebedingte Fraktur — am häufigsten Wirbel, Hüfte und Handgelenk.
+            </p>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              <strong>Prävention:</strong> Krafttraining, Stoßbelastung, 1.000–1.200 mg Kalzium pro Tag (Ernährung bevorzugen), 800–2.000 IE Vitamin D, Vermeidung von Rauchen und übermäßigem Alkohol. Eine Knochendichtemessung (DXA) ab 65 oder früher bei Risikofaktoren.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Herz-Kreislauf-Erkrankungen</h3>
+            <p class="text-sm text-stone-500 leading-relaxed mb-2">
+              Vor der Menopause schützt Östrogen das Gefäßsystem. Danach steigen LDL-Cholesterin, Blutdruck und Bauchfett — und damit das Risiko für Herzinfarkt und Schlaganfall. Herz-Kreislauf-Erkrankungen sind die häufigste Todesursache bei postmenopausalen Frauen.
+            </p>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              <strong>Prävention:</strong> Blutdruck regelmäßig messen (Ziel &lt; 130/80), Lipidprofil mindestens alle 5 Jahre, Bewegung 150 min/Woche, kein Rauchen, gesundes Gewicht, mediterrane Kost. Wer bereits einen Bluthochdruck hat, sollte das individuelle Risiko ärztlich einordnen lassen.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Kognitiver Abbau</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              „Brain Fog" in der Perimenopause ist meist vorübergehend. Frauen haben dennoch ein doppelt so hohes Alzheimer-Risiko wie Männer — der genaue Beitrag der Menopause ist Gegenstand der Forschung. Aktuell beste Prävention: alles, was auch Herz und Gefäße schützt, plus geistige und soziale Aktivität.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Conclusion -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wechseljahre sind kein Defekt, sondern eine Phase. Bei den meisten Frauen lassen sich Symptome mit Ernährung, Bewegung, Schlafhygiene und Stressreduktion deutlich lindern. Pflanzliche Präparate können moderat helfen — bei realistischen Erwartungen. Wer stark belastet ist, hat mit der modernen HRT eine wirksame, gut untersuchte Option.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wichtig sind die langfristigen Weichen: Krafttraining und Knochenpflege ab der Perimenopause, regelmäßige Vorsorge, ehrliche Symptomdokumentation. Wer den Übergang aktiv begleitet, gewinnt nicht nur weniger Beschwerden — sondern bessere Jahrzehnte danach. Eine erste objektive Einordnung der Symptome liefert der
+          <router-link :to="localePath('menopauseSymptom')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Menopause-Symptom-Rechner</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticles slug="menopause-natuerlich-begleiten" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/MenopauseNaturalRelief.vue
+++ b/src/pages/blog/en/MenopauseNaturalRelief.vue
@@ -1,0 +1,517 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'Menopause — Natural Symptom Relief and When to See a Doctor | Health Calculators',
+  description: 'Menopause explained — perimenopause vs menopause, common symptoms, natural relief through diet, exercise, phytoestrogens, sleep and stress. Plus red flags, HRT overview and long-term bone and heart risks.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Menopause — Natural Symptom Relief and When to See a Doctor',
+      description: 'Menopause explained — perimenopause vs menopause, common symptoms, natural relief, red flags, HRT overview and long-term bone and heart risks.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-13',
+      dateModified: '2026-05-13',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/menopause-natural-relief',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'MedicalWebPage',
+      name: 'Menopause — Natural Relief and Medical Care',
+      about: { '@type': 'MedicalCondition', name: 'Menopause' },
+      audience: { '@type': 'PeopleAudience', audienceType: 'Women 40–65' },
+      lastReviewed: '2026-05-13',
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is the difference between perimenopause and menopause?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Perimenopause is the transition phase with fluctuating hormones, usually starting in the mid-40s and lasting 4–10 years. Menopause is the point 12 months after your last period — on average at age 51. Afterwards you are in postmenopause.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Which natural remedies help with hot flashes?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Well-supported options include regular exercise, weight loss if BMI > 25, avoiding triggers such as caffeine, alcohol and spicy food, paced breathing, and phytoestrogens from soy and flaxseed. Effects are individual and usually moderate.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'When should I see a doctor about menopause symptoms?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'See a doctor for heavy bleeding, any bleeding after 12 months of amenorrhea, a one-sided breast lump, persistent depression, chest pain, unexplained weight loss, or symptoms that dominate daily life. Hormone therapy (HRT) decisions also need a thorough medical consultation.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Does menopause raise the risk of osteoporosis and heart attack?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Yes. Estrogen loss accelerates bone loss (up to 2 % per year in the first 5–10 years) and worsens lipid profiles. Postmenopausal women have substantially higher risk of osteoporosis and cardiovascular disease — prevention should start early.',
+          },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Menopause — Natural Symptom Relief and When to See a Doctor</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 13, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">14 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Medical disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          <strong>Medical disclaimer:</strong> This article does not replace medical advice, diagnosis, or treatment. Menopause symptoms are individual, and some overlap with other conditions (thyroid disease, anemia, depression). Severe symptoms, unusual bleeding, or questions about hormone therapy require a clinician's evaluation.
+        </p>
+      </div>
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Menopause</strong> is not a disease but a hormonal transition every woman goes through. On average it occurs at age 51 — earlier for some (premature ovarian insufficiency before 40), later for others. The years before are called <strong>perimenopause</strong>, which can start in the mid-40s with irregular cycles, mood swings or sleep problems and lasts an average of 4–10 years.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article maps the phases, describes the most common symptoms, summarizes what really helps for natural relief, and clearly states when medical care is non-negotiable. It also covers hormone therapy (HRT) and the often-underestimated long-term consequences for bone and heart health.
+        </p>
+      </div>
+
+      <!-- Perimenopause vs Menopause -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Perimenopause, menopause, postmenopause — what is what?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Menopause is not a point in time but a process. Three phases can be distinguished clearly, even though the transitions blur:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Phase</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Typical onset</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Hallmark</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Perimenopause</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~ 45 years</td>
+                <td class="px-6 py-3 text-stone-900">Cycle length varies, FSH rises in phases, first symptoms appear</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Menopause</td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">~ 51 years</td>
+                <td class="px-6 py-3 text-stone-900">Final menstrual period — diagnosed in retrospect after 12 months without one</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Postmenopause</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">afterwards</td>
+                <td class="px-6 py-3 text-stone-900">Estrogen permanently low, symptoms usually ease, long-term risks rise</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hormonally, progesterone falls first because ovulation becomes less frequent. Estrogen swings strongly at first — with high peaks and deep troughs — and only later drops persistently. These swings explain why perimenopause is often more symptomatic than postmenopause itself.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          To objectively measure how strong your symptoms are, use the
+          <router-link :to="localePath('menopauseSymptom')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">menopause symptom calculator</router-link>
+          to compute your MRS score — a validated scale covering 11 symptoms across three domains.
+        </p>
+      </div>
+
+      <!-- Common symptoms -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The most common symptoms</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Roughly 80 % of women experience menopause-related symptoms. About a quarter find them severely disruptive. Symptoms are diverse, but three groups dominate:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Vasomotor symptoms</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Hot flashes and night sweats are the classic picture. A hot flash typically lasts 1–5 minutes, starts in the chest and rises to the head, often followed by chills. Some women experience them ten times a day, others hardly at all. They last on average 7–10 years — sometimes much longer.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Psychological and cognitive symptoms</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Irritability, low mood, anxiety, concentration problems, "brain fog" — all common companions. Women with a history of PMS or postpartum depression are more susceptible. Sleep loss makes these symptoms worse.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Genitourinary symptoms</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Vaginal dryness, burning, painful intercourse, recurrent urinary tract infections, urge and stress incontinence. This "genitourinary syndrome of menopause" (GSM) affects about 50 % of women, often only later — and often persists if left untreated.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Sleep disturbance</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Trouble falling and staying asleep affects 40–60 % of women in the transition — partly hormonal, partly a consequence of night sweats. Chronic sleep loss amplifies almost every other symptom and is an independent cardiovascular risk factor.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Joint and muscle pain</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Estrogen is anti-inflammatory and protects cartilage. As it drops, many women report morning stiffness, joint pain (especially hands and knees) and muscle aches. This "menopausal arthralgia" is often underestimated and confused with rheumatic disease.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Natural relief intro -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Natural relief — what really helps</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          "Natural" does not automatically mean ineffective — and it does not automatically mean safe either. The measures below have demonstrated measurable symptom relief in studies. Realistic expectations: a 30–50 % reduction across multiple symptoms when combined. Anyone expecting complete relief will be disappointed.
+        </p>
+      </div>
+
+      <!-- Diet -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">1. Diet: phytoestrogens and a Mediterranean pattern</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>Phytoestrogens</strong> are plant compounds that bind weakly to estrogen receptors. Soy isoflavones (genistein, daidzein) are the most studied. Meta-analyses show a moderate effect on hot flashes — typically a 20–25 % reduction over placebo. Effective intake is 40–80 mg isoflavones per day (about 200–400 mL soy milk or 100 g tofu).
+        </p>
+        <div class="space-y-3 mb-4">
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Soy:</strong> Tofu, tempeh, edamame, soy milk, fermented products (miso, natto) provide highly bioavailable daidzein.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Flaxseed:</strong> Freshly ground, 1–2 tablespoons per day. Provides lignans with phytoestrogenic activity plus omega-3.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Legumes:</strong> Chickpeas, lentils, beans — moderate isoflavone content plus fiber and plant protein.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Mediterranean diet:</strong> Olive oil, vegetables, fish, nuts — lowers inflammation markers and protects the heart and vessels in postmenopause.</p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>What to avoid:</strong> Alcohol, caffeine and spicy foods are classic hot-flash triggers. A 2–4 week trial without alcohol and with reduced caffeine (max one morning coffee) quickly reveals whether these matter for you.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Weight gain in postmenopause is common because basal metabolic rate falls. The
+          <router-link :to="localePath('bmi')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI calculator</router-link>
+          provides a first orientation. Weight loss when BMI exceeds 25 measurably reduces hot flashes.
+        </p>
+      </div>
+
+      <!-- Exercise -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">2. Exercise: strength training becomes mandatory</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Before menopause, exercise is a recommendation. After it, it becomes a medical necessity. With estrogen loss, the decline in muscle mass and bone density accelerates. Only loading the body counteracts this.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Type of training</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Frequency</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Effect</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Strength training</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">2–3 × per week</td>
+                <td class="px-6 py-3 text-stone-900">Muscle and bone, metabolism, mood</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Moderate aerobic</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">150 min/week</td>
+                <td class="px-6 py-3 text-stone-900">Cardiovascular health, sleep, fewer hot flashes</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Impact loading (jumps, hops)</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">2 × per week</td>
+                <td class="px-6 py-3 text-stone-900">Bone density (especially hip and spine)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Yoga, Tai Chi</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">2–3 × per week</td>
+                <td class="px-6 py-3 text-stone-900">Stress, sleep, balance, fall prevention</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A controlled trial in women aged 50–65 doing two strength sessions per week showed preserved bone density at the spine and hip after one year — while the control group lost 1–2 %. To estimate your personal fracture risk, use the
+          <router-link :to="localePath('osteoporosisRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">osteoporosis risk calculator</router-link>.
+        </p>
+      </div>
+
+      <!-- Sleep hygiene -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">3. Sleep hygiene</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Sleep loss is often the most burdensome consequence of menopause — and one of the few areas where behavior change makes a big difference. The steps are mundane but effective when applied consistently:
+        </p>
+        <div class="space-y-3 mb-4">
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Keep the bedroom cool:</strong> 16–18 °C, breathable bedding, several thin layers instead of one thick duvet.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Consistent schedule:</strong> Go to bed and get up at the same time — including weekends. Circadian rhythm is sensitive to irregularity.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>No alcohol in the evening:</strong> It helps with falling asleep but heavily fragments the second half of the night.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>No caffeine after 2 p.m.:</strong> Caffeine half-life rises with age — afternoon coffee is still active at bedtime.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Dim screens:</strong> At least 60 minutes before sleep, avoid bright direct light to the eyes.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>For night sweats:</strong> Water within reach, layers to strip off, a fan. If you stay under 6 hours of sleep for more than 4 weeks despite these steps, seek medical advice.</p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          CBT-I (cognitive behavioral therapy for insomnia) is the most effective non-drug treatment for sleep problems — including during menopause. Online programs are widely available and often covered by insurance.
+        </p>
+      </div>
+
+      <!-- Stress -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">4. Stress reduction and breathing</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Stress amplifies almost every menopause symptom. Chronically raised cortisol worsens sleep, mood and hot flashes. Two methods are particularly well supported:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Paced breathing</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Slow abdominal breathing at 6 breaths per minute (5 seconds in, 5 seconds out). Twice daily for 15 minutes — and additionally at the first sign of a hot flash. A randomized trial showed about a 30–40 % reduction in hot flashes after 9 weeks.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Mindfulness (MBSR)</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Mindfulness-based stress reduction reduces not primarily the frequency of hot flashes but the subjective burden — how disturbing they feel. Mood and sleep also improve in most trials.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Social support</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Women who talk openly about menopause — with a partner, friends or in groups — report less distress. The phase is normal and finite; making it a taboo only makes it worse.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Herbal supplements -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">5. Herbal supplements — the honest picture</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Pharmacies are full of menopause supplements. The evidence is mixed — some products perform like placebo, others show moderate effects. Important: "herbal" does not equal "free of side effects".
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Supplement</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Evidence</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Caveats</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Black cohosh (Cimicifuga)</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Moderate for hot flashes</td>
+                <td class="px-6 py-3 text-stone-900">Rare liver effects — avoid with liver disease</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Soy isoflavones (standardized)</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Moderate (20–25 % reduction)</td>
+                <td class="px-6 py-3 text-stone-900">Discuss with a clinician if breast cancer history</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Red clover</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Mixed</td>
+                <td class="px-6 py-3 text-stone-900">Phytoestrogen activity — same caution as soy</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">St. John's wort</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Good for mild depression</td>
+                <td class="px-6 py-3 text-stone-900">Many drug interactions (oral contraceptives, anticoagulants)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Sage</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Weak, for sweating</td>
+                <td class="px-6 py-3 text-stone-900">Strong tea or extract — not for long-term daily use</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">Evening primrose oil</td>
+                <td class="px-6 py-3 text-stone-900 font-medium">Weak</td>
+                <td class="px-6 py-3 text-stone-900">Effect barely better than placebo</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Start with one supplement, give it 8–12 weeks, document symptoms (the MRS score is handy), then decide. Combining multiple herbal products at once increases interaction risk without reliably increasing benefit.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">How severe are your symptoms?</h3>
+        <p class="text-stone-300 text-sm mb-5">The validated MRS score rates 11 symptoms across 3 domains — in 2 minutes.</p>
+        <router-link
+          :to="localePath('menopauseSymptom')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Open the menopause symptom calculator &rarr;</router-link>
+      </div>
+
+      <!-- Red flags -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Red flags — when to see a doctor</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Most menopause symptoms are uncomfortable but harmless. Some complaints, however, require prompt medical evaluation because they may indicate other conditions:
+        </p>
+        <div class="bg-rose-50 border border-rose-200 rounded-xl p-6 mb-4">
+          <ul class="space-y-3 text-sm text-rose-900 leading-relaxed">
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Bleeding after 12 months of amenorrhea:</strong> Postmenopausal bleeding always needs work-up (endometrial cancer risk).</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Very heavy or prolonged bleeding:</strong> Frequent heavy bleeding in perimenopause may indicate fibroids, polyps or hyperplasia.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>One-sided breast lump or skin changes:</strong> Immediate mammography/ultrasound.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Persistent depression, suicidal thoughts:</strong> Psychotherapy, antidepressants if needed — treatable also in perimenopause.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Palpitations, chest pain, shortness of breath:</strong> Women often have atypical heart-attack symptoms — do not wait.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Unexplained weight loss, persistent fatigue:</strong> Rule out thyroid, anemia, diabetes — not everything is "menopause".</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Severe hot flashes before age 40:</strong> Premature ovarian insufficiency (POI) — needs its own work-up.</span></li>
+            <li class="flex gap-3"><span class="font-bold">!</span><span><strong>Symptoms that dominate daily life:</strong> Sleep under 5 hours, inability to work, social withdrawal — effective help exists.</span></li>
+          </ul>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Before the first consultation, keep a symptom diary: frequency of hot flashes, sleep hours, mood, cycle length. It saves time and improves treatment choices.
+        </p>
+      </div>
+
+      <!-- HRT overview -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">HRT — hormone therapy in brief</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hormone therapy (HRT, MHT) replaces estrogen — and progesterone in women with a uterus to protect the endometrium. It is the most effective treatment for hot flashes, genitourinary symptoms and bone loss during the early years after menopause.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          After the WHI study (2002), HRT was long considered risky. More nuanced analyses since around 2015 show: <strong>in healthy women under 60 and within 10 years of their last period</strong>, benefits often outweigh risks. This is called the "window of opportunity".
+        </p>
+        <div class="space-y-3 mb-4">
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Transdermal (patch, gel):</strong> Lower thrombosis risk than oral tablets — today's standard for systemic therapy.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Micronized progesterone:</strong> Preferred over synthetic progestins — better breast-cancer profile.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Local estrogen (vaginal cream, tablet, ring):</strong> Treats dryness, incontinence and pain — minimal systemic effect, safe even long-term.</p>
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-stone-400 mt-2"></div>
+            <p class="text-base text-stone-600 leading-relaxed"><strong>Contraindications:</strong> Current or past breast cancer, endometrial cancer, acute thromboembolism, severe liver disease, unexplained vaginal bleeding.</p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          An honest risk discussion is part of every HRT consultation: breast-cancer risk rises slightly after 5 years of combined HRT (about 1 additional case per 1000 women per year), thrombosis risk doubles with oral therapy. Knowing your individual
+          <router-link :to="localePath('cardiovascularRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">cardiovascular risk</router-link>
+          makes the conversation more focused.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Non-hormonal medications are alternatives: SSRIs/SNRIs (paroxetine, venlafaxine), gabapentin, or the newer NK3 receptor antagonist fezolinetant — all prescription drugs with their own side-effect profiles.
+        </p>
+      </div>
+
+      <!-- Long-term risks -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Long-term risks — bone and heart</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Menopause is not just a phase with symptoms but a health turning point. Two long-term risks are often underestimated:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Osteoporosis</h3>
+            <p class="text-sm text-stone-500 leading-relaxed mb-2">
+              In the first 5–10 years after the final period, women can lose up to 2 % of bone density per year. One in two women over 50 will experience an osteoporosis-related fracture in her lifetime — most often vertebra, hip, or wrist.
+            </p>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              <strong>Prevention:</strong> Strength training, impact loading, 1,000–1,200 mg calcium per day (food first), 800–2,000 IU vitamin D, no smoking and limited alcohol. A DXA bone-density scan is recommended at age 65, earlier with risk factors.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Cardiovascular disease</h3>
+            <p class="text-sm text-stone-500 leading-relaxed mb-2">
+              Before menopause, estrogen protects the vascular system. Afterwards, LDL cholesterol, blood pressure and visceral fat rise — and with them the risk of heart attack and stroke. Cardiovascular disease is the leading cause of death in postmenopausal women.
+            </p>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              <strong>Prevention:</strong> Measure blood pressure regularly (target &lt; 130/80), check lipids every 5 years, exercise 150 min/week, no smoking, healthy weight, Mediterranean pattern. If you already have high blood pressure, get individual risk assessed by a clinician.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Cognitive decline</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              "Brain fog" in perimenopause is usually transient. Yet women have about double the lifetime Alzheimer's risk of men — the exact contribution of menopause is still under study. Best current prevention: everything that protects the heart and vessels, plus mental and social activity.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Conclusion -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Menopause is not a defect, it is a phase. For most women, symptoms ease noticeably with diet, exercise, sleep hygiene and stress reduction. Herbal supplements may help moderately — with realistic expectations. For women with severe symptoms, modern HRT is an effective, well-studied option.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The long-term decisions matter most: strength training and bone care from perimenopause on, regular check-ups, honest symptom tracking. Women who navigate this transition actively gain not just less suffering — but better decades after. A first objective look at your symptoms comes from the
+          <router-link :to="localePath('menopauseSymptom')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">menopause symptom calculator</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="menopause-natural-relief" />
+    </div>
+  </article>
+</template>

--- a/src/pages/menopauseNatural.meta.js
+++ b/src/pages/menopauseNatural.meta.js
@@ -1,0 +1,11 @@
+import BlogDe from './blog/MenopauseNatuerlich.vue'
+import BlogEn from './blog/en/MenopauseNaturalRelief.vue'
+
+export default {
+  key: 'menopauseNatural',
+  blogOnly: true,
+  blog: {
+    de: { slug: 'menopause-natuerlich-begleiten', component: BlogDe },
+    en: { slug: 'menopause-natural-relief', component: BlogEn },
+  },
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-177-menopause
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-177-menopause-20260513-120030`
**Cost:** $6.099276999999998

Closes jenslaufer/health-calculators#177

### Prompt
> Implement the blog article from issue #177: "Menopause — Natural Symptom Relief and When to See a Doctor".

## Pattern
Blog-only article (NO calculator). Follow the EXACT pattern of existing blog articles in `src/pages/blog/` (DE) and `src/pages/blog/en/` (EN).

## Files to create
1. `src/pages/blog/MenopauseNatuerlich.vue` (DE)
2. `src/pages/blog/en/MenopauseNaturalRelief.vue` (EN)

## Content requirements (per issue #177)
- 2500–3500 Wörter EN + DE parallel
- Struktur: Perimenopause vs. menopause → Common symptoms → Natural relief (diet, exercise, phytoestrogens, sleep hygiene, stress) → Red flags (see doctor) → HRT overview → Long-term bone/heart risks
- Medical disclaimer prominently at the top
- SEO: Title, Meta description, canonical, hreflang DE↔EN, Article + FAQPage + MedicalWebPage structured data
- Internal links: /en/menopause-symptom-calculator, /en/bmi-calculator, /en/osteoporosis-risk-calculator (verify routes exist first)

## Tests
- Unit tests for both components
- `npm test` must pass
- `npm run build` must succeed
- Sitemap updated with both URLs


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'menopause',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## CRITICAL CONSTRAINTS
- DO NOT modify or delete ANY existing blog articles, calculators, or shared configuration
- DO NOT modify router, views, or discovery files
- DO NOT change existing test assertions — only ADD new ones
- Verify target internal links exist before linking