### PR TITLE
Add RelatedCalculators component to 85 calc pages (#260)

### DIFF
--- a/e2e/related-calculators.spec.js
+++ b/e2e/related-calculators.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+test('RelatedCalculators renders 4 sibling links on a calc page', async ({ page }) => {
+  await page.goto('de/one-rep-max-rechner/')
+  const block = page.locator('[data-testid="related-calculators"]')
+  await expect(block).toBeVisible()
+  await expect(block.locator('a')).toHaveCount(4)
+})

--- a/src/__tests__/relatedCalculators.test.js
+++ b/src/__tests__/relatedCalculators.test.js
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import { calculatorMetas } from '../discovery.js'
+
+function makeI18n(locale = 'de') {
+  return createI18n({
+    legacy: false,
+    locale,
+    missingWarn: false,
+    fallbackWarn: false,
+    messages: { de: {}, en: {} },
+  })
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+  })
+}
+
+async function mountWith(calcKey, locale = 'de') {
+  const i18n = makeI18n(locale)
+  const router = makeRouter()
+  router.push(`/${locale}/`)
+  await router.isReady()
+  return mount(RelatedCalculators, {
+    props: { calcKey },
+    global: { plugins: [i18n, router] },
+  })
+}
+
+describe('RelatedCalculators', () => {
+  it('returns siblings in same group, excludes current, max 4 (oneRepMax/fitnessRecovery)', async () => {
+    const wrapper = await mountWith('oneRepMax')
+    const links = wrapper.findAll('[data-testid="related-calculators"] a')
+    expect(links).toHaveLength(4)
+    const current = calculatorMetas.find(m => m.key === 'oneRepMax')
+    const expected = calculatorMetas
+      .filter(m => m.group === current.group && m.key !== 'oneRepMax')
+      .sort((a, b) => a.key.localeCompare(b.key))
+      .slice(0, 4)
+      .map(m => m.key)
+    expect(expected).not.toContain('oneRepMax')
+    expect(expected).toHaveLength(4)
+  })
+
+  it('returns 4 alphabetically sorted siblings for bmi (bodyComposition)', async () => {
+    const wrapper = await mountWith('bmi')
+    const links = wrapper.findAll('[data-testid="related-calculators"] a')
+    expect(links).toHaveLength(4)
+    const hrefs = links.map(a => a.attributes('href'))
+    // Alphabetically first 4 in bodyComposition excluding bmi: bmiFrauen, bmiMaenner, bodyFat, bodyType
+    expect(hrefs[0]).toContain('/de/bmi-rechner-frauen')
+    expect(hrefs[1]).toContain('/de/bmi-rechner-maenner')
+    expect(hrefs[2]).toContain('/de/koerperfett-rechner')
+  })
+
+  it('renders nothing when calcKey does not exist', async () => {
+    const wrapper = await mountWith('nonexistent')
+    expect(wrapper.find('[data-testid="related-calculators"]').exists()).toBe(false)
+  })
+
+  it('renders nothing when group has only one calculator', async () => {
+    const original = calculatorMetas.slice()
+    // Inject a synthetic single-member group temporarily
+    calculatorMetas.length = 0
+    calculatorMetas.push({ key: 'lonely', group: 'soloGroup', slugs: { de: 'lonely', en: 'lonely' } })
+    const wrapper = await mountWith('lonely')
+    expect(wrapper.find('[data-testid="related-calculators"]').exists()).toBe(false)
+    calculatorMetas.length = 0
+    calculatorMetas.push(...original)
+  })
+})

--- a/src/components/RelatedCalculators.vue
+++ b/src/components/RelatedCalculators.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calculatorMetas } from '../discovery.js'
+
+const { localePath, locale } = useLocaleRouter()
+const { t } = useI18n()
+
+const props = defineProps({
+  calcKey: { type: String, required: true },
+})
+
+const related = computed(() => {
+  const current = calculatorMetas.find(m => m.key === props.calcKey)
+  if (!current) return []
+  return calculatorMetas
+    .filter(m => m.group === current.group && m.key !== props.calcKey)
+    .sort((a, b) => a.key.localeCompare(b.key))
+    .slice(0, 4)
+})
+
+const heading = computed(() => (locale.value === 'en' ? 'Related Calculators' : 'Verwandte Rechner'))
+</script>
+
+<template>
+  <div v-if="related.length" data-testid="related-calculators">
+    <h2 class="text-2xl font-bold text-stone-900 mb-4">{{ heading }}</h2>
+    <div class="grid gap-4 sm:grid-cols-2">
+      <router-link
+        v-for="calc in related"
+        :key="calc.key"
+        :to="localePath(calc.key)"
+        class="block bg-white border border-stone-200 rounded-xl shadow-sm p-6 hover:border-stone-300 hover:shadow transition-all duration-150"
+      >
+        <h3 class="text-base font-semibold text-stone-900 mb-1">{{ t(`home.calculators.${calc.key}.name`) }}</h3>
+        <p class="text-sm text-stone-500 leading-relaxed">{{ t(`home.calculators.${calc.key}.description`) }}</p>
+      </router-link>
+    </div>
+  </div>
+</template>

--- a/src/pages/AlcoholUnitsCalculator.vue
+++ b/src/pages/AlcoholUnitsCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -376,6 +377,7 @@ function resetDrink(drink) {
       </p>
     </div>
 
+    <RelatedCalculators calc-key="alcoholUnits" class="mt-8" />
     <BlogArticleLink calculator-key="alcoholUnits" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/AnemiaRiskCalculator.vue
+++ b/src/pages/AnemiaRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -236,5 +237,6 @@ const hbUnit = computed(() => unit.value === 'imperial' ? 'g/L' : 'g/dL')
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="anemiaRisk" class="mt-8" />
   <BlogArticleLink calculator-key="anemiaRisk" />
 </template>

--- a/src/pages/AnionGapCalculator.vue
+++ b/src/pages/AnionGapCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -219,6 +220,7 @@ const plausibilityWarning = computed(() => {
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="anionGap" class="mt-8" />
     <BlogArticleLink calculator-key="anionGap" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/ApgarScoreCalculator.vue
+++ b/src/pages/ApgarScoreCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -170,5 +171,6 @@ const componentList = APGAR_COMPONENTS
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="apgarScore" class="mt-8" />
   <BlogArticleLink calculator-key="apgarScore" />
 </template>

--- a/src/pages/AsthmaControlCalculator.vue
+++ b/src/pages/AsthmaControlCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -183,6 +184,7 @@ function reset() {
     </div>
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="asthmaControl" class="mt-8" />
     <BlogArticleLink calculator-key="asthmaControl" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/BabyFeedingAmountCalculator.vue
+++ b/src/pages/BabyFeedingAmountCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -242,6 +243,7 @@ function fmt(v, decimals = 0) {
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="babyFeedingAmount" class="mt-8" />
     <BlogArticleLink calculator-key="babyFeedingAmount" />
   </div>
 </template>

--- a/src/pages/BabyMilestonesCalculator.vue
+++ b/src/pages/BabyMilestonesCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -260,6 +261,7 @@ function selectBracket(b) {
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="babyMilestones" class="mt-8" />
     <BlogArticleLink calculator-key="babyMilestones" />
   </div>
 </template>

--- a/src/pages/BacCalculator.vue
+++ b/src/pages/BacCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -294,5 +295,6 @@ const bacCategory = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="bac" class="mt-8" />
   <BlogArticleLink calculator-key="bac" />
 </template>

--- a/src/pages/BiologicalAgeCalculator.vue
+++ b/src/pages/BiologicalAgeCalculator.vue
@@ -5,6 +5,7 @@ import { useHead } from '../composables/useHead.js'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
 const { t } = useI18n()
@@ -539,6 +540,7 @@ const blogSlug = computed(() => locale.value === 'de' ? 'biologisches-alter-bere
     </div>
   </div>
 
+  <RelatedCalculators calc-key="biologicalAge" class="mt-8" />
   <BlogArticleLink calculator-key="biologicalAge" />
 
   <AdSlot class="mt-8" />

--- a/src/pages/BloodAlcoholEstimatorCalculator.vue
+++ b/src/pages/BloodAlcoholEstimatorCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -267,5 +268,6 @@ const effectsRows = [
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="bloodAlcoholEstimator" class="mt-8" />
   <BlogArticleLink calculator-key="bloodAlcoholEstimator" />
 </template>

--- a/src/pages/BloodPressureCalculator.vue
+++ b/src/pages/BloodPressureCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -158,6 +159,7 @@ const recommendationKeys = {
       </div>
     </div>
 
+    <RelatedCalculators calc-key="bloodPressure" class="mt-8" />
     <BlogArticleLink calculator-key="bloodPressure" />
 
     <AdSlot class="mt-8" />

--- a/src/pages/BloodSugarConverter.vue
+++ b/src/pages/BloodSugarConverter.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -276,6 +277,7 @@ const outputUnit = computed(() => (unit.value === 'mg' ? 'mmol/L' : 'mg/dL'))
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="bloodSugar" class="mt-8" />
     <BlogArticleLink calculator-key="bloodSugar" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/BmiCalculator.vue
+++ b/src/pages/BmiCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
@@ -152,6 +153,7 @@ const barPosition = computed(() => getBmiBarPosition(bmi.value))
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="bmi" class="mt-8" />
     <BlogArticleLink calculator-key="bmi" />
 
     <AdSlot class="mt-8" />

--- a/src/pages/BmiFrauenCalculator.vue
+++ b/src/pages/BmiFrauenCalculator.vue
@@ -6,6 +6,7 @@ import { calcBmi, getBmiCategory, getBmiBarPosition } from '../composables/useBm
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 
 const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
@@ -156,6 +157,7 @@ const barPosition = computed(() => getBmiBarPosition(bmi.value))
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="bmiFrauen" class="mt-8" />
     <AdSlot class="mt-8" />
   </div>
 </template>

--- a/src/pages/BmiMaennerCalculator.vue
+++ b/src/pages/BmiMaennerCalculator.vue
@@ -6,6 +6,7 @@ import { calcBmi, getBmiCategory, getBmiBarPosition } from '../composables/useBm
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 
 const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
@@ -156,6 +157,7 @@ const barPosition = computed(() => getBmiBarPosition(bmi.value))
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="bmiMaenner" class="mt-8" />
     <AdSlot class="mt-8" />
   </div>
 </template>

--- a/src/pages/BmrCalculator.vue
+++ b/src/pages/BmrCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -157,5 +158,6 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="bmr" class="mt-8" />
   <BlogArticleLink calculator-key="bmr" />
 </template>

--- a/src/pages/BodyFatCalculator.vue
+++ b/src/pages/BodyFatCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -235,5 +236,6 @@ const unitLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'cm' :
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="bodyFat" class="mt-8" />
   <BlogArticleLink calculator-key="bodyFat" />
 </template>

--- a/src/pages/BodyTemperatureCalculator.vue
+++ b/src/pages/BodyTemperatureCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -243,6 +244,7 @@ function switchUnit(newUnit) {
       </p>
     </div>
 
+    <RelatedCalculators calc-key="bodyTemperature" class="mt-8" />
     <BlogArticleLink calculator-key="bodyTemperature" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/BodyTypeCalculator.vue
+++ b/src/pages/BodyTypeCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -377,6 +378,7 @@ const unitLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'cm' :
       </div>
     </template>
 
+    <RelatedCalculators calc-key="bodyType" class="mt-8" />
     <BlogArticleLink calculator-key="bodyType" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/BreastCancerRiskCalculator.vue
+++ b/src/pages/BreastCancerRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -212,5 +213,6 @@ function pct(v) {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="breastCancerRisk" class="mt-8" />
   <BlogArticleLink calculator-key="breastCancerRisk" />
 </template>

--- a/src/pages/BreastMilkAlcoholCalculator.vue
+++ b/src/pages/BreastMilkAlcoholCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -242,5 +243,6 @@ const timeUntilSafeFormatted = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="breastMilkAlcohol" class="mt-8" />
   <BlogArticleLink calculator-key="breastMilkAlcohol" />
 </template>

--- a/src/pages/BsaCalculator.vue
+++ b/src/pages/BsaCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -263,6 +264,7 @@ const allBsa = computed(() => {
       </div>
     </div>
 
+    <RelatedCalculators calc-key="bsa" class="mt-8" />
     <BlogArticleLink calculator-key="bsa" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/CaffeineCalculator.vue
+++ b/src/pages/CaffeineCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -267,5 +268,6 @@ const drinkKeys = Object.keys(DRINKS)
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="caffeine" class="mt-8" />
   <BlogArticleLink calculator-key="caffeine" />
 </template>

--- a/src/pages/CalorieDeficitCalculator.vue
+++ b/src/pages/CalorieDeficitCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -194,5 +195,6 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="calorieDeficit" class="mt-8" />
   <BlogArticleLink calculator-key="calorieDeficit" />
 </template>

--- a/src/pages/CaloriesBurnedCalculator.vue
+++ b/src/pages/CaloriesBurnedCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
@@ -202,6 +203,7 @@ const sessionOptions = [1, 2, 3, 4, 5, 6, 7]
     </div>
   </div>
 
+  <RelatedCalculators calc-key="caloriesBurned" class="mt-8" />
   <BlogArticleLink calculator-key="caloriesBurned" />
   <AffiliateBanner />
 </template>

--- a/src/pages/CardiovascularRiskCalculator.vue
+++ b/src/pages/CardiovascularRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -231,5 +232,6 @@ function reset() {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="cardiovascularRisk" class="mt-8" />
   <BlogArticleLink calculator-key="cardiovascularRisk" />
 </template>

--- a/src/pages/ChildCaloriesCalculator.vue
+++ b/src/pages/ChildCaloriesCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -273,6 +274,7 @@ const refRows = [
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="childCalories" class="mt-8" />
     <BlogArticleLink calculator-key="childCalories" />
   </div>
 </template>

--- a/src/pages/ChildDosageCalculator.vue
+++ b/src/pages/ChildDosageCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -271,6 +272,7 @@ const primaryWarning = computed(() => warnings.value[0] || null)
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="childDosage" class="mt-8" />
     <BlogArticleLink calculator-key="childDosage" />
   </div>
 </template>

--- a/src/pages/ChildGrowthCalculator.vue
+++ b/src/pages/ChildGrowthCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -386,5 +387,6 @@ function barWidth(p) {
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="childGrowth" class="mt-8" />
   <BlogArticleLink calculator-key="childGrowth" />
 </template>

--- a/src/pages/CholesterolRatioCalculator.vue
+++ b/src/pages/CholesterolRatioCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -255,5 +256,6 @@ function trigBand(ratio) {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="cholesterolRatio" class="mt-8" />
   <BlogArticleLink calculator-key="cholesterolRatio" />
 </template>

--- a/src/pages/CopdAssessmentCalculator.vue
+++ b/src/pages/CopdAssessmentCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -265,6 +266,7 @@ function reset() {
     </div>
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="copdAssessment" class="mt-8" />
     <BlogArticleLink calculator-key="copdAssessment" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/CorrectedCalciumCalculator.vue
+++ b/src/pages/CorrectedCalciumCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -238,6 +239,7 @@ function fmtSigned(v) {
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="correctedCalcium" class="mt-8" />
     <BlogArticleLink calculator-key="correctedCalcium" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/CreatinineClearanceCalculator.vue
+++ b/src/pages/CreatinineClearanceCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -205,6 +206,7 @@ const interpretation = computed(() => {
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="creatinineClearance" class="mt-8" />
     <BlogArticleLink calculator-key="creatinineClearance" />
   </div>
 </template>

--- a/src/pages/DehydrationRiskCalculator.vue
+++ b/src/pages/DehydrationRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -255,5 +256,6 @@ const requirementDisplay = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="dehydrationRisk" class="mt-8" />
   <BlogArticleLink calculator-key="dehydrationRisk" />
 </template>

--- a/src/pages/DiabetesRiskCalculator.vue
+++ b/src/pages/DiabetesRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
@@ -215,6 +216,7 @@ function switchUnit(u) {
       <p class="text-stone-500 text-base">{{ t('diabetesRisk.description') }}</p>
     </div>
 
+    <RelatedCalculators calc-key="diabetesRisk" class="mt-8" />
     <BlogArticleLink calculatorKey="diabetesRisk" />
 
     <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-6">

--- a/src/pages/DueDateCalculator.vue
+++ b/src/pages/DueDateCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -275,5 +276,6 @@ const hasResults = computed(() => !!edd.value)
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="dueDate" class="mt-8" />
   <BlogArticleLink calculator-key="dueDate" />
 </template>

--- a/src/pages/ErectileDysfunctionCalculator.vue
+++ b/src/pages/ErectileDysfunctionCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -157,5 +158,6 @@ function reset() {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="erectileDysfunction" class="mt-8" />
   <BlogArticleLink calculator-key="erectileDysfunction" />
 </template>

--- a/src/pages/FertilityWindowCalculator.vue
+++ b/src/pages/FertilityWindowCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -194,5 +195,6 @@ const hasResults = computed(() => !!window.value)
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="fertilityWindow" class="mt-8" />
   <BlogArticleLink calculator-key="fertilityWindow" />
 </template>

--- a/src/pages/FfmiRechnerCalculator.vue
+++ b/src/pages/FfmiRechnerCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -205,5 +206,6 @@ const categoryLevel = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="ffmiRechner" class="mt-8" />
   <BlogArticleLink calculator-key="ffmiRechner" />
 </template>

--- a/src/pages/GfrCalculator.vue
+++ b/src/pages/GfrCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -260,6 +261,7 @@ const ckdStage = computed(() => {
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="gfr" class="mt-8" />
     <BlogArticleLink calculator-key="gfr" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/HbA1cConverter.vue
+++ b/src/pages/HbA1cConverter.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -279,6 +280,7 @@ const hasResult = computed(() =>
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="hba1c" class="mt-8" />
     <BlogArticleLink calculator-key="hba1c" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/HeadCircumferenceCalculator.vue
+++ b/src/pages/HeadCircumferenceCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -244,5 +245,6 @@ function barWidth(p) {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="headCircumference" class="mt-8" />
   <BlogArticleLink calculator-key="headCircumference" />
 </template>

--- a/src/pages/HeartFailureRiskCalculator.vue
+++ b/src/pages/HeartFailureRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -261,5 +262,6 @@ function reset() {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="heartFailureRisk" class="mt-8" />
   <BlogArticleLink calculator-key="heartFailureRisk" />
 </template>

--- a/src/pages/HeartRateZones.vue
+++ b/src/pages/HeartRateZones.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -138,5 +139,6 @@ const zones = computed(() => {
 
 
     <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="heartRate" class="mt-8" />
   <BlogArticleLink calculator-key="heartRate" />
 </template>

--- a/src/pages/HepatitisRiskCalculator.vue
+++ b/src/pages/HepatitisRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -185,5 +186,6 @@ const categoryLevel = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="hepatitisRisk" class="mt-8" />
   <BlogArticleLink calculator-key="hepatitisRisk" />
 </template>

--- a/src/pages/IdealWeightCalculator.vue
+++ b/src/pages/IdealWeightCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -165,5 +166,6 @@ const fmt = (v) => v?.toFixed(1)
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="idealWeight" class="mt-8" />
   <BlogArticleLink calculator-key="idealWeight" />
 </template>

--- a/src/pages/IntermittentFastingCalculator.vue
+++ b/src/pages/IntermittentFastingCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -216,6 +217,7 @@ const timelineSegments = computed(() => {
 
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+  <RelatedCalculators calc-key="intermittentFasting" class="mt-8" />
   <BlogArticleLink calculator-key="intermittentFasting" />
   <AffiliateBanner />
 </template>

--- a/src/pages/IronDeficiencyCalculator.vue
+++ b/src/pages/IronDeficiencyCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -309,5 +310,6 @@ const ferritinUnit = computed(() => unit.value === 'si' ? 'µg/L' : 'ng/mL')
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="ironDeficiency" class="mt-8" />
   <BlogArticleLink calculator-key="ironDeficiency" />
 </template>

--- a/src/pages/KetoCalculator.vue
+++ b/src/pages/KetoCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -261,5 +262,6 @@ const macros = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="keto" class="mt-8" />
   <BlogArticleLink calculator-key="keto" />
 </template>

--- a/src/pages/LeanBodyMassCalculator.vue
+++ b/src/pages/LeanBodyMassCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -171,5 +172,6 @@ const heightLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'cm'
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="leanBodyMass" class="mt-8" />
   <BlogArticleLink calculator-key="leanBodyMass" />
 </template>

--- a/src/pages/LifeExpectancyCalculator.vue
+++ b/src/pages/LifeExpectancyCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -493,5 +494,6 @@ const countryKeys = Object.keys(BASE_LE)
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="lifeExpectancy" class="mt-8" />
   <BlogArticleLink calculator-key="lifeExpectancy" />
 </template>

--- a/src/pages/MacroCalculator.vue
+++ b/src/pages/MacroCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -222,5 +223,6 @@ const macros = computed(() => {
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="macro" class="mt-8" />
   <BlogArticleLink calculator-key="macro" />
 </template>

--- a/src/pages/MalePatternCalculator.vue
+++ b/src/pages/MalePatternCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -164,5 +165,6 @@ function reset() {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="malePattern" class="mt-8" />
   <BlogArticleLink calculator-key="malePattern" />
 </template>

--- a/src/pages/MenopauseSymptomCalculator.vue
+++ b/src/pages/MenopauseSymptomCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -224,5 +225,6 @@ const severityLevels = [0, 1, 2, 3, 4]
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="menopauseSymptom" class="mt-8" />
   <BlogArticleLink calculator-key="menopauseSymptom" />
 </template>

--- a/src/pages/NewbornBilirubinCalculator.vue
+++ b/src/pages/NewbornBilirubinCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -161,6 +162,7 @@ function formatThreshold(value) {
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="newbornBilirubin" class="mt-8" />
     <BlogArticleLink calculator-key="newbornBilirubin" />
   </div>
 </template>

--- a/src/pages/OneRepMaxCalculator.vue
+++ b/src/pages/OneRepMaxCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
@@ -178,6 +179,7 @@ const percentageChart = computed(() => {
     <p class="text-sm text-stone-500 leading-relaxed">{{ t('oneRepMax.howItWorksText') }}</p>
   </div>
 
+  <RelatedCalculators calc-key="oneRepMax" class="mt-8" />
   <BlogArticleLink calculator-key="oneRepMax" />
   <AffiliateBanner />
 </template>

--- a/src/pages/OsteoporosisRiskCalculator.vue
+++ b/src/pages/OsteoporosisRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -276,5 +277,6 @@ const heightUnit = computed(() => unit.value === 'imperial' ? 'in' : 'cm')
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="osteoporosisRisk" class="mt-8" />
   <BlogArticleLink calculator-key="osteoporosisRisk" />
 </template>

--- a/src/pages/OvulationCalculator.vue
+++ b/src/pages/OvulationCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -173,5 +174,6 @@ const hasResults = computed(() => !!lmpDate.value)
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="ovulation" class="mt-8" />
   <BlogArticleLink calculator-key="ovulation" />
 </template>

--- a/src/pages/PainScaleCalculator.vue
+++ b/src/pages/PainScaleCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -221,6 +222,7 @@ const categoryRows = [
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="painScale" class="mt-8" />
     <BlogArticleLink calculator-key="painScale" />
   </div>
 </template>

--- a/src/pages/PcosSymptomsCalculator.vue
+++ b/src/pages/PcosSymptomsCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -224,5 +225,6 @@ const categoryBg = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="pcosSymptoms" class="mt-8" />
   <BlogArticleLink calculator-key="pcosSymptoms" />
 </template>

--- a/src/pages/PearlIndexRechnerCalculator.vue
+++ b/src/pages/PearlIndexRechnerCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -180,5 +181,6 @@ function formatPi(value) {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="pearlIndexRechner" class="mt-8" />
   <BlogArticleLink calculator-key="pearlIndexRechner" />
 </template>

--- a/src/pages/PediatricBloodPressureCalculator.vue
+++ b/src/pages/PediatricBloodPressureCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -182,6 +183,7 @@ const interpretation = computed(() => {
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="pediatricBloodPressure" class="mt-8" />
     <BlogArticleLink calculator-key="pediatricBloodPressure" />
   </div>
 </template>

--- a/src/pages/PeriodCalculator.vue
+++ b/src/pages/PeriodCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -195,5 +196,6 @@ const hasResults = computed(() => !!lmpDate.value)
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="period" class="mt-8" />
   <BlogArticleLink calculator-key="period" />
 </template>

--- a/src/pages/PmsSymptomCalculator.vue
+++ b/src/pages/PmsSymptomCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -210,5 +211,6 @@ const progressPct = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="pmsSymptom" class="mt-8" />
   <BlogArticleLink calculator-key="pmsSymptom" />
 </template>

--- a/src/pages/PregnancyBMICalculator.vue
+++ b/src/pages/PregnancyBMICalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -224,5 +225,6 @@ const categoryColor = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="pregnancyBMI" class="mt-8" />
   <BlogArticleLink calculator-key="pregnancyBMI" />
 </template>

--- a/src/pages/PregnancyCalculator.vue
+++ b/src/pages/PregnancyCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -175,5 +176,6 @@ const hasResults = computed(() => !!lmpDate.value)
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="pregnancy" class="mt-8" />
   <BlogArticleLink calculator-key="pregnancy" />
 </template>

--- a/src/pages/PregnancyCaloriesCalculator.vue
+++ b/src/pages/PregnancyCaloriesCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -289,6 +290,7 @@ const trimesterRows = [
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="pregnancyCalories" class="mt-8" />
     <BlogArticleLink calculator-key="pregnancyCalories" />
   </div>
 </template>

--- a/src/pages/PregnancyWeightGainCalculator.vue
+++ b/src/pages/PregnancyWeightGainCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -334,5 +335,6 @@ const yAxisTicks = computed(() => {
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="pregnancyWeightGain" class="mt-8" />
   <BlogArticleLink calculator-key="pregnancyWeightGain" />
 </template>

--- a/src/pages/ProstateRiskCalculator.vue
+++ b/src/pages/ProstateRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -174,5 +175,6 @@ const categoryBg = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="prostateRisk" class="mt-8" />
   <BlogArticleLink calculator-key="prostateRisk" />
 </template>

--- a/src/pages/ProteinCalculator.vue
+++ b/src/pages/ProteinCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -287,5 +288,6 @@ const foodSources = computed(() => {
 
 
     <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="protein" class="mt-8" />
   <BlogArticleLink calculator-key="protein" />
 </template>

--- a/src/pages/ProteinNeedCalculator.vue
+++ b/src/pages/ProteinNeedCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -286,5 +287,6 @@ const foodExamples = computed(() => [
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="proteinNeed" class="mt-8" />
   <BlogArticleLink calculator-key="proteinNeed" />
 </template>

--- a/src/pages/RunningPaceCalculator.vue
+++ b/src/pages/RunningPaceCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -334,6 +335,7 @@ function formatPace(secPerKm) {
 
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+  <RelatedCalculators calc-key="runningPace" class="mt-8" />
   <BlogArticleLink calculator-key="runningPace" />
   <AffiliateBanner />
 </template>

--- a/src/pages/SchritteKalorienRechnerCalculator.vue
+++ b/src/pages/SchritteKalorienRechnerCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -194,6 +195,7 @@ const referenceRows = [
 
     <AdSlot class="mt-8" />
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="schritteKalorienRechner" class="mt-8" />
     <BlogArticleLink calculator-key="schritteKalorienRechner" />
   </div>
 </template>

--- a/src/pages/SleepCycleCalculator.vue
+++ b/src/pages/SleepCycleCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -136,5 +137,6 @@ const options = computed(() => {
 
 
     <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="sleep" class="mt-8" />
   <BlogArticleLink calculator-key="sleep" />
 </template>

--- a/src/pages/SmokingCostCalculator.vue
+++ b/src/pages/SmokingCostCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -252,5 +253,6 @@ function fmt(value) {
   </div>
 
   <AdSlot class="mt-8" />
+  <RelatedCalculators calc-key="smokingCost" class="mt-8" />
   <BlogArticleLink calculator-key="smokingCost" />
 </template>

--- a/src/pages/SodiumCorrectionCalculator.vue
+++ b/src/pages/SodiumCorrectionCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -253,6 +254,7 @@ const plausibilityWarning = computed(() => {
 
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+    <RelatedCalculators calc-key="sodiumCorrection" class="mt-8" />
     <BlogArticleLink calculator-key="sodiumCorrection" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/StrokeRiskCalculator.vue
+++ b/src/pages/StrokeRiskCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -241,5 +242,6 @@ const referenceRows = [
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="strokeRisk" class="mt-8" />
   <BlogArticleLink calculator-key="strokeRisk" />
 </template>

--- a/src/pages/TdeeCalculator.vue
+++ b/src/pages/TdeeCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -165,5 +166,6 @@ const formatNumber = (n) => Math.round(n).toLocaleString()
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="tdee" class="mt-8" />
   <BlogArticleLink calculator-key="tdee" />
 </template>

--- a/src/pages/TestosteroneLevelCalculator.vue
+++ b/src/pages/TestosteroneLevelCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -178,5 +179,6 @@ const freeColor = computed(() => {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="testosteroneLevel" class="mt-8" />
   <BlogArticleLink calculator-key="testosteroneLevel" />
 </template>

--- a/src/pages/ThyroidFunctionCalculator.vue
+++ b/src/pages/ThyroidFunctionCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -219,5 +220,6 @@ function reset() {
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="thyroidFunction" class="mt-8" />
   <BlogArticleLink calculator-key="thyroidFunction" />
 </template>

--- a/src/pages/VitaminDCalculator.vue
+++ b/src/pages/VitaminDCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -419,6 +420,7 @@ const statusColors = {
       </p>
     </div>
 
+    <RelatedCalculators calc-key="vitaminD" class="mt-8" />
     <BlogArticleLink calculator-key="vitaminD" />
     <AdSlot class="mt-8" />
   </div>

--- a/src/pages/Vo2MaxCalculator.vue
+++ b/src/pages/Vo2MaxCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
@@ -282,6 +283,7 @@ const testTypes = [
 
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
+  <RelatedCalculators calc-key="vo2Max" class="mt-8" />
   <BlogArticleLink calculator-key="vo2Max" />
   <AffiliateBanner />
 </template>

--- a/src/pages/WaistHipRatioCalculator.vue
+++ b/src/pages/WaistHipRatioCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -165,5 +166,6 @@ const recColors = { low: 'text-green-600', moderate: 'text-yellow-600', high: 't
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="waistHipRatio" class="mt-8" />
   <BlogArticleLink calculator-key="waistHipRatio" />
 </template>

--- a/src/pages/WaterIntakeCalculator.vue
+++ b/src/pages/WaterIntakeCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -151,5 +152,6 @@ const glassRatio = computed(() => {
 
     <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="water" class="mt-8" />
   <BlogArticleLink calculator-key="water" />
 </template>

--- a/src/pages/WhtrRechnerCalculator.vue
+++ b/src/pages/WhtrRechnerCalculator.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
@@ -172,5 +173,6 @@ const halfHeight = computed(() => (height.value ? (height.value / 2).toFixed(1) 
 
   <AdSlot class="mt-8" />
   <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+  <RelatedCalculators calc-key="whtrRechner" class="mt-8" />
   <BlogArticleLink calculator-key="whtrRechner" />
 </template>


### PR DESCRIPTION
## Summary
- New `src/components/RelatedCalculators.vue` (~40 LOC) — pattern parallel to `RelatedArticles.vue`. Reads `calculatorMetas` from `src/discovery.js`, filters by current `group`, sorts by `key`, slices to 4, renders `<router-link>` via `useLocaleRouter().localePath`. Bilingual heading ("Verwandte Rechner" / "Related Calculators"). `data-testid="related-calculators"` on outer wrapper.
- Integrated into **85 calc pages** in `src/pages/*.vue` (every non-`blogOnly` meta), injected before `<BlogArticleLink>` (or before `<AdSlot>` on the 2 calc pages without `<BlogArticleLink>`: `BmiFrauenCalculator.vue`, `BmiMaennerCalculator.vue`).
- 4 vitest unit tests + 1 Playwright e2e test.

## Scope note vs. spec
The spec mentioned 89 calc-vues. Actual non-`blogOnly` count is **85** (88 `*.meta.js` minus 3 `blogOnly: true`). The 4-file delta is `Home.vue`, `BlogHome.vue`, `BlogHomeEn.vue`, `NotFound.vue` — explicitly excluded by the spec's negative constraints. All 85 eligible calc views were edited.

## SEO impact
- **+340 new internal links total** (85 pages × 4 sibling links per language; both languages share the same Vue file so both locales get the block).
- Note: the spec estimated "+712 total" assuming 89 × 2 languages × 4. With 85 calc pages and a shared component covering both locales, actual count is 85 × 4 = 340 link slots (rendered locale-aware at runtime).
- Spoke-to-spoke wiring within `bodyComposition` (11), `fitnessRecovery` (45), `nutritionEnergy` (12), `pregnancy` (17).
- **Sitemap URL count: 346 (unchanged)** — confirmed in build output.

## Quality gate
- `npm test` ✅ — 89 test files, 2352 tests passing (incl. 4 new in `relatedCalculators.test.js`).
- `npm run build` ✅ — vite-ssg + sitemap (346 URLs) + llms.txt (342 links).
- `npx playwright test` ✅ — 1010/1010 passing (incl. new `e2e/related-calculators.spec.js`).

## Test plan
- [x] Unit: returns ≤4 same-group siblings sorted alphabetically, excludes current calc
- [x] Unit: renders nothing for unknown `calcKey`
- [x] Unit: renders nothing when group has only one calculator
- [x] E2E: `/de/one-rep-max-rechner/` shows 4 visible sibling links under `[data-testid="related-calculators"]`
- [x] Spot-checked AlcoholUnitsCalculator.vue (BlogArticleLink anchor) and BmiFrauenCalculator.vue (AdSlot fallback anchor)

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)