### PR TITLE
hc-142-breast-cancer-risk: Implement the Breast Cancer Risk Calculator as described in 

### DIFF
--- a/e2e/breastCancerRisk.spec.js
+++ b/e2e/breastCancerRisk.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/brustkrebs-risiko-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/Brustkrebs-Risiko-Rechner/)
+})
+
+test('low-risk 40-year-old shows ~baseline 5-year risk', async ({ page }) => {
+  await page.getByTestId('age').fill('40')
+  await page.getByTestId('menarche').selectOption('14+')
+  await page.getByTestId('first-birth').selectOption('<20')
+  await page.getByTestId('relatives').selectOption('0')
+  await page.getByTestId('biopsies').selectOption('0')
+  await page.getByTestId('ah-no').click()
+
+  const result = page.getByTestId('five-year-risk')
+  await expect(result).toBeVisible()
+  const text = await result.textContent()
+  const num = parseFloat(text.replace('%', '').trim())
+  expect(num).toBeGreaterThan(0.5)
+  expect(num).toBeLessThan(1.2)
+})
+
+test('high-risk profile flags elevated', async ({ page }) => {
+  await page.getByTestId('age').fill('55')
+  await page.getByTestId('menarche').selectOption('<12')
+  await page.getByTestId('first-birth').selectOption('nulliparous')
+  await page.getByTestId('relatives').selectOption('2')
+  await page.getByTestId('biopsies').selectOption('2')
+  await page.getByTestId('ah-yes').click()
+
+  await expect(page.getByTestId('elevated-hint')).toBeVisible()
+  await expect(page.getByTestId('risk-category')).toBeVisible()
+})
+
+test('shows relative risk and average for age', async ({ page }) => {
+  await page.getByTestId('age').fill('50')
+  await page.getByTestId('menarche').selectOption('12-13')
+  await page.getByTestId('first-birth').selectOption('25-29')
+  await page.getByTestId('relatives').selectOption('1')
+  await page.getByTestId('biopsies').selectOption('0')
+  await page.getByTestId('ah-no').click()
+
+  await expect(page.getByTestId('relative-risk')).toBeVisible()
+  await expect(page.getByTestId('average-risk')).toBeVisible()
+})
+
+test('no result shown without age', async ({ page }) => {
+  await expect(page.getByTestId('five-year-risk')).toHaveCount(0)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -26,7 +26,7 @@ const EXPECTED_KEYS = [
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
-  'ironDeficiency', 'ffmiRechner', 'pregnancyCalories',
+  'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'breastCancerRisk',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -113,6 +113,7 @@ const EXPECTED_ROUTE_MAP = {
   ironDeficiency: { de: 'eisenmangel-rechner', en: 'iron-deficiency-calculator' },
   ffmiRechner: { de: 'ffmi-rechner', en: 'ffmi-calculator' },
   pregnancyCalories: { de: 'kalorienbedarf-schwangerschaft-rechner', en: 'pregnancy-calorie-needs-calculator' },
+  breastCancerRisk: { de: 'brustkrebs-risiko-rechner', en: 'breast-cancer-risk-calculator' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -188,6 +189,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'ffmi-berechnen',
   'kalorienbedarf-schwangerschaft-berechnen',
   'menopause-natuerlich-begleiten',
+  'brustkrebs-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -263,11 +265,12 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'ffmi-calculator-guide',
   'pregnancy-calorie-needs-guide',
   'menopause-natural-relief',
+  'breast-cancer-risk-calculator-guide',
 ]
 
 describe('calculator discovery', () => {
   it('discovers all 81 calculators', () => {
-    expect(calculatorMetas).toHaveLength(83)
+    expect(calculatorMetas).toHaveLength(84)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
@@ -275,7 +278,7 @@ describe('calculator discovery', () => {
   })
 
   it('builds calculatorComponents map for all 81 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(83)
+    expect(Object.keys(calculatorComponents)).toHaveLength(84)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -299,14 +302,14 @@ describe('calculator discovery', () => {
 
 describe('blog component discovery', () => {
   it('discovers all 84 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(84)
+    expect(Object.keys(blogComponentsDe)).toHaveLength(85)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
   it('discovers all 84 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(84)
+    expect(Object.keys(blogComponentsEn)).toHaveLength(85)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -333,8 +336,8 @@ describe('calculator groups', () => {
 
   it('groups contain all 81 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(83)
-    expect(new Set(allKeys).size).toBe(83)
+    expect(allKeys).toHaveLength(84)
+    expect(new Set(allKeys).size).toBe(84)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -355,7 +358,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -405,7 +408,7 @@ describe('i18n completeness', () => {
 
 describe('SSG routes', () => {
   it('generates exactly 460 routes', () => {
-    expect(routes).toHaveLength(460)
+    expect(routes).toHaveLength(465)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/breastCancerRisk.test.js
+++ b/src/__tests__/breastCancerRisk.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcBreastCancerRisk,
+  calcRelativeRisk,
+  riskCategory,
+} from '../utils/breastCancerRisk.js'
+
+// Simplified Gail-style breast cancer risk model
+// Reference values derived from Gail JM et al. (1989) and Costantino JP et al. (1999)
+
+describe('calcRelativeRisk', () => {
+  it('low-risk baseline profile returns RR = 1.0', () => {
+    const rr = calcRelativeRisk({
+      ageAtMenarche: 14,
+      biopsies: 0,
+      atypicalHyperplasia: false,
+      firstDegreeRelatives: 0,
+      ageAtFirstBirth: 18,
+      nulliparous: false,
+    })
+    expect(rr).toBeCloseTo(1.0, 3)
+  })
+
+  it('early menarche (<12) increases RR', () => {
+    const rr = calcRelativeRisk({
+      ageAtMenarche: 11,
+      biopsies: 0,
+      atypicalHyperplasia: false,
+      firstDegreeRelatives: 0,
+      ageAtFirstBirth: 18,
+      nulliparous: false,
+    })
+    expect(rr).toBeCloseTo(1.21, 2)
+  })
+
+  it('one biopsy without AH increases RR', () => {
+    const rr = calcRelativeRisk({
+      ageAtMenarche: 14,
+      biopsies: 1,
+      atypicalHyperplasia: false,
+      firstDegreeRelatives: 0,
+      ageAtFirstBirth: 18,
+      nulliparous: false,
+    })
+    // 1.70 * 0.93 = 1.581
+    expect(rr).toBeCloseTo(1.581, 2)
+  })
+
+  it('atypical hyperplasia multiplies risk by 1.82 when biopsy present', () => {
+    const rr = calcRelativeRisk({
+      ageAtMenarche: 14,
+      biopsies: 1,
+      atypicalHyperplasia: true,
+      firstDegreeRelatives: 0,
+      ageAtFirstBirth: 18,
+      nulliparous: false,
+    })
+    // 1.70 * 1.82 = 3.094
+    expect(rr).toBeCloseTo(3.094, 2)
+  })
+
+  it('two or more first-degree relatives doubles risk substantially', () => {
+    const rr = calcRelativeRisk({
+      ageAtMenarche: 14,
+      biopsies: 0,
+      atypicalHyperplasia: false,
+      firstDegreeRelatives: 2,
+      ageAtFirstBirth: 18,
+      nulliparous: false,
+    })
+    expect(rr).toBeGreaterThan(5)
+  })
+
+  it('nulliparous + one relative > age-20 birth + one relative', () => {
+    const rrNullipar = calcRelativeRisk({
+      ageAtMenarche: 14, biopsies: 0, atypicalHyperplasia: false,
+      firstDegreeRelatives: 1, nulliparous: true,
+    })
+    const rrYoung = calcRelativeRisk({
+      ageAtMenarche: 14, biopsies: 0, atypicalHyperplasia: false,
+      firstDegreeRelatives: 1, ageAtFirstBirth: 19,
+    })
+    expect(rrNullipar).toBeGreaterThan(rrYoung)
+  })
+})
+
+describe('calcBreastCancerRisk', () => {
+  it('returns null for invalid age', () => {
+    expect(calcBreastCancerRisk({ age: null })).toBeNull()
+    expect(calcBreastCancerRisk({ age: 20 })).toBeNull()
+    expect(calcBreastCancerRisk({ age: 100 })).toBeNull()
+  })
+
+  it('low-risk 40-year-old returns ~baseline 5-year risk', () => {
+    const result = calcBreastCancerRisk({
+      age: 40, ageAtMenarche: 14, biopsies: 0,
+      atypicalHyperplasia: false, firstDegreeRelatives: 0,
+      ageAtFirstBirth: 18,
+    })
+    expect(result.fiveYearRisk).toBeCloseTo(result.averageFiveYearRisk, 3)
+    expect(result.relativeRisk).toBeCloseTo(1.0, 2)
+  })
+
+  it('high-risk profile increases 5-year risk', () => {
+    const low = calcBreastCancerRisk({
+      age: 50, ageAtMenarche: 14, biopsies: 0,
+      atypicalHyperplasia: false, firstDegreeRelatives: 0,
+      ageAtFirstBirth: 22,
+    })
+    const high = calcBreastCancerRisk({
+      age: 50, ageAtMenarche: 11, biopsies: 2,
+      atypicalHyperplasia: true, firstDegreeRelatives: 2,
+      nulliparous: true,
+    })
+    expect(high.fiveYearRisk).toBeGreaterThan(low.fiveYearRisk * 3)
+  })
+
+  it('flags elevated when 5-year risk exceeds 1.66%', () => {
+    const result = calcBreastCancerRisk({
+      age: 60, ageAtMenarche: 11, biopsies: 2,
+      atypicalHyperplasia: true, firstDegreeRelatives: 2,
+      nulliparous: true,
+    })
+    expect(result.elevated).toBe(true)
+  })
+
+  it('caps 5-year risk at 0.99', () => {
+    const result = calcBreastCancerRisk({
+      age: 75, ageAtMenarche: 10, biopsies: 5,
+      atypicalHyperplasia: true, firstDegreeRelatives: 2,
+      nulliparous: true,
+    })
+    expect(result.fiveYearRisk).toBeLessThanOrEqual(0.99)
+  })
+
+  it('5-year risk increases with age for same profile', () => {
+    const young = calcBreastCancerRisk({
+      age: 40, ageAtMenarche: 14, biopsies: 0,
+      atypicalHyperplasia: false, firstDegreeRelatives: 0,
+      ageAtFirstBirth: 22,
+    })
+    const old = calcBreastCancerRisk({
+      age: 65, ageAtMenarche: 14, biopsies: 0,
+      atypicalHyperplasia: false, firstDegreeRelatives: 0,
+      ageAtFirstBirth: 22,
+    })
+    expect(old.fiveYearRisk).toBeGreaterThan(young.fiveYearRisk)
+  })
+})
+
+describe('riskCategory', () => {
+  it('classifies values into low/average/elevated/high', () => {
+    expect(riskCategory(0.005)).toBe('low')
+    expect(riskCategory(0.014)).toBe('average')
+    expect(riskCategory(0.020)).toBe('elevated')
+    expect(riskCategory(0.060)).toBe('high')
+  })
+
+  it('returns null for null input', () => {
+    expect(riskCategory(null)).toBeNull()
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -67,7 +67,7 @@ describe('generateLlmsTxt', () => {
 
   it('generates 334 links (83 calcs × 2 locales + 84 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(334)
+    expect(links).toHaveLength(338)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -20,7 +20,7 @@ const EXPECTED_KEYS = [
   'apgarScore', 'osteoporosisRisk', 'whtrRechner', 'hepatitisRisk', 'correctedCalcium',
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
-  'ironDeficiency', 'ffmiRechner', 'pregnancyCalories',
+  'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'breastCancerRisk',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -95,6 +95,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'ffmi-berechnen',
   'kalorienbedarf-schwangerschaft-berechnen',
   'menopause-natuerlich-begleiten',
+  'brustkrebs-risiko-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -169,12 +170,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'ffmi-calculator-guide',
   'pregnancy-calorie-needs-guide',
   'menopause-natural-relief',
+  'breast-cancer-risk-calculator-guide',
 ]
 
 describe('discoverMetas', () => {
   it('discovers all 82 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(83)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(84)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -215,7 +217,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 84 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(84)
+    expect(de).toHaveLength(85)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
@@ -224,7 +226,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 84 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(84)
+    expect(en).toHaveLength(85)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -294,7 +296,7 @@ describe('generateSitemap', () => {
 
   it('generates correct total URL count (2 home + 166 calcs + 2 blog index + 168 blog articles = 338)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(338)
+    expect(urlCount).toBe(342)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -755,6 +755,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'menopauseNatural',
     related: ['menopause-symptom-calculator-guide', 'osteoporosis-risk-calculator-guide', 'cardiovascular-risk-framingham'],
   },
+  {
+    slug: 'breast-cancer-risk-calculator-guide',
+    title: 'Breast Cancer Risk Calculator: How the Gail Model Works',
+    description: 'Calculate your breast cancer risk with the Gail model — 5-year and lifetime risk, key risk factors, screening thresholds and prevention options explained.',
+    date: '2026-05-13',
+    readTime: '9 min',
+    calculatorKey: 'breastCancerRisk',
+    related: ['menopause-symptom-calculator-guide', 'osteoporosis-risk-calculator-guide', 'biological-age-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -755,6 +755,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'menopauseNatural',
     related: ['menopause-symptome-bewerten', 'osteoporose-risiko-berechnen', 'herz-kreislauf-risiko-berechnen'],
   },
+  {
+    slug: 'brustkrebs-risiko-berechnen',
+    title: 'Brustkrebs-Risiko berechnen: Was das Gail-Modell wirklich aussagt',
+    description: 'Brustkrebs-Risiko mit dem Gail-Modell berechnen — 5-Jahres- und Lebenszeitrisiko, Risikofaktoren, Schwellenwerte und Vorsorgeempfehlungen verständlich erklärt.',
+    date: '2026-05-13',
+    readTime: '9 min',
+    calculatorKey: 'breastCancerRisk',
+    related: ['menopause-symptome-bewerten', 'osteoporose-risiko-berechnen', 'biologisches-alter-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/breastCancerRisk.json
+++ b/src/locales/calculators/de/breastCancerRisk.json
@@ -1,0 +1,88 @@
+{
+  "home": {
+    "calculators": {
+      "breastCancerRisk": {
+        "name": "Brustkrebs-Risiko-Rechner",
+        "description": "Schätze dein 5-Jahres-Brustkrebsrisiko mit dem Gail-Modell."
+      }
+    }
+  },
+  "breastCancerRisk": {
+    "meta": {
+      "title": "Brustkrebs-Risiko-Rechner — Gail-Modell für 5-Jahres-Risiko",
+      "description": "Schätze dein 5-Jahres- und Lebenszeit-Brustkrebsrisiko mit dem Gail-Modell. Berücksichtigt Alter, Familiengeschichte, Menarche, Biopsien. Kostenlos, sofort, ohne Anmeldung."
+    },
+    "title": "Brustkrebs-Risiko-Rechner",
+    "description": "Schätze dein 5-Jahres-Brustkrebsrisiko mit einem vereinfachten Gail-Modell.",
+    "age": "Aktuelles Alter",
+    "ageHelp": "35–85 Jahre",
+    "ageAtMenarche": "Alter bei der ersten Regelblutung",
+    "menarcheUnder12": "Unter 12",
+    "menarche1213": "12–13",
+    "menarche14plus": "14 oder älter",
+    "firstBirth": "Erste Lebendgeburt",
+    "nulliparous": "Keine Kinder",
+    "firstBirthUnder20": "Unter 20",
+    "firstBirth2024": "20–24",
+    "firstBirth2529": "25–29",
+    "firstBirth30plus": "30 oder älter",
+    "firstDegreeRelatives": "Verwandte 1. Grades mit Brustkrebs",
+    "relatives0": "Keine",
+    "relatives1": "Eine",
+    "relatives2": "Zwei oder mehr",
+    "biopsies": "Anzahl Brustbiopsien",
+    "biopsies0": "Keine",
+    "biopsies1": "Eine",
+    "biopsies2": "Zwei oder mehr",
+    "atypicalHyperplasia": "Atypische Hyperplasie bei Biopsie",
+    "ahYes": "Ja",
+    "ahNo": "Nein / Unbekannt",
+    "calculate": "Risiko berechnen",
+    "fiveYearRisk": "5-Jahres-Risiko",
+    "averageRisk": "Durchschnitt deines Alters",
+    "relativeRisk": "Relatives Risiko",
+    "category": "Kategorie",
+    "categoryLow": "Niedrig",
+    "categoryAverage": "Durchschnittlich",
+    "categoryElevated": "Erhöht",
+    "categoryHigh": "Hoch",
+    "elevatedHint": "Über der Gail-Schwelle von 1,66 % — bitte mit einem Arzt besprechen.",
+    "disclaimer": "Diese Schätzung ersetzt keine ärztliche Beratung. Sprich bei erhöhtem Risiko mit deinem Frauenarzt oder Brustzentrum.",
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der Rechner verwendet eine vereinfachte Variante des Gail-Modells (NCI Breast Cancer Risk Assessment Tool). Aus den eingegebenen Risikofaktoren wird ein relatives Risiko berechnet und mit der altersabhängigen Brustkrebs-Inzidenz multipliziert. Eine 5-Jahres-Wahrscheinlichkeit ≥ 1,66 % gilt als erhöht.",
+    "factorsTitle": "Risikofaktoren auf einen Blick",
+    "factor": "Faktor",
+    "effect": "Effekt auf das Risiko",
+    "effectMenarcheEarly": "Frühe Menarche (< 12) erhöht das Risiko um ca. 20 %",
+    "effectFamily": "Eine Verwandte 1. Grades verdoppelt das Risiko in etwa",
+    "effectAH": "Atypische Hyperplasie nahezu verdoppelt das Risiko",
+    "effectFirstBirth": "Erste Geburt ≥ 30 oder Nulliparität erhöht das Risiko",
+    "effectAge": "Mit dem Alter steigt das Risiko fast linear bis ~75 Jahre",
+    "faq": [
+      {
+        "q": "Was ist das Gail-Modell?",
+        "a": "Das Gail-Modell (Gail et al. 1989) schätzt das individuelle 5-Jahres- und Lebenszeitrisiko für Brustkrebs anhand mehrerer Risikofaktoren — Alter, Menarche, erste Geburt, Familienanamnese und Biopsien. Es ist die Basis des NCI Breast Cancer Risk Assessment Tools."
+      },
+      {
+        "q": "Ab welchem Wert gilt mein Risiko als erhöht?",
+        "a": "Bei einem 5-Jahres-Risiko ≥ 1,66 % sprechen Leitlinien (NCI, ASCO) von erhöhtem Risiko. In diesem Fall kann eine engmaschigere Vorsorge oder eine medikamentöse Prävention sinnvoll sein."
+      },
+      {
+        "q": "Welche Risikofaktoren werden berücksichtigt?",
+        "a": "Aktuelles Alter, Alter bei der ersten Regelblutung, Alter bei der ersten Lebendgeburt oder Nulliparität, Brustbiopsien (mit/ohne atypische Hyperplasie) sowie Brustkrebs bei Verwandten 1. Grades (Mutter, Schwester, Tochter)."
+      },
+      {
+        "q": "Welche Faktoren fehlen?",
+        "a": "Das Gail-Modell unterschätzt das Risiko bei BRCA1/BRCA2-Mutationen, Brustkrebs bei männlichen Verwandten oder Verwandten 2. Grades. Auch Brustdichte, Lebensstil und Hormontherapie sind nicht enthalten."
+      },
+      {
+        "q": "Wie genau ist die Schätzung?",
+        "a": "Auf Populationsebene gut kalibriert (Costantino 1999, AUC ≈ 0,58–0,65). Für die individuelle Vorhersage bleibt die Aussagekraft begrenzt — nutze den Wert als Ausgangspunkt für ein ärztliches Gespräch, nicht als Diagnose."
+      },
+      {
+        "q": "Was kann ich bei erhöhtem Risiko tun?",
+        "a": "Bei einem 5-Jahres-Risiko ≥ 1,66 % bieten Brustzentren intensivere Vorsorge an (jährliche Mammographie und/oder MRT). Bei Hochrisiko (z. B. ≥ 3 % über 5 Jahre) kann eine Chemoprävention mit Tamoxifen oder Raloxifen besprochen werden."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/breastCancerRisk.json
+++ b/src/locales/calculators/en/breastCancerRisk.json
@@ -1,0 +1,88 @@
+{
+  "home": {
+    "calculators": {
+      "breastCancerRisk": {
+        "name": "Breast Cancer Risk Calculator",
+        "description": "Estimate your 5-year breast cancer risk using the Gail model."
+      }
+    }
+  },
+  "breastCancerRisk": {
+    "meta": {
+      "title": "Breast Cancer Risk Calculator — Gail Model 5-Year Risk",
+      "description": "Estimate your 5-year and lifetime breast cancer risk with the Gail model. Considers age, family history, menarche, biopsies. Free, instant, no sign-up."
+    },
+    "title": "Breast Cancer Risk Calculator",
+    "description": "Estimate your 5-year breast cancer risk with a simplified Gail model.",
+    "age": "Current age",
+    "ageHelp": "35–85 years",
+    "ageAtMenarche": "Age at first menstrual period",
+    "menarcheUnder12": "Under 12",
+    "menarche1213": "12–13",
+    "menarche14plus": "14 or older",
+    "firstBirth": "First live birth",
+    "nulliparous": "No children",
+    "firstBirthUnder20": "Under 20",
+    "firstBirth2024": "20–24",
+    "firstBirth2529": "25–29",
+    "firstBirth30plus": "30 or older",
+    "firstDegreeRelatives": "First-degree relatives with breast cancer",
+    "relatives0": "None",
+    "relatives1": "One",
+    "relatives2": "Two or more",
+    "biopsies": "Number of breast biopsies",
+    "biopsies0": "None",
+    "biopsies1": "One",
+    "biopsies2": "Two or more",
+    "atypicalHyperplasia": "Atypical hyperplasia on biopsy",
+    "ahYes": "Yes",
+    "ahNo": "No / unknown",
+    "calculate": "Calculate risk",
+    "fiveYearRisk": "5-year risk",
+    "averageRisk": "Average for your age",
+    "relativeRisk": "Relative risk",
+    "category": "Category",
+    "categoryLow": "Low",
+    "categoryAverage": "Average",
+    "categoryElevated": "Elevated",
+    "categoryHigh": "High",
+    "elevatedHint": "Above the Gail threshold of 1.66 % — discuss with a clinician.",
+    "disclaimer": "This estimate is not a substitute for medical advice. If your risk is elevated, talk to a gynecologist or breast clinic.",
+    "howItWorks": "How it works",
+    "howItWorksText": "This calculator uses a simplified version of the Gail model (NCI Breast Cancer Risk Assessment Tool). It combines your risk factors into a relative risk and multiplies it by age-specific breast cancer incidence. A 5-year probability ≥ 1.66 % is considered elevated.",
+    "factorsTitle": "Risk factors at a glance",
+    "factor": "Factor",
+    "effect": "Effect on risk",
+    "effectMenarcheEarly": "Early menarche (< 12) raises risk by ~20 %",
+    "effectFamily": "One first-degree relative roughly doubles risk",
+    "effectAH": "Atypical hyperplasia nearly doubles risk",
+    "effectFirstBirth": "First birth ≥ 30 or nulliparity raises risk",
+    "effectAge": "Risk rises nearly linearly with age up to ~75 years",
+    "faq": [
+      {
+        "q": "What is the Gail model?",
+        "a": "The Gail model (Gail et al. 1989) estimates individual 5-year and lifetime breast cancer risk from several risk factors — age, menarche, first birth, family history, and prior biopsies. It is the basis of the NCI Breast Cancer Risk Assessment Tool."
+      },
+      {
+        "q": "When is my risk considered elevated?",
+        "a": "Guidelines (NCI, ASCO) define a 5-year risk ≥ 1.66 % as elevated. At that level you may be eligible for enhanced screening or risk-reducing medication."
+      },
+      {
+        "q": "Which risk factors are included?",
+        "a": "Current age, age at menarche, age at first live birth or nulliparity, number of breast biopsies (with or without atypical hyperplasia), and breast cancer in first-degree relatives (mother, sister, daughter)."
+      },
+      {
+        "q": "Which factors are not included?",
+        "a": "The Gail model underestimates risk for BRCA1/BRCA2 carriers and women with male relatives or second-degree relatives affected. Breast density, lifestyle, and hormone therapy are not included either."
+      },
+      {
+        "q": "How accurate is this estimate?",
+        "a": "At a population level, the Gail model is well calibrated (Costantino 1999, AUC ≈ 0.58–0.65). Individual prediction accuracy remains modest — treat the result as a conversation starter, not a diagnosis."
+      },
+      {
+        "q": "What if my risk is elevated?",
+        "a": "If your 5-year risk is ≥ 1.66 %, ask your physician about enhanced screening (annual mammography ± MRI). At very high risk (e.g. ≥ 3 % over 5 years), preventive medication with tamoxifen or raloxifene may be discussed."
+      }
+    ]
+  }
+}

--- a/src/pages/BreastCancerRiskCalculator.vue
+++ b/src/pages/BreastCancerRiskCalculator.vue
@@ -1,0 +1,216 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcBreastCancerRisk, riskCategory } from '../utils/breastCancerRisk.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('breastCancerRisk.faq') || [])
+
+useHead(() => ({
+  title: t('breastCancerRisk.meta.title'),
+  description: t('breastCancerRisk.meta.description'),
+  routeKey: 'breastCancerRisk',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Breast Cancer Risk Calculator',
+    url: 'https://healthcalculator.app/en/breast-cancer-risk-calculator',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const age = ref(null)
+const menarcheBracket = ref('14+')
+const firstBirthBracket = ref('<20')
+const firstDegreeRelatives = ref('0')
+const biopsies = ref('0')
+const atypicalHyperplasia = ref(false)
+
+const menarcheValue = computed(() => {
+  if (menarcheBracket.value === '<12') return 11
+  if (menarcheBracket.value === '12-13') return 12
+  return 14
+})
+
+const firstBirthInputs = computed(() => {
+  switch (firstBirthBracket.value) {
+    case 'nulliparous': return { nulliparous: true, ageAtFirstBirth: null }
+    case '<20': return { nulliparous: false, ageAtFirstBirth: 19 }
+    case '20-24': return { nulliparous: false, ageAtFirstBirth: 22 }
+    case '25-29': return { nulliparous: false, ageAtFirstBirth: 27 }
+    case '30+': return { nulliparous: false, ageAtFirstBirth: 32 }
+    default: return { nulliparous: false, ageAtFirstBirth: 19 }
+  }
+})
+
+const biopsiesNum = computed(() => Number(biopsies.value) || 0)
+const relativesNum = computed(() => Number(firstDegreeRelatives.value) || 0)
+
+const result = computed(() => calcBreastCancerRisk({
+  age: age.value,
+  ageAtMenarche: menarcheValue.value,
+  ageAtFirstBirth: firstBirthInputs.value.ageAtFirstBirth,
+  nulliparous: firstBirthInputs.value.nulliparous,
+  firstDegreeRelatives: relativesNum.value,
+  biopsies: biopsiesNum.value,
+  atypicalHyperplasia: atypicalHyperplasia.value,
+}))
+
+const category = computed(() => result.value ? riskCategory(result.value.fiveYearRisk) : null)
+
+const categoryLabel = computed(() => {
+  if (!category.value) return null
+  return t(`breastCancerRisk.category${category.value.charAt(0).toUpperCase() + category.value.slice(1)}`)
+})
+
+const categoryColor = computed(() => {
+  if (!category.value) return ''
+  if (category.value === 'low') return 'text-green-600'
+  if (category.value === 'average') return 'text-stone-700'
+  if (category.value === 'elevated') return 'text-orange-500'
+  return 'text-red-600'
+})
+
+function pct(v) {
+  if (v == null) return '—'
+  return (v * 100).toFixed(2) + ' %'
+}
+</script>
+
+<template>
+  <div class="mb-10">
+    <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+    <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('breastCancerRisk.title') }}</h1>
+    <p class="text-base text-stone-500 font-normal">{{ t('breastCancerRisk.description') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('breastCancerRisk.age') }}</label>
+        <input v-model.number="age" type="number" min="35" max="85" placeholder="50" data-testid="age"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        <p class="text-xs text-stone-400 mt-1">{{ t('breastCancerRisk.ageHelp') }}</p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('breastCancerRisk.ageAtMenarche') }}</label>
+        <select v-model="menarcheBracket" data-testid="menarche"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150">
+          <option value="<12">{{ t('breastCancerRisk.menarcheUnder12') }}</option>
+          <option value="12-13">{{ t('breastCancerRisk.menarche1213') }}</option>
+          <option value="14+">{{ t('breastCancerRisk.menarche14plus') }}</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('breastCancerRisk.firstBirth') }}</label>
+        <select v-model="firstBirthBracket" data-testid="first-birth"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150">
+          <option value="nulliparous">{{ t('breastCancerRisk.nulliparous') }}</option>
+          <option value="<20">{{ t('breastCancerRisk.firstBirthUnder20') }}</option>
+          <option value="20-24">{{ t('breastCancerRisk.firstBirth2024') }}</option>
+          <option value="25-29">{{ t('breastCancerRisk.firstBirth2529') }}</option>
+          <option value="30+">{{ t('breastCancerRisk.firstBirth30plus') }}</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('breastCancerRisk.firstDegreeRelatives') }}</label>
+        <select v-model="firstDegreeRelatives" data-testid="relatives"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150">
+          <option value="0">{{ t('breastCancerRisk.relatives0') }}</option>
+          <option value="1">{{ t('breastCancerRisk.relatives1') }}</option>
+          <option value="2">{{ t('breastCancerRisk.relatives2') }}</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('breastCancerRisk.biopsies') }}</label>
+        <select v-model="biopsies" data-testid="biopsies"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150">
+          <option value="0">{{ t('breastCancerRisk.biopsies0') }}</option>
+          <option value="1">{{ t('breastCancerRisk.biopsies1') }}</option>
+          <option value="2">{{ t('breastCancerRisk.biopsies2') }}</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('breastCancerRisk.atypicalHyperplasia') }}</label>
+        <div class="flex gap-2">
+          <button type="button" @click="atypicalHyperplasia = true" data-testid="ah-yes"
+            :class="atypicalHyperplasia === true ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-3 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('breastCancerRisk.ahYes') }}</button>
+          <button type="button" @click="atypicalHyperplasia = false" data-testid="ah-no"
+            :class="atypicalHyperplasia === false ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-3 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('breastCancerRisk.ahNo') }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <AffiliateBanner class="my-6" />
+
+  <div v-if="result" class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+    <div class="flex items-baseline gap-3 mb-4">
+      <span class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none" data-testid="five-year-risk">{{ pct(result.fiveYearRisk) }}</span>
+      <span :class="categoryColor" class="text-lg font-semibold" data-testid="risk-category">{{ categoryLabel }}</span>
+    </div>
+
+    <div v-if="result.elevated" class="bg-orange-50 border border-orange-200 rounded-lg p-4 mb-4" data-testid="elevated-hint">
+      <p class="text-sm text-orange-800 font-medium">{{ t('breastCancerRisk.elevatedHint') }}</p>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-4">
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('breastCancerRisk.averageRisk') }}</p>
+        <p class="text-lg font-bold text-stone-900 tabular-nums" data-testid="average-risk">{{ pct(result.averageFiveYearRisk) }}</p>
+      </div>
+      <div class="bg-stone-50 rounded-lg p-4">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('breastCancerRisk.relativeRisk') }}</p>
+        <p class="text-lg font-bold text-stone-900 tabular-nums" data-testid="relative-risk">{{ result.relativeRisk.toFixed(2) }} &times;</p>
+      </div>
+    </div>
+
+    <p class="text-xs text-stone-500 leading-relaxed">{{ t('breastCancerRisk.disclaimer') }}</p>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 overflow-hidden mb-6">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-stone-50 border-b border-stone-200">
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('breastCancerRisk.factor') }}</th>
+          <th class="text-left px-6 py-3 font-semibold text-stone-700">{{ t('breastCancerRisk.effect') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-stone-100">
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('breastCancerRisk.ageAtMenarche') }}</td><td class="px-6 py-3 text-stone-600">{{ t('breastCancerRisk.effectMenarcheEarly') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('breastCancerRisk.firstDegreeRelatives') }}</td><td class="px-6 py-3 text-stone-600">{{ t('breastCancerRisk.effectFamily') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('breastCancerRisk.atypicalHyperplasia') }}</td><td class="px-6 py-3 text-stone-600">{{ t('breastCancerRisk.effectAH') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('breastCancerRisk.firstBirth') }}</td><td class="px-6 py-3 text-stone-600">{{ t('breastCancerRisk.effectFirstBirth') }}</td></tr>
+        <tr><td class="px-6 py-3 text-stone-900 font-medium">{{ t('breastCancerRisk.age') }}</td><td class="px-6 py-3 text-stone-600">{{ t('breastCancerRisk.effectAge') }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8">
+    <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('breastCancerRisk.howItWorks') }}</h2>
+    <p class="text-sm text-stone-500 leading-relaxed">{{ t('breastCancerRisk.howItWorksText') }}</p>
+  </div>
+
+  <AdSlot class="mt-8" />
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <BlogArticleLink calculator-key="breastCancerRisk" />
+</template>

--- a/src/pages/blog/BrustkrebsRisikoBerechnen.vue
+++ b/src/pages/blog/BrustkrebsRisikoBerechnen.vue
@@ -1,0 +1,211 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Was ist das Gail-Modell?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Das Gail-Modell (Gail et al. 1989) schätzt das individuelle 5-Jahres- und Lebenszeitrisiko für invasiven Brustkrebs anhand von Alter, Menarche, erster Geburt, Familienanamnese und Brustbiopsien. Es ist Grundlage des NCI Breast Cancer Risk Assessment Tools.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Ab welchem Wert gilt das Risiko als erhöht?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Ein 5-Jahres-Risiko ≥ 1,66 % gilt nach NCI- und ASCO-Leitlinien als erhöht. Frauen oberhalb dieser Schwelle profitieren von intensiverer Vorsorge oder einer medikamentösen Prävention mit Tamoxifen bzw. Raloxifen.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Welche Risikofaktoren fehlen im Gail-Modell?',
+      acceptedAnswer: { '@type': 'Answer', text: 'BRCA1/2-Mutationen, Brustkrebs bei männlichen Verwandten oder Verwandten zweiten Grades, Brustdichte, Hormontherapie und Lebensstilfaktoren sind nicht enthalten. Bei familiärer Häufung sollte zusätzlich das Tyrer-Cuzick- oder BRCAPRO-Modell verwendet werden.' },
+    },
+  ],
+}
+
+useHead({
+  title: 'Brustkrebs-Risiko berechnen: Gail-Modell, Risikofaktoren & Vorsorge | Health Calculators',
+  description: 'Brustkrebs-Risiko mit dem Gail-Modell berechnen — 5-Jahres- und Lebenszeitrisiko, Risikofaktoren, Schwellenwerte und Vorsorgeempfehlungen verständlich erklärt.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Brustkrebs-Risiko berechnen: Was das Gail-Modell wirklich aussagt',
+      description: 'Brustkrebs-Risiko mit dem Gail-Modell berechnen — 5-Jahres- und Lebenszeitrisiko, Risikofaktoren, Schwellenwerte und Vorsorgeempfehlungen verständlich erklärt.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-13',
+      dateModified: '2026-05-13',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/brustkrebs-risiko-berechnen',
+      },
+    },
+    faqJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Brustkrebs-Risiko berechnen: Was das Gail-Modell wirklich aussagt</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">13. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Brustkrebs ist die häufigste Krebserkrankung bei Frauen — etwa jede achte Frau erkrankt im Lauf ihres Lebens. Die gute Nachricht: <strong>Risiko ist nicht gleich Schicksal.</strong> Mit dem <strong>Gail-Modell</strong> lässt sich das persönliche 5-Jahres-Risiko aus wenigen Angaben recht zuverlässig schätzen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt, wie das Modell funktioniert, welche Risikofaktoren zählen, ab welchem Wert dein Risiko als „erhöht" gilt — und was du dann konkret tun kannst.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Das Gail-Modell auf einen Blick</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das Gail-Modell wurde 1989 von Mitchell Gail am US National Cancer Institute entwickelt und seither mehrfach validiert (Costantino 1999). Es kombiniert <strong>sechs Variablen</strong> zu einem relativen Risiko und multipliziert dieses mit der altersabhängigen Brustkrebs-Inzidenz:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-base text-stone-600 leading-relaxed mb-4">
+          <li>Aktuelles Alter (35–85 Jahre)</li>
+          <li>Alter bei der ersten Regelblutung (Menarche)</li>
+          <li>Alter bei der ersten Lebendgeburt oder Nulliparität</li>
+          <li>Anzahl Verwandter ersten Grades mit Brustkrebs</li>
+          <li>Anzahl Brustbiopsien</li>
+          <li>Atypische Hyperplasie in einer Biopsie</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das Ergebnis ist eine Wahrscheinlichkeit in Prozent — z. B. „<em>3,2 % Risiko, in den nächsten 5 Jahren an invasivem Brustkrebs zu erkranken</em>".
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risikofaktoren im Detail</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Faktor</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Relatives Risiko</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Menarche &lt; 12 Jahre</td><td class="px-6 py-3 text-stone-600">×1,21</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Eine Biopsie ohne atypische Hyperplasie</td><td class="px-6 py-3 text-stone-600">×1,58</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Eine Biopsie mit atypischer Hyperplasie</td><td class="px-6 py-3 text-stone-600">×3,09</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Eine Verwandte 1. Grades</td><td class="px-6 py-3 text-stone-600">×2,6–2,8</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Zwei oder mehr Verwandte 1. Grades</td><td class="px-6 py-3 text-stone-600">×4,2–6,8</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Nulliparität oder erste Geburt ≥ 30</td><td class="px-6 py-3 text-stone-600">×1,93</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die größten Hebel: <strong>familiäre Belastung</strong> und <strong>atypische Hyperplasie</strong>. Beide können das Risiko vervielfachen, oft auf das Drei- bis Fünffache der Altersnorm.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risikokategorien — was bedeutet dein Ergebnis?</h2>
+        <div class="space-y-3">
+          <div class="bg-green-50 border border-green-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Niedrig: 5-Jahres-Risiko &lt; 1,2 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Reguläre Vorsorge (ab 50: Mammographie-Screening alle 2 Jahre, in Deutschland Kassenleistung).</p>
+          </div>
+          <div class="bg-stone-100 border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Durchschnittlich: 1,2 – 1,66 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Bevölkerungsdurchschnitt. Standardvorsorge, gesundheitsbewusster Lebensstil (Bewegung, wenig Alkohol, gesundes Gewicht).</p>
+          </div>
+          <div class="bg-orange-50 border border-orange-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Erhöht: 1,66 – 3,0 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Schwellenwert nach NCI/ASCO. Gespräch mit Frauenarzt oder Brustzentrum, ggf. intensiviertes Screening (jährliche Mammographie ± Tastuntersuchung).</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Hoch: &gt; 3,0 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Zuweisung an spezialisiertes Brustzentrum. Genetische Beratung (BRCA-Test), MRT zusätzlich zur Mammographie, ggf. Chemoprävention mit Tamoxifen oder Raloxifen.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was das Gail-Modell <em>nicht</em> kann</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das Modell wurde an US-amerikanischen weißen Frauen entwickelt. Es <strong>unterschätzt</strong> das Risiko bei:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-base text-stone-600 leading-relaxed mb-4">
+          <li>BRCA1/BRCA2-Mutationen → hier Tyrer-Cuzick oder BRCAPRO verwenden</li>
+          <li>Männlichen Verwandten mit Brustkrebs oder Verwandten 2. Grades</li>
+          <li>Sehr dichtem Brustgewebe (Mammographie ACR-C/D)</li>
+          <li>Vorheriger Strahlentherapie des Thorax (z. B. wegen M. Hodgkin)</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei mehreren erkrankten Verwandten — besonders mit jungem Erkrankungsalter oder Ovarialkrebs in der Familie — solltest du zusätzlich eine humangenetische Beratung in Erwägung ziehen.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt dein Brustkrebs-Risiko berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Gail-Modell mit 5-Jahres-Risiko, Vergleich zur Altersnorm und klarer Einordnung. Kostenlos, sofort, ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('breastCancerRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Lebensstil — die kontrollierbaren Faktoren</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Etwa 30 % aller Brustkrebsfälle ließen sich laut WHO durch Lebensstilfaktoren vermeiden. Die wichtigsten Hebel:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-base text-stone-600 leading-relaxed">
+          <li><strong>Alkohol:</strong> Jedes Glas pro Tag erhöht das Risiko um ca. 7–10 %.</li>
+          <li><strong>Übergewicht nach der Menopause:</strong> BMI &gt; 30 verdoppelt das Risiko nahezu.</li>
+          <li><strong>Bewegung:</strong> 150 min/Woche moderate Bewegung senken das Risiko um 10–20 %.</li>
+          <li><strong>Stillen:</strong> Schützt — pro Stilljahr sinkt das Risiko um ca. 4 %.</li>
+          <li><strong>Hormonersatztherapie (HRT):</strong> Kombinierte Östrogen-Gestagen-Therapie &gt; 5 Jahre erhöht das Risiko.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Rechner</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Frauengesundheit hängt eng zusammen. Wenn dich dein Brustkrebs-Risiko beschäftigt, sind diese drei Werte ebenfalls relevant — sie alle teilen Risikofaktoren wie Östrogen-Exposition, Alter und Lebensstil:
+        </p>
+        <ul class="list-disc list-inside space-y-2 text-base text-stone-600 leading-relaxed">
+          <li>Bewerte deine Wechseljahresbeschwerden mit dem
+            <router-link :to="localeBlogPath('menopause-symptome-bewerten')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Menopause-Rechner</router-link> — HRT-Entscheidungen beeinflussen das Brustkrebsrisiko direkt.
+          </li>
+          <li>Prüfe dein
+            <router-link :to="localeBlogPath('osteoporose-risiko-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Osteoporose-Risiko</router-link> — beide Erkrankungen treten gehäuft nach der Menopause auf.
+          </li>
+          <li>Vergleiche deinen Wert mit deinem
+            <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biologischen Alter</router-link> — ein guter Indikator für Krebs- und Herz-Kreislauf-Risiko zugleich.
+          </li>
+        </ul>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das Gail-Modell ersetzt keine ärztliche Untersuchung — aber es liefert einen verlässlichen Ausgangspunkt. Berechne dein persönliches 5-Jahres-Risiko mit dem
+          <router-link :to="localePath('breastCancerRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Brustkrebs-Risiko-Rechner</router-link>
+          und besprich auffällige Werte (≥ 1,66 % über 5 Jahre) frühzeitig mit deinem Frauenarzt oder einem zertifizierten Brustzentrum.
+        </p>
+      </div>
+
+      <RelatedArticles slug="brustkrebs-risiko-berechnen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/BreastCancerRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/BreastCancerRiskCalculatorGuide.vue
@@ -1,0 +1,211 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is the Gail model?',
+      acceptedAnswer: { '@type': 'Answer', text: 'The Gail model (Gail et al. 1989) estimates individual 5-year and lifetime risk of invasive breast cancer from age, menarche, first birth, family history and prior breast biopsies. It powers the NCI Breast Cancer Risk Assessment Tool.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'When is my breast cancer risk considered elevated?',
+      acceptedAnswer: { '@type': 'Answer', text: 'A 5-year risk of 1.66 % or higher is the NCI/ASCO threshold for elevated risk. Above that, enhanced screening and risk-reducing medication (tamoxifen, raloxifene) may be offered.' },
+    },
+    {
+      '@type': 'Question',
+      name: 'Which risk factors does the Gail model miss?',
+      acceptedAnswer: { '@type': 'Answer', text: 'BRCA1/2 mutations, male relatives with breast cancer, second-degree relatives, dense breast tissue, hormone replacement therapy and lifestyle are not included. Strong family history calls for the Tyrer-Cuzick or BRCAPRO model in addition.' },
+    },
+  ],
+}
+
+useHead({
+  title: 'Breast Cancer Risk Calculator: How the Gail Model Works | Health Calculators',
+  description: 'Calculate your breast cancer risk with the Gail model — 5-year and lifetime risk, key risk factors, screening thresholds and prevention options explained.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Breast Cancer Risk Calculator: How the Gail Model Works',
+      description: 'Calculate your breast cancer risk with the Gail model — 5-year and lifetime risk, key risk factors, screening thresholds and prevention options explained.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-13',
+      dateModified: '2026-05-13',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/breast-cancer-risk-calculator-guide',
+      },
+    },
+    faqJsonLd,
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Breast Cancer Risk Calculator: How the Gail Model Works</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 13, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Breast cancer is the most common cancer in women — about <strong>one in eight</strong> women will develop it in her lifetime. The good news: risk is not destiny. The <strong>Gail model</strong> turns a handful of personal data points into a reasonably accurate estimate of your 5-year breast cancer risk.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide walks you through how the model works, which factors carry the most weight, what counts as "elevated" risk, and what you can actually do about it.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The Gail model in 60 seconds</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Built in 1989 by Mitchell Gail at the US National Cancer Institute and validated repeatedly since (Costantino 1999), the Gail model combines <strong>six variables</strong> into a relative risk multiplier, then applies that to age-specific breast cancer incidence:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-base text-stone-600 leading-relaxed mb-4">
+          <li>Current age (35–85 years)</li>
+          <li>Age at first menstrual period (menarche)</li>
+          <li>Age at first live birth or nulliparity</li>
+          <li>Number of first-degree relatives with breast cancer</li>
+          <li>Number of breast biopsies</li>
+          <li>Atypical hyperplasia on biopsy</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The output is a probability — for example: "<em>You have a 3.2 % probability of developing invasive breast cancer in the next 5 years.</em>"
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risk factors in detail</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Factor</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Relative risk</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Menarche &lt; 12 years</td><td class="px-6 py-3 text-stone-600">×1.21</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">One biopsy, no atypical hyperplasia</td><td class="px-6 py-3 text-stone-600">×1.58</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">One biopsy with atypical hyperplasia</td><td class="px-6 py-3 text-stone-600">×3.09</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">One first-degree relative</td><td class="px-6 py-3 text-stone-600">×2.6–2.8</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Two or more first-degree relatives</td><td class="px-6 py-3 text-stone-600">×4.2–6.8</td></tr>
+              <tr><td class="px-6 py-3 text-stone-900 font-medium">Nulliparity or first birth ≥ 30</td><td class="px-6 py-3 text-stone-600">×1.93</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The biggest levers are <strong>family history</strong> and <strong>atypical hyperplasia</strong>. Either can multiply your risk three- to fivefold above the population average for your age.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risk categories — what your result means</h2>
+        <div class="space-y-3">
+          <div class="bg-green-50 border border-green-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Low: 5-year risk &lt; 1.2 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Routine screening — most guidelines: biennial mammography from age 50 (or 40, depending on country).</p>
+          </div>
+          <div class="bg-stone-100 border border-stone-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Average: 1.2 – 1.66 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Population average. Standard screening plus healthy-lifestyle basics (alcohol, weight, physical activity).</p>
+          </div>
+          <div class="bg-orange-50 border border-orange-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">Elevated: 1.66 – 3.0 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">NCI/ASCO threshold for "high risk." Talk to your gynecologist or a breast clinic — annual mammography ± clinical exam may be appropriate.</p>
+          </div>
+          <div class="bg-red-50 border border-red-200 rounded-xl p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-1">High: &gt; 3.0 %</h3>
+            <p class="text-sm text-stone-600 leading-relaxed">Specialist referral. Consider genetic counseling (BRCA testing), supplemental MRI screening, and discuss preventive medication (tamoxifen, raloxifene).</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What the Gail model <em>cannot</em> do</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The model was developed on US white women and <strong>underestimates</strong> risk in several important groups:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-base text-stone-600 leading-relaxed mb-4">
+          <li>BRCA1/BRCA2 carriers → use Tyrer-Cuzick or BRCAPRO instead</li>
+          <li>Male relatives with breast cancer or second-degree relatives</li>
+          <li>Very dense breast tissue (BI-RADS C or D)</li>
+          <li>Previous chest radiation (e.g. for Hodgkin lymphoma)</li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A strong family history — multiple affected relatives, very young age at diagnosis, or ovarian cancer in the family — warrants formal genetic counseling beyond a quick risk calculator.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your breast cancer risk now</h3>
+        <p class="text-stone-300 text-sm mb-5">Gail model with 5-year risk, comparison to your age-group average and a clear classification. Free, instant, no sign-up.</p>
+        <router-link
+          :to="localePath('breastCancerRisk')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Lifestyle — the levers you control</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The WHO estimates roughly 30 % of breast cancer cases could be prevented by lifestyle. The most evidence-backed moves:
+        </p>
+        <ul class="list-disc list-inside space-y-1 text-base text-stone-600 leading-relaxed">
+          <li><strong>Alcohol:</strong> each daily drink raises risk by about 7–10 %.</li>
+          <li><strong>Postmenopausal obesity:</strong> BMI &gt; 30 nearly doubles risk.</li>
+          <li><strong>Physical activity:</strong> 150 min/week of moderate exercise cuts risk by 10–20 %.</li>
+          <li><strong>Breastfeeding:</strong> protective — risk falls by ~4 % per year of breastfeeding.</li>
+          <li><strong>Hormone replacement therapy (HRT):</strong> combined estrogen-progestin therapy &gt; 5 years raises risk.</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related calculators</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Women's health risks cluster. If breast cancer risk is on your mind, these three indicators share underlying drivers — estrogen exposure, age and lifestyle:
+        </p>
+        <ul class="list-disc list-inside space-y-2 text-base text-stone-600 leading-relaxed">
+          <li>Score your menopause symptoms with the
+            <router-link :to="localeBlogPath('menopause-symptom-calculator-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Menopause Symptom Calculator</router-link> — HRT decisions affect breast cancer risk directly.
+          </li>
+          <li>Check your
+            <router-link :to="localeBlogPath('osteoporosis-risk-calculator-guide')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">osteoporosis risk</router-link> — both conditions cluster after menopause.
+          </li>
+          <li>Compare against your
+            <router-link :to="localeBlogPath('biological-age-calculator')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">biological age</router-link> — a strong combined indicator for cancer and cardiovascular risk.
+          </li>
+        </ul>
+      </div>
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bottom line</h2>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The Gail model is not a substitute for a clinical exam — but it is a solid starting point. Calculate your personal 5-year risk with the
+          <router-link :to="localePath('breastCancerRisk')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Breast Cancer Risk Calculator</router-link>
+          and bring elevated results (≥ 1.66 % over 5 years) to a gynecologist or a certified breast clinic early.
+        </p>
+      </div>
+
+      <RelatedArticles slug="breast-cancer-risk-calculator-guide" />
+    </div>
+  </article>
+</template>

--- a/src/pages/breastCancerRisk.meta.js
+++ b/src/pages/breastCancerRisk.meta.js
@@ -1,0 +1,16 @@
+import Component from './BreastCancerRiskCalculator.vue'
+import BlogDe from './blog/BrustkrebsRisikoBerechnen.vue'
+import BlogEn from './blog/en/BreastCancerRiskCalculatorGuide.vue'
+
+export default {
+  key: 'breastCancerRisk',
+  component: Component,
+  slugs: { de: 'brustkrebs-risiko-rechner', en: 'breast-cancer-risk-calculator' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 110,
+  blog: {
+    de: { slug: 'brustkrebs-risiko-berechnen', component: BlogDe },
+    en: { slug: 'breast-cancer-risk-calculator-guide', component: BlogEn },
+  },
+}

--- a/src/utils/breastCancerRisk.js
+++ b/src/utils/breastCancerRisk.js
@@ -1,0 +1,90 @@
+// Simplified Gail model — 5-year breast cancer risk estimate.
+// References: Gail JM et al. JNCI 1989; Costantino JP et al. JNCI 1999;
+// NCI Breast Cancer Risk Assessment Tool (BCRAT).
+// This is an estimate — not a clinical decision tool.
+
+const BASELINE_INCIDENCE_5Y = {
+  35: 0.0044, 40: 0.0073, 45: 0.0114, 50: 0.0166,
+  55: 0.0203, 60: 0.0245, 65: 0.0287, 70: 0.0314,
+  75: 0.0322, 80: 0.0301,
+}
+
+function baselineFiveYearRisk(age) {
+  if (!age || age < 35 || age > 85) return null
+  const ages = Object.keys(BASELINE_INCIDENCE_5Y).map(Number).sort((a, b) => a - b)
+  let lower = ages[0]
+  for (const a of ages) if (a <= age) lower = a
+  return BASELINE_INCIDENCE_5Y[lower]
+}
+
+function rrMenarche(ageAtMenarche) {
+  if (!ageAtMenarche) return 1.0
+  if (ageAtMenarche < 12) return 1.21
+  if (ageAtMenarche <= 13) return 1.10
+  return 1.00
+}
+
+function rrBiopsies(n) {
+  if (!n || n <= 0) return 1.00
+  if (n === 1) return 1.70
+  return 2.88
+}
+
+function rrAtypicalHyperplasia(hasAH, biopsies) {
+  if (!biopsies || biopsies <= 0) return 1.0
+  if (hasAH === true) return 1.82
+  if (hasAH === false) return 0.93
+  return 1.0
+}
+
+const FIRST_BIRTH_MATRIX = {
+  '<20':         [1.00, 2.61, 6.80],
+  '20-24':       [1.24, 2.68, 5.78],
+  '25-29':       [1.55, 2.76, 4.91],
+  '>=30':        [1.93, 2.83, 4.17],
+  'nulliparous': [1.93, 2.83, 4.17],
+}
+
+function rrFamilyAndFirstBirth(firstDegreeRelatives, ageAtFirstBirth, nulliparous) {
+  const relKey = firstDegreeRelatives >= 2 ? 2 : (firstDegreeRelatives === 1 ? 1 : 0)
+  let bracket = 'nulliparous'
+  if (!nulliparous && ageAtFirstBirth != null) {
+    if (ageAtFirstBirth < 20) bracket = '<20'
+    else if (ageAtFirstBirth < 25) bracket = '20-24'
+    else if (ageAtFirstBirth < 30) bracket = '25-29'
+    else bracket = '>=30'
+  }
+  return FIRST_BIRTH_MATRIX[bracket][relKey]
+}
+
+export function calcRelativeRisk(inputs) {
+  return rrMenarche(inputs.ageAtMenarche)
+    * rrBiopsies(inputs.biopsies)
+    * rrAtypicalHyperplasia(inputs.atypicalHyperplasia, inputs.biopsies)
+    * rrFamilyAndFirstBirth(
+        Number(inputs.firstDegreeRelatives) || 0,
+        inputs.ageAtFirstBirth,
+        inputs.nulliparous,
+      )
+}
+
+export function calcBreastCancerRisk(inputs) {
+  const baseline = baselineFiveYearRisk(inputs.age)
+  if (baseline === null) return null
+  const rr = calcRelativeRisk(inputs)
+  const fiveYearRisk = Math.min(baseline * rr, 0.99)
+  return {
+    fiveYearRisk,
+    averageFiveYearRisk: baseline,
+    relativeRisk: rr,
+    elevated: fiveYearRisk > 0.0166,
+  }
+}
+
+export function riskCategory(fiveYearRisk) {
+  if (fiveYearRisk == null) return null
+  if (fiveYearRisk < 0.012) return 'low'
+  if (fiveYearRisk < 0.0166) return 'average'
+  if (fiveYearRisk < 0.030) return 'elevated'
+  return 'high'
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-142-breast-cancer-risk
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-142-breast-cancer-risk-20260513-220030`
**Cost:** $8.2795235

Closes jenslaufer/health-calculators#142

### Prompt
> Implement the Breast Cancer Risk Calculator as described in issue #142.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Gail model breast cancer risk
- Metric + imperial unit toggle where applicable
- Blog articles: DE + EN (SEO optimized)
- Unit tests for calculation logic
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.


## PARTIAL-COMMIT GUARD (MANDATORY — added 2026-05-07 after FK #270 + HC #231 partial; validated 3-of-3 on FK #280 + HC #232 + HC #233, 4-of-3 on FK #281)
Before `git push`, run:
  git diff --name-only main..HEAD | sort

Output MUST contain ALL of these paths (substitute <DeBlogPascal> + <EnBlogPascal> with your chosen blog Vue component names):
  e2e/breastCancerRisk.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/breastCancerRisk.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/breastCancerRisk.json
  src/locales/calculators/en/breastCancerRisk.json
  src/pages/BreastCancerRiskCalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/breastCancerRisk.meta.js
  src/utils/breastCancerRisk.js

If ANY path is missing → DO NOT push. Stage + commit the missing files first.
Counter check: `git diff --name-only main..HEAD | wc -l` MUST be >= 14.

Reference: study `src/pages/BacCalculator.vue` + `src/pages/bac.meta.js` + `src/locales/calculators/de/bac.json` + `en/bac.json` + `src/__tests__/bac.test.js` + `e2e/bac.spec.js`.

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/breastCancerRisk.js` as an empty stub (export the calc function returning `{}` or throwing). Create `src/__tests__/breastCancerRisk.test.js` with 6+ test cases covering edge cases. Run `npm test -- breastCancerRisk` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement the calculation. Re-run — all green.
3. **View component + locale JSON.** Create `src/pages/BreastCancerRiskCalculator.vue` (skeleton from reference pattern). Then create the locale file(s) — see Locale-Path block below.
4. **E2E test.** Create `e2e/breastCancerRisk.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates.** Create DE + EN blog files. Update blog index pages.
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/breastCancerRisk.meta.js` — discovery anchor. Mirror shape of `src/pages/bac.meta.js`:
  `key: 'breastCancerRisk'`, `component`, `slugs: {de, en}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/breastCancerRisk.json` + `src/locales/calculators/en/breastCancerRisk.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bac.json`).

## File-Checklist (git status MUST show these as new files before push)
Paths below are derived from the branch name and act as suggestions. If repo
naming convention or domain language requires a slightly different filename
(e.g. dropping a redundant suffix), adjust — BUT all 4 categories MUST exist:
(1) calculation logic, (2) unit tests, (3) view + locale, (4) e2e + blog.

- `src/utils/breastCancerRisk.js (or shared util — verify pattern in repo first)`
- `src/__tests__/breastCancerRisk.test.js`
- `src/pages/BreastCancerRiskCalculator.vue`
- `src/pages/breastCancerRisk.meta.js`
- `src/locales/calculators/de/breastCancerRisk.json`
- `src/locales/calculators/en/breastCancerRisk.json`
- `e2e/breastCancerRisk.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test (added by hc-204 / PR #205 on 2026-04-26)
requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'breastCancerRisk',             // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry
only — do NOT edit any existing entries.

Verify after edit: `node -e "import('./src/data/articles.js').then(m => console.log(m.articles.length))"` — count must be N+1 vs main.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks