### PR TITLE
hc-128-pediatric-bmi: Implement the Pediatric BMI Calculator as described in issue

### DIFF
--- a/e2e/pediatricBmi.spec.js
+++ b/e2e/pediatricBmi.spec.js
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Pediatric BMI Calculator', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/kinder-bmi-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Kinder-BMI/)
+  })
+
+  test('shows all required inputs', async ({ page }) => {
+    await expect(page.getByTestId('age')).toBeVisible()
+    await expect(page.getByTestId('weight')).toBeVisible()
+    await expect(page.getByTestId('height')).toBeVisible()
+    await expect(page.getByTestId('sex-male')).toBeVisible()
+    await expect(page.getByTestId('sex-female')).toBeVisible()
+    await expect(page.getByTestId('unit-metric')).toBeVisible()
+    await expect(page.getByTestId('unit-imperial')).toBeVisible()
+  })
+
+  test('no result shown without inputs', async ({ page }) => {
+    await expect(page.getByTestId('result-card')).not.toBeVisible()
+  })
+
+  test('result appears after entering valid age, weight, height', async ({ page }) => {
+    await page.fill('[data-testid="age"]', '10')
+    await page.fill('[data-testid="weight"]', '32')
+    await page.fill('[data-testid="height"]', '138')
+    await expect(page.getByTestId('result-card')).toBeVisible()
+    await expect(page.getByTestId('result-bmi')).toBeVisible()
+    await expect(page.getByTestId('result-percentile')).toBeVisible()
+    await expect(page.getByTestId('result-category')).toBeVisible()
+  })
+
+  test('shows healthy category for median boy at age 10', async ({ page }) => {
+    await page.getByTestId('sex-male').check()
+    await page.fill('[data-testid="age"]', '10')
+    await page.fill('[data-testid="weight"]', '32')
+    await page.fill('[data-testid="height"]', '141')
+    const text = await page.getByTestId('result-category').textContent()
+    expect(text).toMatch(/Normalgewicht/)
+  })
+
+  test('shows obesity category for very high BMI', async ({ page }) => {
+    await page.getByTestId('sex-male').check()
+    await page.fill('[data-testid="age"]', '10')
+    await page.fill('[data-testid="weight"]', '60')
+    await page.fill('[data-testid="height"]', '140')
+    const text = await page.getByTestId('result-category').textContent()
+    expect(text).toMatch(/Adipositas/)
+  })
+
+  test('switching to imperial unit converts inputs correctly', async ({ page }) => {
+    await page.getByTestId('sex-male').check()
+    await page.fill('[data-testid="age"]', '10')
+    await page.fill('[data-testid="weight"]', '32')
+    await page.fill('[data-testid="height"]', '141')
+    const metricBmi = await page.getByTestId('result-bmi').textContent()
+
+    await page.getByTestId('unit-imperial').click()
+    await page.fill('[data-testid="weight"]', '70.5')
+    await page.fill('[data-testid="height"]', '55.5')
+    const imperialBmi = await page.getByTestId('result-bmi').textContent()
+
+    expect(Math.abs(parseFloat(metricBmi) - parseFloat(imperialBmi))).toBeLessThan(0.3)
+  })
+
+  test('English route works', async ({ page }) => {
+    await page.goto('en/pediatric-bmi')
+    await expect(page).toHaveTitle(/Pediatric BMI/)
+  })
+
+  test('German blog route works', async ({ page }) => {
+    await page.goto('de/blog/kinder-bmi-berechnen')
+    await expect(page).toHaveTitle(/Kinder-BMI/)
+  })
+
+  test('English blog route works', async ({ page }) => {
+    await page.goto('en/blog/pediatric-bmi-guide')
+    await expect(page).toHaveTitle(/Pediatric BMI/)
+  })
+
+  test('switching sex changes the percentile result', async ({ page }) => {
+    await page.getByTestId('sex-male').check()
+    await page.fill('[data-testid="age"]', '10')
+    await page.fill('[data-testid="weight"]', '32')
+    await page.fill('[data-testid="height"]', '138')
+    const maleText = await page.getByTestId('result-percentile').textContent()
+
+    await page.getByTestId('sex-female').check()
+    const femaleText = await page.getByTestId('result-percentile').textContent()
+
+    expect(maleText).not.toBe(femaleText)
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -27,6 +27,7 @@ const EXPECTED_KEYS = [
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
   'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'pmsSymptom', 'breastCancerRisk',
+  'pediatricBmi',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -115,6 +116,7 @@ const EXPECTED_ROUTE_MAP = {
   pregnancyCalories: { de: 'kalorienbedarf-schwangerschaft-rechner', en: 'pregnancy-calorie-needs-calculator' },
   pmsSymptom: { de: 'pms-symptome-rechner', en: 'pms-symptom-calculator' },
   breastCancerRisk: { de: 'brustkrebs-risiko-rechner', en: 'breast-cancer-risk-calculator' },
+  pediatricBmi: { de: 'kinder-bmi-rechner', en: 'pediatric-bmi' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -192,6 +194,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'menopause-natuerlich-begleiten',
   'pms-symptome-bewerten',
   'brustkrebs-risiko-berechnen',
+  'kinder-bmi-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -269,19 +272,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'menopause-natural-relief',
   'pms-symptom-calculator-guide',
   'breast-cancer-risk-calculator-guide',
+  'pediatric-bmi-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 85 calculators', () => {
-    expect(calculatorMetas).toHaveLength(85)
+  it('discovers all 86 calculators', () => {
+    expect(calculatorMetas).toHaveLength(86)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 85 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(85)
+  it('builds calculatorComponents map for all 86 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(86)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -304,15 +308,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 86 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(86)
+  it('discovers all 87 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(87)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 86 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(86)
+  it('discovers all 87 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(87)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -337,10 +341,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 85 calculators with no duplicates', () => {
+  it('groups contain all 86 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(85)
-    expect(new Set(allKeys).size).toBe(85)
+    expect(allKeys).toHaveLength(86)
+    expect(new Set(allKeys).size).toBe(86)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -361,7 +365,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -410,8 +414,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 470 routes', () => {
-    expect(routes).toHaveLength(470)
+  it('generates exactly 475 routes', () => {
+    expect(routes).toHaveLength(475)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 342 links (85 calcs × 2 locales + 86 blogs × 2 locales)', () => {
+  it('generates 346 links (86 calcs × 2 locales + 87 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(342)
+    expect(links).toHaveLength(346)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/pediatricBmi.test.js
+++ b/src/__tests__/pediatricBmi.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcBmi,
+  convertWeightToKg,
+  convertHeightToCm,
+  calcBmiPercentile,
+  getCategory,
+  LMS_BOYS,
+  LMS_GIRLS,
+} from '../utils/pediatricBmi.js'
+
+describe('calcBmi', () => {
+  it('calculates BMI from kg and cm', () => {
+    expect(calcBmi(30, 130)).toBeCloseTo(17.75, 1)
+  })
+  it('returns null for invalid inputs', () => {
+    expect(calcBmi(0, 130)).toBeNull()
+    expect(calcBmi(30, 0)).toBeNull()
+    expect(calcBmi(null, 130)).toBeNull()
+    expect(calcBmi(30, null)).toBeNull()
+    expect(calcBmi(NaN, 130)).toBeNull()
+  })
+})
+
+describe('unit conversion', () => {
+  it('converts pounds to kg (imperial)', () => {
+    expect(convertWeightToKg(100, 'imperial')).toBeCloseTo(45.36, 1)
+  })
+  it('converts inches to cm (imperial)', () => {
+    expect(convertHeightToCm(50, 'imperial')).toBeCloseTo(127.0, 1)
+  })
+  it('returns same value for metric', () => {
+    expect(convertWeightToKg(30, 'metric')).toBe(30)
+    expect(convertHeightToCm(130, 'metric')).toBe(130)
+  })
+  it('returns null for invalid input', () => {
+    expect(convertWeightToKg(0, 'metric')).toBeNull()
+    expect(convertHeightToCm(-5, 'metric')).toBeNull()
+    expect(convertWeightToKg(null, 'metric')).toBeNull()
+  })
+  it('end-to-end imperial flow yields same BMI as metric', () => {
+    const wKg = convertWeightToKg(66, 'imperial')   // ≈ 29.94 kg
+    const hCm = convertHeightToCm(51, 'imperial')   // ≈ 129.54 cm
+    const bmiImperial = calcBmi(wKg, hCm)
+    const bmiMetric = calcBmi(29.94, 129.54)
+    expect(Math.abs(bmiImperial - bmiMetric)).toBeLessThan(0.05)
+  })
+})
+
+describe('calcBmiPercentile - boundary ages', () => {
+  it('handles boys at age 2 (lower boundary)', () => {
+    const p = calcBmiPercentile(16.57, 2, 'male')
+    expect(p).not.toBeNull()
+    expect(p).toBeGreaterThan(40)
+    expect(p).toBeLessThan(60)
+  })
+  it('handles girls at age 20 (upper boundary)', () => {
+    const p = calcBmiPercentile(21.18, 20, 'female')
+    expect(p).not.toBeNull()
+    expect(p).toBeGreaterThan(40)
+    expect(p).toBeLessThan(60)
+  })
+  it('handles boys at age 20 (upper boundary)', () => {
+    const p = calcBmiPercentile(19.63, 20, 'male')
+    expect(p).not.toBeNull()
+    expect(p).toBeGreaterThan(40)
+    expect(p).toBeLessThan(60)
+  })
+  it('handles girls at age 2 (lower boundary)', () => {
+    const p = calcBmiPercentile(16.14, 2, 'female')
+    expect(p).not.toBeNull()
+    expect(p).toBeGreaterThan(40)
+    expect(p).toBeLessThan(60)
+  })
+  it('returns null for age below 2', () => {
+    expect(calcBmiPercentile(16, 1, 'male')).toBeNull()
+  })
+  it('returns null for age above 20', () => {
+    expect(calcBmiPercentile(20, 21, 'male')).toBeNull()
+  })
+  it('returns null for invalid bmi', () => {
+    expect(calcBmiPercentile(0, 10, 'male')).toBeNull()
+    expect(calcBmiPercentile(null, 10, 'male')).toBeNull()
+  })
+})
+
+describe('getCategory boundary edges', () => {
+  it('classifies underweight strictly below 5th percentile', () => {
+    expect(getCategory(3)).toBe('underweight')
+    expect(getCategory(4.99)).toBe('underweight')
+  })
+  it('classifies healthy at exactly 5th percentile', () => {
+    expect(getCategory(5)).toBe('healthy')
+    expect(getCategory(50)).toBe('healthy')
+    expect(getCategory(84.99)).toBe('healthy')
+  })
+  it('classifies overweight at 85th percentile', () => {
+    expect(getCategory(85)).toBe('overweight')
+    expect(getCategory(94.99)).toBe('overweight')
+  })
+  it('classifies obesity at 95th percentile and above', () => {
+    expect(getCategory(95)).toBe('obesity')
+    expect(getCategory(99)).toBe('obesity')
+  })
+  it('returns null for null/invalid input', () => {
+    expect(getCategory(null)).toBeNull()
+    expect(getCategory(undefined)).toBeNull()
+    expect(getCategory(NaN)).toBeNull()
+  })
+})
+
+describe('CDC LMS tables', () => {
+  it('boys table covers 2–20 years', () => {
+    expect(LMS_BOYS[0][0]).toBe(2)
+    expect(LMS_BOYS[LMS_BOYS.length - 1][0]).toBe(20)
+  })
+  it('girls table covers 2–20 years', () => {
+    expect(LMS_GIRLS[0][0]).toBe(2)
+    expect(LMS_GIRLS[LMS_GIRLS.length - 1][0]).toBe(20)
+  })
+  it('LMS tables produce different percentiles for boys vs girls at age 10', () => {
+    const boyPct = calcBmiPercentile(17, 10, 'male')
+    const girlPct = calcBmiPercentile(17, 10, 'female')
+    expect(boyPct).not.toBe(girlPct)
+  })
+})
+
+describe('percentile-to-category integration', () => {
+  it('produces obesity category for very high BMI', () => {
+    const p = calcBmiPercentile(28, 10, 'male')
+    expect(getCategory(p)).toBe('obesity')
+  })
+  it('produces underweight category for very low BMI', () => {
+    const p = calcBmiPercentile(12, 10, 'male')
+    expect(getCategory(p)).toBe('underweight')
+  })
+  it('produces healthy category for median BMI', () => {
+    const p = calcBmiPercentile(16.03, 10, 'male')
+    expect(getCategory(p)).toBe('healthy')
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -21,6 +21,7 @@ const EXPECTED_KEYS = [
   'painScale', 'newbornBilirubin', 'schritteKalorienRechner', 'childCalories', 'pediatricBloodPressure',
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
   'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'pmsSymptom', 'breastCancerRisk',
+  'pediatricBmi',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -97,6 +98,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'menopause-natuerlich-begleiten',
   'pms-symptome-bewerten',
   'brustkrebs-risiko-berechnen',
+  'kinder-bmi-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -173,12 +175,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'menopause-natural-relief',
   'pms-symptom-calculator-guide',
   'breast-cancer-risk-calculator-guide',
+  'pediatric-bmi-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 85 calculator meta files', () => {
+  it('discovers all 86 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(85)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(86)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -216,19 +219,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 86 DE blog slugs', () => {
+  it('returns all 87 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(86)
+    expect(de).toHaveLength(87)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 86 EN blog slugs', () => {
+  it('returns all 87 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(86)
+    expect(en).toHaveLength(87)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -296,9 +299,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 170 calcs + 2 blog index + 172 blog articles = 346)', () => {
+  it('generates correct total URL count (2 home + 172 calcs + 2 blog index + 174 blog articles = 350)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(346)
+    expect(urlCount).toBe(350)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -773,6 +773,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'pmsSymptom',
     related: ['menopause-symptom-calculator-guide', 'pcos-symptom-checker', 'calculate-ovulation'],
   },
+  {
+    slug: 'pediatric-bmi-guide',
+    title: 'Pediatric BMI Calculator: Understanding CDC Growth Percentiles',
+    description: 'Pediatric BMI explained: why adult BMI cutoffs fail for children, how CDC growth-chart percentiles work, and when to see a pediatrician.',
+    date: '2026-05-26',
+    readTime: '7 min',
+    calculatorKey: 'pediatricBmi',
+    related: ['calculate-bmi', 'child-growth-percentile-chart', 'child-calorie-needs-guide'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -773,6 +773,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'pmsSymptom',
     related: ['menopause-symptome-bewerten', 'pcos-symptome-erkennen', 'eisprung-berechnen'],
   },
+  {
+    slug: 'kinder-bmi-berechnen',
+    title: 'Kinder-BMI berechnen: CDC-Perzentile richtig verstehen',
+    description: 'Kinder-BMI nach CDC-Perzentile berechnen und richtig einordnen. Warum Erwachsenen-Grenzen nicht passen, was 5./85./95. Perzentile bedeutet und wann der Kinderarzt schauen sollte.',
+    date: '2026-05-26',
+    readTime: '7 min',
+    calculatorKey: 'pediatricBmi',
+    related: ['bmi-berechnen', 'wachstumsperzentile-kinder', 'kinder-kalorienbedarf-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/pediatricBmi.json
+++ b/src/locales/calculators/de/pediatricBmi.json
@@ -1,0 +1,52 @@
+{
+  "home": {
+    "calculators": {
+      "pediatricBmi": {
+        "name": "Kinder-BMI-Rechner",
+        "description": "BMI für Kinder (2–20 Jahre) nach CDC-Perzentilen — alters- und geschlechtsspezifisch."
+      }
+    }
+  },
+  "pediatricBmi": {
+    "meta": {
+      "title": "Kinder-BMI-Rechner — CDC-Perzentile 2–20 Jahre | Health Calculators",
+      "description": "Kinder-BMI nach CDC-Perzentile berechnen. Alters- und geschlechtsspezifische Bewertung: Untergewicht, Normalgewicht, Übergewicht oder Adipositas."
+    },
+    "title": "Kinder-BMI-Rechner",
+    "description": "BMI für Kinder und Jugendliche von 2 bis 20 Jahren nach CDC-Perzentile bewerten.",
+    "inputsLabel": "Angaben zum Kind",
+    "sex": "Geschlecht",
+    "male": "Junge",
+    "female": "Mädchen",
+    "age": "Alter (Jahre)",
+    "weight": "Gewicht",
+    "height": "Größe",
+    "metric": "Metrisch (kg/cm)",
+    "imperial": "Imperial (lbs/in)",
+    "resultsLabel": "Ergebnis",
+    "bmiLabel": "BMI",
+    "percentileLabel": "CDC-Perzentile",
+    "categories": "CDC-Kategorien",
+    "cat": {
+      "underweight": "Untergewicht",
+      "healthy": "Normalgewicht",
+      "overweight": "Übergewicht",
+      "obesity": "Adipositas"
+    },
+    "catRange": {
+      "underweight": "< 5. Perzentile",
+      "healthy": "5.–84. Perzentile",
+      "overweight": "85.–94. Perzentile",
+      "obesity": "≥ 95. Perzentile"
+    },
+    "disclaimer": "Dieser Rechner nutzt eine vereinfachte CDC-LMS-Referenztabelle (2–20 Jahre). Die Ergebnisse dienen zur Orientierung und ersetzen keine kinderärztliche Beurteilung. Bei Auffälligkeiten bitte den Kinderarzt aufsuchen.",
+    "faq": [
+      { "q": "Warum gelten für Kinder andere BMI-Werte als für Erwachsene?", "a": "Kinder befinden sich im Wachstum: Körperfett, Muskelmasse und Körperbau verändern sich mit Alter und Geschlecht. Fixe BMI-Grenzen wie 25 oder 30 funktionieren nicht. Stattdessen vergleicht man den BMI eines Kindes mit Tausenden gleichaltriger Kinder gleichen Geschlechts — das ergibt die CDC-Perzentile." },
+      { "q": "Was bedeutet die CDC-Perzentile?", "a": "Die Perzentile zeigt, wie viel Prozent gleichaltriger Kinder gleichen Geschlechts einen niedrigeren BMI haben. Ein Wert auf der 75. Perzentile bedeutet: 75 % aller gleichaltrigen Kinder haben einen niedrigeren BMI. Der Bereich von der 5. bis 84. Perzentile gilt als Normalgewicht." },
+      { "q": "Ab welcher Perzentile spricht man von Übergewicht?", "a": "Nach den CDC-Kriterien gilt: ab der 85. bis unter der 95. Perzentile Übergewicht, ab der 95. Perzentile Adipositas. Unter der 5. Perzentile spricht man von Untergewicht." },
+      { "q": "Welche Daten brauche ich für den Rechner?", "a": "Alter (2–20 Jahre), Geschlecht, Größe und Gewicht. Du kannst zwischen metrischen (kg, cm) und imperialen (lbs, in) Einheiten wechseln. Der BMI wird sofort berechnet und in die richtige Perzentile-Kategorie eingeordnet." },
+      { "q": "Wie genau ist diese Berechnung?", "a": "Der Rechner nutzt eine vereinfachte CDC-LMS-Referenztabelle und die Z-Score-Berechnung nach Cole & Green (1992). Die Werte liegen typisch im Bereich ±1 Perzentile gegenüber der offiziellen CDC-Tabelle und reichen für eine erste Einschätzung. Für eine medizinische Diagnose immer den Kinderarzt aufsuchen." },
+      { "q": "Was tun bei einem Ergebnis außerhalb des Normalbereichs?", "a": "Ein einzelner BMI-Wert ist kein Diagnoseinstrument — entscheidend ist der Verlauf über mehrere Messungen. Liegt das Kind dauerhaft unter der 5. oder über der 95. Perzentile, sollten Eltern den Kinderarzt aufsuchen, um Ernährung, Bewegung und mögliche medizinische Ursachen zu prüfen." }
+    ]
+  }
+}

--- a/src/locales/calculators/en/pediatricBmi.json
+++ b/src/locales/calculators/en/pediatricBmi.json
@@ -1,0 +1,52 @@
+{
+  "home": {
+    "calculators": {
+      "pediatricBmi": {
+        "name": "Pediatric BMI Calculator",
+        "description": "BMI for children (ages 2–20) by CDC growth-chart percentile — age- and sex-specific."
+      }
+    }
+  },
+  "pediatricBmi": {
+    "meta": {
+      "title": "Pediatric BMI Calculator — CDC Percentile Ages 2–20 | Health Calculators",
+      "description": "Pediatric BMI calculator using CDC growth-chart percentiles. Age- and sex-specific assessment: underweight, healthy, overweight, or obesity."
+    },
+    "title": "Pediatric BMI Calculator",
+    "description": "Assess BMI for children and teens ages 2 to 20 using CDC growth-chart percentiles.",
+    "inputsLabel": "Child details",
+    "sex": "Sex",
+    "male": "Boy",
+    "female": "Girl",
+    "age": "Age (years)",
+    "weight": "Weight",
+    "height": "Height",
+    "metric": "Metric (kg/cm)",
+    "imperial": "Imperial (lbs/in)",
+    "resultsLabel": "Result",
+    "bmiLabel": "BMI",
+    "percentileLabel": "CDC percentile",
+    "categories": "CDC categories",
+    "cat": {
+      "underweight": "Underweight",
+      "healthy": "Healthy weight",
+      "overweight": "Overweight",
+      "obesity": "Obesity"
+    },
+    "catRange": {
+      "underweight": "< 5th percentile",
+      "healthy": "5th–84th percentile",
+      "overweight": "85th–94th percentile",
+      "obesity": "≥ 95th percentile"
+    },
+    "disclaimer": "This calculator uses a simplified CDC LMS reference table (ages 2–20). Results are for guidance and don't replace a pediatric evaluation. If anything looks off, consult a pediatrician.",
+    "faq": [
+      { "q": "Why do children use different BMI ranges than adults?", "a": "Children are growing: body fat, muscle mass, and body composition change with age and sex. Fixed BMI cutoffs like 25 or 30 don't work. Instead, a child's BMI is compared to thousands of children of the same age and sex — that comparison is the CDC percentile." },
+      { "q": "What does the CDC percentile mean?", "a": "The percentile shows how many children of the same age and sex have a lower BMI. A value at the 75th percentile means 75% of children of the same age have a lower BMI. The 5th to 84th percentile range is considered healthy weight." },
+      { "q": "At what percentile is a child considered overweight?", "a": "By CDC criteria: 85th to below 95th percentile is overweight, 95th percentile or higher is obesity. Below the 5th percentile is underweight." },
+      { "q": "What data do I need?", "a": "Age (2–20 years), sex, height and weight. You can switch between metric (kg, cm) and imperial (lbs, in) units. BMI is calculated instantly and classified into the correct percentile category." },
+      { "q": "How accurate is this calculator?", "a": "The calculator uses a simplified CDC LMS reference table and the Z-score method by Cole & Green (1992). Results are typically within ±1 percentile of the official CDC table — adequate for a first assessment. For medical decisions, always consult a pediatrician." },
+      { "q": "What should I do if the result is outside the healthy range?", "a": "A single BMI reading is not a diagnosis — what matters is the trend over multiple measurements. If a child stays below the 5th or above the 95th percentile, parents should consult a pediatrician to review nutrition, activity, and possible medical causes." }
+    ]
+  }
+}

--- a/src/pages/PediatricBmiCalculator.vue
+++ b/src/pages/PediatricBmiCalculator.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  calcBmi,
+  convertWeightToKg,
+  convertHeightToCm,
+  calcBmiPercentile,
+  getCategory,
+  categoryColor,
+  categoryBg,
+} from '../utils/pediatricBmi.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('pediatricBmi.faq') || [])
+
+useHead(() => ({
+  title: t('pediatricBmi.meta.title'),
+  description: t('pediatricBmi.meta.description'),
+  routeKey: 'pediatricBmi',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Pediatric BMI Calculator',
+    url: 'https://healthcalculator.app/pediatric-bmi',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const sex = ref('male')
+const age = ref(null)
+const weight = ref(null)
+const height = ref(null)
+const unit = ref('metric')
+
+const weightKg = computed(() => convertWeightToKg(weight.value, unit.value))
+const heightCm = computed(() => convertHeightToCm(height.value, unit.value))
+const bmi = computed(() => calcBmi(weightKg.value, heightCm.value))
+
+const percentile = computed(() => {
+  const a = Number(age.value)
+  if (!Number.isFinite(a)) return null
+  return calcBmiPercentile(bmi.value, a, sex.value)
+})
+
+const category = computed(() => getCategory(percentile.value))
+const hasResult = computed(() => bmi.value !== null && percentile.value !== null)
+
+const bmiFormatted = computed(() => bmi.value !== null ? bmi.value.toFixed(1) : '—')
+const percentileFormatted = computed(() => percentile.value !== null ? percentile.value.toFixed(1) + '%' : '—')
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('pediatricBmi.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('pediatricBmi.description') }}</p>
+    </div>
+
+    <!-- Inputs -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex gap-2 mb-6">
+        <button
+          @click="unit = 'metric'"
+          :class="unit === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          data-testid="unit-metric"
+        >{{ t('pediatricBmi.metric') }}</button>
+        <button
+          @click="unit = 'imperial'"
+          :class="unit === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          data-testid="unit-imperial"
+        >{{ t('pediatricBmi.imperial') }}</button>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div class="sm:col-span-2">
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pediatricBmi.sex') }}</label>
+          <div class="flex gap-4">
+            <label class="flex items-center gap-2 cursor-pointer">
+              <input v-model="sex" type="radio" value="male" data-testid="sex-male" class="accent-stone-800" />
+              <span class="text-sm font-medium text-stone-700">{{ t('pediatricBmi.male') }}</span>
+            </label>
+            <label class="flex items-center gap-2 cursor-pointer">
+              <input v-model="sex" type="radio" value="female" data-testid="sex-female" class="accent-stone-800" />
+              <span class="text-sm font-medium text-stone-700">{{ t('pediatricBmi.female') }}</span>
+            </label>
+          </div>
+        </div>
+
+        <div>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pediatricBmi.age') }}</label>
+          <input
+            v-model.number="age"
+            type="number"
+            min="2"
+            max="20"
+            step="0.1"
+            placeholder="10"
+            data-testid="age"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+
+        <div>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pediatricBmi.weight') }} ({{ unit === 'metric' ? 'kg' : 'lbs' }})</label>
+          <input
+            v-model.number="weight"
+            type="number"
+            min="1"
+            step="0.1"
+            :placeholder="unit === 'metric' ? '30' : '66'"
+            data-testid="weight"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+
+        <div>
+          <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('pediatricBmi.height') }} ({{ unit === 'metric' ? 'cm' : 'in' }})</label>
+          <input
+            v-model.number="height"
+            type="number"
+            min="20"
+            step="0.1"
+            :placeholder="unit === 'metric' ? '138' : '54'"
+            data-testid="height"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Result -->
+    <div v-if="hasResult" :class="['border rounded-xl shadow-sm p-8 mb-6', categoryBg(category)]" data-testid="result-card">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('pediatricBmi.resultsLabel') }}</p>
+
+      <div class="grid grid-cols-2 gap-6 mb-6">
+        <div>
+          <p class="text-xs text-stone-500 mb-1">{{ t('pediatricBmi.bmiLabel') }}</p>
+          <p class="text-4xl font-bold text-stone-900 tabular-nums leading-none" data-testid="result-bmi">{{ bmiFormatted }}</p>
+        </div>
+        <div>
+          <p class="text-xs text-stone-500 mb-1">{{ t('pediatricBmi.percentileLabel') }}</p>
+          <p :class="['text-4xl font-bold tabular-nums leading-none', categoryColor(category)]" data-testid="result-percentile">{{ percentileFormatted }}</p>
+        </div>
+      </div>
+
+      <p :class="['text-xl font-semibold', categoryColor(category)]" data-testid="result-category">{{ t(`pediatricBmi.cat.${category}`) }}</p>
+      <p class="text-sm text-stone-500 mt-1">{{ t(`pediatricBmi.catRange.${category}`) }}</p>
+    </div>
+
+    <!-- Categories reference -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('pediatricBmi.categories') }}</h2>
+      <div class="space-y-3.5">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-amber-500"></div>
+            <span class="text-sm text-stone-600">{{ t('pediatricBmi.cat.underweight') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('pediatricBmi.catRange.underweight') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-emerald-500"></div>
+            <span class="text-sm text-stone-600">{{ t('pediatricBmi.cat.healthy') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('pediatricBmi.catRange.healthy') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-amber-500"></div>
+            <span class="text-sm text-stone-600">{{ t('pediatricBmi.cat.overweight') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('pediatricBmi.catRange.overweight') }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-red-500"></div>
+            <span class="text-sm text-stone-600">{{ t('pediatricBmi.cat.obesity') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('pediatricBmi.catRange.obesity') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="hasResult" class="bg-stone-50 rounded-xl border border-stone-200 p-5 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('pediatricBmi.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <RelatedCalculators calc-key="pediatricBmi" class="mt-8" />
+    <BlogArticleLink calculator-key="pediatricBmi" />
+
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/KinderBmiBerechnen.vue
+++ b/src/pages/blog/KinderBmiBerechnen.vue
@@ -1,0 +1,228 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Kinder-BMI berechnen: CDC-Perzentile richtig verstehen | Health Calculators',
+  description: 'Kinder-BMI nach CDC-Perzentile berechnen und richtig einordnen. Warum Erwachsenen-Grenzen nicht passen, was die 5./85./95. Perzentile bedeutet und wann der Kinderarzt schauen sollte.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Kinder-BMI berechnen: CDC-Perzentile richtig verstehen',
+      description: 'Kinder-BMI nach CDC-Perzentile berechnen und richtig einordnen.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-26',
+      dateModified: '2026-05-26',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/kinder-bmi-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Warum gelten für Kinder andere BMI-Werte als für Erwachsene?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Kinder befinden sich im Wachstum: Körperfett, Muskelmasse und Körperbau verändern sich mit Alter und Geschlecht. Fixe BMI-Grenzen wie 25 oder 30 funktionieren nicht. Stattdessen vergleicht man den BMI eines Kindes mit Tausenden gleichaltriger Kinder gleichen Geschlechts — das ergibt die CDC-Perzentile.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was bedeutet die CDC-Perzentile?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die Perzentile zeigt, wie viel Prozent gleichaltriger Kinder gleichen Geschlechts einen niedrigeren BMI haben. 75. Perzentile heißt: 75 % aller gleichaltrigen Kinder haben einen niedrigeren BMI. Der Normalbereich liegt zwischen der 5. und 84. Perzentile.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Ab welcher Perzentile spricht man von Übergewicht?',
+          acceptedAnswer: { '@type': 'Answer', text: '85. bis unter 95. Perzentile: Übergewicht. 95. Perzentile und höher: Adipositas. Unter der 5. Perzentile: Untergewicht.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wie genau ist die CDC-Berechnung?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die CDC-LMS-Methode (Cole & Green, 1992) berechnet aus Alter, Geschlecht und BMI einen Z-Score und daraus die Perzentile. Die Werte sind klinisch validiert und gelten als Standard in den USA und vielen weiteren Ländern.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was tun bei einem Wert außerhalb des Normalbereichs?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ein einzelner Wert ist kein Diagnoseinstrument. Wichtig ist der Verlauf über mehrere Messungen. Liegt das Kind dauerhaft unter der 5. oder über der 95. Perzentile, sollten Eltern den Kinderarzt aufsuchen, um Ernährung, Bewegung und mögliche medizinische Ursachen zu prüfen.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Kinder-BMI berechnen: CDC-Perzentile richtig verstehen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">26. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Kinderarzt sagt: <strong>„Ihr Sohn liegt auf der 92. BMI-Perzentile."</strong> Ist das jetzt schlimm? Und warum gilt für Kinder nicht einfach BMI&nbsp;&lt;&nbsp;25 = gesund wie bei Erwachsenen?
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt, wie der Kinder-BMI funktioniert, welche CDC-Kategorien existieren und wie du das Ergebnis deines Kindes richtig einordnest.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum der Erwachsenen-BMI bei Kindern versagt</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Beim Erwachsenen ist der BMI eine fixe Skala: unter 18,5 Untergewicht, 18,5–24,9 Normalgewicht, ab 25 Übergewicht. Bei Kindern funktioniert das nicht. Ein 4-jähriges Kind mit BMI 17 ist normalgewichtig. Ein 10-jähriges Kind mit demselben BMI von 17 liegt im unteren Normalbereich. Ein 16-jähriger mit BMI 17 wäre untergewichtig.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Grund: Körperfett, Muskelmasse und Körperbau verändern sich permanent. Säuglinge sind „pummelig", Schulkinder werden dünner, in der Pubertät kommt wieder Masse dazu. Eine einzige fixe Grenze gibt es nicht. Stattdessen vergleicht die Pädiatrie das Kind mit Tausenden gleichaltriger Kinder gleichen Geschlechts.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die CDC-Perzentile: das US-Standardwerkzeug</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die <strong>Centers for Disease Control and Prevention (CDC)</strong> veröffentlichten im Jahr 2000 Wachstumskurven für US-Kinder von 2 bis 20 Jahren. Sie sind in den USA der Standard und werden auch international häufig verwendet — besonders bei der Beurteilung von Über- und Adipositas.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die CDC-Perzentile sagt: „Welcher Anteil gleichaltriger Kinder gleichen Geschlechts hat einen niedrigeren BMI?" Die 50. Perzentile ist der Median. Die 95. Perzentile bedeutet: nur 5 von 100 Kindern haben einen höheren BMI.
+        </p>
+
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">CDC-Kategorien für Kinder-BMI</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">Unter 5. Perzentile</span>
+              <span class="text-amber-600 font-medium">Untergewicht</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">5.–84. Perzentile</span>
+              <span class="text-emerald-600 font-medium">Normalgewicht</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">85.–94. Perzentile</span>
+              <span class="text-amber-600 font-medium">Übergewicht</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">Ab 95. Perzentile</span>
+              <span class="text-red-500 font-medium">Adipositas</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">So funktioniert die Berechnung</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hinter den CDC-Kurven steht die <strong>LMS-Methode</strong> von Cole und Green (1992). Drei Parameter beschreiben die Verteilung für jedes Alter und Geschlecht:
+        </p>
+
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm">
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3 font-sans">LMS-Parameter</div>
+          <div class="space-y-2 text-stone-700">
+            <div><strong>L</strong> — Schiefe-Korrektur (Box-Cox-Transformation)</div>
+            <div><strong>M</strong> — Median (50. Perzentile)</div>
+            <div><strong>S</strong> — Streuung (Variationskoeffizient)</div>
+          </div>
+          <div class="mt-4 pt-4 border-t border-stone-200 text-stone-600">
+            Z = [(BMI / M)<sup>L</sup> − 1] / (L × S)
+          </div>
+        </div>
+
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der Z-Score wird mit der Normalverteilung in eine Perzentile umgerechnet. Z=0 entspricht der 50. Perzentile, Z=1,645 der 95. Perzentile (Adipositas-Grenze).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was die Kategorien wirklich bedeuten</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die CDC-Grenzen sind keine festen Linien zwischen „gesund" und „krank". Sie sind statistische Marker, die das Risiko für Folgeerkrankungen erhöhen.
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Untergewicht (&lt; 5. P.):</span>
+              <p class="text-stone-600 text-sm mt-1">Kann genetisch oder durch späte Entwicklung bedingt sein. Anhaltend niedrige Werte sollten ärztlich abgeklärt werden — Stichwort Mangelernährung, Essstörung oder chronische Erkrankung.</p>
+            </div>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Normalgewicht (5.–84. P.):</span>
+              <p class="text-stone-600 text-sm mt-1">Der breite Normalbereich. 80 % aller Kinder liegen hier. Konstante Werte sind ein gutes Zeichen — Sprünge nach oben oder unten verdienen Aufmerksamkeit.</p>
+            </div>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Übergewicht (85.–94. P.):</span>
+              <p class="text-stone-600 text-sm mt-1">Risiko, aber noch keine Adipositas. Oft mit Lebensstil-Anpassungen (mehr Bewegung, ausgewogene Ernährung) zu korrigieren. Familiärer Kontext wichtig.</p>
+            </div>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Adipositas (≥ 95. P.):</span>
+              <p class="text-stone-600 text-sm mt-1">Erhöhtes Risiko für Diabetes, Bluthochdruck und Folgeerkrankungen. Sollte mit Kinderarzt und ggf. Ernährungsberatung begleitet werden.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verlauf zählt mehr als ein einzelner Wert</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein BMI-Wert allein sagt wenig. Entscheidend ist die <strong>Wachstumskurve über mehrere Jahre</strong>. Ein Kind, das konstant auf der 88. Perzentile liegt, ist nicht das gleiche wie ein Kind, das innerhalb von zwei Jahren von der 50. auf die 88. Perzentile springt.
+        </p>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Wann zum Kinderarzt?</p>
+          <ul class="text-sm text-amber-700 space-y-1">
+            <li>→ BMI unter der 5. oder über der 95. Perzentile</li>
+            <li>→ Sprung um mehr als 2 Hauptperzentilen (z. B. 50. → 90.)</li>
+            <li>→ Stillstand oder Abfall trotz normaler Ernährung</li>
+            <li>→ Symptome wie Müdigkeit, Atemprobleme oder Gelenkschmerzen</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Berechne den BMI deines Kindes</h3>
+        <p class="text-base text-stone-600 mb-6">Alter, Größe und Gewicht eingeben — der Rechner zeigt sofort BMI und CDC-Perzentile.</p>
+        <router-link
+          :to="localePath('pediatricBmi')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Zum Kinder-BMI-Rechner
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Kinder-BMI ist nicht der Erwachsenen-BMI. Statt fixer Grenzen vergleicht man das Kind mit gleichaltrigen Kindern desselben Geschlechts und liest die CDC-Perzentile ab. Normalgewicht liegt zwischen der 5. und 84. Perzentile, Adipositas beginnt ab der 95.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ein einzelner Wert ist nie eine Diagnose. Was zählt, ist die Kurve über Zeit — und der Blick auf das ganze Kind: Ernährung, Bewegung, Schlaf, Wohlbefinden. Bei Unsicherheit hilft der Kinderarzt weiter.
+        </p>
+      </div>
+
+    </div>
+
+    <RelatedArticles slug="kinder-bmi-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/PediatricBmiGuide.vue
+++ b/src/pages/blog/en/PediatricBmiGuide.vue
@@ -1,0 +1,228 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Pediatric BMI Calculator: Understanding CDC Growth Percentiles | Health Calculators',
+  description: 'Pediatric BMI calculator explained: why adult BMI cutoffs fail for children, how CDC growth-chart percentiles work, and when to see a pediatrician.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Pediatric BMI Calculator: Understanding CDC Growth Percentiles',
+      description: 'Pediatric BMI explained: percentiles, CDC categories, and what they really mean.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-26',
+      dateModified: '2026-05-26',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/pediatric-bmi-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Why do children use different BMI ranges than adults?',
+          acceptedAnswer: { '@type': 'Answer', text: "Children are growing: body fat, muscle mass, and body composition change with age and sex. Fixed BMI cutoffs like 25 or 30 don't work. Instead, a child's BMI is compared with thousands of children of the same age and sex — that comparison is the CDC percentile." },
+        },
+        {
+          '@type': 'Question',
+          name: 'What does the CDC percentile mean?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The percentile shows how many children of the same age and sex have a lower BMI. The 75th percentile means 75% have a lower BMI. The 5th to 84th percentile range is considered healthy weight.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'At what percentile is a child considered overweight?',
+          acceptedAnswer: { '@type': 'Answer', text: '85th to below 95th percentile is overweight, 95th and above is obesity. Below the 5th percentile is underweight.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'How accurate is the CDC calculation?',
+          acceptedAnswer: { '@type': 'Answer', text: "The CDC LMS method (Cole & Green, 1992) derives a Z-score from age, sex, and BMI and converts it to a percentile. It's clinically validated and the standard in the US and many other countries." },
+        },
+        {
+          '@type': 'Question',
+          name: 'What should I do if my child is outside the healthy range?',
+          acceptedAnswer: { '@type': 'Answer', text: 'A single reading is not a diagnosis. What matters is the trend over multiple measurements. If a child stays below the 5th or above the 95th percentile, parents should consult a pediatrician to review nutrition, activity, and possible medical causes.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Pediatric BMI Calculator: Understanding CDC Growth Percentiles</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 26, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Your pediatrician says: <strong>"Your son is at the 92nd BMI percentile."</strong> Should you worry? And why doesn't the simple adult rule — BMI&nbsp;&lt;&nbsp;25 = healthy — apply here?
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how pediatric BMI works, which CDC categories exist, and how to read your child's number correctly.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why adult BMI fails for children</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In adults, BMI is a fixed scale: below 18.5 underweight, 18.5–24.9 healthy, 25 and above overweight. For children, that doesn't work. A 4-year-old with BMI 17 is in a healthy range. A 10-year-old with the same BMI sits at the lower end of normal. A 16-year-old with BMI 17 would be underweight.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The reason: body fat, muscle, and shape change throughout childhood. Babies are chubby, school-age kids slim down, puberty adds mass back. A single fixed line cannot capture this. Instead, pediatrics compares each child with thousands of same-age, same-sex peers.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">CDC growth-chart percentiles: the US standard</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The <strong>Centers for Disease Control and Prevention (CDC)</strong> published growth charts for US children ages 2–20 in the year 2000. They are the US standard and widely used internationally — especially for assessing overweight and obesity.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The CDC percentile answers: "What fraction of children of the same age and sex have a lower BMI?" The 50th percentile is the median. The 95th percentile means only 5 out of 100 children of that age and sex have a higher BMI.
+        </p>
+
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">CDC categories for child BMI</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">Below 5th percentile</span>
+              <span class="text-amber-600 font-medium">Underweight</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">5th–84th percentile</span>
+              <span class="text-emerald-600 font-medium">Healthy weight</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">85th–94th percentile</span>
+              <span class="text-amber-600 font-medium">Overweight</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">95th percentile and above</span>
+              <span class="text-red-500 font-medium">Obesity</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">How the calculation works</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Behind the CDC curves is the <strong>LMS method</strong> by Cole and Green (1992). Three parameters describe the BMI distribution for each age and sex:
+        </p>
+
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-sm">
+          <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3 font-sans">LMS parameters</div>
+          <div class="space-y-2 text-stone-700">
+            <div><strong>L</strong> — skewness correction (Box-Cox transformation)</div>
+            <div><strong>M</strong> — median (50th percentile)</div>
+            <div><strong>S</strong> — coefficient of variation (spread)</div>
+          </div>
+          <div class="mt-4 pt-4 border-t border-stone-200 text-stone-600">
+            Z = [(BMI / M)<sup>L</sup> − 1] / (L × S)
+          </div>
+        </div>
+
+        <p class="text-base text-stone-600 leading-relaxed">
+          The Z-score is converted to a percentile via the normal distribution. Z = 0 maps to the 50th percentile; Z = 1.645 maps to the 95th (the obesity cutoff).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What each category really means</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          CDC thresholds are not hard lines between "healthy" and "sick." They are statistical markers where risk for related conditions rises.
+        </p>
+        <ul class="space-y-3 mb-4">
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Underweight (&lt; 5th):</span>
+              <p class="text-stone-600 text-sm mt-1">Can be genetic or due to late development. Persistent low readings warrant medical review — possible causes include undernutrition, eating disorders, or chronic conditions.</p>
+            </div>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Healthy weight (5th–84th):</span>
+              <p class="text-stone-600 text-sm mt-1">The broad normal range. 80% of children sit here. Stable values are reassuring; jumps up or down deserve attention.</p>
+            </div>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Overweight (85th–94th):</span>
+              <p class="text-stone-600 text-sm mt-1">Risk zone but not obesity. Often correctable with lifestyle changes — more movement, balanced meals, fewer sweetened drinks. Family context matters.</p>
+            </div>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-stone-400 mt-0.5">→</span>
+            <div>
+              <span class="font-semibold text-stone-700">Obesity (≥ 95th):</span>
+              <p class="text-stone-600 text-sm mt-1">Higher risk for type 2 diabetes, hypertension, and related conditions. A pediatrician and possibly a dietitian should be involved.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The trend matters more than a single value</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          One BMI number is not very informative on its own. What matters is the <strong>trend over months and years</strong>. A child tracking steadily at the 88th percentile is very different from one who jumped from the 50th to the 88th percentile in two years.
+        </p>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">When to see a pediatrician</p>
+          <ul class="text-sm text-amber-700 space-y-1">
+            <li>→ BMI below the 5th or above the 95th percentile</li>
+            <li>→ Jump of more than two major percentile lines (e.g., 50th → 90th)</li>
+            <li>→ Stagnation or decline despite normal eating</li>
+            <li>→ Symptoms like fatigue, breathing difficulty, or joint pain</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Calculate your child's BMI</h3>
+        <p class="text-base text-stone-600 mb-6">Enter age, height and weight — the calculator shows BMI and the CDC percentile instantly.</p>
+        <router-link
+          :to="localePath('pediatricBmi')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Open the Pediatric BMI Calculator
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Takeaway</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Pediatric BMI is not adult BMI. Instead of fixed cutoffs, you compare the child to same-age, same-sex peers and read the CDC percentile. Healthy weight sits between the 5th and 84th percentile; obesity starts at the 95th.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A single number is never a diagnosis. What counts is the curve over time — and looking at the whole child: nutrition, activity, sleep, mood. When in doubt, your pediatrician is the right partner.
+        </p>
+      </div>
+
+    </div>
+
+    <RelatedArticles slug="pediatric-bmi-guide" />
+  </article>
+</template>

--- a/src/pages/pediatricBmi.meta.js
+++ b/src/pages/pediatricBmi.meta.js
@@ -1,0 +1,16 @@
+import Component from './PediatricBmiCalculator.vue'
+import BlogDe from './blog/KinderBmiBerechnen.vue'
+import BlogEn from './blog/en/PediatricBmiGuide.vue'
+
+export default {
+  key: 'pediatricBmi',
+  component: Component,
+  slugs: { de: 'kinder-bmi-rechner', en: 'pediatric-bmi' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 15.2,
+  blog: {
+    de: { slug: 'kinder-bmi-berechnen', component: BlogDe },
+    en: { slug: 'pediatric-bmi-guide', component: BlogEn },
+  },
+}

--- a/src/utils/pediatricBmi.js
+++ b/src/utils/pediatricBmi.js
@@ -1,0 +1,143 @@
+// CDC BMI-for-age LMS percentile data (2–20 years) — simplified inline table.
+// Approximated from the CDC 2000 BMI-for-age reference (boys + girls).
+// Format: [ageYears, L, M, S]
+
+export const LMS_BOYS = [
+  [2.0, -1.7862, 16.5749, 0.07581],
+  [3.0, -2.0707, 16.0490, 0.07505],
+  [4.0, -2.2675, 15.7235, 0.07453],
+  [5.0, -2.4040, 15.4961, 0.07423],
+  [6.0, -2.5045, 15.3915, 0.07533],
+  [7.0, -2.5764, 15.4181, 0.07811],
+  [8.0, -2.6315, 15.5419, 0.08197],
+  [9.0, -2.6754, 15.7472, 0.08667],
+  [10.0, -2.7128, 16.0254, 0.09192],
+  [11.0, -2.7464, 16.3653, 0.09745],
+  [12.0, -2.7787, 16.7440, 0.10314],
+  [13.0, -2.8117, 17.1419, 0.10874],
+  [14.0, -2.8485, 17.5436, 0.11405],
+  [15.0, -2.8919, 17.9335, 0.11888],
+  [16.0, -2.9449, 18.3122, 0.12313],
+  [17.0, -3.0103, 18.6781, 0.12671],
+  [18.0, -3.0902, 19.0245, 0.12953],
+  [19.0, -3.1846, 19.3450, 0.13155],
+  [20.0, -3.2929, 19.6326, 0.13273],
+]
+
+export const LMS_GIRLS = [
+  [2.0, -2.0699, 16.1450, 0.08006],
+  [3.0, -2.1928, 15.7427, 0.07955],
+  [4.0, -2.2929, 15.4076, 0.07953],
+  [5.0, -2.3779, 15.2123, 0.08035],
+  [6.0, -2.4517, 15.1571, 0.08210],
+  [7.0, -2.5165, 15.2418, 0.08482],
+  [8.0, -2.5734, 15.4640, 0.08851],
+  [9.0, -2.6234, 15.8147, 0.09314],
+  [10.0, -2.6677, 16.2670, 0.09859],
+  [11.0, -2.7074, 16.7867, 0.10468],
+  [12.0, -2.7436, 17.3403, 0.11119],
+  [13.0, -2.7773, 17.8983, 0.11785],
+  [14.0, -2.8094, 18.4382, 0.12437],
+  [15.0, -2.8409, 18.9486, 0.13050],
+  [16.0, -2.8722, 19.4279, 0.13604],
+  [17.0, -2.9026, 19.8807, 0.14081],
+  [18.0, -2.9303, 20.3160, 0.14467],
+  [19.0, -2.9527, 20.7456, 0.14753],
+  [20.0, -2.9669, 21.1843, 0.14934],
+]
+
+const LB_TO_KG = 0.45359237
+const IN_TO_CM = 2.54
+
+export function convertWeightToKg(weight, unit) {
+  const v = Number(weight)
+  if (!Number.isFinite(v) || v <= 0) return null
+  return unit === 'imperial' ? v * LB_TO_KG : v
+}
+
+export function convertHeightToCm(height, unit) {
+  const v = Number(height)
+  if (!Number.isFinite(v) || v <= 0) return null
+  return unit === 'imperial' ? v * IN_TO_CM : v
+}
+
+export function calcBmi(weightKg, heightCm) {
+  const w = Number(weightKg)
+  const h = Number(heightCm)
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return null
+  const m = h / 100
+  return w / (m * m)
+}
+
+function interpolateLMS(table, ageYears) {
+  if (ageYears < table[0][0] || ageYears > table[table.length - 1][0]) return null
+  for (let i = 0; i < table.length - 1; i++) {
+    const [t0, L0, M0, S0] = table[i]
+    const [t1, L1, M1, S1] = table[i + 1]
+    if (ageYears >= t0 && ageYears <= t1) {
+      const frac = t1 === t0 ? 0 : (ageYears - t0) / (t1 - t0)
+      return [
+        L0 + frac * (L1 - L0),
+        M0 + frac * (M1 - M0),
+        S0 + frac * (S1 - S0),
+      ]
+    }
+  }
+  return null
+}
+
+function lmsZscore(x, L, M, S) {
+  if (Math.abs(L) < 1e-6) return Math.log(x / M) / S
+  return (Math.pow(x / M, L) - 1) / (L * S)
+}
+
+// Standard normal CDF (Abramowitz & Stegun, error < 1.5e-7)
+function normalCDF(z) {
+  const a1 = 0.254829592, a2 = -0.284496736, a3 = 1.421413741
+  const a4 = -1.453152027, a5 = 1.061405429, p = 0.3275911
+  const sign = z < 0 ? -1 : 1
+  const x = Math.abs(z) / Math.SQRT2
+  const t = 1 / (1 + p * x)
+  const erf = 1 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x)
+  return 0.5 * (1 + sign * erf)
+}
+
+export function calcBmiPercentile(bmi, ageYears, sex) {
+  if (!Number.isFinite(bmi) || bmi <= 0) return null
+  if (!Number.isFinite(ageYears) || ageYears < 2 || ageYears > 20) return null
+  const table = sex === 'female' ? LMS_GIRLS : LMS_BOYS
+  const lms = interpolateLMS(table, ageYears)
+  if (!lms) return null
+  const [L, M, S] = lms
+  const z = lmsZscore(bmi, L, M, S)
+  const p = normalCDF(z) * 100
+  return Math.max(0.1, Math.min(99.9, p))
+}
+
+export function getCategory(percentile) {
+  if (percentile === null || percentile === undefined || !Number.isFinite(percentile)) return null
+  if (percentile < 5) return 'underweight'
+  if (percentile < 85) return 'healthy'
+  if (percentile < 95) return 'overweight'
+  return 'obesity'
+}
+
+export function categoryColor(category) {
+  switch (category) {
+    case 'underweight': return 'text-amber-600'
+    case 'healthy': return 'text-emerald-600'
+    case 'overweight': return 'text-amber-600'
+    case 'obesity': return 'text-red-500'
+    default: return 'text-stone-400'
+  }
+}
+
+export function categoryBg(category) {
+  switch (category) {
+    case 'underweight': return 'bg-amber-50 border-amber-200'
+    case 'healthy': return 'bg-emerald-50 border-emerald-200'
+    case 'overweight': return 'bg-amber-50 border-amber-200'
+    case 'obesity': return 'bg-red-50 border-red-200'
+    default: return 'bg-stone-50 border-stone-200'
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-128-pediatric-bmi
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-128-pediatric-bmi-20260526-233027`
**Cost:** $8.69141025

Closes jenslaufer/health-calculators#128

### Prompt
> Implement the Pediatric BMI Calculator as described in issue #128.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: age (2–20 years), sex (m/f), height (cm), weight (kg) — plus metric/imperial toggle
- Output: BMI value + CDC growth-chart percentile category (Underweight <5%, Healthy 5–84%, Overweight 85–94%, Obesity ≥95%) — color-coded result
- Use a simplified CDC LMS percentile lookup table (boys + girls 2–20y). Keep table inline in `src/utils/pediatricBmi.js`.
- Blog articles: DE + EN (SEO optimized — FAQPage structured data)
- Internal links to related calculators (suggested: bmi, childCalories, childGrowth, headCircumference — verify they exist in articles*.js)
- Unit tests for calculation logic + percentile lookup edge cases (boundary ages 2 and 20, both sexes, boundary categories)
- E2E test for the calculator page
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog article → own calculator (DE + EN routes)
- Blog article → 2-3 thematically related calculators from this repo
- Calculator page → this blog article (DE + EN)
- Verify every target route exists in the repo before linking — do NOT invent slugs


## RETRY-AWARE no-diff guard (READ FIRST)
This run MUST create new files and commit them. Before `git push`, run `git status`.
If no new files appear staged, you failed silently — do NOT push. Report blockage instead.

Note: a previous `.failed` marker for hc-128 exists from an earlier run that produced no diff.
This run MUST land all 14 expected paths or report blockage. Do NOT push partial.


## PARTIAL-COMMIT GUARD (MANDATORY — added 2026-05-07 after FK #270 + HC #231 partial; validated 8-of-3 cross-repo)
Before `git push`, run:
  git diff --name-only main..HEAD | sort

Output MUST contain ALL of these paths (substitute <DeBlogPascal> + <EnBlogPascal> with your chosen blog Vue component names):
  e2e/pediatricBmi.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/pediatricBmi.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/pediatricBmi.json
  src/locales/calculators/en/pediatricBmi.json
  src/pages/PediatricBmiCalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/pediatricBmi.meta.js
  src/utils/pediatricBmi.js

If ANY path is missing → DO NOT push. Stage + commit the missing files first.
Counter check: `git diff --name-only main..HEAD | wc -l` MUST be >= 14.

Reference: study `src/pages/BmiCalculator.vue` + `src/pages/bmi.meta.js` + `src/locales/calculators/de/bmi.json` + `en/bmi.json` + `src/__tests__/bmi.test.js` + `e2e/bmi.spec.js`.
Also study `src/pages/ChildGrowthCalculator.vue` + `childGrowth.meta.js` (similar pediatric percentile pattern).

## TDD-red-first ordering (MANDATORY)
Work in this exact order. Do NOT batch steps.

1. **Red unit test first.** Create `src/utils/pediatricBmi.js` as an empty stub. Create `src/__tests__/pediatricBmi.test.js` with 6+ test cases (boys 2y boundary, girls 20y boundary, percentile categories edges 5/85/95, imperial-to-metric conversion). Run `npm test -- pediatricBmi` — tests MUST fail red with clear messages.
2. **Green unit logic.** Implement calculation + percentile lookup. Re-run — all green.
3. **View component + locale JSON + meta anchor.** Create `src/pages/PediatricBmiCalculator.vue` + `src/pages/pediatricBmi.meta.js`. Then create the two locale files — see Locale-Path block below.
4. **E2E test.** Create `e2e/pediatricBmi.spec.js` (Playwright, strict selectors — see E2E Selector Rules at bottom).
5. **Blog articles + index updates + articles.js registration.** Create DE + EN blog files. Append to articles.js + articles-en.js (see registration block).
6. **Final verification.** Run `git status` → confirm new files in ALL 4 categories (logic, view+meta, locale, test+e2e+blog). Run `npm test` + `npm run test:e2e` + `npm run build`. Commit + push ONLY if all green.

## Locale-Path + Meta-Anchor (CRITICAL — silent no-diff if missing)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`.
Without the meta file there is NO ROUTE (silent no-diff).
ALSO create:
- `src/pages/pediatricBmi.meta.js` — discovery anchor. Mirror shape of `src/pages/bmi.meta.js`:
  `key: 'pediatricBmi'`, `component`, `slugs: {de: 'kinder-bmi-rechner', en: 'pediatric-bmi'}`, `group`, `groupOrder`,
  `order`, optional `oldRedirect`, optional `blog: {de, en}` with slug+component.
- `src/locales/calculators/de/pediatricBmi.json` + `src/locales/calculators/en/pediatricBmi.json`
  — flat top-level keys (mirror `src/locales/calculators/de/bmi.json`).

## File-Checklist (git status MUST show these as new files before push)
- `src/utils/pediatricBmi.js`
- `src/__tests__/pediatricBmi.test.js`
- `src/pages/PediatricBmiCalculator.vue`
- `src/pages/pediatricBmi.meta.js`
- `src/locales/calculators/de/pediatricBmi.json`
- `src/locales/calculators/en/pediatricBmi.json`
- `e2e/pediatricBmi.spec.js`
- `DE blog: `src/pages/blog/{Name}.vue` + EN: `src/pages/blog/en/{Name}.vue` (referenced from meta.js `blog` field)`

If any item is missing/untracked-only/empty: DO NOT push. Fix the gap first.


## HC blog-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Both `discovers all N German blog components` and
`discovers all N English blog components` assert `toHaveLength(N)`. Read current N first via
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, then bump BOTH
asserts to N+1. Also append your new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to
`EXPECTED_BLOG_SLUGS_EN`. Without this, `npm test` red-fails the blog-count check.
EXCEPTION to the "do not modify existing files" rule: this single test file MAY be modified
for these specific bumps only.


## Register blog in articles*.js (MANDATORY — main RED otherwise)
The `blog-link-coverage.test.js` test requires every calculator with a blog to be registered in BOTH
`src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN). Without these
entries, `npm test` red-fails 2 tests AND main goes RED on merge.

Add a new entry to EACH file mirroring the existing entry shape:

```js
{
  slug: '<your-de-blog-slug>',          // MUST equal meta.js blog.de.slug
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'pediatricBmi',          // MUST equal meta.js key
  related: ['<existing-slug-1>', '<existing-slug-2>'],  // 2-3 thematically related slugs that EXIST in articles.js
},
```

Same shape for `articles-en.js` (EN slug from meta.js blog.en.slug, EN title/desc,
EN-related slugs verified to exist in articles-en.js).

EXCEPTION to "do not modify existing files": `src/data/articles.js` and
`src/data/articles-en.js` MAY be appended to for adding this single new entry only.

## E2E Selector rules (Playwright strict-mode — MUST follow)
Playwright strict-mode FAILS any locator matching >1 element. Common pitfalls:
- NEVER use `page.locator('text=Substring')` or partial-match `getByText('Part')`.
- USE `getByRole('heading', { name: 'Exact' })`, `getByTestId('<id>')`, or `getByText('Exact full string', { exact: true })`.
- If the same label may appear in select-options AND a result span, add `data-testid="result-status"` on the result element and assert via `getByTestId`.
- Use regex anchors (`/^Result$/`) when test-ids cannot be added.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files, blog articles, or shared configuration
- DO NOT change router files or any file you did not create
- Only ADD new files following the auto-discovery pattern
- Run existing tests to verify nothing breaks