### PR TITLE
hc-270-wilks-coefficient: Implement the Wilks Coefficient (powerlifting strength index

### DIFF
--- a/e2e/wilksCoefficient.spec.js
+++ b/e2e/wilksCoefficient.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Wilks Coefficient Calculator (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/wilks-coefficient-rechner')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Wilks/)
+  })
+
+  test('h1 contains Wilks', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Wilks')
+  })
+
+  test('back link navigates to home', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('no result shown before inputs', async ({ page }) => {
+    await expect(page.getByTestId('result-card')).toHaveCount(0)
+  })
+
+  test('male 83 kg / 600 kg → Elite band', async ({ page }) => {
+    await page.getByTestId('sex-male').click()
+    await page.getByTestId('unit-kg').click()
+    await page.getByTestId('bodyweight-input').fill('83')
+    await page.getByTestId('total-input').fill('600')
+
+    await expect(page.getByTestId('band')).toHaveText('Elite')
+    const score = await page.getByTestId('wilks-score').innerText()
+    expect(Number(score)).toBeGreaterThan(400)
+  })
+
+  test('male 100 kg / 200 kg → Anfänger band', async ({ page }) => {
+    await page.getByTestId('sex-male').click()
+    await page.getByTestId('unit-kg').click()
+    await page.getByTestId('bodyweight-input').fill('100')
+    await page.getByTestId('total-input').fill('200')
+
+    await expect(page.getByTestId('band')).toHaveText('Anfänger')
+  })
+
+  test('female switching changes the score', async ({ page }) => {
+    await page.getByTestId('unit-kg').click()
+    await page.getByTestId('bodyweight-input').fill('70')
+    await page.getByTestId('total-input').fill('400')
+    await page.getByTestId('sex-male').click()
+    const maleScore = await page.getByTestId('wilks-score').innerText()
+    await page.getByTestId('sex-female').click()
+    const femaleScore = await page.getByTestId('wilks-score').innerText()
+    expect(maleScore).not.toBe(femaleScore)
+  })
+
+  test('related calculators block is visible', async ({ page }) => {
+    await expect(page.getByTestId('related-calculators')).toBeVisible()
+  })
+
+  test('blog article link is visible', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('Wilks Coefficient Calculator (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/wilks-coefficient')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/Wilks/)
+  })
+
+  test('male 93 kg / 700 kg → Elite band', async ({ page }) => {
+    await page.getByTestId('sex-male').click()
+    await page.getByTestId('unit-kg').click()
+    await page.getByTestId('bodyweight-input').fill('93')
+    await page.getByTestId('total-input').fill('700')
+
+    await expect(page.getByTestId('band')).toHaveText('Elite')
+  })
+
+  test('imperial: 220 lb bodyweight, 1100 lb total male → finite score in elite range', async ({ page }) => {
+    await page.getByTestId('sex-male').click()
+    await page.getByTestId('unit-lb').click()
+    await page.getByTestId('bodyweight-input').fill('220')
+    await page.getByTestId('total-input').fill('1100')
+
+    const score = await page.getByTestId('wilks-score').innerText()
+    expect(Number(score)).toBeGreaterThan(100)
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -33,6 +33,7 @@ const EXPECTED_KEYS = [
   'ldlFriedewald',
   'ankleBrachialIndex',
   'pulsePressure',
+  'wilksCoefficient',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -127,6 +128,7 @@ const EXPECTED_ROUTE_MAP = {
   ldlFriedewald: { de: 'ldl-friedewald-rechner', en: 'ldl-cholesterol-friedewald' },
   ankleBrachialIndex: { de: 'knoechel-arm-index-rechner', en: 'ankle-brachial-index' },
   pulsePressure: { de: 'pulsdruck-rechner', en: 'pulse-pressure' },
+  wilksCoefficient: { de: 'wilks-coefficient-rechner', en: 'wilks-coefficient' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -210,8 +212,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'ldl-friedewald-berechnen',
   'knoechel-arm-index-berechnen',
   'pulsdruck-berechnen',
-  'bmi-frauen-berechnen',
-  'bmi-maenner-berechnen',
+  'wilks-koeffizient-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -295,13 +296,12 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'ldl-cholesterol-friedewald-guide',
   'ankle-brachial-index-guide',
   'pulse-pressure-guide',
-  'calculate-bmi-female',
-  'calculate-bmi-male',
+  'wilks-coefficient-guide',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 91 calculators', () => {
-    expect(calculatorMetas).toHaveLength(91)
+  it('discovers all 92 calculators', () => {
+    expect(calculatorMetas).toHaveLength(92)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
@@ -309,7 +309,7 @@ describe('calculator discovery', () => {
   })
 
   it('builds calculatorComponents map for all 91 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(91)
+    expect(Object.keys(calculatorComponents)).toHaveLength(92)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -332,15 +332,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 94 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(94)
+  it('discovers all 93 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(93)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 94 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(94)
+  it('discovers all 93 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(93)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -365,10 +365,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 91 calculators with no duplicates', () => {
+  it('groups contain all 92 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(91)
-    expect(new Set(allKeys).size).toBe(91)
+    expect(allKeys).toHaveLength(92)
+    expect(new Set(allKeys).size).toBe(92)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -389,7 +389,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'pulsePressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'pulsePressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'wilksCoefficient', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
     ])
   })
 
@@ -438,8 +438,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 506 routes', () => {
-    expect(routes).toHaveLength(506)
+  it('generates exactly 505 routes', () => {
+    expect(routes).toHaveLength(505)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 366 links (91 calcs × 2 locales + 92 blogs × 2 locales)', () => {
+  it('generates 370 links (92 calcs × 2 locales + 93 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(366)
+    expect(links).toHaveLength(370)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -27,6 +27,7 @@ const EXPECTED_KEYS = [
   'ldlFriedewald',
   'ankleBrachialIndex',
   'pulsePressure',
+  'wilksCoefficient',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -109,8 +110,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'ldl-friedewald-berechnen',
   'knoechel-arm-index-berechnen',
   'pulsdruck-berechnen',
-  'bmi-frauen-berechnen',
-  'bmi-maenner-berechnen',
+  'wilks-koeffizient-berechnen',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -193,14 +193,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'ldl-cholesterol-friedewald-guide',
   'ankle-brachial-index-guide',
   'pulse-pressure-guide',
-  'calculate-bmi-female',
-  'calculate-bmi-male',
+  'wilks-coefficient-guide',
 ]
 
 describe('discoverMetas', () => {
   it('discovers all 91 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(91)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(92)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -241,7 +240,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 94 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(94)
+    expect(de).toHaveLength(93)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
@@ -250,7 +249,7 @@ describe('discoverBlogSlugs', () => {
   it('returns all 94 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(94)
+    expect(en).toHaveLength(93)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -318,7 +317,7 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 182 calcs + 2 blog index + 188 blog articles = 374)', () => {
+  it('generates correct total URL count (2 home + 184 calcs + 2 blog index + 186 blog articles = 374)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
     expect(urlCount).toBe(374)
   })

--- a/src/__tests__/wilksCoefficient.test.js
+++ b/src/__tests__/wilksCoefficient.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calcWilks,
+  getWilksBand,
+  kgFromLb,
+  lbFromKg,
+  bandColor,
+  bandBg,
+} from '../utils/wilksCoefficient.js'
+
+describe('IPF 2020 Wilks coefficient — male', () => {
+  it('returns null when inputs missing', () => {
+    expect(calcWilks({ bodyweightKg: null, totalKg: 500, sex: 'male' })).toBeNull()
+    expect(calcWilks({ bodyweightKg: 80, totalKg: null, sex: 'male' })).toBeNull()
+    expect(calcWilks({ bodyweightKg: 80, totalKg: 500, sex: null })).toBeNull()
+  })
+
+  it('returns an integer score', () => {
+    const r = calcWilks({ bodyweightKg: 80, totalKg: 500, sex: 'male' })
+    expect(r).not.toBeNull()
+    expect(Number.isInteger(r)).toBe(true)
+  })
+
+  it('male 83 kg / 600 kg total → elite tier', () => {
+    const r = calcWilks({ bodyweightKg: 83, totalKg: 600, sex: 'male' })
+    expect(r).toBeGreaterThan(400)
+    expect(r).toBeLessThan(500)
+  })
+
+  it('male 93 kg / 700 kg total → elite tier', () => {
+    const r = calcWilks({ bodyweightKg: 93, totalKg: 700, sex: 'male' })
+    expect(r).toBeGreaterThan(430)
+    expect(r).toBeLessThan(540)
+  })
+
+  it('male 100 kg / 200 kg total → novice (~115)', () => {
+    const r = calcWilks({ bodyweightKg: 100, totalKg: 200, sex: 'male' })
+    expect(r).toBeGreaterThanOrEqual(100)
+    expect(r).toBeLessThan(200)
+  })
+})
+
+describe('IPF 2020 Wilks coefficient — female', () => {
+  it('female 60 kg / 300 kg total → roughly advanced range', () => {
+    const r = calcWilks({ bodyweightKg: 60, totalKg: 300, sex: 'female' })
+    expect(r).toBeGreaterThan(280)
+    expect(r).toBeLessThan(400)
+  })
+
+  it('female and male yield different scores for the same input', () => {
+    const m = calcWilks({ bodyweightKg: 70, totalKg: 400, sex: 'male' })
+    const f = calcWilks({ bodyweightKg: 70, totalKg: 400, sex: 'female' })
+    expect(m).not.toBe(f)
+  })
+})
+
+describe('Strength bands', () => {
+  it('< 100 → untrained', () => {
+    expect(getWilksBand(0)).toBe('untrained')
+    expect(getWilksBand(50)).toBe('untrained')
+    expect(getWilksBand(99)).toBe('untrained')
+  })
+
+  it('100–199 → novice', () => {
+    expect(getWilksBand(100)).toBe('novice')
+    expect(getWilksBand(150)).toBe('novice')
+    expect(getWilksBand(199)).toBe('novice')
+  })
+
+  it('200–299 → intermediate', () => {
+    expect(getWilksBand(200)).toBe('intermediate')
+    expect(getWilksBand(250)).toBe('intermediate')
+    expect(getWilksBand(299)).toBe('intermediate')
+  })
+
+  it('300–399 → advanced', () => {
+    expect(getWilksBand(300)).toBe('advanced')
+    expect(getWilksBand(350)).toBe('advanced')
+    expect(getWilksBand(399)).toBe('advanced')
+  })
+
+  it('>= 400 → elite', () => {
+    expect(getWilksBand(400)).toBe('elite')
+    expect(getWilksBand(550)).toBe('elite')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(getWilksBand(null)).toBeNull()
+    expect(getWilksBand(NaN)).toBeNull()
+  })
+})
+
+describe('Unit conversion kg ↔ lb', () => {
+  it('converts 220.46 lb to ~100 kg', () => {
+    expect(kgFromLb(220.46)).toBeCloseTo(100, 1)
+  })
+
+  it('converts 100 kg to ~220.46 lb', () => {
+    expect(lbFromKg(100)).toBeCloseTo(220.46, 1)
+  })
+
+  it('Wilks score is identical whether inputs are converted from lb or used as kg', () => {
+    const fromKg = calcWilks({ bodyweightKg: 80, totalKg: 500, sex: 'male' })
+    const bwLb = lbFromKg(80)
+    const totalLb = lbFromKg(500)
+    const fromLb = calcWilks({
+      bodyweightKg: kgFromLb(bwLb),
+      totalKg: kgFromLb(totalLb),
+      sex: 'male',
+    })
+    expect(fromLb).toBe(fromKg)
+  })
+})
+
+describe('Edge cases', () => {
+  it('very light male bodyweight (40 kg) returns a finite score', () => {
+    const r = calcWilks({ bodyweightKg: 40, totalKg: 200, sex: 'male' })
+    expect(r).not.toBeNull()
+    expect(Number.isFinite(r)).toBe(true)
+    expect(r).toBeGreaterThan(0)
+  })
+
+  it('very heavy male bodyweight (180 kg) returns a finite score', () => {
+    const r = calcWilks({ bodyweightKg: 180, totalKg: 800, sex: 'male' })
+    expect(r).not.toBeNull()
+    expect(Number.isFinite(r)).toBe(true)
+    expect(r).toBeGreaterThan(0)
+  })
+
+  it('very light female bodyweight (40 kg) returns a finite score', () => {
+    const r = calcWilks({ bodyweightKg: 40, totalKg: 200, sex: 'female' })
+    expect(r).not.toBeNull()
+    expect(Number.isFinite(r)).toBe(true)
+  })
+
+  it('very heavy female bodyweight (160 kg) returns a finite score', () => {
+    const r = calcWilks({ bodyweightKg: 160, totalKg: 600, sex: 'female' })
+    expect(r).not.toBeNull()
+    expect(Number.isFinite(r)).toBe(true)
+  })
+
+  it('Wilks score scales with total at fixed bodyweight', () => {
+    const low = calcWilks({ bodyweightKg: 80, totalKg: 300, sex: 'male' })
+    const high = calcWilks({ bodyweightKg: 80, totalKg: 600, sex: 'male' })
+    expect(high).toBeGreaterThan(low)
+  })
+
+  it('returns null for invalid sex', () => {
+    expect(calcWilks({ bodyweightKg: 80, totalKg: 500, sex: 'other' })).toBeNull()
+  })
+})
+
+describe('Style helpers', () => {
+  it('bandColor returns distinct classes per band', () => {
+    expect(bandColor('untrained')).toMatch(/text-/)
+    expect(bandColor('elite')).toMatch(/text-/)
+    expect(bandColor('elite')).not.toBe(bandColor('untrained'))
+  })
+
+  it('bandBg returns distinct bg classes per band', () => {
+    expect(bandBg('elite')).toMatch(/bg-/)
+    expect(bandBg('novice')).toMatch(/bg-/)
+  })
+})

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -827,6 +827,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'pulsePressure',
     related: ['measure-blood-pressure', 'mean-arterial-pressure-guide', 'cardiovascular-risk-framingham'],
   },
+  {
+    slug: 'wilks-coefficient-guide',
+    title: 'Wilks Coefficient Calculator Guide: IPF 2020 Formula, Strength Bands',
+    description: 'Calculate your Wilks score from powerlifting total, bodyweight and sex with the IPF 2020 polynomial. Five strength bands, Wilks 1994 vs 2020, Wilks vs DOTS vs GL points.',
+    date: '2026-06-07',
+    readTime: '8 min',
+    calculatorKey: 'wilksCoefficient',
+    related: ['calculate-one-rep-max', 'calculate-lean-body-mass', 'calculate-bmi'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -827,6 +827,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'pulsePressure',
     related: ['blutdruck-richtig-messen', 'mittlerer-arterieller-druck-berechnen', 'herz-kreislauf-risiko-berechnen'],
   },
+  {
+    slug: 'wilks-koeffizient-berechnen',
+    title: 'Wilks-Koeffizient berechnen: Formel, IPF 2020, Stärke-Bänder',
+    description: 'Wilks-Score aus Powerlifting-Total, Körpergewicht und Geschlecht nach IPF 2020 berechnen. Polynom-Formel, Bänder von Untrainiert bis Elite, Wilks vs. DOTS vs. GL-Points.',
+    date: '2026-06-07',
+    readTime: '8 min',
+    calculatorKey: 'wilksCoefficient',
+    related: ['one-rep-max-berechnen', 'magermasse-berechnen', 'bmi-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/wilksCoefficient.json
+++ b/src/locales/calculators/de/wilksCoefficient.json
@@ -1,0 +1,65 @@
+{
+  "home": {
+    "calculators": {
+      "wilksCoefficient": {
+        "name": "Wilks-Koeffizient Rechner",
+        "description": "Powerlifting-Total in einen Wilks-Score (IPF 2020) umrechnen und mit fünf Stärke-Bändern vergleichen — für jedes Körpergewicht und Geschlecht."
+      }
+    }
+  },
+  "wilksCoefficient": {
+    "meta": {
+      "title": "Wilks-Koeffizient berechnen (IPF 2020) — Powerlifting-Score",
+      "description": "Wilks-Score aus Kniebeuge-Bankdrücken-Kreuzheben-Total, Körpergewicht und Geschlecht nach IPF 2020 berechnen. Bänder: Untrainiert, Anfänger, Fortgeschritten, Erfahren, Elite. Metrisch und imperial."
+    },
+    "title": "Wilks-Koeffizient Rechner",
+    "description": "Powerlifting-Totals fair vergleichen — über Körpergewicht und Geschlecht hinweg. IPF 2020-Polynom mit fünf Stärke-Bändern.",
+    "inputsTitle": "Deine Daten",
+    "bodyweightLabel": "Körpergewicht",
+    "totalLabel": "Total (Kniebeuge + Bankdrücken + Kreuzheben)",
+    "bodyweightPlaceholder": "z. B. 83",
+    "totalPlaceholder": "z. B. 500",
+    "sexLabel": "Geschlecht",
+    "sexMale": "Männlich",
+    "sexFemale": "Weiblich",
+    "unitLabel": "Einheit",
+    "unitKg": "Metrisch (kg)",
+    "unitLb": "Imperial (lb)",
+    "resultsLabel": "Wilks-Score",
+    "bandLabel": "Stärke-Band",
+    "formulaTitle": "Formel",
+    "formulaText": "Score = 600 × Total ÷ (A + B·KG + C·KG² + D·KG³ + E·KG⁴) — IPF 2020-Polynom, getrennte Koeffizienten für Männer und Frauen.",
+    "formulaWhy": "Das Wilks-Polynom gewichtet schwerere Heber niedriger, damit Totals über Gewichtsklassen vergleichbar werden. Das IPF 2020-Update passt die Koeffizienten an aktuelle Weltrekord-Daten an.",
+    "categoriesTitle": "Stärke-Bänder",
+    "disclaimer": "Wilks ist eine Vergleichsmetrik für Wettkampf-Lifts. Sie sagt nichts über Trainingsalter, Technik oder sportspezifische Kraft. Für gesundheitliche Einordnung siehe die Körperzusammensetzungs-Rechner.",
+    "band": {
+      "untrained": "Untrainiert",
+      "novice": "Anfänger",
+      "intermediate": "Fortgeschritten",
+      "advanced": "Erfahren",
+      "elite": "Elite"
+    },
+    "bandRange": {
+      "untrained": "< 100",
+      "novice": "100 – 199",
+      "intermediate": "200 – 299",
+      "advanced": "300 – 399",
+      "elite": "≥ 400"
+    },
+    "bandDescription": {
+      "untrained": "Unter Anfängerniveau — Fokus auf konstantes Training, Technik und progressive Überlastung.",
+      "novice": "Erste 1–2 Jahre strukturiertes Training. Newbie-Gains treiben den Großteil des Fortschritts.",
+      "intermediate": "Mehrere Jahre Training. Programmgestaltung wird wichtiger; lineare Progression stockt.",
+      "advanced": "Auf Landesmeisterschaftsniveau. Spezialisierung und Regeneration sind entscheidend.",
+      "elite": "National und international stark. Mini-Gains brauchen Periodisierung, Peak-Wochen und perfekte Ausführung."
+    },
+    "faq": [
+      { "q": "Was ist der Wilks-Koeffizient?", "a": "Der Wilks-Koeffizient ist ein Multiplikator auf das Powerlifting-Total (Kniebeuge + Bankdrücken + Kreuzheben), der Athleten unterschiedlicher Körpergewichte und Geschlechter vergleichbar macht. Der entstehende Wilks-Score entscheidet im Wettkampf gewichtsklassenübergreifend über die Platzierung." },
+      { "q": "Was ist Wilks 2020 (IPF) versus klassischer Wilks?", "a": "Der originale Wilks (1994) wurde 2020 mit aktuellen Weltrekorden neu angepasst. Die IPF nutzt seitdem die neuen Koeffizienten, die schwerere Heber etwas stärker belohnen. Dieser Rechner verwendet das IPF 2020-Polynom." },
+      { "q": "Wie wird der Wilks-Score berechnet?", "a": "Score = Total_kg × 600 / (A + B·KG + C·KG² + D·KG³ + E·KG⁴). Die Konstanten A–E unterscheiden sich für Männer und Frauen. Das Polynom wird beim Körpergewicht in kg ausgewertet und dann mit dem Total multipliziert." },
+      { "q": "Was ist ein guter Wilks-Score?", "a": "Übliche Bänder: < 100 untrainiert, 100–199 Anfänger, 200–299 fortgeschritten, 300–399 erfahren, ≥ 400 Elite. Wettkampfheber auf Landesniveau erreichen 350–450; Weltklasse-Männer 500+. Die Bänder gelten für beide Geschlechter, da Wilks bereits korrigiert." },
+      { "q": "Kann ich Pfund (lb) statt Kilogramm eingeben?", "a": "Ja. Mit dem Einheiten-Schalter auf Imperial (lb) wechseln. Der Rechner rechnet intern mit 1 lb = 0,45359237 kg um und wertet dann das IPF 2020-Polynom aus. Der Wilks-Score ist identisch." },
+      { "q": "Wilks, DOTS oder GL-Points?", "a": "Alle drei normalisieren über das Körpergewicht. Wilks 2020 ist das aktuelle offizielle Scoring der IPF für raw classic. DOTS und GL-Points sind Alternativen in anderen Verbänden. Für die meisten Heber ändert sich die Reihenfolge nur geringfügig." }
+    ]
+  }
+}

--- a/src/locales/calculators/en/wilksCoefficient.json
+++ b/src/locales/calculators/en/wilksCoefficient.json
@@ -1,0 +1,65 @@
+{
+  "home": {
+    "calculators": {
+      "wilksCoefficient": {
+        "name": "Wilks Coefficient Calculator",
+        "description": "Convert your powerlifting total to a Wilks score (IPF 2020) and benchmark against five strength bands — for any bodyweight and sex."
+      }
+    }
+  },
+  "wilksCoefficient": {
+    "meta": {
+      "title": "Wilks Coefficient Calculator (IPF 2020) — Powerlifting Strength Score",
+      "description": "Calculate your Wilks score from squat-bench-deadlift total, bodyweight and sex with the IPF 2020 coefficients. Bands: Untrained, Novice, Intermediate, Advanced, Elite. Metric and imperial."
+    },
+    "title": "Wilks Coefficient Calculator",
+    "description": "Compare powerlifting totals fairly — across bodyweight and sex. IPF 2020 polynomial with five strength bands.",
+    "inputsTitle": "Your stats",
+    "bodyweightLabel": "Bodyweight",
+    "totalLabel": "Total lifted (squat + bench + deadlift)",
+    "bodyweightPlaceholder": "e.g. 83",
+    "totalPlaceholder": "e.g. 500",
+    "sexLabel": "Sex",
+    "sexMale": "Male",
+    "sexFemale": "Female",
+    "unitLabel": "Units",
+    "unitKg": "Metric (kg)",
+    "unitLb": "Imperial (lb)",
+    "resultsLabel": "Wilks score",
+    "bandLabel": "Strength band",
+    "formulaTitle": "Formula",
+    "formulaText": "Score = 600 × total ÷ (A + B·bw + C·bw² + D·bw³ + E·bw⁴) — IPF 2020 polynomial, separate male and female coefficients.",
+    "formulaWhy": "The Wilks polynomial down-weights heavier lifters so totals can be compared across weight classes. The IPF 2020 update refit the coefficients to current world-record data.",
+    "categoriesTitle": "Strength bands",
+    "disclaimer": "Wilks is a comparison metric for competition lifts. It does not reflect training age, technique, or sport-specific strength. For health screening, see the related body-composition calculators.",
+    "band": {
+      "untrained": "Untrained",
+      "novice": "Novice",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced",
+      "elite": "Elite"
+    },
+    "bandRange": {
+      "untrained": "< 100",
+      "novice": "100 – 199",
+      "intermediate": "200 – 299",
+      "advanced": "300 – 399",
+      "elite": "≥ 400"
+    },
+    "bandDescription": {
+      "untrained": "Below novice — focus on consistent training, technique and progressive overload.",
+      "novice": "First 1–2 years of structured lifting. Newbie gains drive most of the progress.",
+      "intermediate": "Several years of training. Programming matters more; linear progression stalls.",
+      "advanced": "Approaching regional-level competitive numbers. Specialization and recovery are critical.",
+      "elite": "National and world-class. Tiny gains require periodization, peak weeks and impeccable execution."
+    },
+    "faq": [
+      { "q": "What is the Wilks coefficient?", "a": "The Wilks coefficient is a multiplier applied to a powerlifter's squat-bench-deadlift total to compare lifters of different bodyweights and sex. The resulting Wilks score is what places lifters across weight classes in a meet." },
+      { "q": "What is Wilks 2020 (IPF) versus the original Wilks?", "a": "The original Wilks (1994) was refit in 2020 using current world records. The IPF adopted the new coefficients to better reward heavier lifters, who were previously slightly under-rewarded. This calculator uses the IPF 2020 polynomial." },
+      { "q": "How is the Wilks score calculated?", "a": "Score = total_kg × 600 / (A + B·bw + C·bw² + D·bw³ + E·bw⁴). The constants A–E differ between male and female lifters. The polynomial is evaluated at the lifter's bodyweight in kg, then multiplied by the total." },
+      { "q": "What is a good Wilks score?", "a": "Common bands: < 100 untrained, 100–199 novice, 200–299 intermediate, 300–399 advanced, ≥ 400 elite. Competitive powerlifters at national level usually score 350–450; world-class men hit 500+. Bands apply to both sexes since Wilks already adjusts for sex." },
+      { "q": "Can I enter pounds instead of kilograms?", "a": "Yes. Switch the units toggle to imperial (lb). The calculator converts to kg internally using 1 lb = 0.45359237 kg, then evaluates the IPF 2020 polynomial. The Wilks score is identical either way." },
+      { "q": "Should I use Wilks or DOTS or GL points?", "a": "All three normalize across bodyweight. Wilks 2020 is the IPF's current official scoring system for raw classic. DOTS and GL points are alternatives used in some federations. For most lifters the rankings move only slightly between systems." }
+    ]
+  }
+}

--- a/src/pages/WilksCoefficientCalculator.vue
+++ b/src/pages/WilksCoefficientCalculator.vue
@@ -1,0 +1,208 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import {
+  calcWilks,
+  getWilksBand,
+  kgFromLb,
+  bandColor,
+  bandBg,
+} from '../utils/wilksCoefficient.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('wilksCoefficient.faq') || [])
+
+useHead(() => ({
+  title: t('wilksCoefficient.meta.title'),
+  description: t('wilksCoefficient.meta.description'),
+  routeKey: 'wilksCoefficient',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Wilks Coefficient Calculator',
+    url: 'https://healthcalculator.app/en/wilks-coefficient',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const bodyweight = ref(null)
+const total = ref(null)
+const sex = ref('male')
+const unit = ref('kg')
+
+const bodyweightKg = computed(() => {
+  if (bodyweight.value == null || bodyweight.value === '') return null
+  return unit.value === 'lb' ? kgFromLb(Number(bodyweight.value)) : Number(bodyweight.value)
+})
+
+const totalKg = computed(() => {
+  if (total.value == null || total.value === '') return null
+  return unit.value === 'lb' ? kgFromLb(Number(total.value)) : Number(total.value)
+})
+
+const score = computed(() =>
+  calcWilks({
+    bodyweightKg: bodyweightKg.value,
+    totalKg: totalKg.value,
+    sex: sex.value,
+  }),
+)
+
+const band = computed(() => getWilksBand(score.value))
+const hasResult = computed(() => score.value != null)
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('wilksCoefficient.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('wilksCoefficient.description') }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-5">{{ t('wilksCoefficient.inputsTitle') }}</h2>
+
+      <div class="mb-6">
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('wilksCoefficient.unitLabel') }}</label>
+        <div class="flex gap-2">
+          <button @click="unit = 'kg'" data-testid="unit-kg" type="button"
+            :class="unit === 'kg' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150">{{ t('wilksCoefficient.unitKg') }}</button>
+          <button @click="unit = 'lb'" data-testid="unit-lb" type="button"
+            :class="unit === 'lb' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150">{{ t('wilksCoefficient.unitLb') }}</button>
+        </div>
+      </div>
+
+      <div class="mb-6">
+        <label class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('wilksCoefficient.sexLabel') }}</label>
+        <div class="flex gap-2">
+          <button @click="sex = 'male'" data-testid="sex-male" type="button"
+            :class="sex === 'male' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150">{{ t('wilksCoefficient.sexMale') }}</button>
+          <button @click="sex = 'female'" data-testid="sex-female" type="button"
+            :class="sex === 'female' ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-600 hover:bg-stone-200'"
+            class="flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150">{{ t('wilksCoefficient.sexFemale') }}</button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label for="bodyweight-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('wilksCoefficient.bodyweightLabel') }} ({{ unit }})
+          </label>
+          <input
+            id="bodyweight-input"
+            v-model.number="bodyweight"
+            data-testid="bodyweight-input"
+            type="number"
+            min="0"
+            :placeholder="t('wilksCoefficient.bodyweightPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+        <div>
+          <label for="total-input" class="block text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">
+            {{ t('wilksCoefficient.totalLabel') }} ({{ unit }})
+          </label>
+          <input
+            id="total-input"
+            v-model.number="total"
+            data-testid="total-input"
+            type="number"
+            min="0"
+            :placeholder="t('wilksCoefficient.totalPlaceholder')"
+            class="w-full border border-stone-300 rounded-lg px-4 py-3.5 text-stone-900 text-base font-medium bg-white focus:outline-none focus:border-stone-600 focus:bg-stone-50 transition-all duration-150"
+          />
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <div v-if="hasResult" :class="['border rounded-xl shadow-sm p-8 mb-6', bandBg(band)]" data-testid="result-card">
+      <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-4">{{ t('wilksCoefficient.resultsLabel') }}</p>
+
+      <div class="flex items-baseline gap-3 mb-2">
+        <span data-testid="wilks-score" class="text-5xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ score }}</span>
+        <span class="text-sm text-stone-400 ml-1">{{ t('wilksCoefficient.bandLabel') }}</span>
+      </div>
+
+      <p :class="['text-lg font-semibold mb-4', bandColor(band)]" data-testid="band">{{ t(`wilksCoefficient.band.${band}`) }}</p>
+
+      <p class="text-sm text-stone-600 leading-relaxed" data-testid="band-description">{{ t(`wilksCoefficient.bandDescription.${band}`) }}</p>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('wilksCoefficient.categoriesTitle') }}</h2>
+      <div class="space-y-3.5">
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-stone-400"></div>
+            <span class="text-sm text-stone-600">{{ t('wilksCoefficient.band.untrained') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('wilksCoefficient.bandRange.untrained') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-amber-500"></div>
+            <span class="text-sm text-stone-600">{{ t('wilksCoefficient.band.novice') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('wilksCoefficient.bandRange.novice') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-emerald-500"></div>
+            <span class="text-sm text-stone-600">{{ t('wilksCoefficient.band.intermediate') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('wilksCoefficient.bandRange.intermediate') }}</span>
+        </div>
+        <div class="flex items-center justify-between border-b border-stone-100 pb-3.5">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-blue-500"></div>
+            <span class="text-sm text-stone-600">{{ t('wilksCoefficient.band.advanced') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('wilksCoefficient.bandRange.advanced') }}</span>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-3">
+            <div class="w-2.5 h-2.5 rounded-full bg-purple-500"></div>
+            <span class="text-sm text-stone-600">{{ t('wilksCoefficient.band.elite') }}</span>
+          </div>
+          <span class="text-sm font-medium text-stone-900 tabular-nums">{{ t('wilksCoefficient.bandRange.elite') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-3">{{ t('wilksCoefficient.formulaTitle') }}</h2>
+      <div class="bg-stone-50 rounded-lg p-4 font-mono text-sm text-stone-700 mb-3" data-testid="formula">
+        {{ t('wilksCoefficient.formulaText') }}
+      </div>
+      <p class="text-sm text-stone-600 leading-relaxed">{{ t('wilksCoefficient.formulaWhy') }}</p>
+    </div>
+
+    <div v-if="hasResult" class="bg-stone-50 rounded-xl border border-stone-200 p-5 mb-6">
+      <p class="text-xs text-stone-500 leading-relaxed">{{ t('wilksCoefficient.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+
+    <RelatedCalculators calc-key="wilksCoefficient" class="mt-8" />
+    <BlogArticleLink calculator-key="wilksCoefficient" />
+
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/WilksKoeffizientBerechnen.vue
+++ b/src/pages/blog/WilksKoeffizientBerechnen.vue
@@ -1,0 +1,208 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Wilks-Koeffizient berechnen: Formel, IPF 2020, Stärke-Bänder | Health Calculators',
+  description: 'Wilks-Score aus Powerlifting-Total, Körpergewicht und Geschlecht nach IPF 2020 berechnen. Polynom-Formel, Bänder von Untrainiert bis Elite, Wilks vs. DOTS vs. GL-Points.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Wilks-Koeffizient berechnen: Formel, IPF 2020, Stärke-Bänder',
+      description: 'Wilks-Formel nach IPF 2020, fünf Stärke-Bänder und der Vergleich zu DOTS und GL-Points.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-06-07',
+      dateModified: '2026-06-07',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/wilks-koeffizient-berechnen',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was ist der Wilks-Koeffizient?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ein Multiplikator, der das Powerlifting-Total (Kniebeuge + Bankdrücken + Kreuzheben) so normalisiert, dass Athleten unterschiedlicher Gewichtsklassen und Geschlechter vergleichbar werden. Der resultierende Wilks-Score entscheidet im Wettkampf gewichtsklassenübergreifend.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was ist neu an Wilks 2020 (IPF)?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Die IPF hat die Koeffizienten 2020 mit aktuellen Weltrekord-Daten neu angepasst. Schwerere Heber werden etwas stärker belohnt, während die Gesamtskala ähnlich bleibt. Dieser Rechner verwendet die IPF 2020-Konstanten.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wie lautet die Wilks-Formel?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Score = Total_kg × 600 / (A + B·KG + C·KG² + D·KG³ + E·KG⁴). Die Konstanten A–E unterscheiden sich für Männer und Frauen. Das Polynom wird beim Körpergewicht in kg ausgewertet und mit dem Total multipliziert.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Welcher Wilks-Score ist gut?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Übliche Bänder: < 100 untrainiert, 100–199 Anfänger, 200–299 fortgeschritten, 300–399 erfahren, ≥ 400 Elite. Wettkampfheber auf Landesniveau erreichen meist 350–450; Weltklasse-Männer 500+.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wilks oder DOTS oder GL-Points?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Alle drei normalisieren über das Körpergewicht. Wilks 2020 ist das aktuelle offizielle Scoring der IPF für raw classic. DOTS und GL-Points sind Alternativen. Die Reihenfolge der Heber ändert sich zwischen den Systemen meist nur geringfügig.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Kann ich Pfund (lb) eingeben?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Ja — im Rechner einfach auf Imperial wechseln. Intern wird mit 1 lb = 0,45359237 kg umgerechnet, das Polynom in kg ausgewertet. Der Wilks-Score ist identisch.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Wilks-Koeffizient berechnen: Formel, IPF 2020, Stärke-Bänder</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">7. Juni 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wer im Wettkampf den 60-kg-Heber gegen den 120-kg-Heber stellen will, braucht eine Norm. Ohne sie gewinnt immer der Schwerere. Der <strong>Wilks-Koeffizient</strong> ist seit 1994 diese Norm — und seit 2020 in der IPF-Variante das offizielle Bewertungssystem für klassisches Powerlifting.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Vier Eingaben (Total, Körpergewicht, Geschlecht, Einheit), ein Polynom, ein Score. Dieser Guide zeigt, wie die Formel funktioniert, was die fünf Stärke-Bänder bedeuten und wann sich der Blick auf DOTS oder GL-Points lohnt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Formel</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          Score = 600 × Total ÷ (A + B·KG + C·KG² + D·KG³ + E·KG⁴)
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          KG ist das Körpergewicht in Kilogramm, Total die Summe der besten Versuche in Kniebeuge, Bankdrücken und Kreuzheben — ebenfalls in Kilogramm. Die fünf Konstanten A–E unterscheiden sich für Männer und Frauen. Die IPF veröffentlicht sie jährlich.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Beispiel: 83-kg-Heber, Total 600 kg (Männer, IPF 2020). Polynom-Nenner ≈ 796 → Score ≈ <strong>452</strong>. Damit liegt der Heber im Elite-Band — Welt-Top-Niveau in seiner Klasse.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die fünf Stärke-Bänder</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">Wilks-Score-Bereiche</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 100</span>
+              <span class="text-stone-600 font-medium">Untrainiert</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">100 – 199</span>
+              <span class="text-amber-600 font-medium">Anfänger</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">200 – 299</span>
+              <span class="text-emerald-600 font-medium">Fortgeschritten</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">300 – 399</span>
+              <span class="text-blue-600 font-medium">Erfahren</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">&ge; 400</span>
+              <span class="text-purple-600 font-medium">Elite</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Die Bänder gelten für beide Geschlechter, weil Wilks bereits für Sex korrigiert. Ein 350er-Score einer Frau ist also genauso „erfahren" wie ein 350er-Score eines Mannes.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wilks 1994 vs. IPF 2020</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Robert Wilks veröffentlichte die ursprüngliche Formel 1994 — gefittet an die damaligen Weltrekorde. Über die Jahre wuchsen die Totals (vor allem bei Frauen und im Superschwergewicht) deutlich, und die Koeffizienten passten nicht mehr. Das IPF-Komitee fittet 2020 das Polynom neu.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Praktisch heißt das: Heber in den oberen Gewichtsklassen kommen mit Wilks-2020 etwas höher raus als mit Wilks-1994, der Mittelbereich bleibt fast unverändert. Wer ältere Wilks-Vergleiche liest, sollte deshalb darauf achten, welche Version verwendet wurde.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Wilks-Score jetzt berechnen</h3>
+        <p class="text-base text-stone-600 mb-6">Total, Körpergewicht, Geschlecht und Einheit eingeben — der Rechner gibt den IPF-2020-Score plus Stärke-Band aus.</p>
+        <router-link
+          :to="localePath('wilksCoefficient')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Zum Wilks-Rechner
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was Wilks <em>nicht</em> abdeckt</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Equipment:</strong> Single-Ply und Multi-Ply geben zusätzliche Kilos. Wilks ist für raw classic gedacht.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Alter:</strong> Junior- und Masters-Hebersklassen bekommen separate altersadjustierte Faktoren (McCulloch / Foster).</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Trainingsalter:</strong> Ein 200er-Score nach 6 Monaten ist beeindruckend, nach 10 Jahren bescheiden — die Zahl sagt nichts darüber.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Einzeldisziplinen:</strong> Wer nur Bankdrücken macht, sollte spezifische Scores wie den IPF-Bench-Coefficient nutzen.</span></li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wilks, DOTS oder GL-Points?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Es gibt drei verbreitete Scoring-Systeme im Kraftsport:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Wilks 2020 (IPF):</strong> aktuelles offizielles IPF-Scoring für raw classic.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>DOTS:</strong> ähnliche Polynom-Form, oft in USAPL und nordamerikanischen Verbänden genutzt.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>GL-Points (Goodlift):</strong> die neuere IPF-Bewertung für equipped lifting.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Für die meisten Heber liefern alle drei sehr ähnliche Rankings. Unterschiede zeigen sich erst in den extremen Gewichtsklassen oder bei equipped vs. raw.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wer den Wilks-Score steigern will, arbeitet an Maximalkraft. Sinnvoll ergänzend: der
+          <router-link :to="localePath('oneRepMax')" class="text-stone-900 underline hover:no-underline">One-Rep-Max-Rechner</router-link>
+          schätzt das echte 1RM aus Multi-Rep-Sätzen — die Grundlage fürs Programmieren von Squat, Bench und Deadlift. Der
+          <router-link :to="localePath('leanBodyMass')" class="text-stone-900 underline hover:no-underline">Magermasse-Rechner</router-link>
+          gibt die Fettfreie Masse aus — Wilks pro Magermasse ist oft aussagekräftiger als der reine Wilks-Score. Wer das Körpergewicht für eine neue Wettkampfklasse plant, kann den
+          <router-link :to="localePath('bmi')" class="text-stone-900 underline hover:no-underline">BMI-Rechner</router-link>
+          und den
+          <router-link :to="localePath('bodyFat')" class="text-stone-900 underline hover:no-underline">Körperfett-Rechner</router-link>
+          zur groben Verlaufskontrolle nutzen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Wilks-Koeffizient ist die schnellste Antwort auf „Wer hebt relativ am stärksten?". Ein Polynom, fünf Konstanten, ein Score — und Heber jeder Gewichtsklasse stehen vergleichbar nebeneinander.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das IPF 2020-Update ist die Version, die heute zählt. 400+ ist Elite, 300+ ein erfahrener Wettkampfheber. Den Score regelmäßig zu tracken zeigt langfristige Fortschritte, die im wöchentlichen Trainingsplan oft untergehen.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticles slug="wilks-koeffizient-berechnen" />
+  </article>
+</template>

--- a/src/pages/blog/en/WilksCoefficientGuide.vue
+++ b/src/pages/blog/en/WilksCoefficientGuide.vue
@@ -1,0 +1,208 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath } = useLocaleRouter()
+
+useHead({
+  title: 'Wilks Coefficient Calculator Guide: IPF 2020 Formula, Strength Bands | Health Calculators',
+  description: 'Calculate your Wilks score from powerlifting total, bodyweight and sex with the IPF 2020 polynomial. Five strength bands, Wilks 1994 vs 2020, Wilks vs DOTS vs GL points.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'Wilks Coefficient Calculator Guide: IPF 2020 Formula, Strength Bands',
+      description: 'Wilks formula per IPF 2020, five strength bands, and how Wilks compares to DOTS and GL points.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-06-07',
+      dateModified: '2026-06-07',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/wilks-coefficient-guide',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is the Wilks coefficient?',
+          acceptedAnswer: { '@type': 'Answer', text: 'A multiplier applied to a powerlifting total (squat + bench + deadlift) that normalises across bodyweight and sex. The resulting Wilks score ranks lifters of different weight classes against each other in a meet.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What changed with Wilks 2020 (IPF)?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The IPF refit the polynomial in 2020 using current world records. Heavier lifters are now slightly better rewarded, while mid-weight scores stay close to the 1994 values. This calculator uses the IPF 2020 constants.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What is the Wilks formula?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Score = total_kg × 600 / (A + B·bw + C·bw² + D·bw³ + E·bw⁴). The constants A–E differ for men and women. The polynomial is evaluated at bodyweight in kg, then multiplied by the total in kg.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What is a good Wilks score?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Common bands: < 100 untrained, 100–199 novice, 200–299 intermediate, 300–399 advanced, ≥ 400 elite. National-level powerlifters typically score 350–450; world-class men reach 500+. Bands apply to both sexes since Wilks already corrects for sex.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Wilks, DOTS or GL points?',
+          acceptedAnswer: { '@type': 'Answer', text: 'All three normalise across bodyweight. Wilks 2020 is the IPF\'s current official scoring for raw classic. DOTS and GL points are alternatives. Rankings between systems usually differ only slightly.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Can I enter pounds?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Yes — switch the units toggle to imperial. The calculator converts using 1 lb = 0.45359237 kg, then evaluates the IPF 2020 polynomial in kg. The Wilks score is identical regardless of input unit.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">Wilks Coefficient Calculator Guide: IPF 2020 Formula, Strength Bands</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">June 7, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          To rank a 60 kg lifter against a 120 kg lifter you need a norm. Without one, the heavier athlete always wins. The <strong>Wilks coefficient</strong> has been that norm since 1994 — and in its IPF 2020 form is the official scoring system for raw classic powerlifting.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Four inputs (total, bodyweight, sex, units), one polynomial, one score. This guide covers how the formula works, what the five strength bands mean, and when DOTS or GL points might be worth a look.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The formula</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4 font-mono text-base text-stone-700 text-center">
+          Score = 600 × total ÷ (A + B·bw + C·bw² + D·bw³ + E·bw⁴)
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          bw is bodyweight in kilograms, total is the sum of best squat, bench press and deadlift attempts — also in kilograms. The five constants A–E differ between men and women. The IPF publishes them annually.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Example: 83 kg male lifter, 600 kg total (IPF 2020). Polynomial denominator ≈ 796 → score ≈ <strong>452</strong>. That puts the lifter solidly in the Elite band — world-class numbers for the class.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The five strength bands</h2>
+        <div class="bg-stone-50 rounded-xl p-6 mb-4">
+          <p class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-3">Wilks score ranges</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-stone-600">&lt; 100</span>
+              <span class="text-stone-600 font-medium">Untrained</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">100 – 199</span>
+              <span class="text-amber-600 font-medium">Novice</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">200 – 299</span>
+              <span class="text-emerald-600 font-medium">Intermediate</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">300 – 399</span>
+              <span class="text-blue-600 font-medium">Advanced</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-stone-600">&ge; 400</span>
+              <span class="text-purple-600 font-medium">Elite</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The bands apply to both sexes because Wilks already adjusts for sex. A 350 score for a woman represents the same "advanced" tier as a 350 score for a man.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wilks 1994 vs IPF 2020</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Robert Wilks published the original polynomial in 1994 — fit to the world records of the time. Over the decades the records grew (especially in women's lifting and super-heavyweight men), and the old coefficients no longer matched. The IPF committee refit the polynomial in 2020.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Practically: lifters in the upper weight classes score slightly higher under Wilks 2020 than under the 1994 version; mid-weight scores are nearly unchanged. When reading historical Wilks comparisons, check which version was used.
+        </p>
+      </div>
+
+      <div class="bg-stone-50 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-stone-900 mb-3">Calculate your Wilks score</h3>
+        <p class="text-base text-stone-600 mb-6">Enter total, bodyweight, sex and units — the calculator returns the IPF 2020 score and your strength band.</p>
+        <router-link
+          :to="localePath('wilksCoefficient')"
+          class="inline-block bg-stone-900 text-white text-sm font-semibold px-6 py-3 rounded-lg hover:bg-stone-700 transition-colors"
+        >
+          Open the Wilks Coefficient Calculator
+        </router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What Wilks does <em>not</em> capture</h2>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Equipment:</strong> single-ply and multi-ply gear add kilos. Wilks is intended for raw classic.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Age:</strong> junior and masters lifters get separate age-adjusted factors (McCulloch / Foster).</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Training age:</strong> a 200 after six months is impressive; the same score after ten years is not. Wilks knows neither.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Single-lift athletes:</strong> bench-only specialists should use lift-specific scoring like the IPF bench coefficient.</span></li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wilks, DOTS or GL points?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Three scoring systems dominate strength sports:
+        </p>
+        <ul class="space-y-2 mb-4">
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>Wilks 2020 (IPF):</strong> current official IPF scoring for raw classic.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>DOTS:</strong> similar polynomial form, common in USAPL and North-American federations.</span></li>
+          <li class="flex gap-3"><span class="text-stone-400 mt-0.5">→</span><span class="text-stone-600"><strong>GL points (Goodlift):</strong> the newer IPF scoring used for equipped lifting.</span></li>
+        </ul>
+        <p class="text-base text-stone-600 leading-relaxed">
+          For most lifters all three return very similar rankings. Differences show up mostly in the extreme weight classes or in equipped vs raw.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Raising your Wilks score is about maximal strength. Useful companions: the
+          <router-link :to="localePath('oneRepMax')" class="text-stone-900 underline hover:no-underline">One-Rep-Max Calculator</router-link>
+          estimates your true 1RM from multi-rep sets — the foundation for programming squat, bench and deadlift. The
+          <router-link :to="localePath('leanBodyMass')" class="text-stone-900 underline hover:no-underline">Lean Body Mass Calculator</router-link>
+          returns fat-free mass — Wilks per kilogram of lean mass is often more informative than the raw Wilks score. If you're planning a new weight class, track progress with the
+          <router-link :to="localePath('bmi')" class="text-stone-900 underline hover:no-underline">BMI Calculator</router-link>
+          and the
+          <router-link :to="localePath('bodyFat')" class="text-stone-900 underline hover:no-underline">Body Fat Calculator</router-link>
+          .
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Takeaway</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The Wilks coefficient is the quickest answer to "who lifts the most for their size?". One polynomial, five constants, one score — and lifters from every weight class stand on the same scale.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          IPF 2020 is the version that counts today. 400+ is elite, 300+ a seasoned competitor. Tracking the score across years reveals the kind of long-arc progress that weekly training logs hide.
+        </p>
+      </div>
+    </div>
+
+    <RelatedArticlesEn slug="wilks-coefficient-guide" />
+  </article>
+</template>

--- a/src/pages/wilksCoefficient.meta.js
+++ b/src/pages/wilksCoefficient.meta.js
@@ -1,0 +1,16 @@
+import Component from './WilksCoefficientCalculator.vue'
+import BlogDe from './blog/WilksKoeffizientBerechnen.vue'
+import BlogEn from './blog/en/WilksCoefficientGuide.vue'
+
+export default {
+  key: 'wilksCoefficient',
+  component: Component,
+  slugs: { de: 'wilks-coefficient-rechner', en: 'wilks-coefficient' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 26.8,
+  blog: {
+    de: { slug: 'wilks-koeffizient-berechnen', component: BlogDe },
+    en: { slug: 'wilks-coefficient-guide', component: BlogEn },
+  },
+}

--- a/src/utils/wilksCoefficient.js
+++ b/src/utils/wilksCoefficient.js
@@ -1,0 +1,98 @@
+// IPF GL Points / Wilks-2020 coefficient — strength score normalising powerlifting
+// totals across bodyweight and sex.
+//
+// Formula (IPF / Wilks 2020):
+//   coeff(bw) = 600 / (A + B*bw + C*bw^2 + D*bw^3 + E*bw^4)
+//   score     = total_kg * coeff(bw)
+//
+// Constants below are the IPF 2020 published values for raw classic squat-bench-deadlift
+// totals. Male and female coefficients differ.
+
+const MALE = {
+  A: 47.46178854,
+  B: 8.472061379,
+  C: 0.07369410346,
+  D: -0.001395833811,
+  E: 7.07665973070743e-6,
+}
+
+const FEMALE = {
+  A: -125.4255398,
+  B: 13.71219419,
+  C: -0.03307250631,
+  D: -0.001050400051,
+  E: 9.38773881462799e-6,
+}
+
+const KG_PER_LB = 0.45359237
+
+export function kgFromLb(lb) {
+  return lb * KG_PER_LB
+}
+
+export function lbFromKg(kg) {
+  return kg / KG_PER_LB
+}
+
+function toPositive(v) {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+export function wilksCoefficient(bodyweightKg, sex) {
+  const bw = toPositive(bodyweightKg)
+  if (bw == null) return null
+  const k = sex === 'male' ? MALE : sex === 'female' ? FEMALE : null
+  if (!k) return null
+  const denom =
+    k.A +
+    k.B * bw +
+    k.C * bw * bw +
+    k.D * bw * bw * bw +
+    k.E * bw * bw * bw * bw
+  if (denom === 0) return null
+  return 600 / denom
+}
+
+export function calcWilks({ bodyweightKg, totalKg, sex }) {
+  const bw = toPositive(bodyweightKg)
+  const total = toPositive(totalKg)
+  if (bw == null || total == null) return null
+  const coeff = wilksCoefficient(bw, sex)
+  if (coeff == null || !Number.isFinite(coeff)) return null
+  return Math.round(total * coeff)
+}
+
+export function getWilksBand(score) {
+  if (score == null || !Number.isFinite(score)) return null
+  if (score >= 400) return 'elite'
+  if (score >= 300) return 'advanced'
+  if (score >= 200) return 'intermediate'
+  if (score >= 100) return 'novice'
+  return 'untrained'
+}
+
+const COLORS = {
+  untrained: 'text-stone-600',
+  novice: 'text-amber-600',
+  intermediate: 'text-emerald-600',
+  advanced: 'text-blue-600',
+  elite: 'text-purple-600',
+}
+
+const BGS = {
+  untrained: 'bg-stone-50 border-stone-200',
+  novice: 'bg-amber-50 border-amber-200',
+  intermediate: 'bg-emerald-50 border-emerald-200',
+  advanced: 'bg-blue-50 border-blue-200',
+  elite: 'bg-purple-50 border-purple-200',
+}
+
+export function bandColor(band) {
+  return COLORS[band] || 'text-stone-600'
+}
+
+export function bandBg(band) {
+  return BGS[band] || 'bg-white border-stone-200'
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-270-wilks-coefficient
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-270-wilks-coefficient-20260607-233022`
**Cost:** $10.991951

Closes jenslaufer/health-calculators#270

### Prompt
> Implement the Wilks Coefficient (powerlifting strength index) Calculator as described in issue #270.

Follow the EXACT same pattern as existing calculators in the repo.
Use the auto-discovery pattern — no shared file modifications.

Requirements:
- Vue 3 + Tailwind CSS calculator component
- Inputs: bodyweight (kg OR lb), total lifted (kg OR lb), sex (male / female) — metric/imperial toggle
- Formula: Wilks-2020 (IPF) polynomial — keep coefficient tables (separate male / female) inline in `src/utils/wilksCoefficient.js`. Use the IPF 2020 published constants.
- Output: Wilks score + strength band (Untrained <100, Novice 100–200, Intermediate 200–300, Advanced 300–400, Elite ≥400) — band depends on sex
- Blog articles: DE + EN (SEO optimized, FAQPage structured data)
- Internal links to oneRepMax, bmi, leanBodyMass, bodyFat
- Unit tests: 6+ cases incl. all 5 strength bands, male vs female coefficient, kg ↔ lb conversion, integer rounding, very-light vs very-heavy bodyweight
- E2E test
- SSG pre-rendering must work

## Internal linking (REQUIRED)
- Blog → own calculator + 2–3 related (oneRepMax, leanBodyMass, bmi)
- Calculator page → this blog (DE + EN)
- Verify every target route exists


## RETRY-AWARE no-diff guard
Before `git push`, run `git status`. If no new files staged → DO NOT push.


## PARTIAL-COMMIT GUARD (MANDATORY)
`git diff --name-only main..HEAD | sort` MUST contain:
  e2e/wilksCoefficient.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/sitemap.test.js
  src/__tests__/wilksCoefficient.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/wilksCoefficient.json
  src/locales/calculators/en/wilksCoefficient.json
  src/pages/WilksCoefficientCalculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/wilksCoefficient.meta.js
  src/utils/wilksCoefficient.js

Counter: `wc -l` >= 14. Missing → DO NOT push.

## EN BLOG COMPONENT IMPORT (MANDATORY)
In `src/pages/blog/en/<EnBlogPascal>.vue`, the related-articles component MUST be
`RelatedArticlesEn` (from `../../../components/RelatedArticlesEn.vue`),
NOT `RelatedArticles` (which is the German component using DE article slugs).
Pre-push check: `grep -E "^import RelatedArticles[^E]" src/pages/blog/en/<file>.vue`
MUST return ZERO lines. DE blog page keeps `RelatedArticles` unchanged.
Reference for correct import: `src/pages/blog/en/CholesterolRatio.vue`.

Reference: study `src/pages/OneRepMaxCalculator.vue` + matching meta/locales/tests/e2e.

## TDD-red-first ordering
1. Red unit tests (6+: 5 strength bands, male vs female coefficient, kg ↔ lb conversion, integer rounding, very-light bw, very-heavy bw).
2. Green logic (IPF 2020 polynomial).
3. View + locale JSON + meta anchor (key: 'wilksCoefficient', slugs: { de: 'wilks-coefficient-rechner', en: 'wilks-coefficient' }).
4. E2E test.
5. Blog DE + EN + articles*.js.
6. Final verify: `npm test` + `npm run test:e2e` + `npm run build`.

## Locale-Path + Meta-Anchor (CRITICAL)
Create `src/pages/wilksCoefficient.meta.js` + locales (mirror oneRepMax).

## HC blog-count + calculator-count assertion bump (MANDATORY)
`grep`, bump +1, append slugs.

## Register blog in articles*.js (MANDATORY)
Append entry to articles.js + articles-en.js (calculatorKey: 'wilksCoefficient').

## E2E Selector rules
- USE `getByRole`, `getByTestId`, `getByText(..., { exact: true })`.

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files (EXCEPT test + articles files)
- Only ADD new files