### PR TITLE
Add Ankle-Brachial Index (ABI) Calculator (HC-268)

### DIFF
--- a/e2e/ankleBrachialIndex.spec.js
+++ b/e2e/ankleBrachialIndex.spec.js
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Ankle-Brachial Index Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/knoechel-arm-index-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Knöchel-Arm-Index/)
+  })
+
+  test('h1 contains Knöchel-Arm-Index', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Knöchel-Arm-Index')
+  })
+
+  test('back link navigates to home', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('no result shown before inputs', async ({ page }) => {
+    await expect(page.getByTestId('result-card')).toHaveCount(0)
+  })
+
+  test('normal case: arms 130/130, ankles 140/140 → 1.08 normal', async ({ page }) => {
+    await page.getByTestId('left-arm-input').fill('130')
+    await page.getByTestId('right-arm-input').fill('130')
+    await page.getByTestId('left-ankle-input').fill('140')
+    await page.getByTestId('right-ankle-input').fill('140')
+
+    await expect(page.getByTestId('overall-value')).toHaveText('1.08')
+    await expect(page.getByTestId('band')).toHaveText('Normal')
+  })
+
+  test('asymmetric: left PAD detected via overall ABI', async ({ page }) => {
+    await page.getByTestId('left-arm-input').fill('130')
+    await page.getByTestId('right-arm-input').fill('135')
+    await page.getByTestId('left-ankle-input').fill('90')
+    await page.getByTestId('right-ankle-input').fill('140')
+
+    await expect(page.getByTestId('left-value')).toHaveText('0.67')
+    await expect(page.getByTestId('right-value')).toHaveText('1.04')
+    await expect(page.getByTestId('band')).toHaveText('Mittel')
+  })
+
+  test('severe band Left=140/140 Ankles=60/60 → 0.43 severely reduced', async ({ page }) => {
+    await page.getByTestId('left-arm-input').fill('140')
+    await page.getByTestId('right-arm-input').fill('140')
+    await page.getByTestId('left-ankle-input').fill('60')
+    await page.getByTestId('right-ankle-input').fill('60')
+
+    await expect(page.getByTestId('band')).toHaveText('Schwer reduziert')
+  })
+
+  test('non-compressible vessels: ankles 220, arms 140 → > 1.4', async ({ page }) => {
+    await page.getByTestId('left-arm-input').fill('140')
+    await page.getByTestId('right-arm-input').fill('140')
+    await page.getByTestId('left-ankle-input').fill('220')
+    await page.getByTestId('right-ankle-input').fill('220')
+
+    await expect(page.getByTestId('band')).toHaveText('Nicht komprimierbar')
+  })
+
+  test('related calculators block is visible', async ({ page }) => {
+    await expect(page.getByTestId('related-calculators')).toBeVisible()
+  })
+
+  test('blog article link is visible', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('Ankle-Brachial Index Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/ankle-brachial-index')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Ankle-Brachial Index/)
+  })
+
+  test('normal case: arms 120/120, ankles 130/130 → normal', async ({ page }) => {
+    await page.getByTestId('left-arm-input').fill('120')
+    await page.getByTestId('right-arm-input').fill('120')
+    await page.getByTestId('left-ankle-input').fill('130')
+    await page.getByTestId('right-ankle-input').fill('130')
+
+    await expect(page.getByTestId('overall-value')).toHaveText('1.08')
+    await expect(page.getByTestId('band')).toHaveText('Normal')
+  })
+
+  test('moderate PAD: ankles 90, arms 140 → 0.64 moderate', async ({ page }) => {
+    await page.getByTestId('left-arm-input').fill('140')
+    await page.getByTestId('right-arm-input').fill('140')
+    await page.getByTestId('left-ankle-input').fill('90')
+    await page.getByTestId('right-ankle-input').fill('90')
+
+    await expect(page.getByTestId('band')).toHaveText('Moderate')
+  })
+})

--- a/src/__tests__/ankleBrachialIndex.test.js
+++ b/src/__tests__/ankleBrachialIndex.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcAbi,
+  getAbiBand,
+  bandColor,
+  bandBg,
+  formatAbi,
+} from '../utils/ankleBrachialIndex.js'
+
+describe('ABI formula', () => {
+  it('uses higher brachial pressure as denominator', () => {
+    const r = calcAbi({ leftArm: 130, rightArm: 140, leftAnkle: 140, rightAnkle: 140 })
+    // brachial = max(130, 140) = 140
+    expect(r.brachial).toBe(140)
+    expect(r.left).toBeCloseTo(1.0, 3)
+    expect(r.right).toBeCloseTo(1.0, 3)
+  })
+
+  it('returns null for missing inputs', () => {
+    expect(calcAbi({ leftArm: 120, rightArm: 120, leftAnkle: 120, rightAnkle: null })).toBeNull()
+    expect(calcAbi({ leftArm: null, rightArm: 120, leftAnkle: 120, rightAnkle: 120 })).toBeNull()
+  })
+
+  it('overall ABI is the lower of left and right per ACC/AHA', () => {
+    // Asymmetric: left ankle low, right ankle normal
+    const r = calcAbi({ leftArm: 140, rightArm: 140, leftAnkle: 100, rightAnkle: 140 })
+    expect(r.left).toBeCloseTo(100 / 140, 3) // ≈ 0.714
+    expect(r.right).toBeCloseTo(1.0, 3)
+    expect(r.overall).toBeCloseTo(100 / 140, 3)
+  })
+
+  it('identical arms vs differing arms — picks max for denominator', () => {
+    const identical = calcAbi({ leftArm: 140, rightArm: 140, leftAnkle: 140, rightAnkle: 140 })
+    const differing = calcAbi({ leftArm: 120, rightArm: 140, leftAnkle: 140, rightAnkle: 140 })
+    expect(identical.overall).toBeCloseTo(1.0, 3)
+    expect(differing.overall).toBeCloseTo(1.0, 3)
+    expect(differing.brachial).toBe(140)
+  })
+})
+
+describe('ABI bands — all six categories', () => {
+  it('≤ 0.5 → severely reduced', () => {
+    expect(getAbiBand(0.5)).toBe('severe')
+    expect(getAbiBand(0.3)).toBe('severe')
+  })
+
+  it('0.5 – 0.79 → moderate', () => {
+    expect(getAbiBand(0.51)).toBe('moderate')
+    expect(getAbiBand(0.7)).toBe('moderate')
+    expect(getAbiBand(0.79)).toBe('moderate')
+  })
+
+  it('0.8 – 0.89 → mild', () => {
+    expect(getAbiBand(0.8)).toBe('mild')
+    expect(getAbiBand(0.85)).toBe('mild')
+    expect(getAbiBand(0.89)).toBe('mild')
+  })
+
+  it('0.9 – 0.99 → borderline', () => {
+    expect(getAbiBand(0.9)).toBe('borderline')
+    expect(getAbiBand(0.95)).toBe('borderline')
+    expect(getAbiBand(0.99)).toBe('borderline')
+  })
+
+  it('1.0 – 1.4 → normal', () => {
+    expect(getAbiBand(1.0)).toBe('normal')
+    expect(getAbiBand(1.2)).toBe('normal')
+    expect(getAbiBand(1.4)).toBe('normal')
+  })
+
+  it('> 1.4 → non-compressible', () => {
+    expect(getAbiBand(1.41)).toBe('nonCompressible')
+    expect(getAbiBand(1.6)).toBe('nonCompressible')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(getAbiBand(null)).toBeNull()
+    expect(getAbiBand(NaN)).toBeNull()
+  })
+})
+
+describe('asymmetric left/right scenarios', () => {
+  it('PAD on left, healthy right — overall ABI flags left disease', () => {
+    const r = calcAbi({ leftArm: 130, rightArm: 135, leftAnkle: 90, rightAnkle: 140 })
+    expect(getAbiBand(r.left)).toBe('moderate') // 90/135 ≈ 0.667
+    expect(getAbiBand(r.right)).toBe('normal') // 140/135 ≈ 1.037
+    expect(getAbiBand(r.overall)).toBe('moderate')
+  })
+
+  it('severe PAD on right, mild on left → overall = severe right', () => {
+    const r = calcAbi({ leftArm: 140, rightArm: 140, leftAnkle: 115, rightAnkle: 65 })
+    // left 115/140 ≈ 0.821 (mild), right 65/140 ≈ 0.464 (severe)
+    expect(getAbiBand(r.left)).toBe('mild')
+    expect(getAbiBand(r.right)).toBe('severe')
+    expect(getAbiBand(r.overall)).toBe('severe')
+  })
+})
+
+describe('end-to-end clinical scenarios', () => {
+  it('normal example: arms 130/130, ankles 140/140 → 1.077 normal', () => {
+    const r = calcAbi({ leftArm: 130, rightArm: 130, leftAnkle: 140, rightAnkle: 140 })
+    expect(r.overall).toBeCloseTo(1.077, 2)
+    expect(getAbiBand(r.overall)).toBe('normal')
+  })
+
+  it('non-compressible: diabetic with calcified vessels — ankle 220, arm 140 → 1.57 → non-compressible', () => {
+    const r = calcAbi({ leftArm: 140, rightArm: 140, leftAnkle: 220, rightAnkle: 220 })
+    expect(r.overall).toBeCloseTo(1.571, 2)
+    expect(getAbiBand(r.overall)).toBe('nonCompressible')
+  })
+})
+
+describe('style helpers', () => {
+  it('returns distinct colors per band', () => {
+    expect(bandColor('normal')).toMatch(/text-/)
+    expect(bandColor('severe')).toMatch(/text-/)
+    expect(bandColor('normal')).not.toBe(bandColor('severe'))
+  })
+
+  it('returns distinct backgrounds per band', () => {
+    expect(bandBg('normal')).toMatch(/bg-/)
+    expect(bandBg('nonCompressible')).toMatch(/bg-/)
+  })
+})
+
+describe('formatAbi', () => {
+  it('formats to 2 decimals', () => {
+    expect(formatAbi(1.077)).toBe('1.08')
+    expect(formatAbi(0.5)).toBe('0.50')
+  })
+  it('returns em-dash for null', () => {
+    expect(formatAbi(null)).toBe('—')
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -31,6 +31,7 @@ const EXPECTED_KEYS = [
   'meanArterialPressure',
   'homaIr',
   'ldlFriedewald',
+  'ankleBrachialIndex',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -123,6 +124,7 @@ const EXPECTED_ROUTE_MAP = {
   meanArterialPressure: { de: 'mittlerer-arterieller-druck-rechner', en: 'mean-arterial-pressure' },
   homaIr: { de: 'homa-ir-rechner', en: 'homa-ir-insulin-resistance' },
   ldlFriedewald: { de: 'ldl-friedewald-rechner', en: 'ldl-cholesterol-friedewald' },
+  ankleBrachialIndex: { de: 'knoechel-arm-index-rechner', en: 'ankle-brachial-index' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -204,6 +206,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'mittlerer-arterieller-druck-berechnen',
   'homa-ir-berechnen',
   'ldl-friedewald-berechnen',
+  'knoechel-arm-index-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -285,19 +288,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'mean-arterial-pressure-guide',
   'homa-ir-insulin-resistance-guide',
   'ldl-cholesterol-friedewald-guide',
+  'ankle-brachial-index-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 89 calculators', () => {
-    expect(calculatorMetas).toHaveLength(89)
+  it('discovers all 90 calculators', () => {
+    expect(calculatorMetas).toHaveLength(90)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 89 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(89)
+  it('builds calculatorComponents map for all 90 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(90)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -320,15 +324,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 90 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(90)
+  it('discovers all 91 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(91)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 90 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(90)
+  it('discovers all 91 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(91)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -353,10 +357,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 89 calculators with no duplicates', () => {
+  it('groups contain all 90 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(89)
-    expect(new Set(allKeys).size).toBe(89)
+    expect(allKeys).toHaveLength(90)
+    expect(new Set(allKeys).size).toBe(90)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -377,7 +381,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -426,8 +430,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 490 routes', () => {
-    expect(routes).toHaveLength(490)
+  it('generates exactly 495 routes', () => {
+    expect(routes).toHaveLength(495)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 358 links (89 calcs × 2 locales + 90 blogs × 2 locales)', () => {
+  it('generates 362 links (90 calcs × 2 locales + 91 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(358)
+    expect(links).toHaveLength(362)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -25,6 +25,7 @@ const EXPECTED_KEYS = [
   'meanArterialPressure',
   'homaIr',
   'ldlFriedewald',
+  'ankleBrachialIndex',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -105,6 +106,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'mittlerer-arterieller-druck-berechnen',
   'homa-ir-berechnen',
   'ldl-friedewald-berechnen',
+  'knoechel-arm-index-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -185,12 +187,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'mean-arterial-pressure-guide',
   'homa-ir-insulin-resistance-guide',
   'ldl-cholesterol-friedewald-guide',
+  'ankle-brachial-index-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 89 calculator meta files', () => {
+  it('discovers all 90 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(89)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(90)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -228,19 +231,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 90 DE blog slugs', () => {
+  it('returns all 91 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(90)
+    expect(de).toHaveLength(91)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 90 EN blog slugs', () => {
+  it('returns all 91 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(90)
+    expect(en).toHaveLength(91)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -308,9 +311,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 178 calcs + 2 blog index + 180 blog articles = 362)', () => {
+  it('generates correct total URL count (2 home + 180 calcs + 2 blog index + 182 blog articles = 366)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(362)
+    expect(urlCount).toBe(366)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -809,6 +809,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'ldlFriedewald',
     related: ['cholesterol-ratio', 'cardiovascular-risk-framingham', 'stroke-risk-calculator-cha2ds2-vasc'],
   },
+  {
+    slug: 'ankle-brachial-index-guide',
+    title: 'Ankle-Brachial Index (ABI) Calculator Guide: Formula, Values, PAD Screening',
+    description: 'Calculate the ABI from four systolic blood pressures. ACC/AHA bands from normal to severe PAD, the calcified-vessel pitfall at ABI > 1.4 and what helps abnormal values.',
+    date: '2026-05-30',
+    readTime: '8 min',
+    calculatorKey: 'ankleBrachialIndex',
+    related: ['measure-blood-pressure', 'cardiovascular-risk-framingham', 'diabetes-risk-score'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -809,6 +809,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'ldlFriedewald',
     related: ['cholesterol-verhaeltnis-rechner', 'herz-kreislauf-risiko-berechnen', 'schlaganfall-risiko-berechnen'],
   },
+  {
+    slug: 'knoechel-arm-index-berechnen',
+    title: 'Knöchel-Arm-Index (ABI) berechnen: Formel, Werte, pAVK-Screening',
+    description: 'ABI per Formel aus vier systolischen Blutdrücken berechnen. ACC/AHA-Bänder von normal bis schwerer pAVK, Mediasklerose-Falle ab 1,4 und was bei auffälligem Wert hilft.',
+    date: '2026-05-30',
+    readTime: '8 min',
+    calculatorKey: 'ankleBrachialIndex',
+    related: ['blutdruck-richtig-messen', 'herz-kreislauf-risiko-berechnen', 'diabetes-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/ankleBrachialIndex.json
+++ b/src/locales/calculators/de/ankleBrachialIndex.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "ankleBrachialIndex": {
+        "name": "Knöchel-Arm-Index (ABI) Rechner",
+        "description": "Linker, rechter und Gesamt-ABI aus vier Manschettendrücken berechnen. Screening auf periphere arterielle Verschlusskrankheit (pAVK)."
+      }
+    }
+  },
+  "ankleBrachialIndex": {
+    "meta": {
+      "title": "Knöchel-Arm-Index (ABI) berechnen — pAVK-Screening",
+      "description": "Knöchel-Arm-Index aus systolischen Blutdrücken an Arm und Knöchel berechnen. Seitengetrennter und Gesamt-ABI mit ACC/AHA-Klassifikation (Normal, Grenzwertig, Leicht, Mittel, Schwer, Nicht-Komprimierbar). Kostenlos und sofort."
+    },
+    "title": "Knöchel-Arm-Index (ABI) Rechner",
+    "description": "Screening auf periphere arterielle Verschlusskrankheit (pAVK) — vier systolische Manschettendrücke eingeben und seitengetrennten sowie Gesamt-ABI nach ACC/AHA erhalten.",
+    "inputsTitle": "Systolische Blutdrücke (mmHg)",
+    "armsLegend": "Arm-Drücke",
+    "anklesLegend": "Knöchel-Drücke",
+    "leftArmLabel": "Linker Arm SBP",
+    "rightArmLabel": "Rechter Arm SBP",
+    "leftAnkleLabel": "Linker Knöchel SBP",
+    "rightAnkleLabel": "Rechter Knöchel SBP",
+    "leftArmPlaceholder": "z. B. 130",
+    "rightArmPlaceholder": "z. B. 135",
+    "leftAnklePlaceholder": "z. B. 140",
+    "rightAnklePlaceholder": "z. B. 138",
+    "unit": "mmHg",
+    "resultsLabel": "Ergebnis",
+    "overallLabel": "Gesamt-ABI (niedrigere Seite)",
+    "leftLabel": "ABI linkes Bein",
+    "rightLabel": "ABI rechtes Bein",
+    "formulaTitle": "Formel",
+    "formulaText": "ABI(Seite) = Knöchel-SBP(Seite) ÷ max(linker Arm-SBP, rechter Arm-SBP). Gesamt-ABI = niedrigerer Wert von links und rechts.",
+    "formulaWhy": "Nach ACC/AHA wird der höhere der beiden Arm-Drücke als Nenner verwendet. Der niedrigere seitige ABI bestimmt die klinische Einordnung, da pAVK oft asymmetrisch auftritt.",
+    "categoriesTitle": "ACC/AHA-Klassifikation",
+    "clinicalNote": "Der ABI ist ein Screening, keine Diagnose. Werte > 1,4 (nicht komprimierbar) sind bei Diabetes und chronischer Niereninsuffizienz häufig — bei unzuverlässigem ABI ist der Zehen-Arm-Index (TBI) indiziert.",
+    "disclaimer": "Dieser Rechner dient der Information. Der ABI sollte von geschultem Personal mit Doppler-Sonde gemessen werden. Auffällige Werte erfordern eine gefäßmedizinische Abklärung.",
+    "band": {
+      "severe": "Schwer reduziert",
+      "moderate": "Mittel",
+      "mild": "Leicht",
+      "borderline": "Grenzwertig",
+      "normal": "Normal",
+      "nonCompressible": "Nicht komprimierbar"
+    },
+    "bandRange": {
+      "severe": "≤ 0,50",
+      "moderate": "0,50 – 0,79",
+      "mild": "0,80 – 0,89",
+      "borderline": "0,90 – 0,99",
+      "normal": "1,00 – 1,40",
+      "nonCompressible": "> 1,40"
+    },
+    "bandDescription": {
+      "severe": "Schwere pAVK — gefäßmedizinische Vorstellung; Risiko einer kritischen Extremitätenischämie.",
+      "moderate": "Mittelschwere pAVK — meist Claudicatio intermittens; klinische Abklärung empfohlen.",
+      "mild": "Leichte pAVK — frühes Stadium; Risikofaktoren konsequent behandeln.",
+      "borderline": "Grenzwertig — Messung wiederholen oder Verlaufskontrolle.",
+      "normal": "Normalwert — kein Hinweis auf pAVK im ABI-Screening.",
+      "nonCompressible": "Nicht komprimierbare Gefäße (Mediasklerose) — ABI unzuverlässig; Zehen-Arm-Index (TBI) erwägen."
+    },
+    "faq": [
+      { "q": "Was ist der Knöchel-Arm-Index?", "a": "Der ABI ist das Verhältnis des systolischen Blutdrucks am Knöchel zum höheren Arm-SBP. Er ist der nicht-invasive Standard zur Erkennung einer peripheren arteriellen Verschlusskrankheit (pAVK). Ein ABI ≤ 0,90 bestätigt eine pAVK mit hoher Spezifität." },
+      { "q": "Wie wird der ABI berechnet?", "a": "Vier systolische Drücke messen (linker Arm, rechter Arm, linker Knöchel, rechter Knöchel). Pro Bein wird der Knöchel-Druck durch den höheren der beiden Arm-Drücke geteilt. Der Gesamt-ABI ist der niedrigere der beiden seitigen Werte." },
+      { "q": "Welcher ABI-Wert ist normal?", "a": "1,00 bis 1,40 gilt nach ACC/AHA als normal. 0,90–0,99 ist grenzwertig, 0,80–0,89 leichte pAVK, 0,50–0,79 mittelschwere pAVK, ≤ 0,50 schwere pAVK." },
+      { "q": "Warum kann der ABI über 1,4 liegen?", "a": "Verkalkte, nicht komprimierbare Arterien — typisch bei Diabetes und chronischer Niereninsuffizienz (Mönckeberg-Mediasklerose) — lassen sich nicht abdrücken. ABI > 1,4 ist unzuverlässig; nächster Schritt sind Zehen-Arm-Index (TBI) oder Duplex-Sonografie." },
+      { "q": "Wer sollte mit ABI gescreent werden?", "a": "Erwachsene ab 65 Jahren, Raucher ab 50, Menschen mit Diabetes sowie alle mit Claudicatio-Symptomen (Wadenschmerz beim Gehen, der in Ruhe abklingt) oder nicht heilenden Fußwunden." },
+      { "q": "Ersetzt das eine klinische ABI-Messung?", "a": "Nein. Eine klinische ABI-Bestimmung erfolgt mit Doppler-Sonde durch geschultes Personal. Dieser Rechner berechnet das Verhältnis, sobald die Werte vorliegen — geeignet zur Dokumentation, Ausbildung oder als grobes Selbst-Screening mit validierten Automatik-Manschetten." }
+    ]
+  }
+}

--- a/src/locales/calculators/en/ankleBrachialIndex.json
+++ b/src/locales/calculators/en/ankleBrachialIndex.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "calculators": {
+      "ankleBrachialIndex": {
+        "name": "Ankle-Brachial Index (ABI) Calculator",
+        "description": "Calculate left, right and overall ABI from four cuff pressures. Screen for peripheral artery disease (PAD)."
+      }
+    }
+  },
+  "ankleBrachialIndex": {
+    "meta": {
+      "title": "Ankle-Brachial Index (ABI) Calculator — Screen for PAD",
+      "description": "Calculate the Ankle-Brachial Index from arm and ankle systolic blood pressures. Per-leg and overall ABI with ACC/AHA clinical bands (Normal, Borderline, Mild, Moderate, Severe, Non-Compressible). Free, instant, no sign-up."
+    },
+    "title": "Ankle-Brachial Index (ABI) Calculator",
+    "description": "Screen for peripheral artery disease (PAD) — enter four systolic cuff pressures and get per-leg and overall ABI with ACC/AHA classification.",
+    "inputsTitle": "Systolic blood pressures (mmHg)",
+    "armsLegend": "Arm pressures",
+    "anklesLegend": "Ankle pressures",
+    "leftArmLabel": "Left arm SBP",
+    "rightArmLabel": "Right arm SBP",
+    "leftAnkleLabel": "Left ankle SBP",
+    "rightAnkleLabel": "Right ankle SBP",
+    "leftArmPlaceholder": "e.g. 130",
+    "rightArmPlaceholder": "e.g. 135",
+    "leftAnklePlaceholder": "e.g. 140",
+    "rightAnklePlaceholder": "e.g. 138",
+    "unit": "mmHg",
+    "resultsLabel": "Result",
+    "overallLabel": "Overall ABI (lower side)",
+    "leftLabel": "Left leg ABI",
+    "rightLabel": "Right leg ABI",
+    "formulaTitle": "Formula",
+    "formulaText": "ABI(side) = ankle SBP(side) ÷ max(left arm SBP, right arm SBP). Overall ABI = lower of left and right.",
+    "formulaWhy": "Per ACC/AHA, the higher of the two brachial pressures is the denominator. The lower per-leg ABI defines the clinical category, since PAD often presents asymmetrically.",
+    "categoriesTitle": "ACC/AHA clinical bands",
+    "clinicalNote": "ABI is a screening test, not a diagnosis. Non-compressible values (> 1.4) are common in diabetes and chronic kidney disease — refer for toe-brachial index (TBI) when ABI is unreliable.",
+    "disclaimer": "This calculator is for information only. ABI should be measured by trained personnel using a Doppler probe. Abnormal results warrant vascular assessment.",
+    "band": {
+      "severe": "Severely Reduced",
+      "moderate": "Moderate",
+      "mild": "Mild",
+      "borderline": "Borderline",
+      "normal": "Normal",
+      "nonCompressible": "Non-Compressible"
+    },
+    "bandRange": {
+      "severe": "≤ 0.50",
+      "moderate": "0.50 – 0.79",
+      "mild": "0.80 – 0.89",
+      "borderline": "0.90 – 0.99",
+      "normal": "1.00 – 1.40",
+      "nonCompressible": "> 1.40"
+    },
+    "bandDescription": {
+      "severe": "Severe PAD — vascular referral indicated; critical limb ischemia risk.",
+      "moderate": "Moderate PAD — likely intermittent claudication; clinical assessment advised.",
+      "mild": "Mild PAD — early disease; address risk factors aggressively.",
+      "borderline": "Borderline — repeat measurement or refer for follow-up.",
+      "normal": "Normal — no evidence of PAD by ABI screening.",
+      "nonCompressible": "Non-compressible vessels (calcified) — ABI unreliable; consider toe-brachial index (TBI)."
+    },
+    "faq": [
+      { "q": "What is the Ankle-Brachial Index?", "a": "The ABI is the ratio of systolic blood pressure at the ankle to the higher arm SBP. It is the standard non-invasive screen for peripheral artery disease (PAD). An ABI ≤ 0.90 confirms PAD with high specificity." },
+      { "q": "How is ABI calculated?", "a": "Take four systolic pressures (left arm, right arm, left ankle, right ankle). For each leg, divide that ankle's pressure by the higher of the two arm pressures. The overall ABI is the lower of the two per-leg ratios." },
+      { "q": "What is a normal ABI?", "a": "1.00 to 1.40 is considered normal per ACC/AHA. 0.90–0.99 is borderline, 0.80–0.89 mild PAD, 0.50–0.79 moderate PAD, and ≤ 0.50 severe PAD." },
+      { "q": "Why can ABI be greater than 1.4?", "a": "Calcified, non-compressible arteries — common in diabetes and chronic kidney disease — resist cuff occlusion. ABI > 1.4 is unreliable; toe-brachial index (TBI) or duplex ultrasound is the next step." },
+      { "q": "Who should be screened with ABI?", "a": "Adults aged 65+, smokers aged 50+, people with diabetes, and anyone with symptoms of claudication (calf pain on walking that resolves with rest) or non-healing foot ulcers." },
+      { "q": "Does this replace a clinical ABI test?", "a": "No. A clinical ABI uses a Doppler probe with manual cuff inflation by a trained vascular technologist. This calculator computes the ratio once you have those measurements — useful for documentation, education or rough self-screening with a validated automated cuff." }
+    ]
+  }
+}

--- a/src/pages/AnkleBrachialIndexCalculator.vue
+++ b/src/pages/AnkleBrachialIndexCalculator.vue
@@ -1,0 +1,235 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  calcAbi,
+  getAbiBand,
+  bandColor,
+  bandBg,
+  formatAbi,
+} from '../utils/ankleBrachialIndex.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('ankleBrachialIndex.faq') || [])
+
+useHead(() => ({
+  title: t('ankleBrachialIndex.meta.title'),
+  description: t('ankleBrachialIndex.meta.description'),
+  routeKey: 'ankleBrachialIndex',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Ankle-Brachial Index Calculator',
+    url: 'https://healthcalculator.app/en/ankle-brachial-index',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const leftArm = ref(null)
+const rightArm = ref(null)
+const leftAnkle = ref(null)
+const rightAnkle = ref(null)
+
+const abi = computed(() =>
+  calcAbi({
+    leftArm: leftArm.value,
+    rightArm: rightArm.value,
+    leftAnkle: leftAnkle.value,
+    rightAnkle: rightAnkle.value,
+  }),
+)
+
+const overallBand = computed(() => (abi.value ? getAbiBand(abi.value.overall) : null))
+const leftBand = computed(() => (abi.value ? getAbiBand(abi.value.left) : null))
+const rightBand = computed(() => (abi.value ? getAbiBand(abi.value.right) : null))
+
+const hasResult = computed(() => abi.value !== null)
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('ankleBrachialIndex.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('ankleBrachialIndex.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-5">{{ t('ankleBrachialIndex.inputsTitle') }}</h2>
+
+      <p class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">{{ t('ankleBrachialIndex.armsLegend') }}</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+        <div>
+          <label for="left-arm-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('ankleBrachialIndex.leftArmLabel') }} ({{ t('ankleBrachialIndex.unit') }})
+          </label>
+          <input
+            id="left-arm-input"
+            v-model.number="leftArm"
+            data-testid="left-arm-input"
+            type="number"
+            min="0"
+            :placeholder="t('ankleBrachialIndex.leftArmPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="right-arm-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('ankleBrachialIndex.rightArmLabel') }} ({{ t('ankleBrachialIndex.unit') }})
+          </label>
+          <input
+            id="right-arm-input"
+            v-model.number="rightArm"
+            data-testid="right-arm-input"
+            type="number"
+            min="0"
+            :placeholder="t('ankleBrachialIndex.rightArmPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+
+      <p class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">{{ t('ankleBrachialIndex.anklesLegend') }}</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label for="left-ankle-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('ankleBrachialIndex.leftAnkleLabel') }} ({{ t('ankleBrachialIndex.unit') }})
+          </label>
+          <input
+            id="left-ankle-input"
+            v-model.number="leftAnkle"
+            data-testid="left-ankle-input"
+            type="number"
+            min="0"
+            :placeholder="t('ankleBrachialIndex.leftAnklePlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="right-ankle-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('ankleBrachialIndex.rightAnkleLabel') }} ({{ t('ankleBrachialIndex.unit') }})
+          </label>
+          <input
+            id="right-ankle-input"
+            v-model.number="rightAnkle"
+            data-testid="right-ankle-input"
+            type="number"
+            min="0"
+            :placeholder="t('ankleBrachialIndex.rightAnklePlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <div v-if="hasResult" :class="['border rounded-xl shadow-sm p-8 mb-6', bandBg(overallBand)]" data-testid="result-card">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('ankleBrachialIndex.resultsLabel') }}</p>
+
+      <div class="flex items-baseline gap-3 mb-2">
+        <span data-testid="overall-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ formatAbi(abi.overall) }}</span>
+        <span class="text-sm text-stone-400 ml-1">{{ t('ankleBrachialIndex.overallLabel') }}</span>
+      </div>
+
+      <p :class="['text-lg font-semibold mb-4', bandColor(overallBand)]" data-testid="band">{{ t(`ankleBrachialIndex.band.${overallBand}`) }}</p>
+
+      <div class="grid grid-cols-2 gap-4 mb-4">
+        <div class="bg-white/60 border border-stone-200 rounded-lg p-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ankleBrachialIndex.leftLabel') }}</p>
+          <p data-testid="left-value" class="text-2xl font-bold text-stone-900 tabular-nums">{{ formatAbi(abi.left) }}</p>
+          <p :class="['text-sm font-medium', bandColor(leftBand)]" data-testid="left-band">{{ t(`ankleBrachialIndex.band.${leftBand}`) }}</p>
+        </div>
+        <div class="bg-white/60 border border-stone-200 rounded-lg p-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('ankleBrachialIndex.rightLabel') }}</p>
+          <p data-testid="right-value" class="text-2xl font-bold text-stone-900 tabular-nums">{{ formatAbi(abi.right) }}</p>
+          <p :class="['text-sm font-medium', bandColor(rightBand)]" data-testid="right-band">{{ t(`ankleBrachialIndex.band.${rightBand}`) }}</p>
+        </div>
+      </div>
+
+      <p class="text-sm text-stone-600 leading-relaxed mb-4" data-testid="band-description">{{ t(`ankleBrachialIndex.bandDescription.${overallBand}`) }}</p>
+
+      <div class="bg-white/60 border border-stone-200 rounded-lg p-4 text-xs text-stone-600 leading-relaxed" data-testid="clinical-note">
+        {{ t('ankleBrachialIndex.clinicalNote') }}
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('ankleBrachialIndex.categoriesTitle') }}</h2>
+      <div class="space-y-3.5">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-red-700"></div>
+            <span class="text-sm text-stone-600">{{ t('ankleBrachialIndex.band.severe') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ankleBrachialIndex.bandRange.severe') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-red-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ankleBrachialIndex.band.moderate') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ankleBrachialIndex.bandRange.moderate') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-orange-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ankleBrachialIndex.band.mild') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ankleBrachialIndex.bandRange.mild') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-amber-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ankleBrachialIndex.band.borderline') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ankleBrachialIndex.bandRange.borderline') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-emerald-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ankleBrachialIndex.band.normal') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ankleBrachialIndex.bandRange.normal') }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-purple-500"></div>
+            <span class="text-sm text-stone-600">{{ t('ankleBrachialIndex.band.nonCompressible') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('ankleBrachialIndex.bandRange.nonCompressible') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('ankleBrachialIndex.formulaTitle') }}</h2>
+      <div class="bg-stone-50 rounded-lg p-4 font-mono text-sm text-stone-700 mb-3" data-testid="formula">
+        {{ t('ankleBrachialIndex.formulaText') }}
+      </div>
+      <p class="text-sm text-stone-600 leading-relaxed">{{ t('ankleBrachialIndex.formulaWhy') }}</p>
+    </div>
+
+    <div v-if="hasResult" class="bg-stone-50 rounded-xl border border-stone-200 p-5 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('ankleBrachialIndex.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <RelatedCalculators calc-key="ankleBrachialIndex" class="mt-8" />
+    <BlogArticleLink calculator-key="ankleBrachialIndex" />
+
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/ankleBrachialIndex.meta.js
+++ b/src/pages/ankleBrachialIndex.meta.js
@@ -1,0 +1,16 @@
+import Component from './AnkleBrachialIndexCalculator.vue'
+import BlogDe from './blog/KnoechelArmIndexBerechnen.vue'
+import BlogEn from './blog/en/AnkleBrachialIndexGuide.vue'
+
+export default {
+  key: 'ankleBrachialIndex',
+  component: Component,
+  slugs: { de: 'knoechel-arm-index-rechner', en: 'ankle-brachial-index' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 26.7,
+  blog: {
+    de: { slug: 'knoechel-arm-index-berechnen', component: BlogDe },
+    en: { slug: 'ankle-brachial-index-guide', component: BlogEn },
+  },
+}

--- a/src/pages/blog/KnoechelArmIndexBerechnen.vue
+++ b/src/pages/blog/KnoechelArmIndexBerechnen.vue
@@ -1,0 +1,216 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Knöchel-Arm-Index (ABI) berechnen: Formel, Werte, pAVK-Screening | Health Calculators',
+  description: 'ABI per Formel aus vier systolischen Blutdrücken (Arm und Knöchel) berechnen. ACC/AHA-Bänder von normal bis schwerer pAVK, Mediasklerose-Warnung ab 1,4, klinische Bedeutung.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Knöchel-Arm-Index (ABI) berechnen: Formel, Werte, pAVK-Screening',
+      description: 'ABI-Formel, ACC/AHA-Klassifikation und was bei auffälligem Knöchel-Arm-Index zu tun ist.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-30',
+      dateModified: '2026-05-30',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/knoechel-arm-index-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist der Knöchel-Arm-Index?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Der ABI (Ankle-Brachial Index) ist das Verhältnis des systolischen Blutdrucks am Knöchel zum höheren Arm-SBP. Er ist der nicht-invasive Standard zur Erkennung einer peripheren arteriellen Verschlusskrankheit (pAVK).' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wie wird der ABI berechnet?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Vier systolische Drücke messen (linker und rechter Arm, linker und rechter Knöchel). ABI(Seite) = Knöchel-SBP / max(linker Arm-SBP, rechter Arm-SBP). Der Gesamt-ABI ist der niedrigere der beiden seitigen Werte.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welcher ABI-Wert ist normal?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Nach ACC/AHA: 1,00–1,40 normal, 0,90–0,99 grenzwertig, 0,80–0,89 leichte pAVK, 0,50–0,79 mittel, ≤ 0,50 schwer. Werte > 1,4 gelten als nicht komprimierbar (Mediasklerose).' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Warum kann der ABI über 1,4 liegen?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Verkalkte Arterien — typisch bei Diabetes und chronischer Niereninsuffizienz — lassen sich nicht abdrücken. ABI > 1,4 ist unzuverlässig. Nächster Schritt sind Zehen-Arm-Index (TBI) oder Duplex-Sonografie.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wer sollte einen ABI-Test machen lassen?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Erwachsene ab 65, Raucher ab 50, Menschen mit Diabetes oder bekannter Atherosklerose sowie alle mit Claudicatio-Symptomen (Wadenschmerz beim Gehen) oder nicht heilenden Fußwunden.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was tun bei niedrigem ABI?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Rauchstopp, Bewegung (Gehtraining), Behandlung von Bluthochdruck, Diabetes und LDL — meist mit Statin und Thrombozytenaggregationshemmer. Ab ABI < 0,5 oder Ruheschmerz ist gefäßmedizinische Vorstellung dringend.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Knöchel-Arm-Index (ABI) berechnen: Formel, Werte, pAVK-Screening</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">30. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Beinschmerzen beim Gehen, die in Ruhe verschwinden? Kalte Füße auf einer Seite? Eine nicht heilende Wunde am Vorfuß? Der <strong>Knöchel-Arm-Index</strong> ist die einfachste Antwort auf die Frage: „Sind die Beinarterien noch durchgängig?"
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Vier Blutdruckmessungen, eine Division — und ein zuverlässiges Screening auf die periphere arterielle Verschlusskrankheit (pAVK). Diese Anleitung zeigt die Formel, die ACC/AHA-Bänder und die Stolperfalle bei verkalkten Gefäßen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          ABI(Seite) = Knöchel-SBP(Seite) ÷ max(linker Arm-SBP, rechter Arm-SBP)
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der höhere der beiden Arm-Drücke wird als Referenz verwendet — denn er spiegelt den zentralen systemischen Druck besser wider. Pro Bein erhält man einen ABI. Der <strong>Gesamt-ABI</strong> ist der niedrigere der beiden Werte, weil pAVK oft nur eine Seite betrifft.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beispiel: Linker Arm 130, rechter Arm 135, linker Knöchel 90, rechter Knöchel 140. ABI links = 90 / 135 ≈ <strong>0,67</strong> (mittel), ABI rechts = 140 / 135 ≈ <strong>1,04</strong> (normal). Gesamt-ABI = 0,67 — Verdacht auf pAVK links.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">ACC/AHA-Bänder auf einen Blick</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">ABI-Klassifikation</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&le; 0,50</span>
+              <span class="text-red-700 font-medium">Schwere pAVK</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">0,50 – 0,79</span>
+              <span class="text-red-500 font-medium">Mittel</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">0,80 – 0,89</span>
+              <span class="text-orange-500 font-medium">Leicht</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">0,90 – 0,99</span>
+              <span class="text-amber-500 font-medium">Grenzwertig</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">1,00 – 1,40</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">&gt; 1,40</span>
+              <span class="text-purple-600 font-medium">Nicht komprimierbar</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ein ABI ≤ 0,90 bestätigt eine pAVK mit hoher Spezifität (95 %+). Werte zwischen 0,90 und 0,99 sind grenzwertig und sollten in 3–6 Monaten kontrolliert oder durch Belastungstest ergänzt werden.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Mediasklerose-Falle: ABI > 1,4</h2>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Achtung bei Diabetes und CKD</p>
+          <p class="text-sm text-amber-700">Ab ABI &gt; 1,4 sind die Knöchelarterien zu verkalkt, um sich abdrücken zu lassen. Der Wert ist diagnostisch unzuverlässig — eine pAVK kann trotzdem vorliegen.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei Mönckeberg-Mediasklerose (typisch bei Diabetes mellitus oder chronischer Niereninsuffizienz) lagert sich Kalzium in die Tunica media ein. Die Manschette komprimiert die Arterie nicht mehr vollständig — der gemessene Druck ist falsch hoch.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Alternative: der <strong>Zehen-Arm-Index (TBI)</strong>. Die Zehenarterien sind selten von Mediasklerose betroffen. Ein TBI &lt; 0,7 deutet auf pAVK hin.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wer sollte einen ABI-Test machen?</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Alle Erwachsenen ab 65 Jahren</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Raucher und Ex-Raucher ab 50 Jahren</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Menschen mit Diabetes ab 50</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Bekannte Atherosklerose (KHK, Schlaganfall in der Vorgeschichte)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Claudicatio intermittens — belastungsabhängiger Wadenschmerz</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Nicht heilende Fußwunden, kalte oder pulslose Extremitäten</span></li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">ABI jetzt berechnen</h3>
+        <p class="text-base text-stone-600 mb-6">Vier systolische Drücke eingeben — der Rechner liefert seitengetrennten und Gesamt-ABI plus ACC/AHA-Klassifikation.</p>
+        <router-link
+          :to="localePath('ankleBrachialIndex')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Zum Knöchel-Arm-Index-Rechner
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was bei auffälligem ABI hilft</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          pAVK ist eine systemische Erkrankung — wer atherosklerotisch verschlossene Beinarterien hat, hat auch ein erhöhtes Herzinfarkt- und Schlaganfallrisiko. Drei Hebel mit der besten Evidenz:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Rauchstopp:</strong> Senkt das Progressionsrisiko der pAVK drastischer als jedes Medikament.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>Strukturiertes Gehtraining:</strong> 3 × pro Woche bis zur Schmerzgrenze — verlängert die schmerzfreie Gehstrecke nachweislich.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Medikamentöse Sekundärprävention:</strong> Statin (LDL-Ziel &lt; 70 mg/dL), Thrombozytenaggregationshemmer, Blutdruckeinstellung &lt; 140/90.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ab ABI &lt; 0,50, Ruheschmerz oder Wundheilungsstörung: gefäßchirurgische oder interventionelle Vorstellung — Bypass, Angioplastie oder Stent können die Extremität retten.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          ABI ist ein Baustein im kardiovaskulären Risikoprofil. Sinnvoll kombinieren mit dem
+          <router-link :to="localePath('bloodPressure')" class="text-stone-900 underline hover:no-underline">Blutdruck-Rechner</router-link>
+          für die Klassifikation der arteriellen Hypertonie, dem
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Herz-Kreislauf-Risiko-Rechner</router-link>
+          nach Framingham/SCORE2 und dem
+          <router-link :to="localePath('diabetesRisk')" class="text-stone-900 underline hover:no-underline">Diabetes-Risiko-Rechner</router-link>,
+          da Diabetes ein wesentlicher Treiber der pAVK ist.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Knöchel-Arm-Index liefert mit minimalem Aufwand eine zuverlässige Aussage darüber, ob die Beinarterien noch frei durchblutet sind. Vier Manschettendrücke, eine Division, ein klares Ergebnis nach ACC/AHA.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei Werten unter 0,90 oder über 1,40 lohnt sich der Gang zur Gefäßmedizin. Beides hat klinische Konsequenzen — und beide Befunde sind häufiger, als die meisten denken.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="knoechel-arm-index-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/AnkleBrachialIndexGuide.vue
+++ b/src/pages/blog/en/AnkleBrachialIndexGuide.vue
@@ -1,0 +1,216 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Ankle-Brachial Index (ABI) Calculator Guide: Formula, Values, PAD Screening | Health Calculators',
+  description: 'Calculate the ABI from four systolic blood pressures (arm and ankle). ACC/AHA bands from normal to severe PAD, the calcified-vessel pitfall at ABI > 1.4, and clinical implications.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Ankle-Brachial Index (ABI) Calculator Guide: Formula, Values, PAD Screening',
+      description: 'ABI formula, ACC/AHA classification and what to do about an abnormal Ankle-Brachial Index.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-30',
+      dateModified: '2026-05-30',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/ankle-brachial-index-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is the Ankle-Brachial Index?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The ABI is the ratio of systolic blood pressure at the ankle to the higher arm SBP. It is the standard non-invasive screen for peripheral artery disease (PAD). An ABI ≤ 0.90 confirms PAD with high specificity.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'How is the ABI calculated?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Measure four systolic pressures (left arm, right arm, left ankle, right ankle). ABI(side) = ankle SBP / max(left arm SBP, right arm SBP). The overall ABI is the lower of the two side ratios.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What is a normal ABI?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Per ACC/AHA: 1.00–1.40 normal, 0.90–0.99 borderline, 0.80–0.89 mild PAD, 0.50–0.79 moderate, ≤ 0.50 severe. Values > 1.4 are non-compressible (medial calcification).' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Why can the ABI be greater than 1.4?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Calcified arteries — common in diabetes and chronic kidney disease — resist cuff occlusion. ABI > 1.4 is unreliable. The toe-brachial index (TBI) or duplex ultrasound is the appropriate next step.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Who should be screened with ABI?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Adults aged 65 and older, smokers aged 50+, people with diabetes or known atherosclerosis, and anyone with claudication (calf pain on walking that resolves with rest) or non-healing foot ulcers.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What helps a low ABI?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Smoking cessation, supervised walking exercise, treatment of hypertension, diabetes and LDL — usually with a statin and antiplatelet therapy. ABI < 0.5 or rest pain warrants prompt vascular referral.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Ankle-Brachial Index (ABI) Calculator Guide: Formula, Values, PAD Screening</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 30, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Leg pain on walking that disappears at rest? A cold foot on one side? A toe ulcer that refuses to heal? The <strong>Ankle-Brachial Index</strong> is the simplest answer to the question: "Are the leg arteries still patent?"
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Four blood pressures, one division — and a reliable screen for peripheral artery disease (PAD). This guide walks through the formula, the ACC/AHA bands, and the pitfall with calcified vessels.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          ABI(side) = ankle SBP(side) ÷ max(left arm SBP, right arm SBP)
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The higher of the two arm pressures is the reference — it best reflects central systemic pressure. Each leg yields its own ABI. The <strong>overall ABI</strong> is the lower of the two, because PAD frequently affects only one side.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Example: left arm 130, right arm 135, left ankle 90, right ankle 140. Left ABI = 90 / 135 ≈ <strong>0.67</strong> (moderate); right ABI = 140 / 135 ≈ <strong>1.04</strong> (normal). Overall ABI = 0.67 — suspicion of PAD on the left.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">ACC/AHA bands at a glance</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">ABI classification</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&le; 0.50</span>
+              <span class="text-red-700 font-medium">Severely Reduced</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">0.50 – 0.79</span>
+              <span class="text-red-500 font-medium">Moderate</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">0.80 – 0.89</span>
+              <span class="text-orange-500 font-medium">Mild</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">0.90 – 0.99</span>
+              <span class="text-amber-500 font-medium">Borderline</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">1.00 – 1.40</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">&gt; 1.40</span>
+              <span class="text-purple-600 font-medium">Non-Compressible</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          An ABI ≤ 0.90 confirms PAD with high specificity (>95 %). Values between 0.90 and 0.99 are borderline and should be repeated in 3–6 months or supplemented with an exercise test.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The medial-calcification pitfall: ABI > 1.4</h2>
+        <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-amber-800 mb-2">Watch out in diabetes and CKD</p>
+          <p class="text-sm text-amber-700">Once the ABI exceeds 1.4, the ankle arteries are too calcified to be compressed by the cuff. The result is diagnostically unreliable — PAD may still be present.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          With Mönckeberg medial calcification (typical of diabetes mellitus and chronic kidney disease), calcium deposits in the tunica media. The cuff cannot fully occlude the artery — the measured pressure reads falsely high.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The alternative is the <strong>toe-brachial index (TBI)</strong>. Toe arteries are rarely affected by medial calcification. A TBI &lt; 0.7 suggests PAD.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Who should be screened?</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">All adults aged 65 and older</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Current and former smokers aged 50+</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">People with diabetes aged 50+</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Known atherosclerosis (prior MI, stroke, carotid disease)</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Intermittent claudication — exercise-induced calf pain</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600">Non-healing foot ulcers, cold or pulseless extremities</span></li>
+        </ul>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Calculate your ABI now</h3>
+        <p class="text-base text-stone-600 mb-6">Enter four systolic pressures — the calculator returns per-leg and overall ABI plus the ACC/AHA category.</p>
+        <router-link
+          :to="localePath('ankleBrachialIndex')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Open the Ankle-Brachial Index Calculator
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What helps an abnormal ABI</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          PAD is a systemic disease — atherosclerotic leg arteries imply elevated heart-attack and stroke risk. Three levers with the strongest evidence:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Quit smoking:</strong> Cuts PAD progression more than any drug.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>Supervised walking exercise:</strong> 3× per week to the pain threshold — proven to extend pain-free walking distance.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Medical secondary prevention:</strong> Statin (target LDL &lt; 70 mg/dL), antiplatelet therapy, blood-pressure control &lt; 140/90.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For ABI &lt; 0.50, rest pain, or impaired wound healing: prompt vascular surgical or interventional referral — bypass, angioplasty or stenting can save the limb.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          ABI is one input in a cardiovascular risk profile. Pair it with the
+          <router-link :to="localePath('bloodPressure')" class="text-stone-900 underline hover:no-underline">Blood Pressure Calculator</router-link>
+          for hypertension classification, the
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Cardiovascular Risk Calculator</router-link>
+          (Framingham/SCORE2), and the
+          <router-link :to="localePath('diabetesRisk')" class="text-stone-900 underline hover:no-underline">Diabetes Risk Calculator</router-link>
+          — diabetes is a major driver of PAD.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Takeaway</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The Ankle-Brachial Index gives a reliable read on leg perfusion with minimal effort. Four cuff pressures, one division, and a clear ACC/AHA result.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Values below 0.90 or above 1.40 are worth a vascular consultation. Both have clinical consequences — and both are more common than most people think.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticlesEn slug="ankle-brachial-index-guide" />
+  </article>
+</template>

--- a/src/utils/ankleBrachialIndex.js
+++ b/src/utils/ankleBrachialIndex.js
@@ -1,0 +1,77 @@
+// Ankle-Brachial Index (ABI) — non-invasive marker for peripheral artery disease (PAD).
+//
+// Formula per ACC/AHA:
+//   ABI(side) = max(left ankle SBP, right ankle SBP) / max(left arm SBP, right arm SBP)
+//   The reported ABI for each leg is computed with the higher of the two arm pressures
+//   as the denominator and that leg's ankle pressure as the numerator.
+//   Final/overall ABI = lower of the two side ABIs.
+//
+// Clinical bands:
+//   ≤ 0.50          Severely Reduced
+//   0.50 – 0.79     Moderate
+//   0.80 – 0.89     Mild
+//   0.90 – 0.99     Borderline
+//   1.00 – 1.40     Normal
+//   > 1.40          Non-Compressible
+
+function toNum(v) {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+export function calcAbi({ leftArm, rightArm, leftAnkle, rightAnkle }) {
+  const la = toNum(leftArm)
+  const ra = toNum(rightArm)
+  const lAnk = toNum(leftAnkle)
+  const rAnk = toNum(rightAnkle)
+  if (la == null || ra == null || lAnk == null || rAnk == null) return null
+
+  const brachial = Math.max(la, ra)
+  const left = lAnk / brachial
+  const right = rAnk / brachial
+  const overall = Math.min(left, right)
+
+  return { left, right, overall, brachial }
+}
+
+export function getAbiBand(abi) {
+  if (abi == null || !Number.isFinite(abi)) return null
+  if (abi > 1.4) return 'nonCompressible'
+  if (abi >= 1.0) return 'normal'
+  if (abi >= 0.9) return 'borderline'
+  if (abi >= 0.8) return 'mild'
+  if (abi > 0.5) return 'moderate'
+  return 'severe'
+}
+
+const COLORS = {
+  severe: 'text-red-700',
+  moderate: 'text-red-500',
+  mild: 'text-orange-500',
+  borderline: 'text-amber-500',
+  normal: 'text-emerald-600',
+  nonCompressible: 'text-purple-600',
+}
+
+const BGS = {
+  severe: 'bg-red-50 border-red-200',
+  moderate: 'bg-red-50 border-red-200',
+  mild: 'bg-orange-50 border-orange-200',
+  borderline: 'bg-amber-50 border-amber-200',
+  normal: 'bg-emerald-50 border-emerald-200',
+  nonCompressible: 'bg-purple-50 border-purple-200',
+}
+
+export function bandColor(band) {
+  return COLORS[band] || 'text-stone-900'
+}
+
+export function bandBg(band) {
+  return BGS[band] || 'bg-white border-stone-200'
+}
+
+export function formatAbi(v) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return v.toFixed(2)
+}


### PR DESCRIPTION
## Summary
- Adds the Ankle-Brachial Index (ABI) calculator — non-invasive PAD screening from four cuff pressures (left/right arm + left/right ankle SBP)
- Computes per-leg and overall ABI per ACC/AHA: ABI(side) = ankle SBP / max(arm SBPs); overall = lower of left/right
- 6 clinical bands (Severe, Moderate, Mild, Borderline, Normal, Non-Compressible) with color coding
- DE + EN SEO-optimized blog articles with FAQPage structured data
- Internal links to bloodPressure, cardiovascularRisk, diabetesRisk

## Test plan
- [x] Unit tests: 19 cases (6 bands, asymmetric L/R, identical arms vs differing, non-compressible >1.4, end-to-end clinical scenarios)
- [x] E2E tests: 13 Playwright tests (DE + EN) — all pass
- [x] Full E2E suite: 1182 tests pass — no regressions
- [x] Vitest suite: 2498 tests pass
- [x] `npm run build` succeeds — SSG pre-renders all 4 new pages
- [x] Sitemap: 366 URLs · llms.txt: 362 links

🤖 Generated with [Claude Code](https://claude.com/claude-code)