### PR TITLE
Add Mean Arterial Pressure (MAP) Calculator (HC-265)

### DIFF
--- a/e2e/meanArterialPressure.spec.js
+++ b/e2e/meanArterialPressure.spec.js
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('de/mittlerer-arterieller-druck-rechner')
+})
+
+test('page loads with correct title', async ({ page }) => {
+  await expect(page).toHaveTitle(/MAP-Rechner/)
+})
+
+test('normal MAP: 120/80 → ~93 mmHg, normal band', async ({ page }) => {
+  await page.getByTestId('systolic-input').fill('120')
+  await page.getByTestId('diastolic-input').fill('80')
+
+  await expect(page.getByTestId('map-value')).toHaveText('93.3')
+  await expect(page.getByTestId('category')).toHaveText('Normal')
+  await expect(page.getByTestId('category')).toHaveClass(/text-emerald/)
+})
+
+test('low MAP: 80/50 → ~60 mmHg, low band', async ({ page }) => {
+  await page.getByTestId('systolic-input').fill('80')
+  await page.getByTestId('diastolic-input').fill('50')
+
+  await expect(page.getByTestId('map-value')).toHaveText('60.0')
+  await expect(page.getByTestId('category')).toHaveText('Niedrig')
+  await expect(page.getByTestId('category')).toHaveClass(/text-amber/)
+})
+
+test('high MAP: 180/110 → ~133 mmHg, high band', async ({ page }) => {
+  await page.getByTestId('systolic-input').fill('180')
+  await page.getByTestId('diastolic-input').fill('110')
+
+  await expect(page.getByTestId('map-value')).toHaveText('133.3')
+  await expect(page.getByTestId('category')).toHaveText('Hoch')
+  await expect(page.getByTestId('category')).toHaveClass(/text-red/)
+})
+
+test('shows older adults note in result card', async ({ page }) => {
+  await page.getByTestId('systolic-input').fill('120')
+  await page.getByTestId('diastolic-input').fill('80')
+
+  await expect(page.getByTestId('older-adults-note')).toBeVisible()
+})
+
+test('no result without inputs', async ({ page }) => {
+  await expect(page.getByTestId('result-card')).toHaveCount(0)
+})
+
+test('back link navigates to home page', async ({ page }) => {
+  await page.getByRole('link', { name: '← Alle Rechner' }).click()
+  await expect(page).toHaveURL(/\/de\/?$/)
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -28,6 +28,7 @@ const EXPECTED_KEYS = [
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
   'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'pmsSymptom', 'breastCancerRisk',
   'pediatricBmi',
+  'meanArterialPressure',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -117,6 +118,7 @@ const EXPECTED_ROUTE_MAP = {
   pmsSymptom: { de: 'pms-symptome-rechner', en: 'pms-symptom-calculator' },
   breastCancerRisk: { de: 'brustkrebs-risiko-rechner', en: 'breast-cancer-risk-calculator' },
   pediatricBmi: { de: 'kinder-bmi-rechner', en: 'pediatric-bmi' },
+  meanArterialPressure: { de: 'mittlerer-arterieller-druck-rechner', en: 'mean-arterial-pressure' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -195,6 +197,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'pms-symptome-bewerten',
   'brustkrebs-risiko-berechnen',
   'kinder-bmi-berechnen',
+  'mittlerer-arterieller-druck-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -273,19 +276,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pms-symptom-calculator-guide',
   'breast-cancer-risk-calculator-guide',
   'pediatric-bmi-guide',
+  'mean-arterial-pressure-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 86 calculators', () => {
-    expect(calculatorMetas).toHaveLength(86)
+  it('discovers all 87 calculators', () => {
+    expect(calculatorMetas).toHaveLength(87)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 86 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(86)
+  it('builds calculatorComponents map for all 87 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(87)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -308,15 +312,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 87 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(87)
+  it('discovers all 88 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(88)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 87 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(87)
+  it('discovers all 88 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(88)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -341,10 +345,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 86 calculators with no duplicates', () => {
+  it('groups contain all 87 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(86)
-    expect(new Set(allKeys).size).toBe(86)
+    expect(allKeys).toHaveLength(87)
+    expect(new Set(allKeys).size).toBe(87)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -365,7 +369,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -414,8 +418,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 475 routes', () => {
-    expect(routes).toHaveLength(475)
+  it('generates exactly 480 routes', () => {
+    expect(routes).toHaveLength(480)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 346 links (86 calcs × 2 locales + 87 blogs × 2 locales)', () => {
+  it('generates 350 links (87 calcs × 2 locales + 88 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(346)
+    expect(links).toHaveLength(350)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/meanArterialPressure.test.js
+++ b/src/__tests__/meanArterialPressure.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { calcMap, getCategory, categoryColor, categoryBg } from '../utils/meanArterialPressure.js'
+
+describe('calcMap — formula', () => {
+  it('calculates MAP from SBP and DBP using (SBP + 2*DBP) / 3', () => {
+    // (120 + 2*80) / 3 = 280 / 3 = 93.33
+    expect(calcMap(120, 80)).toBeCloseTo(93.33, 1)
+  })
+
+  it('handles SBP=DBP boundary case → MAP = SBP', () => {
+    // (100 + 2*100) / 3 = 300/3 = 100
+    expect(calcMap(100, 100)).toBe(100)
+  })
+
+  it('rounds division consistently for non-divisible sums', () => {
+    // (130 + 2*85) / 3 = 300/3 = 100
+    expect(calcMap(130, 85)).toBe(100)
+    // (118 + 2*76) / 3 = 270/3 = 90
+    expect(calcMap(118, 76)).toBe(90)
+  })
+
+  it('accepts decimal inputs', () => {
+    // (120.5 + 2*80.2) / 3 = 280.9/3 = 93.633
+    expect(calcMap(120.5, 80.2)).toBeCloseTo(93.63, 1)
+  })
+
+  it('accepts integer-string-equivalents as numbers', () => {
+    expect(calcMap(140, 90)).toBeCloseTo(106.67, 1)
+  })
+})
+
+describe('calcMap — invalid inputs', () => {
+  it('returns null for null or missing values', () => {
+    expect(calcMap(null, 80)).toBeNull()
+    expect(calcMap(120, null)).toBeNull()
+    expect(calcMap(undefined, undefined)).toBeNull()
+  })
+
+  it('returns null for non-positive values', () => {
+    expect(calcMap(0, 80)).toBeNull()
+    expect(calcMap(120, 0)).toBeNull()
+    expect(calcMap(-10, 80)).toBeNull()
+  })
+
+  it('returns null for NaN values', () => {
+    expect(calcMap(NaN, 80)).toBeNull()
+    expect(calcMap(120, NaN)).toBeNull()
+  })
+
+  it('returns null when DBP > SBP (physiologically impossible)', () => {
+    expect(calcMap(80, 120)).toBeNull()
+  })
+})
+
+describe('getCategory — clinical bands', () => {
+  it('classifies MAP < 70 as low', () => {
+    expect(getCategory(50)).toBe('low')
+    expect(getCategory(69.9)).toBe('low')
+  })
+
+  it('classifies MAP 70–100 as normal', () => {
+    expect(getCategory(70)).toBe('normal')
+    expect(getCategory(85)).toBe('normal')
+    expect(getCategory(100)).toBe('normal')
+  })
+
+  it('classifies MAP > 100 as high', () => {
+    expect(getCategory(100.1)).toBe('high')
+    expect(getCategory(120)).toBe('high')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(getCategory(null)).toBeNull()
+    expect(getCategory(NaN)).toBeNull()
+    expect(getCategory(undefined)).toBeNull()
+  })
+})
+
+describe('end-to-end clinical scenarios', () => {
+  it('very low BP 80/50 → low MAP', () => {
+    const map = calcMap(80, 50)
+    expect(map).toBeCloseTo(60, 0)
+    expect(getCategory(map)).toBe('low')
+  })
+
+  it('normal BP 120/80 → normal MAP', () => {
+    const map = calcMap(120, 80)
+    expect(getCategory(map)).toBe('normal')
+  })
+
+  it('very high BP 180/110 → high MAP', () => {
+    const map = calcMap(180, 110)
+    expect(map).toBeCloseTo(133.33, 1)
+    expect(getCategory(map)).toBe('high')
+  })
+})
+
+describe('category styling helpers', () => {
+  it('returns distinct color classes per band', () => {
+    expect(categoryColor('low')).toMatch(/text-/)
+    expect(categoryColor('normal')).toMatch(/text-/)
+    expect(categoryColor('high')).toMatch(/text-/)
+    expect(categoryColor('low')).not.toBe(categoryColor('normal'))
+    expect(categoryColor('normal')).not.toBe(categoryColor('high'))
+  })
+
+  it('returns distinct background classes per band', () => {
+    expect(categoryBg('low')).toMatch(/bg-/)
+    expect(categoryBg('normal')).toMatch(/bg-/)
+    expect(categoryBg('high')).toMatch(/bg-/)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -22,6 +22,7 @@ const EXPECTED_KEYS = [
   'pregnancyBMI', 'fertilityWindow', 'headCircumference', 'breastMilkAlcohol', 'menopauseSymptom', 'pearlIndexRechner',
   'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'pmsSymptom', 'breastCancerRisk',
   'pediatricBmi',
+  'meanArterialPressure',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -99,6 +100,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'pms-symptome-bewerten',
   'brustkrebs-risiko-berechnen',
   'kinder-bmi-berechnen',
+  'mittlerer-arterieller-druck-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -176,12 +178,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pms-symptom-calculator-guide',
   'breast-cancer-risk-calculator-guide',
   'pediatric-bmi-guide',
+  'mean-arterial-pressure-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 86 calculator meta files', () => {
+  it('discovers all 87 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(86)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(87)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -219,19 +222,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 87 DE blog slugs', () => {
+  it('returns all 88 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(87)
+    expect(de).toHaveLength(88)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 87 EN blog slugs', () => {
+  it('returns all 88 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(87)
+    expect(en).toHaveLength(88)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -299,9 +302,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 172 calcs + 2 blog index + 174 blog articles = 350)', () => {
+  it('generates correct total URL count (2 home + 174 calcs + 2 blog index + 176 blog articles = 354)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(350)
+    expect(urlCount).toBe(354)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -782,6 +782,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'pediatricBmi',
     related: ['calculate-bmi', 'child-growth-percentile-chart', 'child-calorie-needs-guide'],
   },
+  {
+    slug: 'mean-arterial-pressure-guide',
+    title: 'Mean Arterial Pressure (MAP): Formula, Normal Range, Why It Matters',
+    description: 'MAP explained: the (SBP + 2 × DBP) / 3 formula, normal ranges, why 65 mmHg is the critical floor, and what the target should be in older adults.',
+    date: '2026-05-27',
+    readTime: '7 min',
+    calculatorKey: 'meanArterialPressure',
+    related: ['measure-blood-pressure', 'cardiovascular-risk-framingham', 'stroke-risk-calculator-cha2ds2-vasc'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -782,6 +782,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'pediatricBmi',
     related: ['bmi-berechnen', 'wachstumsperzentile-kinder', 'kinder-kalorienbedarf-berechnen'],
   },
+  {
+    slug: 'mittlerer-arterieller-druck-berechnen',
+    title: 'Mittlerer arterieller Druck (MAP) berechnen: Formel, Normalwerte, Bedeutung',
+    description: 'MAP einfach erklärt: Formel (SBP + 2 × DBP) / 3, Normalbereiche, warum 65 mmHg die kritische Grenze ist und wie ältere Erwachsene den Wert einordnen sollten.',
+    date: '2026-05-27',
+    readTime: '7 min',
+    calculatorKey: 'meanArterialPressure',
+    related: ['blutdruck-richtig-messen', 'herz-kreislauf-risiko-berechnen', 'schlaganfall-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/meanArterialPressure.json
+++ b/src/locales/calculators/de/meanArterialPressure.json
@@ -1,0 +1,53 @@
+{
+  "home": {
+    "calculators": {
+      "meanArterialPressure": {
+        "name": "MAP-Rechner",
+        "description": "Mittleren arteriellen Druck (MAP) aus systolischem und diastolischem Blutdruck berechnen."
+      }
+    }
+  },
+  "meanArterialPressure": {
+    "meta": {
+      "title": "MAP-Rechner — Mittlerer arterieller Druck | Health Calculators",
+      "description": "Mittleren arteriellen Druck (MAP) aus Blutdruckwerten berechnen. Formel: (SBP + 2 × DBP) / 3. Klinische Einordnung in niedrig, normal oder hoch."
+    },
+    "title": "Mittlerer arterieller Druck (MAP)",
+    "description": "Geben Sie systolischen und diastolischen Blutdruck ein. Der Rechner ermittelt den mittleren arteriellen Druck (MAP) und ordnet ihn klinisch ein.",
+    "systolic": "Systolisch SBP (mmHg)",
+    "diastolic": "Diastolisch DBP (mmHg)",
+    "resultsLabel": "Ergebnis",
+    "mapLabel": "MAP",
+    "mapUnit": "mmHg",
+    "categoryLabel": "Klinische Einordnung",
+    "categoriesTitle": "MAP-Kategorien",
+    "olderAdultsNote": "Bei älteren Erwachsenen (≥ 65 Jahre) und in der Intensivmedizin gilt ein MAP von mindestens 65 mmHg als Mindestziel für eine ausreichende Organperfusion. Werte zwischen 70 und 90 mmHg gelten meist als sicher.",
+    "formulaTitle": "Formel",
+    "formulaText": "MAP ≈ (SBP + 2 × DBP) / 3",
+    "formulaWhy": "Der diastolische Druck wird doppelt gewichtet, weil das Herz im Herzzyklus etwa zwei Drittel der Zeit in der Diastole verbringt.",
+    "cat": {
+      "low": "Niedrig",
+      "normal": "Normal",
+      "high": "Hoch"
+    },
+    "catRange": {
+      "low": "< 70 mmHg",
+      "normal": "70 – 100 mmHg",
+      "high": "> 100 mmHg"
+    },
+    "catDescription": {
+      "low": "Mögliche Minderdurchblutung der Organe — bei Symptomen wie Schwindel oder Schwäche ärztlich abklären.",
+      "normal": "Ausreichende Organperfusion — ein guter Wert für gesunde Erwachsene.",
+      "high": "Anhaltend erhöhter Wert — kann auf Hypertonie und erhöhtes kardiovaskuläres Risiko hinweisen."
+    },
+    "disclaimer": "Die MAP-Formel (SBP + 2 × DBP) / 3 ist eine klinische Schätzung und ersetzt keine invasive Blutdruckmessung oder ärztliche Beurteilung. Konsultieren Sie bei anhaltenden Auffälligkeiten einen Arzt.",
+    "faq": [
+      { "q": "Was ist der mittlere arterielle Druck (MAP)?", "a": "Der mittlere arterielle Druck ist der durchschnittliche Druck in den Arterien während eines Herzzyklus. Er bestimmt, wie gut Organe wie Gehirn, Nieren und Herzmuskel durchblutet werden. Ein MAP von mindestens 65 mmHg gilt als Mindestziel für eine ausreichende Perfusion." },
+      { "q": "Wie wird MAP berechnet?", "a": "Die übliche klinische Formel lautet: MAP ≈ (SBP + 2 × DBP) / 3. Beispiel: Bei 120/80 mmHg ergibt sich (120 + 160) / 3 = 93,3 mmHg. Der diastolische Druck wird doppelt gewichtet, weil das Herz etwa zwei Drittel der Zeit im Herzzyklus in der Diastole verbringt." },
+      { "q": "Welche MAP-Werte gelten als normal?", "a": "70 bis 100 mmHg gelten als normaler Bereich für gesunde Erwachsene. Werte unter 65 mmHg können auf eine Minderdurchblutung lebenswichtiger Organe hinweisen, Werte dauerhaft über 100 mmHg auf Bluthochdruck und ein erhöhtes kardiovaskuläres Risiko." },
+      { "q": "Was bedeutet ein zu niedriger MAP?", "a": "Ein MAP unter 65 mmHg gilt als kritisch, besonders auf der Intensivstation. Bei wachen Patienten kann er Schwindel, Schwäche oder Bewusstseinstrübung verursachen. Häufige Ursachen sind Volumenmangel, Sepsis, Herzversagen oder Medikamentennebenwirkungen." },
+      { "q": "Gilt der MAP-Zielwert auch für ältere Menschen?", "a": "Bei älteren Erwachsenen (≥ 65 Jahre) ist die zerebrale Autoregulation oft eingeschränkt. Hier wird häufig ein etwas höherer MAP von 70–90 mmHg angestrebt, um eine ausreichende Hirnperfusion zu sichern. Die individuelle Zielsetzung legt der behandelnde Arzt fest." },
+      { "q": "Ersetzt diese Berechnung eine ärztliche Beurteilung?", "a": "Nein. Die Formel (SBP + 2 × DBP) / 3 ist eine vereinfachte Schätzung. Sie reicht für die häusliche Orientierung, ersetzt aber keine direkte arterielle Messung und keine ärztliche Diagnose. Konsultieren Sie bei wiederholt auffälligen Werten Ihren Arzt." }
+    ]
+  }
+}

--- a/src/locales/calculators/en/meanArterialPressure.json
+++ b/src/locales/calculators/en/meanArterialPressure.json
@@ -1,0 +1,53 @@
+{
+  "home": {
+    "calculators": {
+      "meanArterialPressure": {
+        "name": "MAP Calculator",
+        "description": "Compute mean arterial pressure (MAP) from systolic and diastolic blood pressure."
+      }
+    }
+  },
+  "meanArterialPressure": {
+    "meta": {
+      "title": "MAP Calculator — Mean Arterial Pressure | Health Calculators",
+      "description": "Calculate mean arterial pressure (MAP) from blood pressure readings. Formula: (SBP + 2 × DBP) / 3. Clinical bands: low, normal, high."
+    },
+    "title": "Mean Arterial Pressure (MAP)",
+    "description": "Enter your systolic and diastolic blood pressure. The calculator returns the mean arterial pressure (MAP) and a clinical band.",
+    "systolic": "Systolic SBP (mmHg)",
+    "diastolic": "Diastolic DBP (mmHg)",
+    "resultsLabel": "Result",
+    "mapLabel": "MAP",
+    "mapUnit": "mmHg",
+    "categoryLabel": "Clinical band",
+    "categoriesTitle": "MAP categories",
+    "olderAdultsNote": "In older adults (≥ 65 years) and in critical care, a MAP of at least 65 mmHg is the usual minimum target to keep organs adequately perfused. Values between 70 and 90 mmHg are typically considered safe.",
+    "formulaTitle": "Formula",
+    "formulaText": "MAP ≈ (SBP + 2 × DBP) / 3",
+    "formulaWhy": "Diastolic pressure is weighted twice because the heart spends roughly two-thirds of the cardiac cycle in diastole.",
+    "cat": {
+      "low": "Low",
+      "normal": "Normal",
+      "high": "High"
+    },
+    "catRange": {
+      "low": "< 70 mmHg",
+      "normal": "70 – 100 mmHg",
+      "high": "> 100 mmHg"
+    },
+    "catDescription": {
+      "low": "Possible organ hypoperfusion — if you have symptoms like dizziness or weakness, see a doctor.",
+      "normal": "Adequate organ perfusion — a healthy value for most adults.",
+      "high": "Persistently elevated — may indicate hypertension and higher cardiovascular risk."
+    },
+    "disclaimer": "The MAP formula (SBP + 2 × DBP) / 3 is a clinical estimate. It does not replace invasive arterial measurement or medical assessment. See a doctor for persistent abnormal readings.",
+    "faq": [
+      { "q": "What is mean arterial pressure (MAP)?", "a": "Mean arterial pressure is the average pressure in your arteries during one cardiac cycle. It determines how well organs like the brain, kidneys and heart muscle are perfused. A MAP of at least 65 mmHg is generally considered the minimum needed for adequate perfusion." },
+      { "q": "How is MAP calculated?", "a": "The standard clinical formula is MAP ≈ (SBP + 2 × DBP) / 3. For example, at 120/80 mmHg, MAP = (120 + 160) / 3 = 93.3 mmHg. Diastolic pressure is weighted twice because the heart spends roughly two-thirds of the cardiac cycle in diastole." },
+      { "q": "What is a normal MAP range?", "a": "70 to 100 mmHg is considered the normal range for healthy adults. Values below 65 mmHg can signal hypoperfusion of vital organs. Values persistently above 100 mmHg point toward hypertension and increased cardiovascular risk." },
+      { "q": "What does a low MAP mean?", "a": "A MAP below 65 mmHg is considered critical, especially in intensive care. In conscious patients it may cause dizziness, weakness or confusion. Common causes include hypovolemia, sepsis, heart failure or medication side effects." },
+      { "q": "Does the MAP target change for older adults?", "a": "In older adults (≥ 65 years) cerebral autoregulation is often impaired. A slightly higher MAP — typically 70–90 mmHg — is often targeted to maintain brain perfusion. The individual target should be set by the treating physician." },
+      { "q": "Does this calculator replace a medical assessment?", "a": "No. The formula (SBP + 2 × DBP) / 3 is a simplified estimate. It is useful for home orientation but does not replace direct arterial measurement or medical diagnosis. See a doctor for persistent abnormal readings." }
+    ]
+  }
+}

--- a/src/pages/MeanArterialPressureCalculator.vue
+++ b/src/pages/MeanArterialPressureCalculator.vue
@@ -1,0 +1,135 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcMap, getCategory, categoryColor, categoryBg } from '../utils/meanArterialPressure.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('meanArterialPressure.faq') || [])
+
+useHead(() => ({
+  title: t('meanArterialPressure.meta.title'),
+  description: t('meanArterialPressure.meta.description'),
+  routeKey: 'meanArterialPressure',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'MAP Calculator',
+    url: 'https://healthcalculator.app/en/mean-arterial-pressure',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const systolic = ref(null)
+const diastolic = ref(null)
+
+const map = computed(() => calcMap(systolic.value, diastolic.value))
+const category = computed(() => getCategory(map.value))
+const hasResult = computed(() => map.value !== null && category.value !== null)
+const mapFormatted = computed(() => map.value !== null ? map.value.toFixed(1) : '—')
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('meanArterialPressure.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('meanArterialPressure.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label for="systolic" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('meanArterialPressure.systolic') }}
+          </label>
+          <input id="systolic" v-model.number="systolic" type="number" min="1" placeholder="120"
+            data-testid="systolic-input"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        </div>
+        <div>
+          <label for="diastolic" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('meanArterialPressure.diastolic') }}
+          </label>
+          <input id="diastolic" v-model.number="diastolic" type="number" min="1" placeholder="80"
+            data-testid="diastolic-input"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150" />
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <div v-if="hasResult" :class="['border rounded-xl shadow-sm p-8 mb-6', categoryBg(category)]" data-testid="result-card">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('meanArterialPressure.resultsLabel') }}</p>
+
+      <div class="flex items-baseline gap-3 mb-4">
+        <span data-testid="map-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ mapFormatted }}</span>
+        <span class="text-sm text-stone-400 ml-1">{{ t('meanArterialPressure.mapUnit') }}</span>
+      </div>
+
+      <p :class="['text-lg font-semibold mb-1', categoryColor(category)]" data-testid="category">{{ t(`meanArterialPressure.cat.${category}`) }}</p>
+      <p class="text-sm text-stone-600 leading-relaxed mb-4" data-testid="category-description">{{ t(`meanArterialPressure.catDescription.${category}`) }}</p>
+
+      <div class="bg-white/60 border border-stone-200 rounded-lg p-4 text-xs text-stone-600 leading-relaxed" data-testid="older-adults-note">
+        {{ t('meanArterialPressure.olderAdultsNote') }}
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('meanArterialPressure.categoriesTitle') }}</h2>
+      <div class="space-y-3.5">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-amber-500"></div>
+            <span class="text-sm text-stone-600">{{ t('meanArterialPressure.cat.low') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('meanArterialPressure.catRange.low') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-emerald-500"></div>
+            <span class="text-sm text-stone-600">{{ t('meanArterialPressure.cat.normal') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('meanArterialPressure.catRange.normal') }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-red-500"></div>
+            <span class="text-sm text-stone-600">{{ t('meanArterialPressure.cat.high') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('meanArterialPressure.catRange.high') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('meanArterialPressure.formulaTitle') }}</h2>
+      <div class="bg-stone-50 rounded-lg p-4 font-mono text-base text-stone-700 mb-3">
+        {{ t('meanArterialPressure.formulaText') }}
+      </div>
+      <p class="text-sm text-stone-600 leading-relaxed">{{ t('meanArterialPressure.formulaWhy') }}</p>
+    </div>
+
+    <div v-if="hasResult" class="bg-stone-50 rounded-xl border border-stone-200 p-5 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('meanArterialPressure.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <RelatedCalculators calc-key="meanArterialPressure" class="mt-8" />
+    <BlogArticleLink calculator-key="meanArterialPressure" />
+
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/MittlererArteriellerDruckBerechnen.vue
+++ b/src/pages/blog/MittlererArteriellerDruckBerechnen.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Mittlerer arterieller Druck (MAP) berechnen: Formel, Normalwerte, Bedeutung | Health Calculators',
+  description: 'MAP einfach erklärt: Formel (SBP + 2 × DBP) / 3, Normalbereiche, warum 65 mmHg die kritische Grenze ist und wie ältere Erwachsene den Wert einordnen sollten.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Mittlerer arterieller Druck (MAP) berechnen: Formel, Normalwerte, Bedeutung',
+      description: 'MAP erklärt: Formel, klinische Bedeutung, Normalbereiche und Zielwerte bei älteren Erwachsenen.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-27',
+      dateModified: '2026-05-27',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/mittlerer-arterieller-druck-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist der mittlere arterielle Druck (MAP)?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Der mittlere arterielle Druck ist der durchschnittliche Druck in den Arterien während eines Herzzyklus. Er entscheidet, wie gut Organe wie Gehirn, Nieren und Herzmuskel durchblutet werden. Ein MAP von mindestens 65 mmHg gilt als Mindestziel für eine ausreichende Perfusion.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wie berechnet man den MAP?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die klinische Faustformel lautet: MAP ≈ (SBP + 2 × DBP) / 3. Bei einem Blutdruck von 120/80 mmHg ergibt sich (120 + 160) / 3 = 93,3 mmHg. Diastolisch wird doppelt gewichtet, weil das Herz etwa zwei Drittel der Zeit in der Diastole verbringt.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welche MAP-Werte sind normal?',
+          acceptedAnswer: { '@type': 'Answer', text: '70 bis 100 mmHg gelten als Normalbereich für gesunde Erwachsene. Unter 65 mmHg droht eine Minderdurchblutung lebenswichtiger Organe, dauerhaft über 100 mmHg deutet auf Bluthochdruck und ein erhöhtes kardiovaskuläres Risiko hin.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Warum ist MAP wichtiger als nur Systole und Diastole?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die einzelnen Werte sagen, wie hoch der Druck im Maximum (Systole) bzw. Minimum (Diastole) ist. Der MAP beschreibt den durchschnittlichen Perfusionsdruck über den gesamten Herzzyklus — und damit den eigentlich physiologisch relevanten Wert für die Organdurchblutung. Deshalb ist MAP auf Intensivstationen der zentrale Steuerungsparameter.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Gilt der MAP-Zielwert auch für ältere Menschen?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Bei älteren Erwachsenen (≥ 65 Jahre) ist die zerebrale Autoregulation oft eingeschränkt. Hier wird häufig ein etwas höherer MAP von 70–90 mmHg angestrebt, damit das Gehirn ausreichend durchblutet bleibt. Den genauen Zielbereich legt der behandelnde Arzt fest.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Ersetzt die Formel eine echte Messung?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Nein. (SBP + 2 × DBP) / 3 ist eine vereinfachte Schätzung. Für die häusliche Orientierung reicht sie. Eine invasive arterielle Messung im Krankenhaus ist exakter, aber für Alltagsfragen meist nicht nötig.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Mittlerer arterieller Druck (MAP) berechnen: Formel, Normalwerte, Bedeutung</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">27. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          120 zu 80 — diese zwei Zahlen kennt jeder. Aber im Krankenhaus, besonders auf der Intensivstation, schauen Ärzte oft auf eine dritte Zahl: den <strong>mittleren arteriellen Druck (MAP)</strong>. Er sagt, wie gut das Herz die Organe wirklich durchblutet.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt die Formel, die Normalbereiche und warum der MAP für die Organperfusion wichtiger ist als die einzelnen Blutdruckwerte allein.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel: einfach, aber clever</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der MAP wird klinisch mit einer einfachen Formel geschätzt:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          MAP ≈ (SBP + 2 × DBP) / 3
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Warum wird der diastolische Druck doppelt gewichtet? Weil das Herz etwa <strong>zwei Drittel des Herzzyklus in der Diastole</strong> verbringt — also in der Entspannungsphase. Der niedrigere Druck dauert länger, also wirkt er stärker auf den Durchschnitt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beispiel: Bei 120/80 mmHg ergibt sich (120 + 160) / 3 = <strong>93,3 mmHg</strong>. Das ist ein typischer Normalwert für gesunde Erwachsene.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Normalbereiche auf einen Blick</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">MAP-Kategorien</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">Unter 70 mmHg</span>
+              <span class="text-amber-600 font-medium">Niedrig</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">70 – 100 mmHg</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">Über 100 mmHg</span>
+              <span class="text-red-500 font-medium">Hoch</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die kritische Untergrenze für die Organperfusion liegt bei <strong>65 mmHg</strong>. Werte darunter gelten in der Intensivmedizin als alarmierend, weil Nieren, Gehirn und Herzmuskel nicht mehr ausreichend versorgt werden.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum MAP wichtiger ist als Systole oder Diastole allein</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die systolische Zahl (oben) sagt, wie hoch der Druck beim Pumpen wird. Die diastolische (unten) sagt, wie tief er zwischen den Pumpaktionen fällt. Beides sind <em>Momentaufnahmen</em>.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der MAP dagegen ist der <strong>Durchschnittsdruck über den gesamten Zyklus</strong>. Genau dieser Druck treibt das Blut kontinuierlich durch die Kapillaren in Nieren, Gehirn und Herzmuskel. Deshalb steuern Intensivmediziner Katecholamine und Volumengabe nicht nach Systole, sondern nach MAP.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-5 mb-4">
+          <p class="text-sm text-stone-700">
+            Faustregel: Solange der MAP ≥ 65 mmHg liegt, ist die Organperfusion meist gesichert — unabhängig davon, ob die einzelnen Werte „schön" aussehen.
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">MAP bei älteren Erwachsenen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei Menschen ab etwa <strong>65 Jahren</strong> arbeitet die zerebrale Autoregulation träger. Die Gefäße im Gehirn können einen Blutdruckabfall schlechter kompensieren. Deshalb peilen viele Kliniker hier einen MAP von <strong>70 bis 90 mmHg</strong> an — also etwas höher als bei jüngeren Patienten.
+        </p>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Worauf bei älteren Patienten achten?</p>
+          <ul class="text-sm text-amber-700 space-y-1">
+            <li>→ Schwindel oder Stürze bei zu niedrigem MAP</li>
+            <li>→ Sturzgefahr bei orthostatischer Hypotonie</li>
+            <li>→ Medikamenten-Anpassung mit Hausarzt besprechen</li>
+            <li>→ MAP-Ziel individuell vom Arzt festlegen lassen</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann ein niedriger MAP gefährlich wird</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein MAP unter 65 mmHg kann unter anderem entstehen durch:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Volumenmangel (z. B. durch Dehydratation oder Blutung)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Sepsis und septischer Schock</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Herzinsuffizienz mit reduzierter Pumpleistung</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Überdosierung blutdrucksenkender Medikamente</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Symptome wie Schwindel, Schwäche, Verwirrtheit oder kühle Extremitäten sollten ärztlich abgeklärt werden.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Berechne deinen MAP</h3>
+        <p class="text-base text-stone-600 mb-6">Systolisch und diastolisch eingeben — der Rechner liefert MAP und Einordnung.</p>
+        <router-link
+          :to="localePath('meanArterialPressure')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Zum MAP-Rechner
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          MAP allein ist nur ein Mosaikstein. Den vollständigen Blutdruck-Status hilft der
+          <router-link :to="localePath('bloodPressure')" class="text-stone-900 underline hover:no-underline">Blutdruck-Rechner</router-link>
+          einzuordnen. Für die langfristige Risikobewertung ist der
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Herz-Kreislauf-Risiko-Rechner</router-link>
+          hilfreich — und wer Vorhofflimmern hat, sollte den
+          <router-link :to="localePath('strokeRisk')" class="text-stone-900 underline hover:no-underline">Schlaganfall-Risiko-Rechner</router-link>
+          kennen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der MAP ist die unterschätzte dritte Blutdruckzahl. Während Systole und Diastole nur Spitzenwerte zeigen, beschreibt MAP den durchschnittlichen Perfusionsdruck — und damit das, worauf es für die Organe wirklich ankommt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Mit der einfachen Formel (SBP + 2 × DBP) / 3 lässt er sich in Sekunden berechnen. Für die häusliche Orientierung reicht das. Für medizinische Entscheidungen bleibt der Arzt zuständig.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="mittlerer-arterieller-druck-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/MeanArterialPressureGuide.vue
+++ b/src/pages/blog/en/MeanArterialPressureGuide.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Mean Arterial Pressure (MAP): Formula, Normal Range, Why It Matters | Health Calculators',
+  description: 'MAP explained: the (SBP + 2 × DBP) / 3 formula, normal ranges, why 65 mmHg is the critical floor, and what the target should be in older adults.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Mean Arterial Pressure (MAP): Formula, Normal Range, Why It Matters',
+      description: 'MAP explained: formula, clinical relevance, normal range and targets in older adults.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-27',
+      dateModified: '2026-05-27',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/mean-arterial-pressure-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is mean arterial pressure (MAP)?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Mean arterial pressure is the average pressure in your arteries during one cardiac cycle. It determines how well organs like the brain, kidneys and heart muscle are perfused. A MAP of at least 65 mmHg is generally considered the minimum needed for adequate perfusion.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'How is MAP calculated?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The standard clinical formula is MAP ≈ (SBP + 2 × DBP) / 3. For 120/80 mmHg this gives (120 + 160) / 3 = 93.3 mmHg. Diastolic pressure is weighted twice because the heart spends roughly two-thirds of the cardiac cycle in diastole.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What is a normal MAP range?',
+          acceptedAnswer: { '@type': 'Answer', text: '70 to 100 mmHg is the typical normal range in healthy adults. Below 65 mmHg vital organs may be hypoperfused. Persistently above 100 mmHg suggests hypertension and higher cardiovascular risk.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Why is MAP more useful than systolic or diastolic alone?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Systolic shows the peak pressure during contraction; diastolic shows the trough during relaxation. MAP captures the average perfusion pressure across the whole cardiac cycle — the value that actually drives blood flow into kidneys, brain and heart muscle. That is why intensive care uses MAP as the main control parameter.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Does the MAP target change for older adults?',
+          acceptedAnswer: { '@type': 'Answer', text: 'In older adults (≥ 65 years) cerebral autoregulation is often impaired. A slightly higher MAP — typically 70–90 mmHg — is often targeted to maintain brain perfusion. The individual target should be set by the treating physician.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Does the formula replace a real measurement?',
+          acceptedAnswer: { '@type': 'Answer', text: 'No. (SBP + 2 × DBP) / 3 is a simplified estimate that is fine for home orientation. Invasive arterial monitoring in hospital is more accurate, but rarely needed for everyday questions.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Mean Arterial Pressure (MAP): Formula, Normal Range, Why It Matters</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 27, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          120 over 80 — everyone knows those two numbers. But in hospitals, especially in intensive care, doctors often watch a third one: <strong>mean arterial pressure (MAP)</strong>. It tells you how well the heart actually perfuses the organs.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains the formula, the normal range, and why MAP matters more for organ perfusion than systolic or diastolic alone.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula: simple but clever</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The clinical estimate uses one short equation:
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          MAP ≈ (SBP + 2 × DBP) / 3
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Why is diastolic weighted twice? Because the heart spends about <strong>two-thirds of each cycle in diastole</strong> — the relaxation phase. The lower pressure lasts longer, so it pulls the average down more strongly.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Example: at 120/80 mmHg the calculation is (120 + 160) / 3 = <strong>93.3 mmHg</strong>. That is a typical healthy adult value.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Normal ranges at a glance</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">MAP categories</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">Below 70 mmHg</span>
+              <span class="text-amber-600 font-medium">Low</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">70 – 100 mmHg</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">Above 100 mmHg</span>
+              <span class="text-red-500 font-medium">High</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The critical floor for organ perfusion is <strong>65 mmHg</strong>. In critical care, anything below that is treated as an alarm — kidneys, brain and heart muscle are at risk of inadequate perfusion.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why MAP beats systolic or diastolic on their own</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The top number tells you the peak pressure as the heart contracts. The bottom number tells you the trough between beats. Both are <em>snapshots</em>.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          MAP is the <strong>average pressure across the whole cycle</strong>. That is the pressure actually driving blood through the capillaries of kidneys, brain and myocardium. That is why ICU staff titrate fluids and vasopressors against MAP, not against systolic.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-5 mb-4">
+          <p class="text-sm text-stone-700">
+            Rule of thumb: as long as MAP ≥ 65 mmHg, organ perfusion is usually adequate — regardless of how the individual readings "look".
+          </p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">MAP in older adults</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          From roughly age <strong>65 onward</strong>, cerebral autoregulation gets sluggish. Vessels in the brain are less able to compensate for a sudden drop in blood pressure. Many clinicians therefore target a slightly higher MAP — <strong>70 to 90 mmHg</strong> — for older patients.
+        </p>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">What to watch for in older patients</p>
+          <ul class="text-sm text-amber-700 space-y-1">
+            <li>→ Dizziness or falls when MAP is too low</li>
+            <li>→ Orthostatic hypotension increasing fall risk</li>
+            <li>→ Medication adjustments discussed with the family doctor</li>
+            <li>→ Individual MAP targets set by the treating physician</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">When low MAP becomes dangerous</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A MAP below 65 mmHg may be caused by:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Hypovolemia (dehydration, bleeding)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Sepsis and septic shock</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Heart failure with reduced output</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Over-treatment with antihypertensives</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Symptoms such as dizziness, weakness, confusion or cool extremities deserve medical review.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Calculate your MAP</h3>
+        <p class="text-base text-stone-600 mb-6">Enter systolic and diastolic — the calculator returns MAP and a clinical band.</p>
+        <router-link
+          :to="localePath('meanArterialPressure')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Open the MAP Calculator
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          MAP is one piece of the picture. For the full blood pressure status use the
+          <router-link :to="localePath('bloodPressure')" class="text-stone-900 underline hover:no-underline">Blood Pressure Calculator</router-link>.
+          To put long-term risk in context, the
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Cardiovascular Risk Calculator</router-link>
+          is the natural next step. If you have atrial fibrillation, the
+          <router-link :to="localePath('strokeRisk')" class="text-stone-900 underline hover:no-underline">Stroke Risk Calculator</router-link>
+          is worth checking too.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Takeaway</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          MAP is the underrated third blood pressure number. Systolic and diastolic only show peaks; MAP shows the average perfusion pressure — what actually matters for the organs.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          With the formula (SBP + 2 × DBP) / 3 you can compute it in seconds. That is enough for home orientation. Treatment decisions remain with your doctor.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="mean-arterial-pressure-guide" />
+  </article>
+</template>

--- a/src/pages/meanArterialPressure.meta.js
+++ b/src/pages/meanArterialPressure.meta.js
@@ -1,0 +1,16 @@
+import Component from './MeanArterialPressureCalculator.vue'
+import BlogDe from './blog/MittlererArteriellerDruckBerechnen.vue'
+import BlogEn from './blog/en/MeanArterialPressureGuide.vue'
+
+export default {
+  key: 'meanArterialPressure',
+  component: Component,
+  slugs: { de: 'mittlerer-arterieller-druck-rechner', en: 'mean-arterial-pressure' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 2.5,
+  blog: {
+    de: { slug: 'mittlerer-arterieller-druck-berechnen', component: BlogDe },
+    en: { slug: 'mean-arterial-pressure-guide', component: BlogEn },
+  },
+}

--- a/src/utils/meanArterialPressure.js
+++ b/src/utils/meanArterialPressure.js
@@ -1,0 +1,39 @@
+// Mean Arterial Pressure (MAP) — clinical estimate.
+// Formula: MAP ≈ (SBP + 2 × DBP) / 3.
+
+export function calcMap(sbp, dbp) {
+  if (sbp == null || dbp == null) return null
+  const s = Number(sbp)
+  const d = Number(dbp)
+  if (!Number.isFinite(s) || !Number.isFinite(d)) return null
+  if (s <= 0 || d <= 0) return null
+  if (d > s) return null
+  return (s + 2 * d) / 3
+}
+
+export function getCategory(map) {
+  if (map == null || !Number.isFinite(map)) return null
+  if (map < 70) return 'low'
+  if (map <= 100) return 'normal'
+  return 'high'
+}
+
+const COLORS = {
+  low: 'text-amber-600',
+  normal: 'text-emerald-600',
+  high: 'text-red-600',
+}
+
+const BGS = {
+  low: 'bg-amber-50 border-amber-200',
+  normal: 'bg-emerald-50 border-emerald-200',
+  high: 'bg-red-50 border-red-200',
+}
+
+export function categoryColor(category) {
+  return COLORS[category] || 'text-stone-900'
+}
+
+export function categoryBg(category) {
+  return BGS[category] || 'bg-white border-stone-200'
+}


### PR DESCRIPTION
## Summary
- New MAP calculator using the clinical formula `MAP ≈ (SBP + 2 × DBP) / 3`
- Clinical bands: low (<70), normal (70–100), high (>100) with age-adjusted note for older adults (≥65)
- DE + EN blog articles with FAQPage structured data; internal links to bloodPressure, cardiovascularRisk, strokeRisk
- 18 unit tests + 7 Playwright E2E tests; counts in auto-discovery / sitemap / llms-txt bumped

## Test plan
- [x] `npm test` — all 2405 tests pass
- [x] `npm run build` — SSG generates `/de/mittlerer-arterieller-druck-rechner/`, `/en/mean-arterial-pressure/`, both blog routes
- [x] `npx playwright test e2e/meanArterialPressure.spec.js` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)