### PR TITLE
Add LDL Cholesterol Friedewald Calculator (HC-267)

### DIFF
--- a/e2e/ldlFriedewald.spec.js
+++ b/e2e/ldlFriedewald.spec.js
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('LDL Friedewald Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/ldl-friedewald-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/LDL/)
+  })
+
+  test('h1 contains LDL', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('LDL')
+  })
+
+  test('back link navigates to home page', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('mg/dL is selected by default', async ({ page }) => {
+    await expect(page.getByTestId('btn-mg')).toHaveClass(/bg-stone-900/)
+  })
+
+  test('no result shown before inputs', async ({ page }) => {
+    await expect(page.getByTestId('result-card')).toHaveCount(0)
+  })
+
+  test('mg/dL: Total=180 HDL=50 TG=100 → LDL=110, near optimal', async ({ page }) => {
+    await page.getByTestId('total-input').fill('180')
+    await page.getByTestId('hdl-input').fill('50')
+    await page.getByTestId('trig-input').fill('100')
+
+    await expect(page.getByTestId('ldl-value')).toHaveText('110')
+    await expect(page.getByTestId('band')).toHaveText('Fast optimal')
+  })
+
+  test('mg/dL: Total=240 HDL=40 TG=150 → LDL=170, high band', async ({ page }) => {
+    await page.getByTestId('total-input').fill('240')
+    await page.getByTestId('hdl-input').fill('40')
+    await page.getByTestId('trig-input').fill('150')
+
+    await expect(page.getByTestId('ldl-value')).toHaveText('170')
+    await expect(page.getByTestId('band')).toHaveText('Hoch')
+    await expect(page.getByTestId('band')).toHaveClass(/text-orange/)
+  })
+
+  test('mg/dL: very high band Total=260 HDL=40 TG=100 → LDL=200', async ({ page }) => {
+    await page.getByTestId('total-input').fill('260')
+    await page.getByTestId('hdl-input').fill('40')
+    await page.getByTestId('trig-input').fill('100')
+
+    await expect(page.getByTestId('ldl-value')).toHaveText('200')
+    await expect(page.getByTestId('band')).toHaveText('Sehr hoch')
+    await expect(page.getByTestId('band')).toHaveClass(/text-red/)
+  })
+
+  test('Friedewald invalid warning shows for TG ≥ 400 mg/dL', async ({ page }) => {
+    await page.getByTestId('total-input').fill('250')
+    await page.getByTestId('hdl-input').fill('40')
+    await page.getByTestId('trig-input').fill('420')
+
+    await expect(page.getByTestId('invalid-warning')).toBeVisible()
+  })
+
+  test('switching to mmol/L clears inputs and updates labels', async ({ page }) => {
+    await page.getByTestId('total-input').fill('200')
+    await page.getByTestId('hdl-input').fill('50')
+    await page.getByTestId('trig-input').fill('150')
+
+    await page.getByTestId('btn-mmol').click()
+    await expect(page.getByTestId('btn-mmol')).toHaveClass(/bg-stone-900/)
+    await expect(page.getByTestId('total-input')).toHaveValue('')
+    await expect(page.getByTestId('hdl-input')).toHaveValue('')
+    await expect(page.getByTestId('trig-input')).toHaveValue('')
+  })
+
+  test('mmol/L: Total=6.20 HDL=1.04 TG=1.70 → LDL ≈ 4.39 mmol/L (high band via 170 mg/dL)', async ({ page }) => {
+    await page.getByTestId('btn-mmol').click()
+    await page.getByTestId('total-input').fill('6.20')
+    await page.getByTestId('hdl-input').fill('1.04')
+    await page.getByTestId('trig-input').fill('1.70')
+
+    await expect(page.getByTestId('ldl-value')).toHaveText('4.39')
+    await expect(page.getByTestId('band')).toHaveText('Hoch')
+  })
+
+  test('related calculators block is visible', async ({ page }) => {
+    await expect(page.getByTestId('related-calculators')).toBeVisible()
+  })
+
+  test('blog article link is visible', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('LDL Friedewald Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/ldl-cholesterol-friedewald')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/LDL/)
+  })
+
+  test('mg/dL: Total=200 HDL=50 TG=150 → LDL=120, near optimal', async ({ page }) => {
+    await page.getByTestId('total-input').fill('200')
+    await page.getByTestId('hdl-input').fill('50')
+    await page.getByTestId('trig-input').fill('150')
+
+    await expect(page.getByTestId('ldl-value')).toHaveText('120')
+    await expect(page.getByTestId('band')).toHaveText('Near optimal')
+  })
+
+  test('very high band Total=260 HDL=40 TG=100 → LDL=200', async ({ page }) => {
+    await page.getByTestId('total-input').fill('260')
+    await page.getByTestId('hdl-input').fill('40')
+    await page.getByTestId('trig-input').fill('100')
+
+    await expect(page.getByTestId('band')).toHaveText('Very high')
+  })
+
+  test('invalid warning when TG ≥ 400 mg/dL', async ({ page }) => {
+    await page.getByTestId('total-input').fill('250')
+    await page.getByTestId('hdl-input').fill('40')
+    await page.getByTestId('trig-input').fill('420')
+
+    await expect(page.getByTestId('invalid-warning')).toBeVisible()
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -30,6 +30,7 @@ const EXPECTED_KEYS = [
   'pediatricBmi',
   'meanArterialPressure',
   'homaIr',
+  'ldlFriedewald',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -121,6 +122,7 @@ const EXPECTED_ROUTE_MAP = {
   pediatricBmi: { de: 'kinder-bmi-rechner', en: 'pediatric-bmi' },
   meanArterialPressure: { de: 'mittlerer-arterieller-druck-rechner', en: 'mean-arterial-pressure' },
   homaIr: { de: 'homa-ir-rechner', en: 'homa-ir-insulin-resistance' },
+  ldlFriedewald: { de: 'ldl-friedewald-rechner', en: 'ldl-cholesterol-friedewald' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -201,6 +203,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-bmi-berechnen',
   'mittlerer-arterieller-druck-berechnen',
   'homa-ir-berechnen',
+  'ldl-friedewald-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -281,19 +284,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pediatric-bmi-guide',
   'mean-arterial-pressure-guide',
   'homa-ir-insulin-resistance-guide',
+  'ldl-cholesterol-friedewald-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 88 calculators', () => {
-    expect(calculatorMetas).toHaveLength(88)
+  it('discovers all 89 calculators', () => {
+    expect(calculatorMetas).toHaveLength(89)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 88 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(88)
+  it('builds calculatorComponents map for all 89 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(89)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -316,15 +320,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 89 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(89)
+  it('discovers all 90 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(90)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 89 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(89)
+  it('discovers all 90 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(90)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -349,10 +353,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 88 calculators with no duplicates', () => {
+  it('groups contain all 89 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(88)
-    expect(new Set(allKeys).size).toBe(88)
+    expect(allKeys).toHaveLength(89)
+    expect(new Set(allKeys).size).toBe(89)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -373,7 +377,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -422,8 +426,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 485 routes', () => {
-    expect(routes).toHaveLength(485)
+  it('generates exactly 490 routes', () => {
+    expect(routes).toHaveLength(490)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/ldlFriedewald.test.js
+++ b/src/__tests__/ldlFriedewald.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcLdl,
+  calcLdlMgdl,
+  calcLdlMmol,
+  isFriedewaldInvalid,
+  getAtpBand,
+  ldlToMgdl,
+  roundLdl,
+  bandColor,
+  bandBg,
+} from '../utils/ldlFriedewald.js'
+
+describe('Friedewald formula — mg/dL', () => {
+  it('200 − 50 − 150/5 = 120', () => {
+    expect(calcLdlMgdl(200, 50, 150)).toBe(120)
+  })
+
+  it('integer rounding via roundLdl: 200 − 45 − 170/5 = 121 → 121', () => {
+    const ldl = calcLdlMgdl(200, 45, 170)
+    expect(roundLdl(ldl)).toBe(121)
+  })
+
+  it('rounds non-integer LDL to nearest integer (180 − 40 − 175/5 = 105)', () => {
+    expect(roundLdl(calcLdlMgdl(180, 40, 175))).toBe(105)
+  })
+
+  it('returns null for missing inputs', () => {
+    expect(calcLdlMgdl(null, 50, 150)).toBeNull()
+    expect(calcLdlMgdl(200, null, 150)).toBeNull()
+    expect(calcLdlMgdl(200, 50, null)).toBeNull()
+  })
+})
+
+describe('Friedewald formula — mmol/L', () => {
+  it('5.17 − 1.30 − 1.70/2.2 ≈ 3.10', () => {
+    // 5.17 − 1.30 − 0.7727… = 3.0972…
+    expect(calcLdlMmol(5.17, 1.30, 1.70)).toBeCloseTo(3.097, 2)
+  })
+
+  it('wrapper picks mmol path on unit=mmol', () => {
+    const ldl = calcLdl({ total: 5.17, hdl: 1.30, trig: 1.70, unit: 'mmol' })
+    expect(ldl).toBeCloseTo(3.097, 2)
+  })
+
+  it('wrapper picks mg path on default unit', () => {
+    expect(calcLdl({ total: 200, hdl: 50, trig: 150 })).toBe(120)
+  })
+})
+
+describe('Friedewald validity — TG threshold', () => {
+  it('TG ≥ 400 mg/dL → invalid', () => {
+    expect(isFriedewaldInvalid(400, 'mg')).toBe(true)
+    expect(isFriedewaldInvalid(450, 'mg')).toBe(true)
+  })
+
+  it('TG < 400 mg/dL → valid', () => {
+    expect(isFriedewaldInvalid(399, 'mg')).toBe(false)
+    expect(isFriedewaldInvalid(150, 'mg')).toBe(false)
+  })
+
+  it('TG ≥ 4.5 mmol/L → invalid', () => {
+    expect(isFriedewaldInvalid(4.5, 'mmol')).toBe(true)
+    expect(isFriedewaldInvalid(5.0, 'mmol')).toBe(true)
+  })
+
+  it('TG < 4.5 mmol/L → valid', () => {
+    expect(isFriedewaldInvalid(4.49, 'mmol')).toBe(false)
+    expect(isFriedewaldInvalid(1.7, 'mmol')).toBe(false)
+  })
+
+  it('null/undefined trig → not invalid (no warning)', () => {
+    expect(isFriedewaldInvalid(null, 'mg')).toBe(false)
+  })
+})
+
+describe('ATP III bands — all five categories', () => {
+  it('< 100 mg/dL → optimal', () => {
+    expect(getAtpBand(99)).toBe('optimal')
+    expect(getAtpBand(50)).toBe('optimal')
+  })
+
+  it('100 – 129 mg/dL → near optimal', () => {
+    expect(getAtpBand(100)).toBe('nearOptimal')
+    expect(getAtpBand(115)).toBe('nearOptimal')
+    expect(getAtpBand(129)).toBe('nearOptimal')
+  })
+
+  it('130 – 159 mg/dL → borderline high', () => {
+    expect(getAtpBand(130)).toBe('borderline')
+    expect(getAtpBand(150)).toBe('borderline')
+    expect(getAtpBand(159)).toBe('borderline')
+  })
+
+  it('160 – 189 mg/dL → high', () => {
+    expect(getAtpBand(160)).toBe('high')
+    expect(getAtpBand(175)).toBe('high')
+    expect(getAtpBand(189)).toBe('high')
+  })
+
+  it('≥ 190 mg/dL → very high', () => {
+    expect(getAtpBand(190)).toBe('veryHigh')
+    expect(getAtpBand(250)).toBe('veryHigh')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(getAtpBand(null)).toBeNull()
+    expect(getAtpBand(NaN)).toBeNull()
+  })
+})
+
+describe('mmol/L LDL → mg/dL conversion (for ATP banding)', () => {
+  it('converts 3.10 mmol/L ≈ 120 mg/dL', () => {
+    expect(ldlToMgdl(3.10, 'mmol')).toBeCloseTo(119.88, 1)
+  })
+
+  it('passes through mg/dL value unchanged', () => {
+    expect(ldlToMgdl(120, 'mg')).toBe(120)
+  })
+
+  it('returns null for missing input', () => {
+    expect(ldlToMgdl(null, 'mg')).toBeNull()
+  })
+})
+
+describe('end-to-end clinical scenarios', () => {
+  it('mg/dL: Total=180 HDL=50 TG=100 → LDL=110 (near optimal)', () => {
+    const ldl = calcLdl({ total: 180, hdl: 50, trig: 100 })
+    expect(ldl).toBe(110)
+    expect(getAtpBand(ldlToMgdl(ldl, 'mg'))).toBe('nearOptimal')
+  })
+
+  it('mg/dL: Total=240 HDL=40 TG=150 → LDL=170 (high)', () => {
+    const ldl = calcLdl({ total: 240, hdl: 40, trig: 150 })
+    expect(ldl).toBe(170)
+    expect(getAtpBand(ldl)).toBe('high')
+  })
+
+  it('mmol/L scenario: Total=6.20 HDL=1.04 TG=1.70 → LDL ≈ 4.39 mmol/L ≈ 170 mg/dL → high', () => {
+    const ldl = calcLdl({ total: 6.20, hdl: 1.04, trig: 1.70, unit: 'mmol' })
+    expect(ldl).toBeCloseTo(4.387, 2)
+    expect(getAtpBand(ldlToMgdl(ldl, 'mmol'))).toBe('high')
+  })
+
+  it('TG = 400 mg/dL triggers invalid → UI should warn (formula still computes)', () => {
+    expect(isFriedewaldInvalid(400, 'mg')).toBe(true)
+    // Formula remains mathematically defined, but UI should display warning.
+    expect(calcLdl({ total: 250, hdl: 40, trig: 400 })).toBe(130)
+  })
+})
+
+describe('style helpers', () => {
+  it('returns distinct colors per band', () => {
+    expect(bandColor('optimal')).toMatch(/text-/)
+    expect(bandColor('veryHigh')).toMatch(/text-/)
+    expect(bandColor('optimal')).not.toBe(bandColor('veryHigh'))
+  })
+
+  it('returns distinct backgrounds per band', () => {
+    expect(bandBg('optimal')).toMatch(/bg-/)
+    expect(bandBg('veryHigh')).toMatch(/bg-/)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 354 links (88 calcs × 2 locales + 89 blogs × 2 locales)', () => {
+  it('generates 358 links (89 calcs × 2 locales + 90 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(354)
+    expect(links).toHaveLength(358)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -24,6 +24,7 @@ const EXPECTED_KEYS = [
   'pediatricBmi',
   'meanArterialPressure',
   'homaIr',
+  'ldlFriedewald',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -103,6 +104,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'kinder-bmi-berechnen',
   'mittlerer-arterieller-druck-berechnen',
   'homa-ir-berechnen',
+  'ldl-friedewald-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -182,12 +184,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'pediatric-bmi-guide',
   'mean-arterial-pressure-guide',
   'homa-ir-insulin-resistance-guide',
+  'ldl-cholesterol-friedewald-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 88 calculator meta files', () => {
+  it('discovers all 89 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(88)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(89)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -225,19 +228,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 89 DE blog slugs', () => {
+  it('returns all 90 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(89)
+    expect(de).toHaveLength(90)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 89 EN blog slugs', () => {
+  it('returns all 90 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(89)
+    expect(en).toHaveLength(90)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -305,9 +308,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 176 calcs + 2 blog index + 178 blog articles = 358)', () => {
+  it('generates correct total URL count (2 home + 178 calcs + 2 blog index + 180 blog articles = 362)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(358)
+    expect(urlCount).toBe(362)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -800,6 +800,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'homaIr',
     related: ['diabetes-risk-score', 'hba1c-converter-guide', 'calculate-bmi'],
   },
+  {
+    slug: 'ldl-cholesterol-friedewald-guide',
+    title: 'LDL Cholesterol (Friedewald) Calculator Guide: Formula, Limits, Values',
+    description: 'Estimate LDL cholesterol from total cholesterol, HDL and triglycerides using the Friedewald formula. ATP III bands, the 400 mg/dL limit and what helps high LDL.',
+    date: '2026-05-29',
+    readTime: '8 min',
+    calculatorKey: 'ldlFriedewald',
+    related: ['cholesterol-ratio', 'cardiovascular-risk-framingham', 'stroke-risk-calculator-cha2ds2-vasc'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -800,6 +800,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'homaIr',
     related: ['diabetes-risiko-berechnen', 'hba1c-umrechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'ldl-friedewald-berechnen',
+    title: 'LDL-Cholesterin (Friedewald) berechnen: Formel, Grenzen, Werte',
+    description: 'LDL-Cholesterin per Friedewald-Formel aus Gesamtcholesterin, HDL und Triglyceriden schätzen. ATP-III-Bänder, Grenzen ab 400 mg/dL und was bei erhöhtem LDL hilft.',
+    date: '2026-05-29',
+    readTime: '8 min',
+    calculatorKey: 'ldlFriedewald',
+    related: ['cholesterol-verhaeltnis-rechner', 'herz-kreislauf-risiko-berechnen', 'schlaganfall-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/ldlFriedewald.json
+++ b/src/locales/calculators/de/ldlFriedewald.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "ldlFriedewald": {
+        "name": "LDL-Friedewald-Rechner",
+        "description": "LDL-Cholesterin aus Gesamt, HDL und Triglyceriden nach Friedewald schätzen."
+      }
+    }
+  },
+  "ldlFriedewald": {
+    "meta": {
+      "title": "LDL-Cholesterin (Friedewald) berechnen — Formel & ATP-III-Einordnung",
+      "description": "LDL-Cholesterin aus Gesamtcholesterin, HDL und Triglyceriden mit der Friedewald-Formel berechnen. ATP-III-Klassifikation (optimal bis sehr hoch) und Warnung bei TG ≥ 400 mg/dL. Kostenlos und sofort."
+    },
+    "title": "LDL-Friedewald-Rechner",
+    "description": "LDL aus Gesamtcholesterin, HDL und Triglyceriden mit der Friedewald-Formel berechnen — mit ATP-III-Risikobändern.",
+    "unitsLabel": "Einheiten",
+    "unitMg": "mg/dL",
+    "unitMmol": "mmol/L",
+    "totalLabel": "Gesamtcholesterin",
+    "hdlLabel": "HDL",
+    "trigLabel": "Triglyceride",
+    "totalPlaceholderMg": "z. B. 200",
+    "totalPlaceholderMmol": "z. B. 5,17",
+    "hdlPlaceholderMg": "z. B. 50",
+    "hdlPlaceholderMmol": "z. B. 1,30",
+    "trigPlaceholderMg": "z. B. 150",
+    "trigPlaceholderMmol": "z. B. 1,70",
+    "resultsLabel": "Ergebnis",
+    "ldlLabel": "Geschätztes LDL",
+    "ldlUnitMg": "mg/dL",
+    "ldlUnitMmol": "mmol/L",
+    "bandLabel": "ATP-III-Einordnung",
+    "warningInvalid": "Friedewald-Schätzung unzuverlässig: Triglyceride ≥ 400 mg/dL (4,5 mmol/L). Bitte direkte LDL-Messung anfordern.",
+    "formulaTitle": "Formel",
+    "formulaTextMg": "LDL = Gesamtcholesterin − HDL − Triglyceride / 5  (mg/dL)",
+    "formulaTextMmol": "LDL = Gesamtcholesterin − HDL − Triglyceride / 2,2  (mmol/L)",
+    "formulaWhy": "Die Friedewald-Formel (1972) schätzt LDL aus Gesamt, HDL und Triglyceriden. Sie ist die international gebräuchliche Methode in Lipidprofilen — vorausgesetzt, die Triglyceride liegen unter 400 mg/dL (4,5 mmol/L).",
+    "categoriesTitle": "ATP-III-Risikobänder (NCEP)",
+    "clinicalNote": "Die ATP-III-Schwellen sind in mg/dL definiert. Bei Eingabe in mmol/L erfolgt die Bandeinordnung nach interner Umrechnung. Die Schätzung ersetzt keine ärztliche Beurteilung.",
+    "disclaimer": "Dieser Rechner dient der Information. Bei auffälligen Werten — oder Triglyceriden ≥ 400 mg/dL — ist eine direkte LDL-Bestimmung im Labor empfohlen.",
+    "band": {
+      "optimal": "Optimal",
+      "nearOptimal": "Fast optimal",
+      "borderline": "Grenzwertig",
+      "high": "Hoch",
+      "veryHigh": "Sehr hoch"
+    },
+    "bandRange": {
+      "optimal": "< 100 mg/dL",
+      "nearOptimal": "100 – 129 mg/dL",
+      "borderline": "130 – 159 mg/dL",
+      "high": "160 – 189 mg/dL",
+      "veryHigh": "≥ 190 mg/dL"
+    },
+    "bandDescription": {
+      "optimal": "Wunschwert nach ATP III — kardiovaskuläres Risiko gering.",
+      "nearOptimal": "Akzeptabel — Lebensstil im Blick behalten.",
+      "borderline": "Grenzwertig erhöht — Lifestyle-Maßnahmen empfohlen.",
+      "high": "Erhöht — ärztliche Abklärung empfohlen.",
+      "veryHigh": "Sehr hoch — therapeutische Maßnahmen meist erforderlich."
+    },
+    "faq": [
+      { "q": "Was ist die Friedewald-Formel?", "a": "Die Friedewald-Formel (William T. Friedewald, 1972) schätzt LDL-Cholesterin aus Gesamtcholesterin, HDL und Triglyceriden — ohne dass LDL direkt gemessen werden muss. Die Schätzung gilt als robust, wenn Triglyceride unter 400 mg/dL (4,5 mmol/L) liegen." },
+      { "q": "Wann ist die Schätzung unzuverlässig?", "a": "Ab Triglyceriden von 400 mg/dL (4,5 mmol/L) unterschätzt Friedewald das LDL systematisch. In diesem Fall sollte LDL direkt gemessen werden (z. B. mit der Sampson- oder Martin-Hopkins-Formel oder per Ultrazentrifugation)." },
+      { "q": "Welche LDL-Werte gelten als optimal?", "a": "Nach NCEP ATP III gilt LDL unter 100 mg/dL als optimal, 100–129 als fast optimal, 130–159 als grenzwertig hoch, 160–189 als hoch und ab 190 als sehr hoch." },
+      { "q": "Muss ich nüchtern sein?", "a": "Ja — Triglyceride werden durch die letzte Mahlzeit stark beeinflusst. Für eine valide Friedewald-Schätzung sollten 9–12 Stunden Nüchternheit eingehalten werden." },
+      { "q": "Was tun bei erhöhtem LDL?", "a": "Lebensstilmaßnahmen sind zentral: ballaststoffreiche Ernährung, weniger gesättigte Fette und Transfette, regelmäßige Bewegung, Gewichtsreduktion bei Übergewicht. Ab LDL ≥ 190 mg/dL — oder bei zusätzlichen Risikofaktoren — kann eine medikamentöse Therapie (Statine) sinnvoll sein." },
+      { "q": "Warum sind die ATP-III-Bänder in mg/dL definiert?", "a": "Die NCEP ATP-III-Leitlinie stammt aus den USA, wo Cholesterin in mg/dL gemessen wird. International (Europa, Australien) wird oft mmol/L verwendet — der Rechner rechnet für die Bandeinordnung automatisch um (Faktor 38,67)." }
+    ]
+  }
+}

--- a/src/locales/calculators/en/ldlFriedewald.json
+++ b/src/locales/calculators/en/ldlFriedewald.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "ldlFriedewald": {
+        "name": "LDL Cholesterol (Friedewald) Calculator",
+        "description": "Estimate LDL from total cholesterol, HDL and triglycerides via the Friedewald formula."
+      }
+    }
+  },
+  "ldlFriedewald": {
+    "meta": {
+      "title": "LDL Cholesterol Calculator (Friedewald) — Formula & ATP III Bands",
+      "description": "Calculate LDL cholesterol from total cholesterol, HDL and triglycerides using the Friedewald formula. ATP III classification (optimal to very high) and warning when TG ≥ 400 mg/dL. Free, instant, no sign-up."
+    },
+    "title": "LDL Cholesterol — Friedewald Calculator",
+    "description": "Estimate LDL cholesterol from total cholesterol, HDL and triglycerides using the Friedewald formula — with ATP III risk bands.",
+    "unitsLabel": "Units",
+    "unitMg": "mg/dL",
+    "unitMmol": "mmol/L",
+    "totalLabel": "Total cholesterol",
+    "hdlLabel": "HDL",
+    "trigLabel": "Triglycerides",
+    "totalPlaceholderMg": "e.g. 200",
+    "totalPlaceholderMmol": "e.g. 5.17",
+    "hdlPlaceholderMg": "e.g. 50",
+    "hdlPlaceholderMmol": "e.g. 1.30",
+    "trigPlaceholderMg": "e.g. 150",
+    "trigPlaceholderMmol": "e.g. 1.70",
+    "resultsLabel": "Result",
+    "ldlLabel": "Estimated LDL",
+    "ldlUnitMg": "mg/dL",
+    "ldlUnitMmol": "mmol/L",
+    "bandLabel": "ATP III band",
+    "warningInvalid": "Friedewald estimate is inaccurate when triglycerides ≥ 400 mg/dL (4.5 mmol/L). Request a direct LDL measurement.",
+    "formulaTitle": "Formula",
+    "formulaTextMg": "LDL = Total − HDL − Triglycerides / 5  (mg/dL)",
+    "formulaTextMmol": "LDL = Total − HDL − Triglycerides / 2.2  (mmol/L)",
+    "formulaWhy": "The Friedewald formula (1972) estimates LDL from total cholesterol, HDL and triglycerides. It is the most widely used method in routine lipid panels — as long as triglycerides remain below 400 mg/dL (4.5 mmol/L).",
+    "categoriesTitle": "ATP III risk bands (NCEP)",
+    "clinicalNote": "ATP III thresholds are defined in mg/dL. When you enter mmol/L, the calculator converts internally for the band classification. This estimate does not replace a clinician's assessment.",
+    "disclaimer": "This calculator is for information only. For elevated values — or triglycerides ≥ 400 mg/dL — ask your lab for a direct LDL measurement.",
+    "band": {
+      "optimal": "Optimal",
+      "nearOptimal": "Near optimal",
+      "borderline": "Borderline high",
+      "high": "High",
+      "veryHigh": "Very high"
+    },
+    "bandRange": {
+      "optimal": "< 100 mg/dL",
+      "nearOptimal": "100 – 129 mg/dL",
+      "borderline": "130 – 159 mg/dL",
+      "high": "160 – 189 mg/dL",
+      "veryHigh": "≥ 190 mg/dL"
+    },
+    "bandDescription": {
+      "optimal": "Goal per ATP III — cardiovascular risk is low.",
+      "nearOptimal": "Acceptable — keep lifestyle on track.",
+      "borderline": "Borderline elevated — lifestyle measures advised.",
+      "high": "High — clinical review recommended.",
+      "veryHigh": "Very high — therapy is usually warranted."
+    },
+    "faq": [
+      { "q": "What is the Friedewald formula?", "a": "Introduced by William T. Friedewald in 1972, this formula estimates LDL cholesterol from total cholesterol, HDL and triglycerides — without needing a direct LDL assay. The estimate is robust when triglycerides are below 400 mg/dL (4.5 mmol/L)." },
+      { "q": "When is the estimate unreliable?", "a": "Once triglycerides reach 400 mg/dL (4.5 mmol/L) Friedewald systematically underestimates LDL. In that case request a direct LDL measurement, or use the Sampson or Martin-Hopkins equations." },
+      { "q": "What LDL values are considered optimal?", "a": "Per NCEP ATP III, LDL below 100 mg/dL is optimal, 100–129 near optimal, 130–159 borderline high, 160–189 high, and 190 or above very high." },
+      { "q": "Do I need to fast?", "a": "Yes — triglycerides are strongly affected by recent meals. For a valid Friedewald estimate, fast for 9–12 hours before the blood draw." },
+      { "q": "What can I do about high LDL?", "a": "Lifestyle measures come first: a fibre-rich diet, fewer saturated and trans fats, regular exercise, and weight loss when needed. For LDL ≥ 190 mg/dL — or additional risk factors — pharmacotherapy (statins) may be indicated." },
+      { "q": "Why are ATP III bands defined in mg/dL?", "a": "The NCEP ATP III guideline comes from the US, where cholesterol is reported in mg/dL. Other regions use mmol/L — the calculator converts automatically for band classification (factor 38.67)." }
+    ]
+  }
+}

--- a/src/pages/LdlFriedewaldCalculator.vue
+++ b/src/pages/LdlFriedewaldCalculator.vue
@@ -1,0 +1,247 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  calcLdl,
+  isFriedewaldInvalid,
+  ldlToMgdl,
+  getAtpBand,
+  bandColor,
+  bandBg,
+  roundLdl,
+} from '../utils/ldlFriedewald.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('ldlFriedewald.faq') || [])
+
+useHead(() => ({
+  title: t('ldlFriedewald.meta.title'),
+  description: t('ldlFriedewald.meta.description'),
+  routeKey: 'ldlFriedewald',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'LDL Cholesterol Friedewald Calculator',
+    url: 'https://healthcalculator.app/en/ldl-cholesterol-friedewald',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const unit = ref('mg')
+const total = ref(null)
+const hdl = ref(null)
+const trig = ref(null)
+
+function switchUnit(next) {
+  if (unit.value === next) return
+  unit.value = next
+  total.value = null
+  hdl.value = null
+  trig.value = null
+}
+
+const ldlRaw = computed(() =>
+  calcLdl({ total: total.value, hdl: hdl.value, trig: trig.value, unit: unit.value }),
+)
+
+const invalid = computed(() => isFriedewaldInvalid(trig.value, unit.value))
+
+const ldlMgdlForBand = computed(() => ldlToMgdl(ldlRaw.value, unit.value))
+const band = computed(() => getAtpBand(ldlMgdlForBand.value))
+
+const hasResult = computed(() => ldlRaw.value !== null && band.value !== null)
+
+const ldlFormatted = computed(() => {
+  if (ldlRaw.value === null) return '—'
+  if (unit.value === 'mmol') return ldlRaw.value.toFixed(2)
+  return String(roundLdl(ldlRaw.value))
+})
+
+const ldlUnitLabel = computed(() => (unit.value === 'mmol' ? t('ldlFriedewald.ldlUnitMmol') : t('ldlFriedewald.ldlUnitMg')))
+
+const totalPlaceholder = computed(() =>
+  unit.value === 'mmol' ? t('ldlFriedewald.totalPlaceholderMmol') : t('ldlFriedewald.totalPlaceholderMg'),
+)
+const hdlPlaceholder = computed(() =>
+  unit.value === 'mmol' ? t('ldlFriedewald.hdlPlaceholderMmol') : t('ldlFriedewald.hdlPlaceholderMg'),
+)
+const trigPlaceholder = computed(() =>
+  unit.value === 'mmol' ? t('ldlFriedewald.trigPlaceholderMmol') : t('ldlFriedewald.trigPlaceholderMg'),
+)
+const formulaText = computed(() =>
+  unit.value === 'mmol' ? t('ldlFriedewald.formulaTextMmol') : t('ldlFriedewald.formulaTextMg'),
+)
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('ldlFriedewald.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('ldlFriedewald.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+        <span class="text-xs font-semibold text-stone-500 uppercase tracking-widest">{{ t('ldlFriedewald.unitsLabel') }}</span>
+        <div class="flex gap-2">
+          <button
+            data-testid="btn-mg"
+            type="button"
+            @click="switchUnit('mg')"
+            :class="unit === 'mg' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('ldlFriedewald.unitMg') }}</button>
+          <button
+            data-testid="btn-mmol"
+            type="button"
+            @click="switchUnit('mmol')"
+            :class="unit === 'mmol' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150"
+          >{{ t('ldlFriedewald.unitMmol') }}</button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div>
+          <label for="total-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('ldlFriedewald.totalLabel') }} ({{ ldlUnitLabel }})
+          </label>
+          <input
+            id="total-input"
+            v-model.number="total"
+            data-testid="total-input"
+            type="number"
+            step="0.01"
+            min="0"
+            :placeholder="totalPlaceholder"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="hdl-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('ldlFriedewald.hdlLabel') }} ({{ ldlUnitLabel }})
+          </label>
+          <input
+            id="hdl-input"
+            v-model.number="hdl"
+            data-testid="hdl-input"
+            type="number"
+            step="0.01"
+            min="0"
+            :placeholder="hdlPlaceholder"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="trig-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('ldlFriedewald.trigLabel') }} ({{ ldlUnitLabel }})
+          </label>
+          <input
+            id="trig-input"
+            v-model.number="trig"
+            data-testid="trig-input"
+            type="number"
+            step="0.01"
+            min="0"
+            :placeholder="trigPlaceholder"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div v-if="invalid" class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-6" data-testid="invalid-warning">
+      <p class="text-sm font-semibold text-amber-800 mb-1">⚠ {{ t('ldlFriedewald.warningInvalid') }}</p>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <div v-if="hasResult" :class="['border rounded-xl shadow-sm p-8 mb-6', bandBg(band)]" data-testid="result-card">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('ldlFriedewald.resultsLabel') }}</p>
+
+      <div class="flex items-baseline gap-3 mb-4">
+        <span data-testid="ldl-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ ldlFormatted }}</span>
+        <span class="text-sm text-stone-400 ml-1">{{ ldlUnitLabel }}</span>
+      </div>
+
+      <p :class="['text-lg font-semibold mb-1', bandColor(band)]" data-testid="band">{{ t(`ldlFriedewald.band.${band}`) }}</p>
+      <p class="text-sm text-stone-600 leading-relaxed mb-4" data-testid="band-description">{{ t(`ldlFriedewald.bandDescription.${band}`) }}</p>
+
+      <div class="bg-white/60 border border-stone-200 rounded-lg p-4 text-xs text-stone-600 leading-relaxed" data-testid="clinical-note">
+        {{ t('ldlFriedewald.clinicalNote') }}
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('ldlFriedewald.categoriesTitle') }}</h2>
+      <div class="space-y-3.5">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-emerald-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ldlFriedewald.band.optimal') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ldlFriedewald.bandRange.optimal') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-lime-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ldlFriedewald.band.nearOptimal') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ldlFriedewald.bandRange.nearOptimal') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-amber-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ldlFriedewald.band.borderline') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ldlFriedewald.bandRange.borderline') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-orange-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ldlFriedewald.band.high') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ldlFriedewald.bandRange.high') }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-red-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ldlFriedewald.band.veryHigh') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ldlFriedewald.bandRange.veryHigh') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('ldlFriedewald.formulaTitle') }}</h2>
+      <div class="bg-stone-50 rounded-lg p-4 font-mono text-base text-stone-700 mb-3" data-testid="formula">
+        {{ formulaText }}
+      </div>
+      <p class="text-sm text-stone-600 leading-relaxed">{{ t('ldlFriedewald.formulaWhy') }}</p>
+    </div>
+
+    <div v-if="hasResult" class="bg-stone-50 rounded-xl border border-stone-200 p-5 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('ldlFriedewald.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <RelatedCalculators calc-key="ldlFriedewald" class="mt-8" />
+    <BlogArticleLink calculator-key="ldlFriedewald" />
+
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/LdlFriedewaldBerechnen.vue
+++ b/src/pages/blog/LdlFriedewaldBerechnen.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'LDL-Cholesterin (Friedewald) berechnen: Formel, Grenzen, Werte | Health Calculators',
+  description: 'LDL-Cholesterin per Friedewald-Formel aus Gesamtcholesterin, HDL und Triglyceriden schätzen. ATP-III-Bänder, Grenzen ab 400 mg/dL, was bei erhöhtem LDL hilft.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'LDL-Cholesterin (Friedewald) berechnen: Formel, Grenzen, Werte',
+      description: 'Friedewald-Formel, ATP-III-Bänder und was bei erhöhtem LDL wirklich hilft.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-29',
+      dateModified: '2026-05-29',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/ldl-friedewald-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist die Friedewald-Formel?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die Friedewald-Formel (1972) schätzt LDL-Cholesterin aus Gesamtcholesterin, HDL und Triglyceriden: LDL = Gesamt − HDL − Triglyceride/5 (mg/dL). In mmol/L wird durch 2,2 geteilt.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Ab wann ist die Friedewald-Schätzung ungenau?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ab Triglyceriden von 400 mg/dL (4,5 mmol/L) unterschätzt Friedewald das LDL systematisch. Dann ist eine direkte LDL-Messung im Labor empfohlen.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welche LDL-Werte gelten als optimal?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Nach NCEP ATP III gilt: < 100 mg/dL optimal, 100–129 fast optimal, 130–159 grenzwertig, 160–189 hoch, ≥ 190 sehr hoch.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Muss ich für den Test nüchtern sein?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ja — 9 bis 12 Stunden nüchtern. Triglyceride steigen nach einer Mahlzeit deutlich, was die Friedewald-Schätzung verfälscht.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was tun bei erhöhtem LDL?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ballaststoffe, weniger gesättigte Fette und Transfette, mehr Bewegung, Gewichtsreduktion. Bei LDL ≥ 190 mg/dL oder zusätzlichen Risikofaktoren ggf. Statintherapie.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Gibt es bessere Formeln als Friedewald?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Für Triglyceride über 400 mg/dL oder niedrige LDL-Werte schätzen die Sampson-Formel (2020) und Martin-Hopkins-Formel (2013) genauer. Im Routinelabor bleibt Friedewald aber Standard.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">LDL-Cholesterin (Friedewald) berechnen: Formel, Grenzen, Werte</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">29. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Auf den meisten Lipidprofilen taucht das LDL-Cholesterin als errechneter Wert auf — geschätzt nach einer Formel von 1972. Die <strong>Friedewald-Formel</strong> ist bis heute der Standard, hat aber eine klare Achillesferse: hohe Triglyceride.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieser Artikel zeigt die Formel in beiden Einheiten, ordnet die Ergebnisse nach ATP III ein und erklärt, wann eine direkte LDL-Messung sinnvoller ist.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel — zwei Varianten</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          LDL = Gesamt − HDL − Triglyceride / 5  (mg/dL)
+        </div>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          LDL = Gesamt − HDL − Triglyceride / 2,2  (mmol/L)
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Hintergrund: Triglyceride / 5 (bzw. /2,2 in mmol/L) schätzt das VLDL-Cholesterin. Was nach Abzug von HDL und VLDL bleibt, ist das LDL.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beispiel: Gesamt 200, HDL 50, Triglyceride 150 → LDL = 200 − 50 − 30 = <strong>120 mg/dL</strong>. Das liegt im Bereich „fast optimal".
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">ATP-III-Bänder auf einen Blick</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">LDL-Einordnung (NCEP ATP III)</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 100 mg/dL</span>
+              <span class="text-emerald-600 font-medium">Optimal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">100 – 129 mg/dL</span>
+              <span class="text-lime-600 font-medium">Fast optimal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">130 – 159 mg/dL</span>
+              <span class="text-amber-600 font-medium">Grenzwertig</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">160 – 189 mg/dL</span>
+              <span class="text-orange-600 font-medium">Hoch</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">≥ 190 mg/dL</span>
+              <span class="text-red-500 font-medium">Sehr hoch</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die ATP-III-Schwellen stammen aus den USA und sind in mg/dL definiert. Internationale Leitlinien (ESC) verwenden teilweise andere Zielwerte je nach Risikostratifizierung.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wann die Friedewald-Schätzung scheitert</h2>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Hauptgrenze</p>
+          <p class="text-sm text-amber-700">Triglyceride ab 400 mg/dL (4,5 mmol/L) → Friedewald unterschätzt LDL. Direkte Messung anfordern.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Warum? Die Annahme „VLDL = TG/5" gilt nur bei moderaten Triglyceriden. Bei Hypertriglyceridämie (z. B. nach üppigem Essen, bei Diabetes, Pankreatitis-Risiko) verzerren chylomikronenartige Partikel das Verhältnis.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Modernere Schätzer wie <strong>Sampson</strong> (2020) und <strong>Martin-Hopkins</strong> (2013) korrigieren diese Schwäche und sind bei sehr niedrigem LDL oder hohen Triglyceriden zuverlässiger.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was vor dem Test wichtig ist</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">9–12 Stunden vollständig nüchtern (Wasser ist erlaubt)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Kein Alkohol 24 Stunden vor der Blutentnahme</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Keine akute Krankheit oder OP in den letzten 2–6 Wochen</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Ruhig und ausgeschlafen (Stress verschiebt das Lipidprofil)</span></li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">LDL jetzt schätzen lassen</h3>
+        <p class="text-base text-stone-600 mb-6">Gesamtcholesterin, HDL und Triglyceride eingeben — der Rechner liefert Friedewald-LDL und die ATP-III-Einordnung.</p>
+        <router-link
+          :to="localePath('ldlFriedewald')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Zum LDL-Friedewald-Rechner
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was bei erhöhtem LDL hilft</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          LDL ist hochgradig veränderbar — über Ernährung, Bewegung und Gewicht. Drei Hebel mit der besten Evidenz:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Gesättigte Fette und Transfette reduzieren:</strong> Wenig fettes Fleisch, Wurst, Butter, frittierte Speisen.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>Mehr lösliche Ballaststoffe:</strong> Hafer, Hülsenfrüchte, Äpfel, Leinsamen binden Cholesterin im Darm.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Regelmäßige Bewegung + Gewichtsreduktion:</strong> Senkt LDL und Triglyceride, erhöht HDL.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ab LDL ≥ 190 mg/dL — oder bei zusätzlichen kardiovaskulären Risiken — wird ärztlich oft eine Statintherapie empfohlen. Lifestyle bleibt die Basis.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          LDL ist nur ein Baustein. Für die Risikoeinordnung lohnt sich zusätzlich das
+          <router-link :to="localePath('cholesterolRatio')" class="text-stone-900 underline hover:no-underline">Cholesterin-Verhältnis</router-link>
+          (Total/HDL), der
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Herz-Kreislauf-Risiko-Rechner</router-link>
+          nach Framingham/SCORE2 und der
+          <router-link :to="localePath('strokeRisk')" class="text-stone-900 underline hover:no-underline">Schlaganfall-Risiko-Rechner</router-link>
+          bei Vorhofflimmern.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die Friedewald-Formel liefert in der überwiegenden Mehrheit der Routinefälle ein verlässliches LDL — aus drei Werten, die jedes Labor ohnehin misst.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei Triglyceriden über 400 mg/dL kippt sie. Dann ist die direkte Messung der nächste Schritt. Und unabhängig vom Verfahren gilt: Lebensstil bewegt LDL am stärksten und schnellsten.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="ldl-friedewald-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/LdlCholesterolFriedewaldGuide.vue
+++ b/src/pages/blog/en/LdlCholesterolFriedewaldGuide.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'LDL Cholesterol (Friedewald) Calculator Guide: Formula, Limits, Values | Health Calculators',
+  description: 'Estimate LDL cholesterol from total cholesterol, HDL and triglycerides using the Friedewald formula. ATP III bands, the 400 mg/dL limit, and what to do about elevated LDL.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'LDL Cholesterol (Friedewald) Calculator Guide: Formula, Limits, Values',
+      description: 'Friedewald formula, ATP III bands and what actually moves elevated LDL.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-29',
+      dateModified: '2026-05-29',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/ldl-cholesterol-friedewald-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is the Friedewald formula?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Introduced by Friedewald in 1972, the formula estimates LDL cholesterol from total cholesterol, HDL and triglycerides: LDL = Total − HDL − Triglycerides / 5 (mg/dL). In mmol/L the divisor is 2.2.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'When does the Friedewald estimate fail?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Once triglycerides reach 400 mg/dL (4.5 mmol/L), Friedewald systematically underestimates LDL. Request a direct LDL measurement in that case.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What LDL values are optimal?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Per NCEP ATP III: < 100 mg/dL optimal, 100–129 near optimal, 130–159 borderline high, 160–189 high, ≥ 190 very high.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Do I need to fast?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Yes — fast for 9 to 12 hours. Triglycerides rise sharply after a meal, which throws off the Friedewald estimate.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What can I do about high LDL?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Add fibre, cut saturated and trans fats, exercise regularly, and lose excess weight. For LDL ≥ 190 mg/dL or added risk factors, a statin may be indicated.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Are there better formulas than Friedewald?',
+          acceptedAnswer: { '@type': 'Answer', text: 'For triglycerides above 400 mg/dL or very low LDL, the Sampson (2020) and Martin-Hopkins (2013) equations estimate more accurately. Friedewald remains the routine-lab default.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">LDL Cholesterol (Friedewald) Calculator Guide: Formula, Limits, Values</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 29, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          On most lipid panels, LDL cholesterol is not measured directly — it's calculated. The <strong>Friedewald formula</strong> has been the workhorse since 1972 and still is. It has one well-known weak spot: high triglycerides.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide walks through the formula in both unit systems, classifies the result against ATP III, and shows when a direct LDL assay is the better call.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula — two flavours</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          LDL = Total − HDL − Triglycerides / 5  (mg/dL)
+        </div>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          LDL = Total − HDL − Triglycerides / 2.2  (mmol/L)
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Background: Triglycerides / 5 (or / 2.2 in mmol/L) estimates the VLDL cholesterol fraction. Subtract HDL and VLDL from total cholesterol and what remains is the LDL estimate.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Example: Total 200, HDL 50, triglycerides 150 → LDL = 200 − 50 − 30 = <strong>120 mg/dL</strong>. That sits in the "near optimal" range.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">ATP III bands at a glance</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">LDL classification (NCEP ATP III)</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 100 mg/dL</span>
+              <span class="text-emerald-600 font-medium">Optimal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">100 – 129 mg/dL</span>
+              <span class="text-lime-600 font-medium">Near optimal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">130 – 159 mg/dL</span>
+              <span class="text-amber-600 font-medium">Borderline high</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">160 – 189 mg/dL</span>
+              <span class="text-orange-600 font-medium">High</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">≥ 190 mg/dL</span>
+              <span class="text-red-500 font-medium">Very high</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          ATP III cut-offs come from the US guideline and are defined in mg/dL. European ESC guidelines sometimes use different LDL targets based on cardiovascular risk strata.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">When Friedewald breaks down</h2>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Main limit</p>
+          <p class="text-sm text-amber-700">Triglycerides ≥ 400 mg/dL (4.5 mmol/L) → Friedewald underestimates LDL. Request a direct measurement.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Why? The "VLDL = TG/5" assumption only holds at moderate triglyceride levels. With hypertriglyceridemia — after a heavy meal, in diabetes, or with pancreatitis risk — chylomicron-like particles skew the ratio.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Newer estimators like <strong>Sampson</strong> (2020) and <strong>Martin-Hopkins</strong> (2013) correct this weakness and perform better at very low LDL or high triglycerides.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What matters before the test</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Fast fully for 9–12 hours (water is fine)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">No alcohol in the 24 hours before the draw</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">No acute illness or surgery in the past 2–6 weeks</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Rested and calm (stress shifts the lipid profile)</span></li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Estimate your LDL now</h3>
+        <p class="text-base text-stone-600 mb-6">Enter total cholesterol, HDL and triglycerides — the calculator returns the Friedewald LDL and the ATP III band.</p>
+        <router-link
+          :to="localePath('ldlFriedewald')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Open the LDL Friedewald Calculator
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What lowers high LDL</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          LDL responds well to diet, exercise and weight. Three levers with the strongest evidence:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Cut saturated and trans fats:</strong> Less fatty meat, sausage, butter, and fried food.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>More soluble fibre:</strong> Oats, legumes, apples, flaxseed bind cholesterol in the gut.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Regular exercise plus weight loss:</strong> Lowers LDL and triglycerides, raises HDL.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For LDL ≥ 190 mg/dL — or added cardiovascular risk factors — clinicians often recommend a statin. Lifestyle remains the foundation either way.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          LDL is one piece of the picture. For broader context try the
+          <router-link :to="localePath('cholesterolRatio')" class="text-stone-900 underline hover:no-underline">Cholesterol Ratio Calculator</router-link>
+          (Total/HDL), the
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Cardiovascular Risk Calculator</router-link>
+          (Framingham/SCORE2), and the
+          <router-link :to="localePath('strokeRisk')" class="text-stone-900 underline hover:no-underline">Stroke Risk Calculator</router-link>
+          for atrial fibrillation.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Takeaway</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The Friedewald formula gives a reliable LDL for the vast majority of routine cases — from three values every lab measures anyway.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          It breaks once triglycerides climb past 400 mg/dL. That's when a direct measurement is the next step. Whatever the method, lifestyle moves LDL fastest and farthest.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticlesEn slug="ldl-cholesterol-friedewald-guide" />
+  </article>
+</template>

--- a/src/pages/ldlFriedewald.meta.js
+++ b/src/pages/ldlFriedewald.meta.js
@@ -1,0 +1,16 @@
+import Component from './LdlFriedewaldCalculator.vue'
+import BlogDe from './blog/LdlFriedewaldBerechnen.vue'
+import BlogEn from './blog/en/LdlCholesterolFriedewaldGuide.vue'
+
+export default {
+  key: 'ldlFriedewald',
+  component: Component,
+  slugs: { de: 'ldl-friedewald-rechner', en: 'ldl-cholesterol-friedewald' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 26.5,
+  blog: {
+    de: { slug: 'ldl-friedewald-berechnen', component: BlogDe },
+    en: { slug: 'ldl-cholesterol-friedewald-guide', component: BlogEn },
+  },
+}

--- a/src/utils/ldlFriedewald.js
+++ b/src/utils/ldlFriedewald.js
@@ -1,0 +1,96 @@
+// LDL Cholesterol Friedewald Calculator
+// Formula (mg/dL):  LDL = Total − HDL − Triglycerides / 5
+// Formula (mmol/L): LDL = Total − HDL − Triglycerides / 2.2
+// Validity: triglycerides must be < 400 mg/dL (< 4.5 mmol/L).
+//
+// ATP III risk bands (NCEP, mg/dL):
+//   < 100        Optimal
+//   100 – 129    Near optimal
+//   130 – 159    Borderline high
+//   160 – 189    High
+//   ≥ 190        Very high
+
+const TG_INVALID_MGDL = 400
+const TG_INVALID_MMOL = 4.5
+
+function toNum(v) {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function calcLdlMgdl(total, hdl, trig) {
+  const t = toNum(total)
+  const h = toNum(hdl)
+  const tg = toNum(trig)
+  if (t == null || h == null || tg == null) return null
+  return t - h - tg / 5
+}
+
+export function calcLdlMmol(total, hdl, trig) {
+  const t = toNum(total)
+  const h = toNum(hdl)
+  const tg = toNum(trig)
+  if (t == null || h == null || tg == null) return null
+  return t - h - tg / 2.2
+}
+
+export function calcLdl({ total, hdl, trig, unit = 'mg' }) {
+  return unit === 'mmol'
+    ? calcLdlMmol(total, hdl, trig)
+    : calcLdlMgdl(total, hdl, trig)
+}
+
+export function isFriedewaldInvalid(trig, unit = 'mg') {
+  const tg = toNum(trig)
+  if (tg == null) return false
+  return unit === 'mmol' ? tg >= TG_INVALID_MMOL : tg >= TG_INVALID_MGDL
+}
+
+// ATP III bands are defined in mg/dL. Convert mmol/L → mg/dL with 38.67 first.
+const MGDL_PER_MMOL = 38.67
+
+export function ldlToMgdl(ldl, unit = 'mg') {
+  const v = toNum(ldl)
+  if (v == null) return null
+  return unit === 'mmol' ? v * MGDL_PER_MMOL : v
+}
+
+export function getAtpBand(ldlMgdl) {
+  if (ldlMgdl == null || !Number.isFinite(ldlMgdl)) return null
+  if (ldlMgdl < 100) return 'optimal'
+  if (ldlMgdl < 130) return 'nearOptimal'
+  if (ldlMgdl < 160) return 'borderline'
+  if (ldlMgdl < 190) return 'high'
+  return 'veryHigh'
+}
+
+const COLORS = {
+  optimal: 'text-emerald-600',
+  nearOptimal: 'text-lime-600',
+  borderline: 'text-amber-600',
+  high: 'text-orange-600',
+  veryHigh: 'text-red-600',
+}
+
+const BGS = {
+  optimal: 'bg-emerald-50 border-emerald-200',
+  nearOptimal: 'bg-lime-50 border-lime-200',
+  borderline: 'bg-amber-50 border-amber-200',
+  high: 'bg-orange-50 border-orange-200',
+  veryHigh: 'bg-red-50 border-red-200',
+}
+
+export function bandColor(band) {
+  return COLORS[band] || 'text-stone-900'
+}
+
+export function bandBg(band) {
+  return BGS[band] || 'bg-white border-stone-200'
+}
+
+// Integer rounding used by the UI for mg/dL output.
+export function roundLdl(ldl) {
+  if (ldl == null || !Number.isFinite(ldl)) return null
+  return Math.round(ldl)
+}


### PR DESCRIPTION
## Summary
- New LDL cholesterol calculator using the Friedewald formula with mg/dL ↔ mmol/L unit toggle.
- ATP III risk banding (Optimal / Near optimal / Borderline / High / Very high) with color coding.
- Explicit warning when triglycerides ≥ 400 mg/dL (4.5 mmol/L) — "Friedewald inaccurate, request direct LDL measurement".
- Full DE + EN locales, SEO-optimized blog articles with `FAQPage` structured data, internal links to cholesterolRatio / cardiovascularRisk / strokeRisk.

## Test plan
- [x] 27 unit tests (5 ATP III bands, TG ≥ 400 warning, mg/dL & mmol/L formulas, integer rounding) — all passing.
- [x] 17 E2E Playwright tests (DE + EN, all bands, unit toggle, warning) — all passing.
- [x] `npm run build` — SSG generates DE/EN calculator pages, both blog articles, 362 sitemap URLs, 358 llms.txt links.
- [x] Auto-discovery, sitemap, and llms-txt test counts bumped (88→89 calcs, 89→90 blogs, 485→490 routes).
- [x] EN blog uses `RelatedArticlesEn`; DE blog uses `RelatedArticles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)