### PR TITLE
hc-266-homa-ir: Implement the HOMA-IR (Homeostatic Model Assessment for Insu

### DIFF
--- a/e2e/homaIr.spec.js
+++ b/e2e/homaIr.spec.js
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('HOMA-IR Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/homa-ir-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/HOMA-IR-Rechner/)
+  })
+
+  test('h1 contains HOMA-IR', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('HOMA-IR')
+  })
+
+  test('back link navigates to home page', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('conventional units selected by default', async ({ page }) => {
+    await expect(page.getByTestId('btn-imperial')).toHaveClass(/bg-stone-900/)
+  })
+
+  test('no result shown before inputs', async ({ page }) => {
+    await expect(page.getByTestId('result-card')).toHaveCount(0)
+  })
+
+  test('normal HOMA-IR: glucose 85 + insulin 4 → ~0.84, normal band', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('85')
+    await page.getByTestId('insulin-input').fill('4')
+
+    await expect(page.getByTestId('homa-value')).toHaveText('0.84')
+    await expect(page.getByTestId('band')).toHaveText('Normal')
+    await expect(page.getByTestId('band')).toHaveClass(/text-emerald/)
+  })
+
+  test('mild band: glucose 90 + insulin 8 → ~1.78, mild', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('90')
+    await page.getByTestId('insulin-input').fill('8')
+
+    await expect(page.getByTestId('homa-value')).toHaveText('1.78')
+    await expect(page.getByTestId('band')).toHaveText('Leichte Insulinresistenz')
+    await expect(page.getByTestId('band')).toHaveClass(/text-amber/)
+  })
+
+  test('insulin resistance band: glucose 95 + insulin 12 → ~2.81', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('95')
+    await page.getByTestId('insulin-input').fill('12')
+
+    await expect(page.getByTestId('homa-value')).toHaveText('2.81')
+    await expect(page.getByTestId('band')).toHaveText('Insulinresistenz')
+    await expect(page.getByTestId('band')).toHaveClass(/text-orange/)
+  })
+
+  test('severe band: glucose 110 + insulin 20 → ~5.43', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('110')
+    await page.getByTestId('insulin-input').fill('20')
+
+    await expect(page.getByTestId('homa-value')).toHaveText('5.43')
+    await expect(page.getByTestId('band')).toHaveText('Schwere Insulinresistenz')
+    await expect(page.getByTestId('band')).toHaveClass(/text-red/)
+  })
+
+  test('switching to metric clears inputs and updates labels', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('90')
+    await page.getByTestId('insulin-input').fill('8')
+
+    await page.getByTestId('btn-metric').click()
+    await expect(page.getByTestId('btn-metric')).toHaveClass(/bg-stone-900/)
+    await expect(page.getByTestId('glucose-input')).toHaveValue('')
+    await expect(page.getByTestId('insulin-input')).toHaveValue('')
+  })
+
+  test('metric units: glucose 5 mmol/L + insulin 8 µU/mL is computed via SI formula', async ({ page }) => {
+    await page.getByTestId('btn-metric').click()
+    // 8 µU/mL ≈ 55.56 pmol/L; glucose 5 mmol/L
+    // HOMA-IR = (8 × 5) / 22.5 ≈ 1.78
+    await page.getByTestId('glucose-input').fill('5')
+    await page.getByTestId('insulin-input').fill('55.56')
+
+    await expect(page.getByTestId('homa-value')).toHaveText('1.78')
+    await expect(page.getByTestId('band')).toHaveText('Leichte Insulinresistenz')
+  })
+
+  test('formula text is visible after input', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('90')
+    await page.getByTestId('insulin-input').fill('8')
+    await expect(page.getByTestId('formula')).toBeVisible()
+  })
+
+  test('clinical note is shown in the result card', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('90')
+    await page.getByTestId('insulin-input').fill('8')
+    await expect(page.getByTestId('clinical-note')).toBeVisible()
+  })
+
+  test('related calculators block is visible', async ({ page }) => {
+    await expect(page.getByTestId('related-calculators')).toBeVisible()
+  })
+
+  test('blog article link is visible', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('HOMA-IR Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/homa-ir-insulin-resistance')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/HOMA-IR/)
+  })
+
+  test('mild band: glucose 90 + insulin 8 → ~1.78, mild', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('90')
+    await page.getByTestId('insulin-input').fill('8')
+
+    await expect(page.getByTestId('homa-value')).toHaveText('1.78')
+    await expect(page.getByTestId('band')).toHaveText('Mild insulin resistance')
+  })
+
+  test('severe band: glucose 110 + insulin 20 → ~5.43', async ({ page }) => {
+    await page.getByTestId('glucose-input').fill('110')
+    await page.getByTestId('insulin-input').fill('20')
+
+    await expect(page.getByTestId('band')).toHaveText('Severe insulin resistance')
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -29,6 +29,7 @@ const EXPECTED_KEYS = [
   'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'pmsSymptom', 'breastCancerRisk',
   'pediatricBmi',
   'meanArterialPressure',
+  'homaIr',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -119,6 +120,7 @@ const EXPECTED_ROUTE_MAP = {
   breastCancerRisk: { de: 'brustkrebs-risiko-rechner', en: 'breast-cancer-risk-calculator' },
   pediatricBmi: { de: 'kinder-bmi-rechner', en: 'pediatric-bmi' },
   meanArterialPressure: { de: 'mittlerer-arterieller-druck-rechner', en: 'mean-arterial-pressure' },
+  homaIr: { de: 'homa-ir-rechner', en: 'homa-ir-insulin-resistance' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -198,6 +200,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'brustkrebs-risiko-berechnen',
   'kinder-bmi-berechnen',
   'mittlerer-arterieller-druck-berechnen',
+  'homa-ir-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -277,19 +280,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'breast-cancer-risk-calculator-guide',
   'pediatric-bmi-guide',
   'mean-arterial-pressure-guide',
+  'homa-ir-insulin-resistance-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 87 calculators', () => {
-    expect(calculatorMetas).toHaveLength(87)
+  it('discovers all 88 calculators', () => {
+    expect(calculatorMetas).toHaveLength(88)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 87 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(87)
+  it('builds calculatorComponents map for all 88 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(88)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -312,15 +316,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 88 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(88)
+  it('discovers all 89 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(89)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 88 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(88)
+  it('discovers all 89 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(89)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -345,10 +349,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 87 calculators with no duplicates', () => {
+  it('groups contain all 88 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(87)
-    expect(new Set(allKeys).size).toBe(87)
+    expect(allKeys).toHaveLength(88)
+    expect(new Set(allKeys).size).toBe(88)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -369,7 +373,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -418,8 +422,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 480 routes', () => {
-    expect(routes).toHaveLength(480)
+  it('generates exactly 485 routes', () => {
+    expect(routes).toHaveLength(485)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/homaIr.test.js
+++ b/src/__tests__/homaIr.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcHomaIr,
+  calcHomaIrConventional,
+  calcHomaIrSi,
+  getRiskBand,
+  mgdlToMmol,
+  mmolToMgdl,
+  pmolToMicroU,
+  microUToPmol,
+  bandColor,
+  bandBg,
+} from '../utils/homaIr.js'
+
+describe('calcHomaIrConventional — formula', () => {
+  it('calculates (insulin × glucose) / 405', () => {
+    // 5 µU/mL × 90 mg/dL / 405 = 450/405 ≈ 1.111
+    expect(calcHomaIrConventional(5, 90)).toBeCloseTo(1.111, 2)
+  })
+
+  it('returns 2.0 at the resistance boundary (10 × 81 / 405)', () => {
+    expect(calcHomaIrConventional(10, 81)).toBeCloseTo(2.0, 5)
+  })
+})
+
+describe('calcHomaIrSi — formula', () => {
+  it('calculates (insulin × glucose mmol) / 22.5', () => {
+    // 5 µU/mL × 5 mmol/L / 22.5 = 25/22.5 ≈ 1.111
+    expect(calcHomaIrSi(5, 5)).toBeCloseTo(1.111, 2)
+  })
+
+  it('conventional and SI agree after glucose conversion (within 1%)', () => {
+    // 90 mg/dL ≈ 4.9949 mmol/L (factor 18.0182 vs 405/22.5 = 18 exactly)
+    const mmol = mgdlToMmol(90)
+    expect(calcHomaIrSi(5, mmol)).toBeCloseTo(calcHomaIrConventional(5, 90), 1)
+  })
+})
+
+describe('calcHomaIr — wrapper handles units', () => {
+  it('defaults to mg/dL + µU/mL', () => {
+    expect(calcHomaIr({ glucose: 90, insulin: 5 })).toBeCloseTo(1.111, 2)
+  })
+
+  it('handles mmol/L glucose input', () => {
+    const mmol = mgdlToMmol(90)
+    expect(calcHomaIr({ glucose: mmol, insulin: 5, glucoseUnit: 'mmol' })).toBeCloseTo(1.111, 2)
+  })
+
+  it('handles pmol/L insulin input', () => {
+    // 5 µU/mL ≈ 34.725 pmol/L
+    const pmol = microUToPmol(5)
+    expect(calcHomaIr({ glucose: 90, insulin: pmol, insulinUnit: 'pmol' })).toBeCloseTo(1.111, 2)
+  })
+
+  it('handles BOTH units in SI: mmol/L + pmol/L', () => {
+    const mmol = mgdlToMmol(90)
+    const pmol = microUToPmol(5)
+    expect(
+      calcHomaIr({ glucose: mmol, insulin: pmol, glucoseUnit: 'mmol', insulinUnit: 'pmol' }),
+    ).toBeCloseTo(1.111, 2)
+  })
+
+  it('returns null for missing inputs', () => {
+    expect(calcHomaIr({ glucose: null, insulin: 5 })).toBeNull()
+    expect(calcHomaIr({ glucose: 90, insulin: null })).toBeNull()
+  })
+
+  it('returns null for non-positive values', () => {
+    expect(calcHomaIr({ glucose: 0, insulin: 5 })).toBeNull()
+    expect(calcHomaIr({ glucose: 90, insulin: -1 })).toBeNull()
+  })
+
+  it('returns null for NaN values', () => {
+    expect(calcHomaIr({ glucose: NaN, insulin: 5 })).toBeNull()
+    expect(calcHomaIr({ glucose: 90, insulin: NaN })).toBeNull()
+  })
+})
+
+describe('unit conversions', () => {
+  it('converts mg/dL → mmol/L using factor ~18', () => {
+    expect(mgdlToMmol(90)).toBeCloseTo(4.99, 1)
+    expect(mgdlToMmol(180)).toBeCloseTo(9.99, 1)
+  })
+
+  it('converts mmol/L → mg/dL (roundtrip)', () => {
+    expect(mmolToMgdl(mgdlToMmol(100))).toBeCloseTo(100, 5)
+  })
+
+  it('converts pmol/L → µU/mL using factor ~6.945', () => {
+    expect(pmolToMicroU(69.45)).toBeCloseTo(10, 2)
+  })
+
+  it('converts µU/mL → pmol/L (roundtrip)', () => {
+    expect(microUToPmol(pmolToMicroU(60))).toBeCloseTo(60, 5)
+  })
+
+  it('returns null for invalid conversion inputs', () => {
+    expect(mgdlToMmol(null)).toBeNull()
+    expect(mmolToMgdl(undefined)).toBeNull()
+    expect(pmolToMicroU(NaN)).toBeNull()
+    expect(microUToPmol(null)).toBeNull()
+  })
+})
+
+describe('getRiskBand — clinical bands', () => {
+  it('< 1.5 → normal', () => {
+    expect(getRiskBand(0.5)).toBe('normal')
+    expect(getRiskBand(1.0)).toBe('normal')
+    expect(getRiskBand(1.49)).toBe('normal')
+  })
+
+  it('1.5 – 1.99 → mild insulin resistance', () => {
+    expect(getRiskBand(1.5)).toBe('mild')
+    expect(getRiskBand(1.75)).toBe('mild')
+    expect(getRiskBand(1.99)).toBe('mild')
+  })
+
+  it('2.0 – 2.89 → insulin resistance', () => {
+    expect(getRiskBand(2.0)).toBe('resistance')
+    expect(getRiskBand(2.5)).toBe('resistance')
+    expect(getRiskBand(2.89)).toBe('resistance')
+  })
+
+  it('≥ 2.9 → severe', () => {
+    expect(getRiskBand(2.9)).toBe('severe')
+    expect(getRiskBand(5)).toBe('severe')
+    expect(getRiskBand(10)).toBe('severe')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(getRiskBand(null)).toBeNull()
+    expect(getRiskBand(NaN)).toBeNull()
+  })
+})
+
+describe('end-to-end clinical scenarios — all four bands', () => {
+  it('healthy fasting (4 µU/mL × 85 mg/dL) → normal', () => {
+    const v = calcHomaIr({ glucose: 85, insulin: 4 })
+    expect(v).toBeCloseTo(0.84, 1)
+    expect(getRiskBand(v)).toBe('normal')
+  })
+
+  it('borderline (8 µU/mL × 90 mg/dL) → mild', () => {
+    const v = calcHomaIr({ glucose: 90, insulin: 8 })
+    expect(v).toBeCloseTo(1.78, 1)
+    expect(getRiskBand(v)).toBe('mild')
+  })
+
+  it('insulin resistance (12 µU/mL × 95 mg/dL) → resistance', () => {
+    const v = calcHomaIr({ glucose: 95, insulin: 12 })
+    expect(v).toBeCloseTo(2.81, 1)
+    expect(getRiskBand(v)).toBe('resistance')
+  })
+
+  it('severe (20 µU/mL × 110 mg/dL) → severe', () => {
+    const v = calcHomaIr({ glucose: 110, insulin: 20 })
+    expect(v).toBeCloseTo(5.43, 1)
+    expect(getRiskBand(v)).toBe('severe')
+  })
+})
+
+describe('integer rounding behavior', () => {
+  it('preserves precision for integer-valued inputs', () => {
+    // 10 × 90 / 405 = 900/405 = 2.222...
+    expect(calcHomaIrConventional(10, 90)).toBeCloseTo(2.222, 2)
+  })
+
+  it('rounding to one decimal stays within band boundaries', () => {
+    const v = calcHomaIrConventional(7, 90) // 630/405 = 1.555...
+    expect(Number(v.toFixed(1))).toBe(1.6)
+    expect(getRiskBand(v)).toBe('mild')
+  })
+
+  it('result rounded to 2 decimals matches expected for 12 × 100', () => {
+    const v = calcHomaIrConventional(12, 100) // 1200/405 = 2.962...
+    expect(Number(v.toFixed(2))).toBe(2.96)
+    expect(getRiskBand(v)).toBe('severe')
+  })
+})
+
+describe('SI vs conventional equivalence (boundary crosscheck)', () => {
+  it('mmol/L × µU/mL using divisor 22.5 matches mg/dL path', () => {
+    // 10 µU/mL × 5 mmol/L / 22.5 = 50/22.5 ≈ 2.222
+    expect(calcHomaIrSi(10, 5)).toBeCloseTo(2.222, 2)
+    // 5 mmol/L → 90.09 mg/dL → 10 × 90.09 / 405 ≈ 2.224 (tiny rounding)
+    const mg = mmolToMgdl(5)
+    expect(calcHomaIrConventional(10, mg)).toBeCloseTo(2.224, 2)
+  })
+
+  it('pmol/L insulin path agrees with µU/mL path', () => {
+    // 34.725 pmol/L ≈ 5 µU/mL  → with glucose 90 → 1.111
+    expect(calcHomaIr({ glucose: 90, insulin: 34.725, insulinUnit: 'pmol' })).toBeCloseTo(1.111, 2)
+  })
+})
+
+describe('style helpers', () => {
+  it('returns distinct colors per band', () => {
+    expect(bandColor('normal')).toMatch(/text-/)
+    expect(bandColor('mild')).toMatch(/text-/)
+    expect(bandColor('resistance')).toMatch(/text-/)
+    expect(bandColor('severe')).toMatch(/text-/)
+    expect(bandColor('normal')).not.toBe(bandColor('severe'))
+  })
+
+  it('returns distinct backgrounds per band', () => {
+    expect(bandBg('normal')).toMatch(/bg-/)
+    expect(bandBg('severe')).toMatch(/bg-/)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 350 links (87 calcs × 2 locales + 88 blogs × 2 locales)', () => {
+  it('generates 354 links (88 calcs × 2 locales + 89 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(350)
+    expect(links).toHaveLength(354)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -23,6 +23,7 @@ const EXPECTED_KEYS = [
   'ironDeficiency', 'ffmiRechner', 'pregnancyCalories', 'pmsSymptom', 'breastCancerRisk',
   'pediatricBmi',
   'meanArterialPressure',
+  'homaIr',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -101,6 +102,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'brustkrebs-risiko-berechnen',
   'kinder-bmi-berechnen',
   'mittlerer-arterieller-druck-berechnen',
+  'homa-ir-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -179,12 +181,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'breast-cancer-risk-calculator-guide',
   'pediatric-bmi-guide',
   'mean-arterial-pressure-guide',
+  'homa-ir-insulin-resistance-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 87 calculator meta files', () => {
+  it('discovers all 88 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(87)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(88)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -222,19 +225,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 88 DE blog slugs', () => {
+  it('returns all 89 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(88)
+    expect(de).toHaveLength(89)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 88 EN blog slugs', () => {
+  it('returns all 89 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(88)
+    expect(en).toHaveLength(89)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -302,9 +305,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 174 calcs + 2 blog index + 176 blog articles = 354)', () => {
+  it('generates correct total URL count (2 home + 176 calcs + 2 blog index + 178 blog articles = 358)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(354)
+    expect(urlCount).toBe(358)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -791,6 +791,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'meanArterialPressure',
     related: ['measure-blood-pressure', 'cardiovascular-risk-framingham', 'stroke-risk-calculator-cha2ds2-vasc'],
   },
+  {
+    slug: 'homa-ir-insulin-resistance-guide',
+    title: 'HOMA-IR Calculator Guide: Spot Insulin Resistance Early',
+    description: 'Calculate HOMA-IR from fasting glucose and fasting insulin. Formula, risk bands, what the index means and what to do about an elevated value.',
+    date: '2026-05-28',
+    readTime: '7 min',
+    calculatorKey: 'homaIr',
+    related: ['diabetes-risk-score', 'hba1c-converter-guide', 'calculate-bmi'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -791,6 +791,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'meanArterialPressure',
     related: ['blutdruck-richtig-messen', 'herz-kreislauf-risiko-berechnen', 'schlaganfall-risiko-berechnen'],
   },
+  {
+    slug: 'homa-ir-berechnen',
+    title: 'HOMA-IR berechnen: Insulinresistenz früh erkennen',
+    description: 'HOMA-IR aus Nüchternblutzucker und Nüchterninsulin berechnen. Formel, Risikobänder, klinische Bedeutung und was bei erhöhten Werten zu tun ist.',
+    date: '2026-05-28',
+    readTime: '7 min',
+    calculatorKey: 'homaIr',
+    related: ['diabetes-risiko-berechnen', 'hba1c-umrechnen', 'bmi-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/homaIr.json
+++ b/src/locales/calculators/de/homaIr.json
@@ -1,0 +1,64 @@
+{
+  "home": {
+    "calculators": {
+      "homaIr": {
+        "name": "HOMA-IR-Rechner",
+        "description": "Insulinresistenz aus Nüchternblutzucker und Nüchterninsulin berechnen."
+      }
+    }
+  },
+  "homaIr": {
+    "meta": {
+      "title": "HOMA-IR-Rechner — Insulinresistenz berechnen | Health Calculators",
+      "description": "HOMA-IR aus Nüchternglukose und Nüchterninsulin berechnen. Formel, Risikobänder (normal, mild, Insulinresistenz, schwer) und klinische Einordnung."
+    },
+    "title": "HOMA-IR berechnen — Insulinresistenz einschätzen",
+    "description": "Geben Sie Nüchternblutzucker und Nüchterninsulin ein. Der Rechner ermittelt den HOMA-IR-Index und ordnet ihn in vier klinische Risikostufen ein.",
+    "glucoseLabel": "Nüchternblutzucker",
+    "insulinLabel": "Nüchterninsulin",
+    "glucosePlaceholderMg": "z. B. 90",
+    "glucosePlaceholderMmol": "z. B. 5,0",
+    "insulinPlaceholderMicroU": "z. B. 8",
+    "insulinPlaceholderPmol": "z. B. 55",
+    "unitsLabel": "Einheiten",
+    "unitMetric": "SI (mmol/L · pmol/L)",
+    "unitImperial": "Konventionell (mg/dL · µU/mL)",
+    "resultsLabel": "Ergebnis",
+    "homaIrLabel": "HOMA-IR",
+    "homaIrUnit": "Index",
+    "bandLabel": "Risikoeinordnung",
+    "categoriesTitle": "Risikobänder",
+    "formulaTitle": "Formel",
+    "formulaTextMg": "HOMA-IR = (Insulin µU/mL × Glukose mg/dL) / 405",
+    "formulaTextMmol": "HOMA-IR = (Insulin µU/mL × Glukose mmol/L) / 22,5",
+    "formulaWhy": "Die Formel multipliziert Nüchterninsulin und Nüchternblutzucker. Höhere Werte bedeuten, dass mehr Insulin nötig ist, um den Blutzucker zu kontrollieren — ein Hinweis auf Insulinresistenz.",
+    "clinicalNote": "HOMA-IR ist eine Schätzung und ersetzt keinen oralen Glukosetoleranztest oder eine ärztliche Diagnose. Werte ab 2,0 deuten auf eine relevante Insulinresistenz hin und sollten ärztlich abgeklärt werden.",
+    "disclaimer": "Diese Berechnung dient der Information. Bei auffälligen Werten konsultieren Sie bitte Ihren Arzt oder eine Diabetologin. Schwangerschaft, akute Infekte und einige Medikamente können Glukose- und Insulinwerte verzerren.",
+    "band": {
+      "normal": "Normal",
+      "mild": "Leichte Insulinresistenz",
+      "resistance": "Insulinresistenz",
+      "severe": "Schwere Insulinresistenz"
+    },
+    "bandRange": {
+      "normal": "< 1,5",
+      "mild": "1,5 – 1,99",
+      "resistance": "2,0 – 2,89",
+      "severe": "≥ 2,9"
+    },
+    "bandDescription": {
+      "normal": "Insulinsensitivität im gesunden Bereich.",
+      "mild": "Erste Hinweise auf reduzierte Insulinsensitivität — Lebensstil prüfen.",
+      "resistance": "Deutliche Insulinresistenz — ärztliche Abklärung empfohlen.",
+      "severe": "Stark erhöhte Insulinresistenz — hohes Risiko für Typ-2-Diabetes."
+    },
+    "faq": [
+      { "q": "Was ist HOMA-IR?", "a": "HOMA-IR (Homeostatic Model Assessment for Insulin Resistance) ist ein einfacher Marker für Insulinresistenz aus nüchtern gemessenem Blutzucker und Nüchterninsulin. Er wurde 1985 von Matthews und Kollegen eingeführt und ist heute weltweit gebräuchlich." },
+      { "q": "Wie wird der HOMA-IR berechnet?", "a": "Die klassische Formel lautet: HOMA-IR = (Nüchterninsulin in µU/mL × Nüchternglukose in mg/dL) / 405. In SI-Einheiten: HOMA-IR = (Insulin µU/mL × Glukose mmol/L) / 22,5." },
+      { "q": "Welche HOMA-IR-Werte gelten als normal?", "a": "Werte unter 1,5 gelten als normal. 1,5 bis 1,99 sind ein Hinweis auf leichte Insulinresistenz, 2,0 bis 2,89 auf relevante Insulinresistenz und ab 2,9 spricht man von schwerer Insulinresistenz. Die genauen Grenzen variieren je nach Labor und Population." },
+      { "q": "Wann ist der Test sinnvoll?", "a": "HOMA-IR ist nützlich bei Verdacht auf Insulinresistenz, polyzystischem Ovarsyndrom (PCOS), nicht-alkoholischer Fettleber, Übergewicht oder Prädiabetes. Er hilft, das individuelle Diabetesrisiko früh einzuschätzen." },
+      { "q": "Was kann den HOMA-IR verfälschen?", "a": "Akute Infekte, Stress, Steroide, kürzliche Mahlzeiten, Schwangerschaft und einige Medikamente können Insulin- oder Glukosewerte verändern. Der Test setzt eine Nüchternperiode von 8–12 Stunden voraus." },
+      { "q": "Was tun bei erhöhtem HOMA-IR?", "a": "Erhöhte Werte sind ein Warnsignal, aber keine Diagnose. Lebensstilmaßnahmen wie Gewichtsreduktion, regelmäßige Bewegung und kohlenhydratbewusste Ernährung verbessern die Insulinsensitivität messbar. Sprechen Sie mit Ihrem Arzt über weitere Schritte wie HbA1c oder einen oralen Glukosetoleranztest." }
+    ]
+  }
+}

--- a/src/locales/calculators/en/homaIr.json
+++ b/src/locales/calculators/en/homaIr.json
@@ -1,0 +1,64 @@
+{
+  "home": {
+    "calculators": {
+      "homaIr": {
+        "name": "HOMA-IR Calculator",
+        "description": "Estimate insulin resistance from fasting glucose and fasting insulin."
+      }
+    }
+  },
+  "homaIr": {
+    "meta": {
+      "title": "HOMA-IR Calculator — Insulin Resistance | Health Calculators",
+      "description": "Calculate HOMA-IR from fasting glucose and fasting insulin. Formula, risk bands (normal, mild, insulin resistance, severe) and clinical context."
+    },
+    "title": "HOMA-IR — Insulin Resistance Calculator",
+    "description": "Enter fasting blood glucose and fasting insulin. The calculator returns the HOMA-IR index and classifies it into four clinical risk bands.",
+    "glucoseLabel": "Fasting glucose",
+    "insulinLabel": "Fasting insulin",
+    "glucosePlaceholderMg": "e.g. 90",
+    "glucosePlaceholderMmol": "e.g. 5.0",
+    "insulinPlaceholderMicroU": "e.g. 8",
+    "insulinPlaceholderPmol": "e.g. 55",
+    "unitsLabel": "Units",
+    "unitMetric": "SI (mmol/L · pmol/L)",
+    "unitImperial": "Conventional (mg/dL · µU/mL)",
+    "resultsLabel": "Result",
+    "homaIrLabel": "HOMA-IR",
+    "homaIrUnit": "index",
+    "bandLabel": "Risk band",
+    "categoriesTitle": "Risk bands",
+    "formulaTitle": "Formula",
+    "formulaTextMg": "HOMA-IR = (insulin µU/mL × glucose mg/dL) / 405",
+    "formulaTextMmol": "HOMA-IR = (insulin µU/mL × glucose mmol/L) / 22.5",
+    "formulaWhy": "The formula multiplies fasting insulin and fasting glucose. Higher products mean more insulin is needed to keep glucose in range — the signature of insulin resistance.",
+    "clinicalNote": "HOMA-IR is an estimate and does not replace an oral glucose tolerance test or a medical diagnosis. Values from 2.0 upward suggest meaningful insulin resistance and warrant clinical review.",
+    "disclaimer": "This calculator is for information only. If your values look elevated, talk to a clinician. Pregnancy, acute illness and some medications can distort glucose and insulin readings.",
+    "band": {
+      "normal": "Normal",
+      "mild": "Mild insulin resistance",
+      "resistance": "Insulin resistance",
+      "severe": "Severe insulin resistance"
+    },
+    "bandRange": {
+      "normal": "< 1.5",
+      "mild": "1.5 – 1.99",
+      "resistance": "2.0 – 2.89",
+      "severe": "≥ 2.9"
+    },
+    "bandDescription": {
+      "normal": "Insulin sensitivity in the healthy range.",
+      "mild": "Early signs of reduced insulin sensitivity — review lifestyle.",
+      "resistance": "Meaningful insulin resistance — clinical review recommended.",
+      "severe": "Markedly elevated — high risk for type 2 diabetes."
+    },
+    "faq": [
+      { "q": "What is HOMA-IR?", "a": "HOMA-IR (Homeostatic Model Assessment for Insulin Resistance) is a simple marker of insulin resistance based on fasting plasma glucose and fasting insulin. It was introduced by Matthews et al. in 1985 and is now in worldwide clinical use." },
+      { "q": "How is HOMA-IR calculated?", "a": "The classic formula is HOMA-IR = (fasting insulin in µU/mL × fasting glucose in mg/dL) / 405. In SI units it is HOMA-IR = (insulin µU/mL × glucose mmol/L) / 22.5." },
+      { "q": "What HOMA-IR values are considered normal?", "a": "Values below 1.5 are considered normal. 1.5 to 1.99 suggests mild insulin resistance, 2.0 to 2.89 indicates insulin resistance and ≥ 2.9 is severe. Exact cut-offs vary by lab and population." },
+      { "q": "When is the test useful?", "a": "HOMA-IR is helpful when there is suspicion of insulin resistance — for example in PCOS, non-alcoholic fatty liver disease, obesity or prediabetes. It supports an early estimate of diabetes risk." },
+      { "q": "What can distort HOMA-IR?", "a": "Acute illness, stress, glucocorticoids, recent meals, pregnancy and some medications can shift insulin or glucose. The test requires an 8–12 hour fast." },
+      { "q": "What should I do about a high HOMA-IR?", "a": "An elevated value is a warning sign, not a diagnosis. Weight loss, regular physical activity and a carbohydrate-aware diet measurably improve insulin sensitivity. Discuss next steps such as HbA1c or an oral glucose tolerance test with your physician." }
+    ]
+  }
+}

--- a/src/pages/HomaIrCalculator.vue
+++ b/src/pages/HomaIrCalculator.vue
@@ -1,0 +1,210 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { calcHomaIr, getRiskBand, bandColor, bandBg } from '../utils/homaIr.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('homaIr.faq') || [])
+
+useHead(() => ({
+  title: t('homaIr.meta.title'),
+  description: t('homaIr.meta.description'),
+  routeKey: 'homaIr',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'HOMA-IR Calculator',
+    url: 'https://healthcalculator.app/en/homa-ir-insulin-resistance',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+// 'imperial' = conventional units (mg/dL + µU/mL); 'metric' = SI (mmol/L + pmol/L)
+const unitSystem = ref('imperial')
+const glucose = ref(null)
+const insulin = ref(null)
+
+function switchUnits(system) {
+  if (unitSystem.value === system) return
+  unitSystem.value = system
+  glucose.value = null
+  insulin.value = null
+}
+
+const glucoseUnit = computed(() => (unitSystem.value === 'metric' ? 'mmol' : 'mg'))
+const insulinUnit = computed(() => (unitSystem.value === 'metric' ? 'pmol' : 'uU'))
+
+const glucoseUnitLabel = computed(() => (glucoseUnit.value === 'mmol' ? 'mmol/L' : 'mg/dL'))
+const insulinUnitLabel = computed(() => (insulinUnit.value === 'pmol' ? 'pmol/L' : 'µU/mL'))
+
+const homaIr = computed(() =>
+  calcHomaIr({
+    glucose: glucose.value,
+    insulin: insulin.value,
+    glucoseUnit: glucoseUnit.value,
+    insulinUnit: insulinUnit.value,
+  }),
+)
+
+const band = computed(() => getRiskBand(homaIr.value))
+const hasResult = computed(() => homaIr.value !== null && band.value !== null)
+const homaIrFormatted = computed(() => (homaIr.value !== null ? homaIr.value.toFixed(2) : '—'))
+
+const formulaText = computed(() =>
+  glucoseUnit.value === 'mmol' ? t('homaIr.formulaTextMmol') : t('homaIr.formulaTextMg'),
+)
+
+const glucosePlaceholder = computed(() =>
+  glucoseUnit.value === 'mmol' ? t('homaIr.glucosePlaceholderMmol') : t('homaIr.glucosePlaceholderMg'),
+)
+const insulinPlaceholder = computed(() =>
+  insulinUnit.value === 'pmol' ? t('homaIr.insulinPlaceholderPmol') : t('homaIr.insulinPlaceholderMicroU'),
+)
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('homaIr.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('homaIr.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+        <span class="text-xs font-semibold text-stone-500 uppercase tracking-widest">{{ t('homaIr.unitsLabel') }}</span>
+        <div class="flex gap-2">
+          <button
+            data-testid="btn-imperial"
+            type="button"
+            @click="switchUnits('imperial')"
+            :class="unitSystem === 'imperial' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('homaIr.unitImperial') }}</button>
+          <button
+            data-testid="btn-metric"
+            type="button"
+            @click="switchUnits('metric')"
+            :class="unitSystem === 'metric' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('homaIr.unitMetric') }}</button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label for="glucose-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('homaIr.glucoseLabel') }} ({{ glucoseUnitLabel }})
+          </label>
+          <input
+            id="glucose-input"
+            v-model.number="glucose"
+            data-testid="glucose-input"
+            type="number"
+            step="0.1"
+            min="0"
+            :placeholder="glucosePlaceholder"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="insulin-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('homaIr.insulinLabel') }} ({{ insulinUnitLabel }})
+          </label>
+          <input
+            id="insulin-input"
+            v-model.number="insulin"
+            data-testid="insulin-input"
+            type="number"
+            step="0.1"
+            min="0"
+            :placeholder="insulinPlaceholder"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <div v-if="hasResult" :class="['border rounded-xl shadow-sm p-8 mb-6', bandBg(band)]" data-testid="result-card">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('homaIr.resultsLabel') }}</p>
+
+      <div class="flex items-baseline gap-3 mb-4">
+        <span data-testid="homa-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ homaIrFormatted }}</span>
+        <span class="text-sm text-stone-400 ml-1">{{ t('homaIr.homaIrUnit') }}</span>
+      </div>
+
+      <p :class="['text-lg font-semibold mb-1', bandColor(band)]" data-testid="band">{{ t(`homaIr.band.${band}`) }}</p>
+      <p class="text-sm text-stone-600 leading-relaxed mb-4" data-testid="band-description">{{ t(`homaIr.bandDescription.${band}`) }}</p>
+
+      <div class="bg-white/60 border border-stone-200 rounded-lg p-4 text-xs text-stone-600 leading-relaxed" data-testid="clinical-note">
+        {{ t('homaIr.clinicalNote') }}
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('homaIr.categoriesTitle') }}</h2>
+      <div class="space-y-3.5">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-emerald-500"></div>
+            <span class="text-sm text-stone-600">{{ t('homaIr.band.normal') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('homaIr.bandRange.normal') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-amber-500"></div>
+            <span class="text-sm text-stone-600">{{ t('homaIr.band.mild') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('homaIr.bandRange.mild') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-orange-500"></div>
+            <span class="text-sm text-stone-600">{{ t('homaIr.band.resistance') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('homaIr.bandRange.resistance') }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-red-500"></div>
+            <span class="text-sm text-stone-600">{{ t('homaIr.band.severe') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('homaIr.bandRange.severe') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('homaIr.formulaTitle') }}</h2>
+      <div class="bg-stone-50 rounded-lg p-4 font-mono text-base text-stone-700 mb-3" data-testid="formula">
+        {{ formulaText }}
+      </div>
+      <p class="text-sm text-stone-600 leading-relaxed">{{ t('homaIr.formulaWhy') }}</p>
+    </div>
+
+    <div v-if="hasResult" class="bg-stone-50 rounded-xl border border-stone-200 p-5 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('homaIr.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <RelatedCalculators calc-key="homaIr" class="mt-8" />
+    <BlogArticleLink calculator-key="homaIr" />
+
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/HomaIrBerechnen.vue
+++ b/src/pages/blog/HomaIrBerechnen.vue
@@ -1,0 +1,227 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'HOMA-IR berechnen: Insulinresistenz früh erkennen | Health Calculators',
+  description: 'HOMA-IR aus Nüchternblutzucker und Nüchterninsulin berechnen. Formel, Risikobänder, klinische Bedeutung und was bei erhöhten Werten zu tun ist.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'HOMA-IR berechnen: Insulinresistenz früh erkennen',
+      description: 'HOMA-IR-Formel, Risikoeinordnung und praktische Schritte bei erhöhten Werten.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-28',
+      dateModified: '2026-05-28',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/homa-ir-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist HOMA-IR?',
+          acceptedAnswer: { '@type': 'Answer', text: 'HOMA-IR (Homeostatic Model Assessment for Insulin Resistance) ist ein einfacher Marker für Insulinresistenz. Er nutzt nur zwei nüchterne Blutwerte: Glukose und Insulin. Eingeführt 1985 von Matthews und Kollegen.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wie wird HOMA-IR berechnet?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die klassische Formel: HOMA-IR = (Nüchterninsulin in µU/mL × Nüchternglukose in mg/dL) / 405. In SI-Einheiten: (Insulin µU/mL × Glukose mmol/L) / 22,5. Beide Varianten liefern denselben Index.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welche Werte gelten als auffällig?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Unter 1,5: normal. 1,5 bis 1,99: leichte Insulinresistenz. 2,0 bis 2,89: relevante Insulinresistenz. Ab 2,9: schwere Insulinresistenz mit hohem Risiko für Typ-2-Diabetes.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wer sollte HOMA-IR messen lassen?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Sinnvoll bei PCOS, Fettleber, Übergewicht, familiärer Diabetesbelastung oder grenzwertigem HbA1c. Der Test ist günstig, schnell und gibt frühe Hinweise — noch bevor der Blutzucker auffällig wird.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was verfälscht den Wert?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Akute Infekte, Stress, kürzliche Mahlzeiten, Steroide, Schwangerschaft oder eine zu kurze Nüchternperiode (unter 8 Stunden) können sowohl Glukose als auch Insulin verschieben. Im Zweifel den Test in Ruhe wiederholen.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wie lässt sich der HOMA-IR senken?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Gewichtsreduktion, regelmäßige Bewegung — vor allem Krafttraining und Ausdauer kombiniert —, kohlenhydratbewusste Ernährung und ausreichend Schlaf verbessern die Insulinsensitivität messbar. Erste Effekte zeigen sich oft schon nach wenigen Wochen.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">HOMA-IR berechnen: Insulinresistenz früh erkennen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">28. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Blutzucker ist noch normal — und trotzdem stimmt etwas nicht. Genau diese Lücke füllt der <strong>HOMA-IR</strong>. Aus zwei Nüchternblutwerten zeigt er, wie hart die Bauchspeicheldrüse arbeiten muss, um den Zucker im Griff zu halten.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel erklärt Formel, Risikobänder und was sich bei erhöhten Werten konkret tun lässt — bevor aus Insulinresistenz Typ-2-Diabetes wird.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel: zwei Zahlen, ein Index</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Matthews und Kollegen veröffentlichten den Index 1985. Die Idee: Wer insulinresistent ist, produziert nüchtern <em>mehr</em> Insulin, um denselben Blutzucker zu erreichen. Das Produkt aus beiden Werten zeigt diese Mehrarbeit.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          HOMA-IR = (Insulin µU/mL × Glukose mg/dL) / 405
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In SI-Einheiten (mmol/L): HOMA-IR = (Insulin µU/mL × Glukose mmol/L) / 22,5. Beides liefert denselben Index — der Divisor unterscheidet sich nur, weil 22,5 × 18 = 405 ist (Glukose-Umrechnungsfaktor).
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beispiel: Glukose 90 mg/dL, Insulin 8 µU/mL → (8 × 90) / 405 = <strong>1,78</strong>. Das liegt im Bereich „leichte Insulinresistenz".
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risikobänder auf einen Blick</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">HOMA-IR-Einordnung</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 1,5</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">1,5 – 1,99</span>
+              <span class="text-amber-600 font-medium">Leichte Insulinresistenz</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">2,0 – 2,89</span>
+              <span class="text-orange-600 font-medium">Insulinresistenz</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">≥ 2,9</span>
+              <span class="text-red-500 font-medium">Schwer</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die Grenzen stammen aus Querschnittsstudien (u. a. Geloneze 2009). Sie sind ein guter Richtwert, aber nicht in Stein gemeißelt — Labor, Alter und Ethnie können die Bewertung verschieben.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Warum HOMA-IR mehr aussagt als nur der Nüchternzucker</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein Nüchternblutzucker von 95 mg/dL gilt als unauffällig. Aber: Wenn dafür schon 15 µU/mL Insulin im Spiel sind, kämpft die Bauchspeicheldrüse bereits gegen eine wachsende Resistenz an. Der
+          <router-link :to="localePath('hba1c')" class="text-stone-900 underline hover:no-underline">HbA1c-Wert</router-link>
+          zeigt das oft erst Jahre später.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Mit HOMA-IR lässt sich diese stille Vorphase sichtbar machen — und genau hier sind Lebensstiländerungen am wirksamsten.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wer sollte den Wert messen lassen?</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Übergewicht oder Adipositas (BMI ≥ 25)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Polyzystisches Ovarsyndrom (PCOS)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Nicht-alkoholische Fettleber</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Familiäre Belastung mit Typ-2-Diabetes</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Schon grenzwertiger HbA1c oder Nüchternzucker</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wer zu einer dieser Gruppen gehört, profitiert von einer frühen Bestimmung. Der Test kostet wenig und liefert eine klare Richtung.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was den Wert verfälschen kann</h2>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Vor dem Test beachten</p>
+          <ul class="text-sm text-amber-700 space-y-1">
+            <li>→ 8–12 Stunden vollständig nüchtern</li>
+            <li>→ Kein akuter Infekt oder hohes Fieber</li>
+            <li>→ Keine kurzfristige Steroidtherapie</li>
+            <li>→ Vor dem Test ausreichend geschlafen</li>
+          </ul>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In der Schwangerschaft greifen andere Referenzwerte — hier ersetzt der Test nicht den oralen Glukosetoleranztest.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">HOMA-IR direkt berechnen</h3>
+        <p class="text-base text-stone-600 mb-6">Nüchternglukose und Nüchterninsulin eingeben — der Rechner liefert den Index und die Einordnung.</p>
+        <router-link
+          :to="localePath('homaIr')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Zum HOMA-IR-Rechner
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was tun bei erhöhtem HOMA-IR?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Insulinresistenz ist umkehrbar — vor allem in den frühen Stadien. Drei Hebel wirken am stärksten:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Bewegung:</strong> 150 Minuten moderate Ausdauer pro Woche plus zweimal Krafttraining. Muskelzellen werden so deutlich insulinempfindlicher.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>Gewichtsreduktion:</strong> Schon 5–7 % Körpergewicht weniger senken den HOMA-IR oft messbar.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Ernährung:</strong> Weniger raffinierte Kohlenhydrate, mehr Ballaststoffe, ausreichend Protein. Zuckerhaltige Getränke streichen ist der größte Einzelhebel.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei stark erhöhten Werten kommt — auf ärztliche Empfehlung — auch Metformin als Unterstützung in Frage. Die Lebensstilbasis bleibt aber entscheidend.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          HOMA-IR allein ist nur ein Mosaikstein. Für die Langzeitperspektive lohnt sich der
+          <router-link :to="localePath('hba1c')" class="text-stone-900 underline hover:no-underline">HbA1c-Konverter</router-link>,
+          für die strukturierte Risikoabschätzung der
+          <router-link :to="localePath('diabetesRisk')" class="text-stone-900 underline hover:no-underline">Diabetes-Risiko-Rechner</router-link>.
+          Da Übergewicht eine zentrale Ursache ist, hilft auch der
+          <router-link :to="localePath('bmi')" class="text-stone-900 underline hover:no-underline">BMI-Rechner</router-link>
+          beim Einordnen des eigenen Status.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          HOMA-IR ist ein einfacher, aber unterschätzter Marker. Zwei Laborwerte reichen, um die stille Vorstufe von Typ-2-Diabetes sichtbar zu machen — Jahre bevor der Blutzucker steigt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei erhöhten Werten ist die Botschaft selten dramatisch, aber klar: Bewegung, Gewicht, Ernährung. Wer früh ansetzt, hat die besten Karten.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="homa-ir-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/HomaIrInsulinResistanceGuide.vue
+++ b/src/pages/blog/en/HomaIrInsulinResistanceGuide.vue
@@ -1,0 +1,227 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticles from '../../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'HOMA-IR Calculator Guide: Spot Insulin Resistance Early | Health Calculators',
+  description: 'Calculate HOMA-IR from fasting glucose and fasting insulin. Formula, risk bands, what the index means and what to do about an elevated value.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'HOMA-IR Calculator Guide: Spot Insulin Resistance Early',
+      description: 'Formula, risk bands and practical next steps for elevated HOMA-IR values.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-28',
+      dateModified: '2026-05-28',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/homa-ir-insulin-resistance-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is HOMA-IR?',
+          acceptedAnswer: { '@type': 'Answer', text: 'HOMA-IR (Homeostatic Model Assessment for Insulin Resistance) is a simple marker of insulin resistance using just two fasting blood values: glucose and insulin. Introduced by Matthews et al. in 1985.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'How is HOMA-IR calculated?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Classic formula: HOMA-IR = (fasting insulin in µU/mL × fasting glucose in mg/dL) / 405. In SI units: (insulin µU/mL × glucose mmol/L) / 22.5. Both produce the same index.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What values are considered abnormal?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Below 1.5: normal. 1.5 to 1.99: mild insulin resistance. 2.0 to 2.89: meaningful insulin resistance. 2.9 and above: severe insulin resistance with a high risk of type 2 diabetes.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Who should measure HOMA-IR?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Useful in PCOS, fatty liver, obesity, a family history of diabetes, or borderline HbA1c. The test is cheap, fast and provides an early signal — before fasting glucose itself becomes abnormal.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What can distort the value?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Acute illness, stress, recent meals, glucocorticoids, pregnancy or too short a fasting window (under 8 hours) can shift both glucose and insulin. Repeat the test in a calm baseline state if in doubt.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'How can HOMA-IR be lowered?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Weight loss, regular physical activity — combine resistance and aerobic training — carbohydrate-aware nutrition and adequate sleep measurably improve insulin sensitivity. First effects often appear within a few weeks.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">HOMA-IR Calculator Guide: Spot Insulin Resistance Early</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 28, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Fasting glucose looks fine — yet something is off. <strong>HOMA-IR</strong> fills that gap. Two simple fasting labs reveal how hard the pancreas is working to keep blood sugar in range.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains the formula, the risk bands, and what to do about an elevated value — before insulin resistance becomes type 2 diabetes.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula: two values, one index</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Matthews and colleagues introduced the index in 1985. The idea: an insulin-resistant body secretes <em>more</em> fasting insulin to keep blood sugar stable. The product of both values exposes that extra work.
+        </p>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          HOMA-IR = (insulin µU/mL × glucose mg/dL) / 405
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          In SI units (mmol/L): HOMA-IR = (insulin µU/mL × glucose mmol/L) / 22.5. The two divisors differ only because 22.5 × 18 = 405 — the glucose conversion factor.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Example: glucose 90 mg/dL, insulin 8 µU/mL → (8 × 90) / 405 = <strong>1.78</strong>. That sits in the "mild insulin resistance" range.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Risk bands at a glance</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">HOMA-IR bands</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 1.5</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">1.5 – 1.99</span>
+              <span class="text-amber-600 font-medium">Mild insulin resistance</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">2.0 – 2.89</span>
+              <span class="text-orange-600 font-medium">Insulin resistance</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">≥ 2.9</span>
+              <span class="text-red-500 font-medium">Severe</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Cut-offs come from cross-sectional studies (e.g. Geloneze 2009). They are a useful guide rather than a strict rule — lab, age and ethnicity can shift the interpretation.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Why HOMA-IR beats fasting glucose alone</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A fasting glucose of 95 mg/dL still looks "normal". But if it takes 15 µU/mL of insulin to keep it there, the pancreas is already fighting a losing battle. The
+          <router-link :to="localePath('hba1c')" class="text-stone-900 underline hover:no-underline">HbA1c</router-link>
+          often catches up only years later.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          HOMA-IR exposes that silent pre-phase — and that is exactly where lifestyle interventions have the largest leverage.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Who should test?</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Overweight or obesity (BMI ≥ 25)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Polycystic ovary syndrome (PCOS)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Non-alcoholic fatty liver disease</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Family history of type 2 diabetes</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Borderline HbA1c or fasting glucose</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          If any of these apply, an early measurement pays off. The test is inexpensive and gives a clear direction.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What can throw the value off</h2>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Before the test</p>
+          <ul class="text-sm text-amber-700 space-y-1">
+            <li>→ Fast fully for 8–12 hours</li>
+            <li>→ No acute infection or high fever</li>
+            <li>→ No short-term steroid therapy</li>
+            <li>→ Get a proper night of sleep beforehand</li>
+          </ul>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In pregnancy other reference values apply — HOMA-IR does not replace an oral glucose tolerance test there.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Calculate your HOMA-IR</h3>
+        <p class="text-base text-stone-600 mb-6">Enter fasting glucose and fasting insulin — the calculator returns the index and band.</p>
+        <router-link
+          :to="localePath('homaIr')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Open the HOMA-IR Calculator
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What to do about an elevated HOMA-IR</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Insulin resistance is reversible, especially in the early stages. Three levers do most of the work:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Activity:</strong> 150 minutes of moderate aerobic exercise per week plus two resistance sessions. Muscle cells become much more insulin-sensitive.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>Weight loss:</strong> Even 5–7 % body-weight reduction often lowers HOMA-IR noticeably.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Nutrition:</strong> Fewer refined carbs, more fiber, adequate protein. Cutting sugary drinks is the biggest single lever.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For markedly elevated values, metformin may be added on medical advice. Lifestyle remains the foundation.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          HOMA-IR is one piece of the picture. For the long-term view try the
+          <router-link :to="localePath('hba1c')" class="text-stone-900 underline hover:no-underline">HbA1c Converter</router-link>;
+          for a structured risk estimate use the
+          <router-link :to="localePath('diabetesRisk')" class="text-stone-900 underline hover:no-underline">Diabetes Risk Calculator</router-link>.
+          Since excess weight is a central driver, the
+          <router-link :to="localePath('bmi')" class="text-stone-900 underline hover:no-underline">BMI Calculator</router-link>
+          helps anchor your starting point.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Takeaway</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          HOMA-IR is a simple but underused marker. Two lab values are enough to expose the silent prelude to type 2 diabetes — often years before glucose rises.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For elevated values the message is rarely dramatic but always clear: move more, lose some weight, eat better. Early action pays off.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="homa-ir-insulin-resistance-guide" />
+  </article>
+</template>

--- a/src/pages/homaIr.meta.js
+++ b/src/pages/homaIr.meta.js
@@ -1,0 +1,16 @@
+import Component from './HomaIrCalculator.vue'
+import BlogDe from './blog/HomaIrBerechnen.vue'
+import BlogEn from './blog/en/HomaIrInsulinResistanceGuide.vue'
+
+export default {
+  key: 'homaIr',
+  component: Component,
+  slugs: { de: 'homa-ir-rechner', en: 'homa-ir-insulin-resistance' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 7.5,
+  blog: {
+    de: { slug: 'homa-ir-berechnen', component: BlogDe },
+    en: { slug: 'homa-ir-insulin-resistance-guide', component: BlogEn },
+  },
+}

--- a/src/utils/homaIr.js
+++ b/src/utils/homaIr.js
@@ -1,0 +1,102 @@
+// HOMA-IR (Homeostatic Model Assessment for Insulin Resistance)
+// Formula (conventional units): HOMA-IR = (insulin µU/mL × glucose mg/dL) / 405
+// Formula (SI units):            HOMA-IR = (insulin µU/mL × glucose mmol/L) / 22.5
+//
+// Risk bands (clinical reference, Matthews et al. 1985 / Geloneze et al. 2009):
+//   < 1.5        Normal
+//   1.5 – 1.99   Mild insulin resistance
+//   2.0 – 2.89   Insulin resistance
+//   ≥ 2.9        Severe insulin resistance
+
+// Unit conversions
+// Glucose: mg/dL ↔ mmol/L  (factor 18.0182, commonly rounded to 18)
+// Insulin: µU/mL ↔ pmol/L  (factor 6.945, commonly rounded to 6)
+const GLUCOSE_FACTOR = 18.0182
+const INSULIN_FACTOR = 6.945
+
+export function mgdlToMmol(mg) {
+  if (mg == null || !Number.isFinite(Number(mg))) return null
+  return Number(mg) / GLUCOSE_FACTOR
+}
+
+export function mmolToMgdl(mmol) {
+  if (mmol == null || !Number.isFinite(Number(mmol))) return null
+  return Number(mmol) * GLUCOSE_FACTOR
+}
+
+export function pmolToMicroU(pmol) {
+  if (pmol == null || !Number.isFinite(Number(pmol))) return null
+  return Number(pmol) / INSULIN_FACTOR
+}
+
+export function microUToPmol(microU) {
+  if (microU == null || !Number.isFinite(Number(microU))) return null
+  return Number(microU) * INSULIN_FACTOR
+}
+
+// Core formula. Inputs already in conventional µU/mL and mg/dL.
+export function calcHomaIrConventional(insulinMicroU, glucoseMgdl) {
+  if (insulinMicroU == null || glucoseMgdl == null) return null
+  const i = Number(insulinMicroU)
+  const g = Number(glucoseMgdl)
+  if (!Number.isFinite(i) || !Number.isFinite(g)) return null
+  if (i <= 0 || g <= 0) return null
+  return (i * g) / 405
+}
+
+// Core formula in SI units (mmol/L).
+export function calcHomaIrSi(insulinMicroU, glucoseMmol) {
+  if (insulinMicroU == null || glucoseMmol == null) return null
+  const i = Number(insulinMicroU)
+  const g = Number(glucoseMmol)
+  if (!Number.isFinite(i) || !Number.isFinite(g)) return null
+  if (i <= 0 || g <= 0) return null
+  return (i * g) / 22.5
+}
+
+// Convenience wrapper that handles unit selection.
+// glucoseUnit: 'mg' (mg/dL) or 'mmol' (mmol/L)
+// insulinUnit: 'uU' (µU/mL) or 'pmol' (pmol/L)
+export function calcHomaIr({ glucose, insulin, glucoseUnit = 'mg', insulinUnit = 'uU' }) {
+  if (glucose == null || insulin == null) return null
+  const i = Number(insulin)
+  const g = Number(glucose)
+  if (!Number.isFinite(i) || !Number.isFinite(g)) return null
+  if (i <= 0 || g <= 0) return null
+
+  const insulinMicroU = insulinUnit === 'pmol' ? pmolToMicroU(i) : i
+  if (glucoseUnit === 'mmol') {
+    return calcHomaIrSi(insulinMicroU, g)
+  }
+  return calcHomaIrConventional(insulinMicroU, g)
+}
+
+export function getRiskBand(homaIr) {
+  if (homaIr == null || !Number.isFinite(homaIr)) return null
+  if (homaIr < 1.5) return 'normal'
+  if (homaIr < 2.0) return 'mild'
+  if (homaIr < 2.9) return 'resistance'
+  return 'severe'
+}
+
+const COLORS = {
+  normal: 'text-emerald-600',
+  mild: 'text-amber-600',
+  resistance: 'text-orange-600',
+  severe: 'text-red-600',
+}
+
+const BGS = {
+  normal: 'bg-emerald-50 border-emerald-200',
+  mild: 'bg-amber-50 border-amber-200',
+  resistance: 'bg-orange-50 border-orange-200',
+  severe: 'bg-red-50 border-red-200',
+}
+
+export function bandColor(band) {
+  return COLORS[band] || 'text-stone-900'
+}
+
+export function bandBg(band) {
+  return BGS[band] || 'bg-white border-stone-200'
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-266-homa-ir
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-266-homa-ir-20260528-233027`
**Cost:** $7.531391499999998

Closes jenslaufer/health-calculators#266

### Prompt
> Implement the HOMA-IR (Homeostatic Model Assessment for Insulin Resistance) Calculator as described in issue #266.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: fasting glucose (mg/dL OR mmol/L), fasting insulin (µU/mL OR pmol/L) — metric/imperial toggle
- Formula: HOMA-IR = (fasting insulin µU/mL × fasting glucose mg/dL) / 405, or mmol/L variant divisor 22.5
- Output: HOMA-IR index + risk band (Normal <1.5, Mild IR 1.5–2.0, Insulin Resistance 2.0–2.9, Severe ≥2.9) — color-coded, clinical note
- Unit conversion helpers (mg/dL ↔ mmol/L for glucose; µU/mL ↔ pmol/L for insulin)
- Blog articles: DE + EN (SEO optimized, FAQPage structured data)
- Internal links to diabetesRisk, hba1c, bmi
- Unit tests: 6+ cases incl. all 4 risk bands, mmol/L vs mg/dL conversion, pmol/L vs µU/mL conversion, integer rounding
- E2E test
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog → own calculator + 2–3 related (diabetesRisk, hba1c, bmi)
- Calculator page → this blog (DE + EN)
- Verify every target route exists


## RETRY-AWARE no-diff guard
Before `git push`, run `git status`. If no new files staged → DO NOT push.


## PARTIAL-COMMIT GUARD (MANDATORY)
`git diff --name-only main..HEAD | sort` MUST contain:
  e2e/homaIr.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/homaIr.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/homaIr.json
  src/locales/calculators/en/homaIr.json
  src/pages/HomaIrCalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/homaIr.meta.js
  src/utils/homaIr.js

Counter: `wc -l` >= 14. Missing → DO NOT push.

Reference: study `src/pages/Hba1cCalculator.vue` + `src/pages/hba1c.meta.js` + `src/locales/calculators/{de,en}/hba1c.json` + `src/__tests__/hba1c.test.js` + `e2e/hba1c.spec.js`.

## TDD-red-first ordering
1. Red unit tests (6+: 4 risk bands, mmol/L ↔ mg/dL conversion, pmol/L ↔ µU/mL conversion, integer-rounding).
2. Green logic.
3. View + locale JSON + meta anchor (key: 'homaIr', slugs: { de: 'homa-ir-rechner', en: 'homa-ir-insulin-resistance' }).
4. E2E test.
5. Blog DE + EN + articles*.js registration.
6. Final verify: `npm test` + `npm run test:e2e` + `npm run build`.

## Locale-Path + Meta-Anchor (CRITICAL)
Create `src/pages/homaIr.meta.js` + `src/locales/calculators/de/homaIr.json` + `src/locales/calculators/en/homaIr.json` (mirror hba1c shape).

## HC blog-count + calculator-count assertion bump (MANDATORY)
`grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js`, bump calculator + blog counts +1, append new slugs to `EXPECTED_BLOG_SLUGS_DE`/EN.

## Register blog in articles*.js (MANDATORY — main RED otherwise)
Append new entry to BOTH `src/data/articles.js` + `src/data/articles-en.js` (slug, title, description ~155 chars, date today, readTime, calculatorKey: 'homaIr', related: 2–3 existing slugs).

## E2E Selector rules
- NEVER `text=Substring`. USE `getByRole`, `getByTestId`, `getByText(..., { exact: true })`.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files (EXCEPT test + articles files listed)
- Only ADD new files