### PR TITLE
Add Pulse Pressure Calculator (HC-269)

### DIFF
--- a/e2e/pulsePressure.spec.js
+++ b/e2e/pulsePressure.spec.js
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Pulse Pressure Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/pulsdruck-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Pulsdruck/)
+  })
+
+  test('h1 contains Pulsdruck', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Pulsdruck')
+  })
+
+  test('back link navigates to home', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('no result shown before inputs', async ({ page }) => {
+    await expect(page.getByTestId('result-card')).toHaveCount(0)
+  })
+
+  test('normal band: 120/80 → 40 mmHg normal', async ({ page }) => {
+    await page.getByTestId('systolic-input').fill('120')
+    await page.getByTestId('diastolic-input').fill('80')
+
+    await expect(page.getByTestId('pp-value')).toHaveText('40')
+    await expect(page.getByTestId('band')).toHaveText('Normal')
+  })
+
+  test('narrow band trigger: 110/80 → 30 mmHg eng', async ({ page }) => {
+    await page.getByTestId('systolic-input').fill('110')
+    await page.getByTestId('diastolic-input').fill('80')
+
+    await expect(page.getByTestId('pp-value')).toHaveText('30')
+    await expect(page.getByTestId('band')).toHaveText('Eng')
+  })
+
+  test('wide band trigger: 160/80 → 80 mmHg weit', async ({ page }) => {
+    await page.getByTestId('systolic-input').fill('160')
+    await page.getByTestId('diastolic-input').fill('80')
+
+    await expect(page.getByTestId('pp-value')).toHaveText('80')
+    await expect(page.getByTestId('band')).toHaveText('Weit')
+  })
+
+  test('age context appears when age is provided', async ({ page }) => {
+    await page.getByTestId('systolic-input').fill('140')
+    await page.getByTestId('diastolic-input').fill('80')
+    await page.getByTestId('age-input').fill('70')
+
+    await expect(page.getByTestId('age-context')).toBeVisible()
+  })
+
+  test('related calculators block is visible', async ({ page }) => {
+    await expect(page.getByTestId('related-calculators')).toBeVisible()
+  })
+
+  test('blog article link is visible', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('Pulse Pressure Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/pulse-pressure')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Pulse Pressure/)
+  })
+
+  test('normal band: 120/80 → 40 mmHg normal', async ({ page }) => {
+    await page.getByTestId('systolic-input').fill('120')
+    await page.getByTestId('diastolic-input').fill('80')
+
+    await expect(page.getByTestId('pp-value')).toHaveText('40')
+    await expect(page.getByTestId('band')).toHaveText('Normal')
+  })
+
+  test('wide band: 170/70 → 100 mmHg wide', async ({ page }) => {
+    await page.getByTestId('systolic-input').fill('170')
+    await page.getByTestId('diastolic-input').fill('70')
+
+    await expect(page.getByTestId('pp-value')).toHaveText('100')
+    await expect(page.getByTestId('band')).toHaveText('Wide')
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -32,6 +32,7 @@ const EXPECTED_KEYS = [
   'homaIr',
   'ldlFriedewald',
   'ankleBrachialIndex',
+  'pulsePressure',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -125,6 +126,7 @@ const EXPECTED_ROUTE_MAP = {
   homaIr: { de: 'homa-ir-rechner', en: 'homa-ir-insulin-resistance' },
   ldlFriedewald: { de: 'ldl-friedewald-rechner', en: 'ldl-cholesterol-friedewald' },
   ankleBrachialIndex: { de: 'knoechel-arm-index-rechner', en: 'ankle-brachial-index' },
+  pulsePressure: { de: 'pulsdruck-rechner', en: 'pulse-pressure' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -207,6 +209,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'homa-ir-berechnen',
   'ldl-friedewald-berechnen',
   'knoechel-arm-index-berechnen',
+  'pulsdruck-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -289,19 +292,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'homa-ir-insulin-resistance-guide',
   'ldl-cholesterol-friedewald-guide',
   'ankle-brachial-index-guide',
+  'pulse-pressure-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 90 calculators', () => {
-    expect(calculatorMetas).toHaveLength(90)
+  it('discovers all 91 calculators', () => {
+    expect(calculatorMetas).toHaveLength(91)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 90 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(90)
+  it('builds calculatorComponents map for all 91 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(91)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -324,15 +328,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 91 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(91)
+  it('discovers all 92 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(92)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 91 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(91)
+  it('discovers all 92 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(92)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -357,10 +361,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 90 calculators with no duplicates', () => {
+  it('groups contain all 91 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(90)
-    expect(new Set(allKeys).size).toBe(90)
+    expect(allKeys).toHaveLength(91)
+    expect(new Set(allKeys).size).toBe(91)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -381,7 +385,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'pulsePressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -430,8 +434,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 495 routes', () => {
-    expect(routes).toHaveLength(495)
+  it('generates exactly 500 routes', () => {
+    expect(routes).toHaveLength(500)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 362 links (90 calcs × 2 locales + 91 blogs × 2 locales)', () => {
+  it('generates 366 links (91 calcs × 2 locales + 92 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(362)
+    expect(links).toHaveLength(366)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/pulsePressure.test.js
+++ b/src/__tests__/pulsePressure.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcPulsePressure,
+  getPulsePressureBand,
+  getAgeContext,
+  bandColor,
+  bandBg,
+  formatPp,
+} from '../utils/pulsePressure.js'
+
+describe('Pulse Pressure formula', () => {
+  it('PP = SBP − DBP', () => {
+    expect(calcPulsePressure(120, 80)).toBe(40)
+    expect(calcPulsePressure(140, 70)).toBe(70)
+    expect(calcPulsePressure(110, 75)).toBe(35)
+  })
+
+  it('returns null when inputs are missing or invalid', () => {
+    expect(calcPulsePressure(null, 80)).toBeNull()
+    expect(calcPulsePressure(120, null)).toBeNull()
+    expect(calcPulsePressure('', '')).toBeNull()
+    expect(calcPulsePressure(0, 0)).toBeNull()
+    expect(calcPulsePressure(-1, 50)).toBeNull()
+  })
+
+  it('returns null if DBP exceeds SBP (physiologically impossible)', () => {
+    expect(calcPulsePressure(80, 120)).toBeNull()
+  })
+
+  it('SBP = DBP edge case returns 0 pulse pressure', () => {
+    expect(calcPulsePressure(100, 100)).toBe(0)
+  })
+})
+
+describe('Pulse Pressure bands — all three categories', () => {
+  it('< 40 → narrow (heart-failure / aortic-stenosis flag)', () => {
+    expect(getPulsePressureBand(30)).toBe('narrow')
+    expect(getPulsePressureBand(39)).toBe('narrow')
+    expect(getPulsePressureBand(20)).toBe('narrow')
+  })
+
+  it('40 – 60 → normal', () => {
+    expect(getPulsePressureBand(40)).toBe('normal')
+    expect(getPulsePressureBand(50)).toBe('normal')
+    expect(getPulsePressureBand(60)).toBe('normal')
+  })
+
+  it('> 60 → wide (arterial-stiffness / aortic-regurgitation flag)', () => {
+    expect(getPulsePressureBand(61)).toBe('wide')
+    expect(getPulsePressureBand(80)).toBe('wide')
+    expect(getPulsePressureBand(100)).toBe('wide')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(getPulsePressureBand(null)).toBeNull()
+    expect(getPulsePressureBand(NaN)).toBeNull()
+  })
+})
+
+describe('narrow-warning trigger (< 40)', () => {
+  it('SBP 110, DBP 80 → PP 30 → narrow', () => {
+    const pp = calcPulsePressure(110, 80)
+    expect(pp).toBe(30)
+    expect(getPulsePressureBand(pp)).toBe('narrow')
+  })
+
+  it('very low BP 90/65 → PP 25 → narrow', () => {
+    const pp = calcPulsePressure(90, 65)
+    expect(pp).toBe(25)
+    expect(getPulsePressureBand(pp)).toBe('narrow')
+  })
+})
+
+describe('wide-warning trigger (> 60)', () => {
+  it('SBP 160, DBP 80 → PP 80 → wide', () => {
+    const pp = calcPulsePressure(160, 80)
+    expect(pp).toBe(80)
+    expect(getPulsePressureBand(pp)).toBe('wide')
+  })
+
+  it('very high BP 180/90 → PP 90 → wide', () => {
+    const pp = calcPulsePressure(180, 90)
+    expect(pp).toBe(90)
+    expect(getPulsePressureBand(pp)).toBe('wide')
+  })
+})
+
+describe('SBP = DBP edge case', () => {
+  it('100/100 → PP 0 → narrow band', () => {
+    const pp = calcPulsePressure(100, 100)
+    expect(pp).toBe(0)
+    expect(getPulsePressureBand(pp)).toBe('narrow')
+  })
+})
+
+describe('age context output', () => {
+  it('< 40 → young', () => {
+    expect(getAgeContext(20)).toBe('young')
+    expect(getAgeContext(39)).toBe('young')
+  })
+
+  it('40 – 59 → middle', () => {
+    expect(getAgeContext(40)).toBe('middle')
+    expect(getAgeContext(50)).toBe('middle')
+    expect(getAgeContext(59)).toBe('middle')
+  })
+
+  it('60+ → older', () => {
+    expect(getAgeContext(60)).toBe('older')
+    expect(getAgeContext(75)).toBe('older')
+  })
+
+  it('returns null for missing age', () => {
+    expect(getAgeContext(null)).toBeNull()
+    expect(getAgeContext('')).toBeNull()
+  })
+})
+
+describe('style helpers', () => {
+  it('returns distinct colors per band', () => {
+    expect(bandColor('narrow')).toMatch(/text-/)
+    expect(bandColor('normal')).toMatch(/text-/)
+    expect(bandColor('wide')).toMatch(/text-/)
+    expect(bandColor('narrow')).not.toBe(bandColor('normal'))
+    expect(bandColor('wide')).not.toBe(bandColor('normal'))
+  })
+
+  it('returns distinct backgrounds per band', () => {
+    expect(bandBg('narrow')).toMatch(/bg-/)
+    expect(bandBg('normal')).toMatch(/bg-/)
+    expect(bandBg('wide')).toMatch(/bg-/)
+  })
+})
+
+describe('formatPp', () => {
+  it('formats as integer mmHg', () => {
+    expect(formatPp(40)).toBe('40')
+    expect(formatPp(60)).toBe('60')
+    expect(formatPp(75.4)).toBe('75')
+  })
+  it('returns em-dash for null', () => {
+    expect(formatPp(null)).toBe('—')
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -26,6 +26,7 @@ const EXPECTED_KEYS = [
   'homaIr',
   'ldlFriedewald',
   'ankleBrachialIndex',
+  'pulsePressure',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -107,6 +108,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'homa-ir-berechnen',
   'ldl-friedewald-berechnen',
   'knoechel-arm-index-berechnen',
+  'pulsdruck-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -188,12 +190,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'homa-ir-insulin-resistance-guide',
   'ldl-cholesterol-friedewald-guide',
   'ankle-brachial-index-guide',
+  'pulse-pressure-guide',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 90 calculator meta files', () => {
+  it('discovers all 91 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(90)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(91)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -231,19 +234,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 91 DE blog slugs', () => {
+  it('returns all 92 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(91)
+    expect(de).toHaveLength(92)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 91 EN blog slugs', () => {
+  it('returns all 92 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(91)
+    expect(en).toHaveLength(92)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -311,9 +314,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 180 calcs + 2 blog index + 182 blog articles = 366)', () => {
+  it('generates correct total URL count (2 home + 182 calcs + 2 blog index + 184 blog articles = 370)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(366)
+    expect(urlCount).toBe(370)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -818,6 +818,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'ankleBrachialIndex',
     related: ['measure-blood-pressure', 'cardiovascular-risk-framingham', 'diabetes-risk-score'],
   },
+  {
+    slug: 'pulse-pressure-guide',
+    title: 'Pulse Pressure Calculator Guide: Formula, Normal Values, Narrow vs. Wide',
+    description: 'Calculate pulse pressure (SBP − DBP). Narrow < 40 (heart failure, aortic stenosis), normal 40–60, wide > 60 mmHg (arterial stiffness, aortic regurgitation) — with age context.',
+    date: '2026-05-31',
+    readTime: '7 min',
+    calculatorKey: 'pulsePressure',
+    related: ['measure-blood-pressure', 'mean-arterial-pressure-guide', 'cardiovascular-risk-framingham'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -818,6 +818,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'ankleBrachialIndex',
     related: ['blutdruck-richtig-messen', 'herz-kreislauf-risiko-berechnen', 'diabetes-risiko-berechnen'],
   },
+  {
+    slug: 'pulsdruck-berechnen',
+    title: 'Pulsdruck berechnen: Formel, Normalwerte, Eng vs. Weit',
+    description: 'Pulsdruck (SBP − DBP) berechnen und einordnen. Eng < 40 (Herzinsuffizienz, Aortenstenose), normal 40–60, weit > 60 mmHg (Gefäßsteifigkeit, Aorteninsuffizienz) — plus Alterskontext.',
+    date: '2026-05-31',
+    readTime: '7 min',
+    calculatorKey: 'pulsePressure',
+    related: ['blutdruck-richtig-messen', 'mittlerer-arterieller-druck-berechnen', 'herz-kreislauf-risiko-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/pulsePressure.json
+++ b/src/locales/calculators/de/pulsePressure.json
@@ -1,0 +1,63 @@
+{
+  "home": {
+    "calculators": {
+      "pulsePressure": {
+        "name": "Pulsdruck-Rechner",
+        "description": "Pulsdruck berechnen (PP = SBP − DBP) und klinische Einordnung prüfen — eng, normal oder weit."
+      }
+    }
+  },
+  "pulsePressure": {
+    "meta": {
+      "title": "Pulsdruck-Rechner — Eng, Normal, Weit (PP = SBP − DBP)",
+      "description": "Pulsdruck aus systolischem und diastolischem Blutdruck berechnen. Klinische Einordnung (eng < 40, normal 40–60, weit > 60 mmHg) mit Hinweisen auf Herzinsuffizienz und Gefäßsteifigkeit. Kostenlos und sofort."
+    },
+    "title": "Pulsdruck-Rechner",
+    "description": "Diastolischen vom systolischen Blutdruck abziehen — Pulsdruck plus klinische Einordnung (eng, normal, weit) und altersabhängiger Kontext.",
+    "inputsTitle": "Blutdruck (mmHg)",
+    "systolicLabel": "Systolisch (SBP)",
+    "diastolicLabel": "Diastolisch (DBP)",
+    "ageLabel": "Alter (Jahre, optional)",
+    "systolicPlaceholder": "z. B. 120",
+    "diastolicPlaceholder": "z. B. 80",
+    "agePlaceholder": "z. B. 55",
+    "unit": "mmHg",
+    "resultsLabel": "Ergebnis",
+    "ppLabel": "Pulsdruck",
+    "formulaTitle": "Formel",
+    "formulaText": "PP = SBP − DBP",
+    "formulaWhy": "Der Pulsdruck spiegelt das Schlagvolumen und die Steifigkeit der großen Arterien wider. Ein enger Wert kann auf reduziertes Herzzeitvolumen hinweisen (Herzinsuffizienz, Aortenstenose, Schock); ein weiter Wert auf arterielle Versteifung, Aorteninsuffizienz oder Hyperthyreose.",
+    "categoriesTitle": "Klinische Einordnung",
+    "clinicalNote": "Der Pulsdruck ist ein Signal — er ist immer im Kontext von Systole, Diastole, Herzfrequenz und Symptomatik zu interpretieren. Ein Einzelwert in Ruhe diagnostiziert keine Erkrankung.",
+    "disclaimer": "Dieser Rechner dient der Information und ersetzt keine ärztliche Bewertung. Bei dauerhaft auffälligen Werten außerhalb von 40–60 mmHg oder bei Symptomen ärztlich abklären.",
+    "ageContextTitle": "Altersabhängiger Kontext",
+    "ageContext": {
+      "young": "Unter 40 Jahren — der Pulsdruck liegt typischerweise im unteren Normalbereich (30–45 mmHg). Ein weiter PP ist in diesem Alter ungewöhnlich und sollte abgeklärt werden.",
+      "middle": "40–59 Jahre — leichte Zunahmen des PP durch beginnende arterielle Versteifung sind normal. Ein dauerhaftes PP > 60 mmHg verdient besondere Aufmerksamkeit für kardiovaskuläre Risikofaktoren.",
+      "older": "Ab 60 Jahren — der Pulsdruck steigt natürlicherweise mit der Gefäßsteifigkeit. PP > 60 mmHg ist in dieser Gruppe ein unabhängiger Marker für kardiovaskuläre Ereignisse."
+    },
+    "band": {
+      "narrow": "Eng",
+      "normal": "Normal",
+      "wide": "Weit"
+    },
+    "bandRange": {
+      "narrow": "< 40 mmHg",
+      "normal": "40 – 60 mmHg",
+      "wide": "> 60 mmHg"
+    },
+    "bandDescription": {
+      "narrow": "Enger Pulsdruck — möglicherweise reduziertes Schlagvolumen. An Herzinsuffizienz, schwere Aortenstenose, Perikardtamponade oder hypovolämischen Schock denken.",
+      "normal": "Normaler Pulsdruck — passend zu gesundem Schlagvolumen und arterieller Compliance.",
+      "wide": "Weiter Pulsdruck — Hinweis auf erhöhte arterielle Steifigkeit, Aorteninsuffizienz, schwere Anämie oder Hyperthyreose; bei älteren Erwachsenen unabhängiger kardiovaskulärer Risikomarker."
+    },
+    "faq": [
+      { "q": "Was ist der Pulsdruck?", "a": "Der Pulsdruck (PP) ist die Differenz zwischen systolischem und diastolischem Blutdruck: PP = SBP − DBP. Er spiegelt die Kraft pro Herzschlag und die Dehnbarkeit der großen Arterien wider." },
+      { "q": "Welcher Pulsdruck ist normal?", "a": "40 bis 60 mmHg in Ruhe gelten bei Erwachsenen als normal. Werte unter 40 sind eng, Werte über 60 sind weit." },
+      { "q": "Warum ist ein enger Pulsdruck relevant?", "a": "Ein enger PP (< 40 mmHg) kann auf ein reduziertes Schlagvolumen hindeuten — z. B. Herzinsuffizienz, Aortenstenose, Perikardtamponade oder Hypovolämie. Dauerhaft enger PP mit Symptomen erfordert kardiologische Abklärung." },
+      { "q": "Warum ist ein weiter Pulsdruck relevant?", "a": "Ein weiter PP (> 60 mmHg) spiegelt meist eine altersbedingte arterielle Versteifung wider, kann aber auch Aorteninsuffizienz, schwere Anämie oder Hyperthyreose anzeigen. Bei älteren Erwachsenen ist er ein unabhängiger kardiovaskulärer Risikomarker." },
+      { "q": "Wie beeinflusst das Alter den Pulsdruck?", "a": "Nach dem 50. Lebensjahr steigt der Pulsdruck oft, weil die großen Arterien an Elastizität verlieren. Ein PP von 50–60 bei einem 70-Jährigen ist deutlich weniger besorgniserregend als der gleiche Wert bei einem 25-Jährigen." },
+      { "q": "Ersetzt das eine klinische Bewertung?", "a": "Nein. Der Pulsdruck ist eine Zahl im größeren klinischen Bild aus SBP, DBP, Herzfrequenz, Symptomen und Vorgeschichte. Dieser Rechner eignet sich für Eigenmonitoring oder Wissensvermittlung, nicht zur Diagnose." }
+    ]
+  }
+}

--- a/src/locales/calculators/en/pulsePressure.json
+++ b/src/locales/calculators/en/pulsePressure.json
@@ -1,0 +1,63 @@
+{
+  "home": {
+    "calculators": {
+      "pulsePressure": {
+        "name": "Pulse Pressure Calculator",
+        "description": "Calculate pulse pressure (PP = SBP − DBP) and check the clinical band — narrow, normal or wide."
+      }
+    }
+  },
+  "pulsePressure": {
+    "meta": {
+      "title": "Pulse Pressure Calculator — Narrow, Normal, Wide (PP = SBP − DBP)",
+      "description": "Calculate pulse pressure from systolic and diastolic blood pressure. Get the clinical band (narrow < 40, normal 40–60, wide > 60 mmHg) with heart-failure and arterial-stiffness flags. Free, instant, no sign-up."
+    },
+    "title": "Pulse Pressure Calculator",
+    "description": "Subtract diastolic from systolic blood pressure — get the pulse pressure plus clinical interpretation (narrow, normal, wide) and an age context note.",
+    "inputsTitle": "Blood pressure (mmHg)",
+    "systolicLabel": "Systolic (SBP)",
+    "diastolicLabel": "Diastolic (DBP)",
+    "ageLabel": "Age (years, optional)",
+    "systolicPlaceholder": "e.g. 120",
+    "diastolicPlaceholder": "e.g. 80",
+    "agePlaceholder": "e.g. 55",
+    "unit": "mmHg",
+    "resultsLabel": "Result",
+    "ppLabel": "Pulse pressure",
+    "formulaTitle": "Formula",
+    "formulaText": "PP = SBP − DBP",
+    "formulaWhy": "Pulse pressure reflects stroke volume and large-artery stiffness. A narrow value can signal low cardiac output (heart failure, aortic stenosis, shock); a wide value flags arterial stiffening, aortic regurgitation or hyperthyroidism.",
+    "categoriesTitle": "Clinical bands",
+    "clinicalNote": "Pulse pressure is one signal — interpret with systolic, diastolic, heart rate, and clinical context. A single resting value does not diagnose disease.",
+    "disclaimer": "This calculator is for information only. It does not replace medical assessment. If your pulse pressure is consistently outside 40–60 mmHg or symptomatic, consult a clinician.",
+    "ageContextTitle": "Age context",
+    "ageContext": {
+      "young": "Under 40 years — pulse pressure typically sits in the lower half of the normal range (30–45 mmHg). A wide PP at this age is unusual and warrants follow-up.",
+      "middle": "40–59 years — small increases in PP are common as large arteries stiffen. Persistent PP > 60 mmHg deserves attention to cardiovascular risk factors.",
+      "older": "60 years and older — pulse pressure naturally rises with arterial stiffness. PP > 60 mmHg is an independent marker for cardiovascular events in this group."
+    },
+    "band": {
+      "narrow": "Narrow",
+      "normal": "Normal",
+      "wide": "Wide"
+    },
+    "bandRange": {
+      "narrow": "< 40 mmHg",
+      "normal": "40 – 60 mmHg",
+      "wide": "> 60 mmHg"
+    },
+    "bandDescription": {
+      "narrow": "Narrow pulse pressure — possible reduced stroke volume. Consider heart failure, severe aortic stenosis, cardiac tamponade or hypovolemic shock.",
+      "normal": "Normal pulse pressure — consistent with healthy stroke volume and arterial compliance.",
+      "wide": "Wide pulse pressure — flags increased large-artery stiffness, aortic regurgitation, severe anemia or hyperthyroidism; independent cardiovascular risk marker in older adults."
+    },
+    "faq": [
+      { "q": "What is pulse pressure?", "a": "Pulse pressure (PP) is the difference between systolic and diastolic blood pressure: PP = SBP − DBP. It reflects the force the heart generates with each contraction and the compliance of the large arteries." },
+      { "q": "What is a normal pulse pressure?", "a": "40 to 60 mmHg at rest is generally considered normal in adults. Values below 40 are narrow; values above 60 are wide." },
+      { "q": "Why does a narrow pulse pressure matter?", "a": "A narrow PP (< 40 mmHg) can indicate reduced stroke volume — e.g. heart failure, aortic stenosis, cardiac tamponade, or hypovolemia. Persistent narrow PP with symptoms warrants cardiac evaluation." },
+      { "q": "Why does a wide pulse pressure matter?", "a": "Wide PP (> 60 mmHg) usually reflects arterial stiffening with age but can also indicate aortic regurgitation, severe anemia or hyperthyroidism. In older adults a wide PP is an independent cardiovascular risk marker." },
+      { "q": "How does age affect pulse pressure?", "a": "Pulse pressure tends to rise after age 50 as large arteries lose elasticity. A PP of 50–60 in a 70-year-old is far less concerning than the same value in a 25-year-old." },
+      { "q": "Does this replace a clinical assessment?", "a": "No. Pulse pressure is one number in a wider clinical picture that includes SBP, DBP, heart rate, symptoms and history. Use this calculator for self-tracking or education, not diagnosis." }
+    ]
+  }
+}

--- a/src/pages/PulsePressureCalculator.vue
+++ b/src/pages/PulsePressureCalculator.vue
@@ -1,0 +1,178 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  calcPulsePressure,
+  getPulsePressureBand,
+  getAgeContext,
+  bandColor,
+  bandBg,
+  formatPp,
+} from '../utils/pulsePressure.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('pulsePressure.faq') || [])
+
+useHead(() => ({
+  title: t('pulsePressure.meta.title'),
+  description: t('pulsePressure.meta.description'),
+  routeKey: 'pulsePressure',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Pulse Pressure Calculator',
+    url: 'https://healthcalculator.app/en/pulse-pressure',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const systolic = ref(null)
+const diastolic = ref(null)
+const age = ref(null)
+
+const pp = computed(() => calcPulsePressure(systolic.value, diastolic.value))
+const band = computed(() => getPulsePressureBand(pp.value))
+const ageBucket = computed(() => getAgeContext(age.value))
+const hasResult = computed(() => pp.value !== null)
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('pulsePressure.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('pulsePressure.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-5">{{ t('pulsePressure.inputsTitle') }}</h2>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+        <div>
+          <label for="systolic-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('pulsePressure.systolicLabel') }} ({{ t('pulsePressure.unit') }})
+          </label>
+          <input
+            id="systolic-input"
+            v-model.number="systolic"
+            data-testid="systolic-input"
+            type="number"
+            min="0"
+            :placeholder="t('pulsePressure.systolicPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="diastolic-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('pulsePressure.diastolicLabel') }} ({{ t('pulsePressure.unit') }})
+          </label>
+          <input
+            id="diastolic-input"
+            v-model.number="diastolic"
+            data-testid="diastolic-input"
+            type="number"
+            min="0"
+            :placeholder="t('pulsePressure.diastolicPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label for="age-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+          {{ t('pulsePressure.ageLabel') }}
+        </label>
+        <input
+          id="age-input"
+          v-model.number="age"
+          data-testid="age-input"
+          type="number"
+          min="0"
+          :placeholder="t('pulsePressure.agePlaceholder')"
+          class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+        />
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <div v-if="hasResult" :class="['border rounded-xl shadow-sm p-8 mb-6', bandBg(band)]" data-testid="result-card">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('pulsePressure.resultsLabel') }}</p>
+
+      <div class="flex items-baseline gap-3 mb-2">
+        <span data-testid="pp-value" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ formatPp(pp) }}</span>
+        <span class="text-sm text-stone-400 ml-1">{{ t('pulsePressure.unit') }} · {{ t('pulsePressure.ppLabel') }}</span>
+      </div>
+
+      <p :class="['text-lg font-semibold mb-4', bandColor(band)]" data-testid="band">{{ t(`pulsePressure.band.${band}`) }}</p>
+
+      <p class="text-sm text-stone-600 leading-relaxed mb-4" data-testid="band-description">{{ t(`pulsePressure.bandDescription.${band}`) }}</p>
+
+      <div v-if="ageBucket" class="bg-white/60 border border-stone-200 rounded-lg p-4 mb-4" data-testid="age-context">
+        <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-1">{{ t('pulsePressure.ageContextTitle') }}</p>
+        <p class="text-sm text-stone-600 leading-relaxed">{{ t(`pulsePressure.ageContext.${ageBucket}`) }}</p>
+      </div>
+
+      <div class="bg-white/60 border border-stone-200 rounded-lg p-4 text-xs text-stone-600 leading-relaxed" data-testid="clinical-note">
+        {{ t('pulsePressure.clinicalNote') }}
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('pulsePressure.categoriesTitle') }}</h2>
+      <div class="space-y-3.5">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-red-600"></div>
+            <span class="text-sm text-stone-600">{{ t('pulsePressure.band.narrow') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('pulsePressure.bandRange.narrow') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-emerald-500"></div>
+            <span class="text-sm text-stone-600">{{ t('pulsePressure.band.normal') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('pulsePressure.bandRange.normal') }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-orange-500"></div>
+            <span class="text-sm text-stone-600">{{ t('pulsePressure.band.wide') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('pulsePressure.bandRange.wide') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('pulsePressure.formulaTitle') }}</h2>
+      <div class="bg-stone-50 rounded-lg p-4 font-mono text-sm text-stone-700 mb-3" data-testid="formula">
+        {{ t('pulsePressure.formulaText') }}
+      </div>
+      <p class="text-sm text-stone-600 leading-relaxed">{{ t('pulsePressure.formulaWhy') }}</p>
+    </div>
+
+    <div v-if="hasResult" class="bg-stone-50 rounded-xl border border-stone-200 p-5 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('pulsePressure.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <RelatedCalculators calc-key="pulsePressure" class="mt-8" />
+    <BlogArticleLink calculator-key="pulsePressure" />
+
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/PulsdruckBerechnen.vue
+++ b/src/pages/blog/PulsdruckBerechnen.vue
@@ -1,0 +1,216 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Pulsdruck berechnen: Formel, Normalwerte, Eng vs. Weit | Health Calculators',
+  description: 'Pulsdruck per Formel (SBP − DBP) berechnen. Klinische Bedeutung von engem (< 40), normalem (40–60) und weitem (> 60 mmHg) Pulsdruck — Hinweise auf Herzinsuffizienz und Gefäßsteifigkeit.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Pulsdruck berechnen: Formel, Normalwerte, Eng vs. Weit',
+      description: 'Pulsdruck-Formel, Normalbereich, klinische Bedeutung von engem und weitem Pulsdruck und altersabhängige Einordnung.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-31',
+      dateModified: '2026-05-31',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/pulsdruck-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist der Pulsdruck?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Der Pulsdruck (PP) ist die Differenz zwischen systolischem und diastolischem Blutdruck: PP = SBP − DBP. Er spiegelt die Kraft pro Herzschlag und die Dehnbarkeit der großen Arterien wider.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welcher Pulsdruck ist normal?',
+          acceptedAnswer: { '@type': 'Answer', text: '40 bis 60 mmHg in Ruhe gelten bei Erwachsenen als normal. Werte unter 40 sind eng, Werte über 60 sind weit.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Warum ist ein enger Pulsdruck relevant?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ein enger PP (< 40 mmHg) kann auf reduziertes Schlagvolumen hindeuten — z. B. Herzinsuffizienz, schwere Aortenstenose, Perikardtamponade oder hypovolämischen Schock.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Warum ist ein weiter Pulsdruck relevant?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ein weiter PP (> 60 mmHg) spiegelt meist eine altersbedingte arterielle Versteifung wider, kann aber auch Aorteninsuffizienz, schwere Anämie oder Hyperthyreose anzeigen. Bei älteren Erwachsenen ist er ein unabhängiger kardiovaskulärer Risikomarker.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wie beeinflusst das Alter den Pulsdruck?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Nach dem 50. Lebensjahr steigt der Pulsdruck oft, weil die großen Arterien an Elastizität verlieren. Ein PP von 50–60 bei einem 70-Jährigen ist weniger besorgniserregend als der gleiche Wert bei einem 25-Jährigen.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was tun bei dauerhaft auffälligem Pulsdruck?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Mehrfach unter standardisierten Bedingungen messen, kardiovaskuläre Risikofaktoren (Blutdruck, LDL, Diabetes, Rauchen) konsequent behandeln und bei anhaltend engem PP mit Symptomen oder weitem PP > 70 mmHg kardiologisch abklären lassen.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Pulsdruck berechnen: Formel, Normalwerte, Eng vs. Weit</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">31. Mai 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Auf jedem Blutdruckergebnis stehen zwei Zahlen — systolisch und diastolisch. Die <strong>dritte Zahl</strong>, der Pulsdruck, fehlt meist im Befund, sagt aber überraschend viel über Herz und Gefäße aus.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Eine einzige Subtraktion verrät, ob das Schlagvolumen passt und wie steif die großen Arterien sind. Diese Anleitung zeigt Formel, Normalbereich und klinische Bedeutung — und warum „eng" und „weit" verschiedene Geschichten erzählen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          PP = SBP − DBP
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei einem Standardwert von <strong>120/80 mmHg</strong> ist der Pulsdruck genau 40 — die untere Normgrenze. Bei 140/70 wären es 70 mmHg, also bereits weit. Bei 100/85 nur 15 mmHg, also deutlich eng.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der Wert reflektiert zwei Dinge gleichzeitig: das vom linken Ventrikel ausgeworfene Schlagvolumen und die Compliance der Aorta. Beides verändert sich mit Alter, Pathologie und Volumenstatus.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Klinische Bänder</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">Pulsdruck-Klassifikation</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 40 mmHg</span>
+              <span class="text-red-600 font-medium">Eng</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">40 – 60 mmHg</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">&gt; 60 mmHg</span>
+              <span class="text-orange-600 font-medium">Weit</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Diese Grenzen sind grobe Orientierungen für Erwachsene in Ruhe. Während Belastung steigt der Pulsdruck physiologisch — eine Einzelmessung darf nie isoliert interpretiert werden.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Enger Pulsdruck (&lt; 40 mmHg): Was steckt dahinter?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein enger Pulsdruck spricht für ein <strong>reduziertes Schlagvolumen</strong>. Häufige Ursachen:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Herzinsuffizienz:</strong> Das geschwächte Herz wirft pro Schlag weniger Volumen aus.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Schwere Aortenstenose:</strong> Die verengte Klappe begrenzt den systolischen Auswurf.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Perikardtamponade / konstriktive Perikarditis:</strong> Behinderte Füllung → geringeres Schlagvolumen.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Hypovolämischer Schock:</strong> Volumendefizit, kompensatorischer Vasokonstriktion.</span></li>
+        </ul>
+        <div class="bg-red-50 border border-red-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-red-800 mb-2">Warnzeichen</p>
+          <p class="text-sm text-red-700">PP &lt; 25 mmHg mit Tachykardie, kalter Peripherie oder Bewusstseinstrübung → notfallmäßige Abklärung. Ein enger PP bei niedrigem systolischen Druck (z. B. 90/75) ist klinisch relevanter als ein enger PP bei normalem Druck (130/100).</p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Weiter Pulsdruck (&gt; 60 mmHg): Was steckt dahinter?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Ein weiter Pulsdruck zeigt entweder <strong>versteifte große Arterien</strong> oder einen erhöhten Auswurf an:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Arterielle Versteifung (Alter, Atherosklerose):</strong> Häufigste Ursache; die unelastische Aorta dämpft den Druckpuls nicht mehr.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Aorteninsuffizienz:</strong> Diastolischer Rückfluss senkt den DBP, klassisches Bild „Wasserschlag-Puls".</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Hyperthyreose:</strong> Erhöhtes Herzzeitvolumen, periphere Vasodilatation.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Schwere Anämie, AV-Fistel, Beriberi:</strong> Hochzirkulatorische Zustände.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei Erwachsenen &gt; 60 Jahren ist ein PP &gt; 60 mmHg ein <strong>unabhängiger Risikomarker</strong> für Herzinfarkt, Schlaganfall und Herzinsuffizienz — sogar bei normalem Mittelwert.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Alter und Pulsdruck</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bis etwa zum 50. Lebensjahr steigen Systole und Diastole parallel — der Pulsdruck bleibt stabil bei 40–45 mmHg. Danach steigt vor allem die Systole, die Diastole fällt sogar leicht: der PP nimmt zu. Das ist <em>ein</em> Alterungsphänomen — wird er zu hoch, ist es ein <em>pathologisches</em>.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Ein PP von 55 bei einem 30-Jährigen ist auffälliger als ein PP von 70 bei einem 75-Jährigen. Immer im Altersrahmen interpretieren.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Pulsdruck jetzt berechnen</h3>
+        <p class="text-base text-stone-600 mb-6">Systole, Diastole (optional Alter) eingeben — der Rechner liefert PP, klinische Einordnung und altersabhängigen Kontext.</p>
+        <router-link
+          :to="localePath('pulsePressure')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Zum Pulsdruck-Rechner
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was bei auffälligem Pulsdruck hilft</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Standardisiert messen:</strong> 5 Minuten sitzen, drei Messungen im Abstand von einer Minute, Mittelwert nutzen.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>Kardiovaskuläre Risikofaktoren senken:</strong> Blutdruck, LDL, Diabetes, Rauchstopp, Gewicht — alle reduzieren auch arterielle Steifigkeit.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Bei engem PP mit Symptomen:</strong> Echokardiografie zur Beurteilung von Klappen und Funktion.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">4.</span><span class="text-stone-600"><strong>Bei weitem PP &gt; 70 mmHg:</strong> Herzfrequenz, Schilddrüsenfunktion und ggf. Aortenklappe abklären.</span></li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Pulsdruck ist eine Kennzahl unter mehreren. Sinnvoll kombinieren mit dem
+          <router-link :to="localePath('bloodPressure')" class="text-stone-900 underline hover:no-underline">Blutdruck-Rechner</router-link>
+          für die Klassifikation der arteriellen Hypertonie, dem
+          <router-link :to="localePath('meanArterialPressure')" class="text-stone-900 underline hover:no-underline">Rechner für den mittleren arteriellen Druck (MAP)</router-link>
+          für die Organperfusion und dem
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Herz-Kreislauf-Risiko-Rechner</router-link>
+          für das 10-Jahres-Risiko nach Framingham / SCORE2.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Eine Subtraktion, drei Bänder, viele Hinweise. Der Pulsdruck ergänzt Systole und Diastole um Information über Schlagvolumen und Gefäßsteifigkeit, die das Mittelwertbild allein nicht zeigt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Werte unter 40 oder über 60 mmHg sind keine Diagnose — aber ein guter Anlass, genauer hinzuschauen.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="pulsdruck-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/PulsePressureGuide.vue
+++ b/src/pages/blog/en/PulsePressureGuide.vue
@@ -1,0 +1,216 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Pulse Pressure Calculator Guide: Formula, Normal Values, Narrow vs. Wide | Health Calculators',
+  description: 'Calculate pulse pressure (SBP − DBP). Clinical meaning of narrow (< 40), normal (40–60) and wide (> 60 mmHg) pulse pressure — flags for heart failure and arterial stiffness.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Pulse Pressure Calculator Guide: Formula, Normal Values, Narrow vs. Wide',
+      description: 'Pulse pressure formula, normal range, clinical meaning of narrow and wide PP, and age-based interpretation.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-05-31',
+      dateModified: '2026-05-31',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/pulse-pressure-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is pulse pressure?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Pulse pressure (PP) is the difference between systolic and diastolic blood pressure: PP = SBP − DBP. It reflects the force the heart generates with each contraction and the compliance of the large arteries.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What is a normal pulse pressure?',
+          acceptedAnswer: { '@type': 'Answer', text: '40 to 60 mmHg at rest is generally considered normal in adults. Below 40 is narrow; above 60 is wide.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Why does a narrow pulse pressure matter?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Narrow PP (< 40 mmHg) can signal reduced stroke volume — e.g. heart failure, severe aortic stenosis, cardiac tamponade or hypovolemic shock.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Why does a wide pulse pressure matter?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Wide PP (> 60 mmHg) usually reflects arterial stiffening but can also indicate aortic regurgitation, severe anemia or hyperthyroidism. In older adults it is an independent cardiovascular risk marker.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'How does age affect pulse pressure?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Pulse pressure tends to rise after age 50 as large arteries lose elasticity. A PP of 50–60 in a 70-year-old is less concerning than the same value in a 25-year-old.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What to do about a persistently abnormal pulse pressure?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Measure multiple times under standardized conditions, treat cardiovascular risk factors (blood pressure, LDL, diabetes, smoking) aggressively, and seek cardiology assessment for persistent narrow PP with symptoms or wide PP > 70 mmHg.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Pulse Pressure Calculator Guide: Formula, Normal Values, Narrow vs. Wide</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">May 31, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">7 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Every blood-pressure reading prints two numbers — systolic and diastolic. The <strong>third number</strong>, pulse pressure, rarely appears on the printout, yet it carries surprising information about the heart and the great vessels.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A single subtraction tells you whether stroke volume looks adequate and how stiff the large arteries have become. This guide covers the formula, normal range and clinical meaning — and why "narrow" and "wide" tell very different stories.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          PP = SBP − DBP
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          At the textbook value of <strong>120/80 mmHg</strong>, pulse pressure is exactly 40 — the lower normal limit. At 140/70 it is 70 mmHg, already wide. At 100/85 it is only 15 mmHg, distinctly narrow.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The number reflects two things at once: the stroke volume ejected by the left ventricle, and the compliance of the aorta. Both change with age, pathology and volume status.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Clinical bands</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">Pulse-pressure classification</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 40 mmHg</span>
+              <span class="text-red-600 font-medium">Narrow</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">40 – 60 mmHg</span>
+              <span class="text-emerald-600 font-medium">Normal</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">&gt; 60 mmHg</span>
+              <span class="text-orange-600 font-medium">Wide</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          These thresholds are rough orientations for resting adults. PP rises during exercise as a normal response — a single value is never interpreted in isolation.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Narrow pulse pressure (&lt; 40 mmHg): what's behind it?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A narrow PP suggests <strong>reduced stroke volume</strong>. Common causes:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Heart failure:</strong> The weakened ventricle ejects less volume per beat.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Severe aortic stenosis:</strong> A tight valve limits systolic ejection.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Cardiac tamponade / constrictive pericarditis:</strong> Impaired filling lowers stroke volume.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Hypovolemic shock:</strong> Volume deficit with compensatory vasoconstriction.</span></li>
+        </ul>
+        <div class="bg-red-50 border border-red-200 rounded-xl p-5 mb-4">
+          <p class="text-sm font-semibold text-red-800 mb-2">Warning signs</p>
+          <p class="text-sm text-red-700">PP &lt; 25 mmHg with tachycardia, cold periphery or altered mental status → urgent evaluation. A narrow PP at low SBP (e.g. 90/75) is far more concerning than a narrow PP at normal pressure (130/100).</p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wide pulse pressure (&gt; 60 mmHg): what's behind it?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A wide PP points to either <strong>stiffened large arteries</strong> or an elevated cardiac output:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Arterial stiffening (age, atherosclerosis):</strong> Most common driver; the rigid aorta no longer dampens the pressure pulse.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Aortic regurgitation:</strong> Diastolic backflow drops the DBP — classic "water-hammer" pulse.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Hyperthyroidism:</strong> Elevated cardiac output and peripheral vasodilation.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Severe anemia, AV fistula, beriberi:</strong> High-output circulatory states.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In adults over 60, a PP &gt; 60 mmHg is an <strong>independent risk marker</strong> for myocardial infarction, stroke and heart failure — even when the mean arterial pressure looks normal.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Age and pulse pressure</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Up to about age 50, SBP and DBP rise in parallel — PP stays around 40–45 mmHg. After that, SBP keeps climbing while DBP slightly falls, so PP widens. This is an <em>ageing</em> phenomenon; when it widens too far, it becomes a <em>pathological</em> one.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A PP of 55 in a 30-year-old is more striking than a PP of 70 in a 75-year-old. Always interpret in the age frame.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Calculate your pulse pressure</h3>
+        <p class="text-base text-stone-600 mb-6">Enter SBP, DBP and (optionally) age — the calculator returns PP, the clinical band and an age-context note.</p>
+        <router-link
+          :to="localePath('pulsePressure')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Open the Pulse Pressure Calculator
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What helps an abnormal pulse pressure</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">1.</span><span class="text-stone-600"><strong>Measure properly:</strong> Sit quietly for 5 minutes, take three readings a minute apart, use the average.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">2.</span><span class="text-stone-600"><strong>Lower cardiovascular risk factors:</strong> Blood pressure, LDL, diabetes, smoking cessation, weight — all reduce arterial stiffness too.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">3.</span><span class="text-stone-600"><strong>Narrow PP with symptoms:</strong> Echocardiogram to assess valves and function.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">4.</span><span class="text-stone-600"><strong>Wide PP &gt; 70 mmHg:</strong> Check heart rate, thyroid function and, if indicated, the aortic valve.</span></li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Pulse pressure is one number in a wider profile. Pair it with the
+          <router-link :to="localePath('bloodPressure')" class="text-stone-900 underline hover:no-underline">Blood Pressure Calculator</router-link>
+          for hypertension classification, the
+          <router-link :to="localePath('meanArterialPressure')" class="text-stone-900 underline hover:no-underline">Mean Arterial Pressure (MAP) Calculator</router-link>
+          for organ perfusion, and the
+          <router-link :to="localePath('cardiovascularRisk')" class="text-stone-900 underline hover:no-underline">Cardiovascular Risk Calculator</router-link>
+          (Framingham / SCORE2) for the 10-year picture.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Takeaway</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          One subtraction, three bands, plenty of signal. Pulse pressure adds information about stroke volume and arterial stiffness that mean pressure alone cannot reveal.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Values under 40 or above 60 mmHg are not diagnoses — but they are a good reason to look closer.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticlesEn slug="pulse-pressure-guide" />
+  </article>
+</template>

--- a/src/pages/pulsePressure.meta.js
+++ b/src/pages/pulsePressure.meta.js
@@ -1,0 +1,16 @@
+import Component from './PulsePressureCalculator.vue'
+import BlogDe from './blog/PulsdruckBerechnen.vue'
+import BlogEn from './blog/en/PulsePressureGuide.vue'
+
+export default {
+  key: 'pulsePressure',
+  component: Component,
+  slugs: { de: 'pulsdruck-rechner', en: 'pulse-pressure' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 2.6,
+  blog: {
+    de: { slug: 'pulsdruck-berechnen', component: BlogDe },
+    en: { slug: 'pulse-pressure-guide', component: BlogEn },
+  },
+}

--- a/src/utils/pulsePressure.js
+++ b/src/utils/pulsePressure.js
@@ -1,0 +1,64 @@
+// Pulse Pressure (PP) — difference between systolic and diastolic blood pressure.
+//
+// Formula: PP = SBP − DBP
+//
+// Clinical bands (resting, brachial cuff):
+//   < 40 mmHg     Narrow — possible reduced stroke volume (heart failure, aortic stenosis, shock).
+//   40 – 60 mmHg  Normal.
+//   > 60 mmHg     Wide — arterial stiffening, aortic regurgitation, hyperthyroidism;
+//                 in adults > 60 it is an independent cardiovascular risk marker.
+
+function toNum(v) {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function calcPulsePressure(sbp, dbp) {
+  const s = toNum(sbp)
+  const d = toNum(dbp)
+  if (s == null || d == null) return null
+  if (s <= 0 || d <= 0) return null
+  if (d > s) return null
+  return s - d
+}
+
+export function getPulsePressureBand(pp) {
+  if (pp == null || !Number.isFinite(pp)) return null
+  if (pp < 40) return 'narrow'
+  if (pp <= 60) return 'normal'
+  return 'wide'
+}
+
+export function getAgeContext(age) {
+  const a = toNum(age)
+  if (a == null) return null
+  if (a < 40) return 'young'
+  if (a < 60) return 'middle'
+  return 'older'
+}
+
+const COLORS = {
+  narrow: 'text-red-600',
+  normal: 'text-emerald-600',
+  wide: 'text-orange-600',
+}
+
+const BGS = {
+  narrow: 'bg-red-50 border-red-200',
+  normal: 'bg-emerald-50 border-emerald-200',
+  wide: 'bg-orange-50 border-orange-200',
+}
+
+export function bandColor(band) {
+  return COLORS[band] || 'text-stone-900'
+}
+
+export function bandBg(band) {
+  return BGS[band] || 'bg-white border-stone-200'
+}
+
+export function formatPp(v) {
+  if (v == null || !Number.isFinite(v)) return '—'
+  return String(Math.round(v))
+}


### PR DESCRIPTION
## Summary
- New calculator: Pulse Pressure (PP = SBP − DBP) with three clinical bands (Narrow <40, Normal 40–60, Wide >60 mmHg)
- Color-coded band, heart-failure / aortic-stenosis flag for narrow, arterial-stiffness / aortic-regurgitation flag for wide
- Optional age input adds age-context note (young, middle, older)
- DE + EN blog articles with FAQPage structured data, linking to blood pressure, mean arterial pressure and cardiovascular risk calculators

## Test plan
- [x] 21 unit tests pass (all 3 bands, narrow-warning, wide-warning, SBP=DBP edge, age context)
- [x] 13 Playwright E2E tests pass (DE + EN, all bands)
- [x] Full test suite (2524 tests) passes
- [x] `npm run build` succeeds — SSG generates /de/pulsdruck-rechner, /en/pulse-pressure and both blog pages
- [x] Sitemap: 370 URLs, llms.txt: 366 links

🤖 Generated with [Claude Code](https://claude.com/claude-code)