### PR TITLE
SEO: lang toggle as <a href> for crawler discovery (#258)

### DIFF
--- a/e2e/lang-toggle.spec.js
+++ b/e2e/lang-toggle.spec.js
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('lang toggle — crawlable <a href> (issue #258)', () => {
+  test('DE page has crawler-visible <a> with EN href in DOM', async ({ page }) => {
+    await page.goto('de/bmi-rechner')
+    const toggle = page.locator('a[aria-label="Switch to English"]').first()
+    await expect(toggle).toBeVisible()
+    const href = await toggle.getAttribute('href')
+    expect(href).toMatch(/^\/en\//)
+  })
+
+  test('click EN toggle navigates to EN page via SPA', async ({ page }) => {
+    await page.goto('de/bmi-rechner')
+    const toggle = page.locator('a[aria-label="Switch to English"]').first()
+    const href = await toggle.getAttribute('href')
+    await toggle.click()
+    await expect(page).toHaveURL(href)
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,12 @@
 <script setup>
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '@unhead/vue'
 import { useLocaleRouter } from './composables/useLocaleRouter.js'
+import { switchLocalePath } from './composables/useLocaleRouter.js'
 
+const route = useRoute()
 const router = useRouter()
 const menuOpen = ref(false)
 const { t } = useI18n()
@@ -45,33 +47,41 @@ router.afterEach(() => { menuOpen.value = false })
               class="text-sm font-medium text-stone-400 hover:text-stone-800 transition-colors duration-150"
             >{{ t('nav.blog') }}</router-link>
             <div class="flex items-center gap-1 text-sm">
-              <button
-                @click="switchLocale('de')"
+              <a
+                :href="switchLocalePath(route, 'de')"
+                @click.prevent="switchLocale('de')"
                 :class="locale === 'de' ? 'font-bold text-stone-900' : 'font-medium text-stone-400 hover:text-stone-600'"
                 class="transition-colors duration-150"
-              >DE</button>
+                aria-label="Zu Deutsch wechseln"
+              >DE</a>
               <span class="text-stone-300">|</span>
-              <button
-                @click="switchLocale('en')"
+              <a
+                :href="switchLocalePath(route, 'en')"
+                @click.prevent="switchLocale('en')"
                 :class="locale === 'en' ? 'font-bold text-stone-900' : 'font-medium text-stone-400 hover:text-stone-600'"
                 class="transition-colors duration-150"
-              >EN</button>
+                aria-label="Switch to English"
+              >EN</a>
             </div>
           </div>
 
           <div class="md:hidden flex items-center gap-3">
             <div class="flex items-center gap-1 text-sm">
-              <button
-                @click="switchLocale('de')"
+              <a
+                :href="switchLocalePath(route, 'de')"
+                @click.prevent="switchLocale('de')"
                 :class="locale === 'de' ? 'font-bold text-stone-900' : 'font-medium text-stone-400 hover:text-stone-600'"
                 class="transition-colors duration-150"
-              >DE</button>
+                aria-label="Zu Deutsch wechseln"
+              >DE</a>
               <span class="text-stone-300">|</span>
-              <button
-                @click="switchLocale('en')"
+              <a
+                :href="switchLocalePath(route, 'en')"
+                @click.prevent="switchLocale('en')"
                 :class="locale === 'en' ? 'font-bold text-stone-900' : 'font-medium text-stone-400 hover:text-stone-600'"
                 class="transition-colors duration-150"
-              >EN</button>
+                aria-label="Switch to English"
+              >EN</a>
             </div>
             <button
               @click="menuOpen = !menuOpen"

--- a/src/__tests__/lang-toggle.test.js
+++ b/src/__tests__/lang-toggle.test.js
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@unhead/vue', () => ({ useHead: vi.fn() }))
+
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import App from '../App.vue'
+import { calculatorMetas } from '../discovery.js'
+import { de, en } from '../locales/index.js'
+
+const DummyView = { template: '<div />' }
+
+function makeI18n(locale = 'de') {
+  return createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: 'en',
+    messages: { de, en },
+  })
+}
+
+function makeRouter(calc) {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', redirect: '/de/' },
+      { path: '/de/', component: DummyView, meta: { routeKey: 'home', locale: 'de' } },
+      { path: '/en/', component: DummyView, meta: { routeKey: 'home', locale: 'en' } },
+      { path: `/de/${calc.slugs.de}`, component: DummyView, meta: { routeKey: calc.key, locale: 'de' } },
+      { path: `/en/${calc.slugs.en}`, component: DummyView, meta: { routeKey: calc.key, locale: 'en' } },
+      { path: '/:pathMatch(.*)*', component: DummyView },
+    ],
+  })
+}
+
+async function mountApp(calc, path, locale = 'de') {
+  const router = makeRouter(calc)
+  router.push(path)
+  await router.isReady()
+  const i18n = makeI18n(locale)
+  const wrapper = mount(App, { global: { plugins: [router, i18n] } })
+  return { wrapper, router }
+}
+
+describe('lang toggle — crawlable <a href> (issue #258)', () => {
+  it('DE /de/<bmi-de-slug> renders <a href> pointing to EN counterpart', async () => {
+    const first = calculatorMetas[0]
+    const { wrapper } = await mountApp(first, `/de/${first.slugs.de}`, 'de')
+    const anchors = wrapper.findAll(`a[href="/en/${first.slugs.en}"]`)
+    expect(anchors.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('EN counterpart renders <a href> pointing to DE counterpart', async () => {
+    const first = calculatorMetas[0]
+    const { wrapper } = await mountApp(first, `/en/${first.slugs.en}`, 'en')
+    const anchors = wrapper.findAll(`a[href="/de/${first.slugs.de}"]`)
+    expect(anchors.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('toggle is an <a> element, not a <button>', async () => {
+    const first = calculatorMetas[0]
+    const { wrapper } = await mountApp(first, `/de/${first.slugs.de}`, 'de')
+    expect(wrapper.find('a[aria-label="Switch to English"]').exists()).toBe(true)
+    expect(wrapper.find('button[aria-label="Switch to English"]').exists()).toBe(false)
+  })
+
+  it('click navigates via router to other locale (no hard reload)', async () => {
+    const first = calculatorMetas[0]
+    const { wrapper, router } = await mountApp(first, `/de/${first.slugs.de}`, 'de')
+    const toggle = wrapper.find('a[aria-label="Switch to English"]')
+    await toggle.trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe(`/en/${first.slugs.en}`)
+  })
+
+  it('samples 5 DE calc slugs — all render <a href> pointing to EN counterpart', async () => {
+    const samples = calculatorMetas.slice(0, 5)
+    for (const calc of samples) {
+      const { wrapper } = await mountApp(calc, `/de/${calc.slugs.de}`, 'de')
+      const expectedHref = `/en/${calc.slugs.en}`
+      const anchors = wrapper.findAll(`a[href="${expectedHref}"]`)
+      expect(anchors.length, `Expected <a href="${expectedHref}"> for /de/${calc.slugs.de}`).toBeGreaterThanOrEqual(1)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- 4 lang-toggle `<button>` → `<a :href="switchLocalePath(route, target)">` + `@click.prevent` (Desktop DE/EN + Mobile DE/EN in `src/App.vue`)
- Googlebot now discovers the alternate-locale URL directly from the DOM; SPA behaviour preserved
- aria-labels added (`Switch to English` / `Zu Deutsch wechseln`)
- Mirrors finanzkalkulatoren PR #303 (live in prod 2026-05-15 17:28 CEST)

## Context
This is a hand-fix after `hc-258-en-toggle-crawler-discovery.yaml` failed silently in the agent-task runner (worker exited 0 with no diff after ~60min — likely Alpine/musl rolldown or Chromium-install issue per existing `learning_alpine_rolldown_host_glibc_mismatch`).

## Verified
- ✅ SSG build emits `<a href="/en/bmi-calculator">` in `/de/bmi-rechner/index.html` and inverse for EN
- ✅ vitest full suite: 88 files / 2348 tests green
- ✅ new `src/__tests__/lang-toggle.test.js`: 5/5 green (TDD red→green cycle observed)
- ⏳ playwright e2e — to be run by `/quality-gate` on this PR (host environment)

## Test plan
- [ ] `/quality-gate` runs unit + build + e2e in clean container
- [ ] After merge: `curl -s https://healthcalculator.app/de/bmi-rechner/ | grep -oE 'href="/en/[^"]*"'` returns a link
- [ ] GSC: monitor "indexed pages" count for non-DE coverage in the following ~2 weeks

Closes #258