### PR TITLE
hc-263-trailing-slash-minipc: Implement issue jenslaufer/health-calculators#263 verbatim p

### DIFF
--- a/src/__tests__/lang-toggle.test.js
+++ b/src/__tests__/lang-toggle.test.js
@@ -28,8 +28,8 @@ function makeRouter(calc) {
       { path: '/', redirect: '/de/' },
       { path: '/de/', component: DummyView, meta: { routeKey: 'home', locale: 'de' } },
       { path: '/en/', component: DummyView, meta: { routeKey: 'home', locale: 'en' } },
-      { path: `/de/${calc.slugs.de}`, component: DummyView, meta: { routeKey: calc.key, locale: 'de' } },
-      { path: `/en/${calc.slugs.en}`, component: DummyView, meta: { routeKey: calc.key, locale: 'en' } },
+      { path: `/de/${calc.slugs.de}/`, component: DummyView, meta: { routeKey: calc.key, locale: 'de' } },
+      { path: `/en/${calc.slugs.en}/`, component: DummyView, meta: { routeKey: calc.key, locale: 'en' } },
       { path: '/:pathMatch(.*)*', component: DummyView },
     ],
   })
@@ -47,39 +47,39 @@ async function mountApp(calc, path, locale = 'de') {
 describe('lang toggle — crawlable <a href> (issue #258)', () => {
   it('DE /de/<bmi-de-slug> renders <a href> pointing to EN counterpart', async () => {
     const first = calculatorMetas[0]
-    const { wrapper } = await mountApp(first, `/de/${first.slugs.de}`, 'de')
-    const anchors = wrapper.findAll(`a[href="/en/${first.slugs.en}"]`)
+    const { wrapper } = await mountApp(first, `/de/${first.slugs.de}/`, 'de')
+    const anchors = wrapper.findAll(`a[href="/en/${first.slugs.en}/"]`)
     expect(anchors.length).toBeGreaterThanOrEqual(1)
   })
 
   it('EN counterpart renders <a href> pointing to DE counterpart', async () => {
     const first = calculatorMetas[0]
-    const { wrapper } = await mountApp(first, `/en/${first.slugs.en}`, 'en')
-    const anchors = wrapper.findAll(`a[href="/de/${first.slugs.de}"]`)
+    const { wrapper } = await mountApp(first, `/en/${first.slugs.en}/`, 'en')
+    const anchors = wrapper.findAll(`a[href="/de/${first.slugs.de}/"]`)
     expect(anchors.length).toBeGreaterThanOrEqual(1)
   })
 
   it('toggle is an <a> element, not a <button>', async () => {
     const first = calculatorMetas[0]
-    const { wrapper } = await mountApp(first, `/de/${first.slugs.de}`, 'de')
+    const { wrapper } = await mountApp(first, `/de/${first.slugs.de}/`, 'de')
     expect(wrapper.find('a[aria-label="Switch to English"]').exists()).toBe(true)
     expect(wrapper.find('button[aria-label="Switch to English"]').exists()).toBe(false)
   })
 
   it('click navigates via router to other locale (no hard reload)', async () => {
     const first = calculatorMetas[0]
-    const { wrapper, router } = await mountApp(first, `/de/${first.slugs.de}`, 'de')
+    const { wrapper, router } = await mountApp(first, `/de/${first.slugs.de}/`, 'de')
     const toggle = wrapper.find('a[aria-label="Switch to English"]')
     await toggle.trigger('click')
     await flushPromises()
-    expect(router.currentRoute.value.path).toBe(`/en/${first.slugs.en}`)
+    expect(router.currentRoute.value.path).toBe(`/en/${first.slugs.en}/`)
   })
 
   it('samples 5 DE calc slugs — all render <a href> pointing to EN counterpart', async () => {
     const samples = calculatorMetas.slice(0, 5)
     for (const calc of samples) {
-      const { wrapper } = await mountApp(calc, `/de/${calc.slugs.de}`, 'de')
-      const expectedHref = `/en/${calc.slugs.en}`
+      const { wrapper } = await mountApp(calc, `/de/${calc.slugs.de}/`, 'de')
+      const expectedHref = `/en/${calc.slugs.en}/`
       const anchors = wrapper.findAll(`a[href="${expectedHref}"]`)
       expect(anchors.length, `Expected <a href="${expectedHref}"> for /de/${calc.slugs.de}`).toBeGreaterThanOrEqual(1)
     }

--- a/src/composables/useLocaleRouter.js
+++ b/src/composables/useLocaleRouter.js
@@ -19,7 +19,7 @@ export { routeMap, keyToGroup }
 export function localePath(routeKey, locale) {
   const slug = routeMap[routeKey]?.[locale]
   if (slug === undefined) return `/${locale}/`
-  return slug ? `/${locale}/${slug}` : `/${locale}/`
+  return slug ? `/${locale}/${slug}/` : `/${locale}/`
 }
 
 export function localeBlogPath(slug, locale) {


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-263-trailing-slash-minipc
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-263-trailing-slash-minipc-20260522-144027`
**Cost:** $0.9919595

Closes jenslaufer/health-calculators#263

### Prompt
> Implement issue jenslaufer/health-calculators#263 verbatim per the spec below.
Goal: A/B comparison against fabrik worker on the same ticket — keep the diff
minimal and follow the spec literally. Do NOT improvise field names, values,
or scope.

## Befund
Das gestern gemergte `RelatedCalculators.vue` (PR #261) emittiert Links ohne
Trailing-Slash, obwohl die kanonische URL-Form mit Trailing-Slash ist. Jeder
Klick/Crawler-Hop löst einen 301-Redirect aus. Root-Cause liegt in
`src/composables/useLocaleRouter.js` Zeile 22 — `localePath()` gibt für
nicht-leere Slugs keinen Trailing-Slash zurück.

## Fix (Option A, minimal-invasiv, empfohlen)
`src/composables/useLocaleRouter.js` Zeile 22:

```diff
-  return slug ? `/${locale}/${slug}` : `/${locale}/`
+  return slug ? `/${locale}/${slug}/` : `/${locale}/`
```

`localeBlogPath` Zeile 26 ggf. analog (`/${locale}/blog/${slug}/`) — erst
prüfen ob Blog-Pages auf Production trailing-slash kanonisch sind. Falls ja,
anpassen; falls nein, unverändert lassen.

## Test-Update
- `src/composables/__tests__/useLocaleRouter.test.js` falls vorhanden:
  `localePath()`-Assertions um Trailing-Slash erweitern.
- `src/__tests__/relatedCalculators.test.js` falls `to`-Assertions die alte
  Form prüfen: anpassen.

## Acceptance
- [ ] `localePath()` emittiert Trailing-Slash für Calc-Slugs.
- [ ] `localeBlogPath()` verifiziert (mit oder ohne, je nach Production-Form).
- [ ] `npm test` grün.
- [ ] `npm run build` grün.
- [ ] `npx playwright test` grün.

## Negative Constraints
- KEIN Touch an `discovery.js`, `articles.js`, oder Router-Config.
- KEIN Refactor von `switchLocale`/`switchLocalePath`.
- Trailing-Slash-Logik bleibt single-source in `localePath()` (kein
  per-Component-Append).
- KEIN Touch an Files außerhalb des Scopes.
- DO NOT DELETE unrelated files.

## Final QG (abort on any failure before push)
1. `npm test` — must pass.
2. `npm run build` — must succeed.
3. `npx playwright test` — must pass.
Abort if any stage fails; do NOT push a broken branch.