### PR TITLE
fix(hc-279): BMI gender-variant blogs — fixes RED main

### DIFF
--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -213,6 +213,8 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'knoechel-arm-index-berechnen',
   'pulsdruck-berechnen',
   'wilks-koeffizient-berechnen',
+  'bmi-bei-frauen',
+  'bmi-bei-maennern',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -297,6 +299,8 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'ankle-brachial-index-guide',
   'pulse-pressure-guide',
   'wilks-coefficient-guide',
+  'bmi-for-women',
+  'bmi-for-men',
 ]
 
 describe('calculator discovery', () => {
@@ -332,15 +336,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 93 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(93)
+  it('discovers all 95 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(95)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 93 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(93)
+  it('discovers all 95 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(95)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -438,8 +442,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 505 routes', () => {
-    expect(routes).toHaveLength(505)
+  it('generates exactly 511 routes', () => {
+    expect(routes).toHaveLength(511)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/blog-article-link.test.js
+++ b/src/__tests__/blog-article-link.test.js
@@ -46,7 +46,7 @@ describe('BlogArticleLink', () => {
     router.push('/de/')
     await router.isReady()
     const wrapper = mount(BlogArticleLink, {
-      props: { calculatorKey: 'bmiFrauen' },
+      props: { calculatorKey: '__no_such_calculator__' },
       global: { plugins: [i18n, router] },
     })
     expect(wrapper.find('a').exists()).toBe(false)

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 370 links (92 calcs × 2 locales + 93 blogs × 2 locales)', () => {
+  it('generates 374 links (92 calcs × 2 locales + 95 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(370)
+    expect(links).toHaveLength(374)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -111,6 +111,8 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'knoechel-arm-index-berechnen',
   'pulsdruck-berechnen',
   'wilks-koeffizient-berechnen',
+  'bmi-bei-frauen',
+  'bmi-bei-maennern',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -194,6 +196,8 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'ankle-brachial-index-guide',
   'pulse-pressure-guide',
   'wilks-coefficient-guide',
+  'bmi-for-women',
+  'bmi-for-men',
 ]
 
 describe('discoverMetas', () => {
@@ -237,19 +241,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 94 DE blog slugs', () => {
+  it('returns all 95 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(93)
+    expect(de).toHaveLength(95)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 94 EN blog slugs', () => {
+  it('returns all 95 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(93)
+    expect(en).toHaveLength(95)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -317,9 +321,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 184 calcs + 2 blog index + 186 blog articles = 374)', () => {
+  it('generates correct total URL count (2 home + 184 calcs + 2 blog index + 190 blog articles = 378)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(374)
+    expect(urlCount).toBe(378)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -836,6 +836,24 @@ slug: 'calculate-vo2max',
     calculatorKey: 'wilksCoefficient',
     related: ['calculate-one-rep-max', 'calculate-lean-body-mass', 'calculate-bmi'],
   },
+  {
+    slug: 'bmi-for-women',
+    title: 'BMI for Women: How Meaningful Is the Body Mass Index?',
+    description: 'Understand BMI for women: body-fat distribution vs men, hormonal phases, menopause weight shift, the pregnancy caveat and realistic healthy ranges. With a worked example.',
+    date: '2026-06-08',
+    readTime: '8 min',
+    calculatorKey: 'bmiFrauen',
+    related: ['calculate-bmi', 'calculate-ideal-weight', 'calculate-body-fat'],
+  },
+  {
+    slug: 'bmi-for-men',
+    title: 'BMI for Men: Muscle Mass, Belly Fat and the Limits of the Index',
+    description: 'Understand BMI for men: why muscle mass inflates it, why belly fat drives risk, BMI limits for athletes and waist circumference as a complement. With a worked example.',
+    date: '2026-06-08',
+    readTime: '8 min',
+    calculatorKey: 'bmiMaenner',
+    related: ['calculate-bmi', 'calculate-body-fat', 'calculate-ideal-weight'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -836,6 +836,24 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'wilksCoefficient',
     related: ['one-rep-max-berechnen', 'magermasse-berechnen', 'bmi-berechnen'],
   },
+  {
+    slug: 'bmi-bei-frauen',
+    title: 'BMI bei Frauen: Wie aussagekräftig ist der Body Mass Index?',
+    description: 'BMI bei Frauen verstehen: Körperfettverteilung, Hormonphasen, Wechseljahre und warum der BMI nicht nach Geschlecht unterscheidet. Mit Rechenbeispiel.',
+    date: '2026-06-08',
+    readTime: '8 min',
+    calculatorKey: 'bmiFrauen',
+    related: ['bmi-berechnen', 'idealgewicht-berechnen', 'koerperfett-berechnen'],
+  },
+  {
+    slug: 'bmi-bei-maennern',
+    title: 'BMI bei Männern: Muskelmasse, Bauchfett und die Grenzen des Index',
+    description: 'BMI bei Männern verstehen: warum Muskelmasse den Wert aufbläht, weshalb Bauchfett zählt, BMI-Grenzen für Sportler und der Taillenumfang als Ergänzung. Mit Rechenbeispiel.',
+    date: '2026-06-08',
+    readTime: '8 min',
+    calculatorKey: 'bmiMaenner',
+    related: ['bmi-berechnen', 'koerperfett-berechnen', 'idealgewicht-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/pages/BmiFrauenCalculator.vue
+++ b/src/pages/BmiFrauenCalculator.vue
@@ -7,6 +7,7 @@ import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
 
 const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
@@ -158,6 +159,7 @@ const barPosition = computed(() => getBmiBarPosition(bmi.value))
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <RelatedCalculators calc-key="bmiFrauen" class="mt-8" />
+    <BlogArticleLink calculator-key="bmiFrauen" />
     <AdSlot class="mt-8" />
   </div>
 </template>

--- a/src/pages/BmiMaennerCalculator.vue
+++ b/src/pages/BmiMaennerCalculator.vue
@@ -7,6 +7,7 @@ import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import AdSlot from '../components/AdSlot.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
 
 const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
@@ -158,6 +159,7 @@ const barPosition = computed(() => getBmiBarPosition(bmi.value))
     <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <RelatedCalculators calc-key="bmiMaenner" class="mt-8" />
+    <BlogArticleLink calculator-key="bmiMaenner" />
     <AdSlot class="mt-8" />
   </div>
 </template>

--- a/src/pages/blog/BmiBeiFrauen.vue
+++ b/src/pages/blog/BmiBeiFrauen.vue
@@ -1,0 +1,245 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'BMI bei Frauen: Wie aussagekräftig ist der Body Mass Index? | Health Calculators',
+  description: 'BMI bei Frauen verstehen: Körperfettverteilung, Hormonphasen, Wechseljahre und warum der BMI nicht nach Geschlecht unterscheidet. Mit Rechenbeispiel.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'BMI bei Frauen: Wie aussagekräftig ist der Body Mass Index?',
+    description: 'BMI bei Frauen verstehen: Körperfettverteilung, Hormonphasen, Wechseljahre und warum der BMI nicht nach Geschlecht unterscheidet. Mit Rechenbeispiel.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-06-08',
+    dateModified: '2026-06-08',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/bmi-bei-frauen',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">BMI bei Frauen: Wie aussagekräftig ist der Body Mass Index?</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">8. Juni 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der <strong>BMI</strong> verwendet für Männer und Frauen dieselbe Formel und dieselben Grenzwerte. Das ist praktisch — aber irreführend. Denn der weibliche Körper unterscheidet sich beim Fettanteil, bei der Fettverteilung und im Verlauf der Hormonphasen deutlich vom männlichen.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Artikel erfährst du, wie du den <strong>BMI bei Frauen</strong> richtig einordnest, welche Lebensphasen das Gewicht verschieben und warum der BMI ein guter Startpunkt, aber kein vollständiges Bild ist.
+        </p>
+      </div>
+
+      <!-- Gleiche Formel, anderer Körper -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Gleiche Formel, anderer Körper</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die BMI-Formel ist geschlechtsneutral:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4 text-center">
+          <p class="text-lg font-semibold text-stone-900">BMI = Körpergewicht (kg) &divide; Körpergröße (m)&sup2;</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Frauen haben jedoch von Natur aus einen höheren Körperfettanteil als Männer — bei gleichem BMI typischerweise rund <strong>8 bis 10 Prozentpunkte mehr</strong>. Ein gesunder Körperfettanteil liegt bei Frauen etwa zwischen 21 und 33 %, bei Männern zwischen 8 und 20 %. Der BMI „sieht" diesen Unterschied nicht: Eine Frau und ein Mann mit identischem BMI von 24 haben eine völlig unterschiedliche Körperzusammensetzung.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Hinzu kommt die <strong>Fettverteilung</strong>: Frauen lagern Fett eher an Hüften, Gesäß und Oberschenkeln ein (gynoide oder „Birnen"-Form), Männer eher am Bauch (androide oder „Apfel"-Form). Bauchfett ist stoffwechselaktiver und gesundheitlich riskanter — ein weiterer Grund, warum derselbe BMI nicht dasselbe Risiko bedeutet.
+        </p>
+      </div>
+
+      <!-- BMI-Tabelle -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI-Tabelle: WHO-Klassifikation (gilt für beide Geschlechter)</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die WHO definiert dieselben Bereiche für Frauen und Männer:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">BMI</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Gesundheitsrisiko</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-blue-400 mr-2"></span>Untergewicht
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 18,5</td>
+                <td class="px-6 py-3 text-stone-500">Erhöht (u.&nbsp;a. Zyklusstörungen)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-green-600 mr-2"></span>Normalgewicht
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">18,5 – 24,9</td>
+                <td class="px-6 py-3 text-stone-500">Gering</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-yellow-500 mr-2"></span>Übergewicht
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">25,0 – 29,9</td>
+                <td class="px-6 py-3 text-stone-500">Leicht erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-orange-500 mr-2"></span>Adipositas Grad I
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">30,0 – 34,9</td>
+                <td class="px-6 py-3 text-stone-500">Erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-400 mr-2"></span>Adipositas Grad II
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">35,0 – 39,9</td>
+                <td class="px-6 py-3 text-stone-500">Hoch</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-600 mr-2"></span>Adipositas Grad III
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 40,0</td>
+                <td class="px-6 py-3 text-stone-500">Sehr hoch</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wichtig: Auffällig niedriges Gewicht (BMI unter 18,5) kann bei Frauen den Zyklus stören und bis zum Ausbleiben der Periode (Amenorrhö) führen. Ein BMI im unteren Normbereich ist nicht automatisch „gesünder".
+        </p>
+      </div>
+
+      <!-- Hormonphasen -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hormonphasen und Gewicht über den Zyklus</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Das Gewicht einer Frau schwankt über den Monat — der BMI tut das nicht absichtlich, reagiert aber auf jede Tageswaage.
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Zyklusbedingte Wassereinlagerung</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              In der zweiten Zyklushälfte (Lutealphase) und kurz vor der Periode lagert der Körper durch den Progesteron- und Östrogenverlauf häufig 1–2 kg Wasser ein. Dieses Gewicht ist kein Fett — wiege dich für eine stabile BMI-Einschätzung immer zur gleichen Zyklusphase, am besten morgens nüchtern.
+          </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Hormonelle Verhütung</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Manche Frauen berichten unter hormoneller Verhütung über leichte Gewichtsveränderungen, meist durch Wassereinlagerung. Der Effekt auf den BMI ist in der Regel klein und individuell.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Wechseljahre -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Wechseljahre: Wenn sich Gewicht und Fettverteilung verschieben</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Mit der Menopause sinkt der Östrogenspiegel. Das hat zwei Folgen für den Körper:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Verschiebung zum Bauchfett</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Fett wird zunehmend am Bauch statt an Hüften und Oberschenkeln eingelagert — der Körper nähert sich der androiden Verteilung an. Das erhöht das kardiometabolische Risiko, ohne dass der BMI sich verändern muss.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Sinkender Grundumsatz und Muskelabbau</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Mit dem Alter nimmt die Muskelmasse ab (Sarkopenie), der Grundumsatz sinkt. Bei gleichbleibender Ernährung steigt das Gewicht oft langsam an. Krafttraining und ausreichend Protein wirken dem entgegen.
+            </p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mt-4">
+          Gerade in den Wechseljahren ist der Taillenumfang aussagekräftiger als der BMI: Ein Taillenumfang ab etwa <strong>80 cm</strong> gilt bei Frauen als Warnsignal, ab <strong>88 cm</strong> als deutlich erhöhtes Risiko.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deinen BMI als Frau berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Sofortergebnis mit Kategorie-Einordnung — kostenlos und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('bmiFrauen')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <!-- Schwangerschaft -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Schwangerschaft: Der BMI ist hier nicht das richtige Werkzeug</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Während der Schwangerschaft ist die Gewichtszunahme erwünscht und gesund — der normale BMI-Maßstab passt hier nicht. Statt den aktuellen BMI zu bewerten, betrachten Fachleute den <strong>Vor-Schwangerschafts-BMI</strong> und leiten daraus die empfohlene Gewichtszunahme nach den IOM-2009-Leitlinien ab.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Wenn du schwanger bist oder eine Schwangerschaft planst, nutze deshalb einen
+          <router-link :to="localeBlogPath('bmi-schwangerschaft-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Ansatz für die Schwangerschaft</router-link>
+          statt des Standard-Rechners.
+        </p>
+      </div>
+
+      <!-- Rechenbeispiel -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Rechenbeispiel: BMI einer Frau einordnen</h2>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base text-stone-700 leading-relaxed mb-2"><strong>Anna, 38 Jahre, 1,68 m, 65 kg:</strong></p>
+          <p class="text-base text-stone-700 leading-relaxed mb-2">BMI = 65 &divide; (1,68 &times; 1,68) = 65 &divide; 2,8224 = <strong>23,0</strong></p>
+          <p class="text-sm text-stone-500 leading-relaxed">Das liegt im <strong>Normalgewicht</strong> (18,5–24,9). Annas Körperfettanteil von z.&nbsp;B. 27 % ist für eine Frau ihres Alters völlig gesund — bei einem Mann mit demselben BMI wäre derselbe Fettanteil bereits erhöht.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Steigt Annas Gewicht in den Wechseljahren auf 72 kg, ergibt sich ein BMI von 25,5 (leichtes Übergewicht). Entscheidend ist dann nicht allein die Zahl, sondern <em>wo</em> die zusätzlichen Kilos sitzen — ein Taillenumfang unter 80 cm relativiert das Risiko deutlich.
+        </p>
+      </div>
+
+      <!-- Disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          <strong>Hinweis:</strong> BMI ist ein grober Richtwert und ersetzt keine ärztliche Beurteilung. Bei Zyklusstörungen, ungewollter Gewichtsveränderung oder Fragen rund um Schwangerschaft und Wechseljahre wende dich an deine Ärztin oder deinen Arzt.
+        </p>
+      </div>
+
+      <!-- Fazit -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der BMI ist auch für Frauen ein nützlicher erster Anhaltspunkt — aber er unterscheidet nicht nach Geschlecht, ignoriert die Fettverteilung und reagiert auf zyklus- und hormonbedingte Schwankungen. Ergänze ihn deshalb mit Taillenumfang und Körperfettanteil.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Berechne deinen Wert mit unserem
+          <router-link :to="localePath('bmiFrauen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner für Frauen</router-link>,
+          lies die Grundlagen im
+          <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">allgemeinen BMI-Artikel</router-link>
+          und ergänze das Ergebnis mit deinem
+          <router-link :to="localeBlogPath('koerperfett-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Körperfettanteil</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticles slug="bmi-bei-frauen" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/BmiBeiMaennern.vue
+++ b/src/pages/blog/BmiBeiMaennern.vue
@@ -1,0 +1,253 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'BMI bei Männern: Muskelmasse, Bauchfett & die Grenzen des Index | Health Calculators',
+  description: 'BMI bei Männern verstehen: warum Muskelmasse den Wert aufbläht, weshalb Bauchfett zählt, BMI-Grenzen für Sportler und der Taillenumfang als Ergänzung. Mit Rechenbeispiel.',
+  routeKey: 'blogArticle',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'BMI bei Männern: Muskelmasse, Bauchfett und die Grenzen des Index',
+    description: 'BMI bei Männern verstehen: warum Muskelmasse den Wert aufbläht, weshalb Bauchfett zählt, BMI-Grenzen für Sportler und der Taillenumfang als Ergänzung. Mit Rechenbeispiel.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-06-08',
+    dateModified: '2026-06-08',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/de/blog/bmi-bei-maennern',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">BMI bei Männern: Muskelmasse, Bauchfett und die Grenzen des Index</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">8. Juni 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Beim <strong>BMI bei Männern</strong> kollidieren zwei Effekte: Mehr Muskelmasse treibt den Wert nach oben, ohne dass das Gesundheitsrisiko steigt — gleichzeitig sitzt Fett bei Männern bevorzugt am Bauch, wo es besonders gefährlich ist. Der BMI allein kann beide Punkte nicht auseinanderhalten.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Artikel erfährst du, warum der BMI bei muskulösen Männern in die Irre führt, wo seine Grenzen bei Sportlern liegen und warum der Taillenumfang die entscheidende Ergänzung ist.
+        </p>
+      </div>
+
+      <!-- Muskelmasse -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Muskelmasse bläht den BMI auf</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der BMI nutzt für alle dieselbe Formel:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4 text-center">
+          <p class="text-lg font-semibold text-stone-900">BMI = Körpergewicht (kg) &divide; Körpergröße (m)&sup2;</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Männer haben im Schnitt mehr Muskelmasse als Frauen — und Muskeln sind dichter und schwerer als Fett. Der BMI „sieht" nur das Gesamtgewicht und kann nicht unterscheiden, ob es aus Muskeln oder Fett besteht. Ein durchtrainierter Mann landet deshalb schnell im Bereich „Übergewicht", obwohl sein Körperfettanteil niedrig ist.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Beispiel:</strong> Ein Kraftsportler mit 100 kg bei 1,80 m hat einen BMI von 100 &divide; (1,80 &times; 1,80) = <strong>30,9</strong> — laut Tabelle „adipös", obwohl er sichtbar definiert ist. Für ihn ist der BMI schlicht das falsche Werkzeug.
+        </p>
+      </div>
+
+      <!-- BMI-Tabelle -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI-Tabelle: WHO-Klassifikation</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Die WHO definiert dieselben Bereiche für Männer und Frauen:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Kategorie</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">BMI</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Gesundheitsrisiko</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-blue-400 mr-2"></span>Untergewicht
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 18,5</td>
+                <td class="px-6 py-3 text-stone-500">Erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-green-600 mr-2"></span>Normalgewicht
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">18,5 – 24,9</td>
+                <td class="px-6 py-3 text-stone-500">Gering</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-yellow-500 mr-2"></span>Übergewicht
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">25,0 – 29,9</td>
+                <td class="px-6 py-3 text-stone-500">Leicht erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-orange-500 mr-2"></span>Adipositas Grad I
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">30,0 – 34,9</td>
+                <td class="px-6 py-3 text-stone-500">Erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-400 mr-2"></span>Adipositas Grad II
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">35,0 – 39,9</td>
+                <td class="px-6 py-3 text-stone-500">Hoch</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-600 mr-2"></span>Adipositas Grad III
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 40,0</td>
+                <td class="px-6 py-3 text-stone-500">Sehr hoch</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Bauchfett -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Bauchfett: Das eigentliche Risiko</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Männer lagern Fett bevorzugt am Bauch ein (androide oder „Apfel"-Form). Dieses <strong>viszerale Fett</strong> umgibt die inneren Organe, ist stoffwechselaktiv und mit einem höheren Risiko für Typ-2-Diabetes, Bluthochdruck und Herz-Kreislauf-Erkrankungen verbunden.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Das Tückische: Zwei Männer mit demselben BMI von 27 können völlig unterschiedliche Risiken haben — der eine trägt das Gewicht als Muskeln, der andere als Bauchfett. Der BMI allein verrät das nicht. Genau hier setzt der Taillenumfang an.
+        </p>
+      </div>
+
+      <!-- BMI-Grenzen für Sportler -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI-Grenzen für Sportler und muskulöse Männer</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Kraftsportler und Bodybuilder</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Bei hoher Muskelmasse überschätzt der BMI das Risiko systematisch. Hier sind Körperfettanteil und fettfreie Masse (FFMI) deutlich aussagekräftiger.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Ausdauersportler</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Läufer und Radfahrer liegen oft im unteren Normbereich. Für sie funktioniert der BMI besser, weil ihre Muskelmasse moderat ist — trotzdem ergänzt der Taillenumfang das Bild.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">„Skinny Fat" — schlank, aber fettreich</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Manche Männer haben einen normalen BMI, aber wenig Muskeln und viel Bauchfett. Hier <em>unterschätzt</em> der BMI das Risiko. Ein normaler BMI ist also keine Entwarnung.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deinen BMI als Mann berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Sofortergebnis mit Kategorie-Einordnung — kostenlos und ohne Anmeldung.</p>
+        <router-link
+          :to="localePath('bmiMaenner')"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Jetzt kostenlos berechnen &rarr;</router-link>
+      </div>
+
+      <!-- Taillenumfang -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Taillenumfang als Ergänzung zum BMI</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der Taillenumfang misst direkt das Bauchfett — genau die Größe, die der BMI ignoriert. Miss morgens nüchtern, im Stehen, etwa auf Höhe des Bauchnabels und ohne den Bauch einzuziehen.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Taillenumfang (Mann)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Risiko</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 94 cm</td>
+                <td class="px-6 py-3 text-stone-500">Gering</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">94 – 102 cm</td>
+                <td class="px-6 py-3 text-stone-500">Erhöht</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&gt; 102 cm</td>
+                <td class="px-6 py-3 text-stone-500">Deutlich erhöht</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          BMI und Taillenumfang gemeinsam ergeben ein viel verlässlicheres Bild: Ein hoher BMI bei schlanker Taille deutet eher auf Muskeln hin, ein normaler BMI bei dickem Bauch auf verstecktes Risiko.
+        </p>
+      </div>
+
+      <!-- Rechenbeispiel -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Rechenbeispiel: BMI eines Mannes einordnen</h2>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base text-stone-700 leading-relaxed mb-2"><strong>Markus, 35 Jahre, 1,82 m, 92 kg:</strong></p>
+          <p class="text-base text-stone-700 leading-relaxed mb-2">BMI = 92 &divide; (1,82 &times; 1,82) = 92 &divide; 3,3124 = <strong>27,8</strong></p>
+          <p class="text-sm text-stone-500 leading-relaxed">Das liegt im Bereich <strong>Übergewicht</strong> (25,0–29,9). Entscheidend ist jetzt der Taillenumfang: Misst Markus 90 cm, ist das Risiko gering — der hohe BMI stammt aus Muskelmasse vom Krafttraining. Misst er 105 cm, ist das Risiko trotz identischem BMI deutlich erhöht.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Dieselbe BMI-Zahl, zwei völlig verschiedene Gesundheitslagen — genau deshalb sollte der BMI bei Männern nie isoliert betrachtet werden.
+        </p>
+      </div>
+
+      <!-- Disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          <strong>Hinweis:</strong> BMI ist ein grober Richtwert und ersetzt keine ärztliche Beurteilung. Bei Bluthochdruck, auffälligen Blutwerten oder deutlich erhöhtem Taillenumfang sprich mit deinem Arzt oder deiner Ärztin.
+        </p>
+      </div>
+
+      <!-- Fazit -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Fazit</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Bei Männern kann der BMI in beide Richtungen täuschen: Muskelmasse treibt ihn nach oben, „Skinny Fat" verschleiert das Risiko nach unten. Der Taillenumfang macht den entscheidenden Unterschied sichtbar — das Bauchfett.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Berechne deinen Wert mit unserem
+          <router-link :to="localePath('bmiMaenner')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI-Rechner für Männer</router-link>,
+          lies die Grundlagen im
+          <router-link :to="localeBlogPath('bmi-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">allgemeinen BMI-Artikel</router-link>
+          und ergänze das Ergebnis mit deinem
+          <router-link :to="localeBlogPath('koerperfett-berechnen')" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">Körperfettanteil</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticles slug="bmi-bei-maennern" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/BmiForMen.vue
+++ b/src/pages/blog/en/BmiForMen.vue
@@ -1,0 +1,250 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+
+useHead({
+  title: 'BMI for Men: Muscle Mass, Belly Fat & the Limits of the Index | Health Calculators',
+  description: 'Understand BMI for men: why muscle mass inflates it, why belly fat drives risk, BMI limits for athletes and waist circumference as a complement. With a worked example.',
+  path: '/en/blog/bmi-for-men',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'BMI for Men: Muscle Mass, Belly Fat and the Limits of the Index',
+    description: 'Understand BMI for men: why muscle mass inflates it, why belly fat drives risk, BMI limits for athletes and waist circumference as a complement. With a worked example.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-06-08',
+    dateModified: '2026-06-08',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/bmi-for-men',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link to="/en/blog" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">BMI for Men: Muscle Mass, Belly Fat and the Limits of the Index</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">June 8, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          For <strong>BMI in men</strong>, two effects collide: more muscle mass pushes the number up without raising health risk, while fat in men preferentially sits on the belly, where it's most dangerous. BMI alone can't tell these two apart.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article explains why BMI misleads for muscular men, where its limits lie for athletes, and why waist circumference is the crucial complement.
+        </p>
+      </div>
+
+      <!-- Muscle mass -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Muscle mass inflates BMI</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          BMI uses the same formula for everyone:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4 text-center">
+          <p class="text-lg font-semibold text-stone-900">BMI = Body weight (kg) &divide; Height (m)&sup2;</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          On average, men carry more muscle than women — and muscle is denser and heavier than fat. BMI only "sees" total weight; it can't tell whether that weight is muscle or fat. A well-trained man therefore lands in the "overweight" band quickly, even with a low body-fat percentage.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          <strong>Example:</strong> a strength athlete weighing 100 kg at 1.80 m has a BMI of 100 &divide; (1.80 &times; 1.80) = <strong>30.9</strong> — labelled "obese" by the table, despite being visibly lean. For him, BMI is simply the wrong tool.
+        </p>
+      </div>
+
+      <!-- BMI table -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI table: WHO classification</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The WHO defines the same ranges for men and women:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">BMI</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Health risk</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-blue-400 mr-2"></span>Underweight
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 18.5</td>
+                <td class="px-6 py-3 text-stone-500">Increased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-green-600 mr-2"></span>Normal weight
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">18.5 – 24.9</td>
+                <td class="px-6 py-3 text-stone-500">Low</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-yellow-500 mr-2"></span>Overweight
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">25.0 – 29.9</td>
+                <td class="px-6 py-3 text-stone-500">Slightly increased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-orange-500 mr-2"></span>Obesity Class I
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">30.0 – 34.9</td>
+                <td class="px-6 py-3 text-stone-500">Increased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-400 mr-2"></span>Obesity Class II
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">35.0 – 39.9</td>
+                <td class="px-6 py-3 text-stone-500">High</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-600 mr-2"></span>Obesity Class III
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 40.0</td>
+                <td class="px-6 py-3 text-stone-500">Very high</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Belly fat -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Belly fat: the real risk</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Men preferentially store fat around the abdomen (an android or "apple" shape). This <strong>visceral fat</strong> surrounds the internal organs, is metabolically active, and is linked to higher risk of type 2 diabetes, high blood pressure and cardiovascular disease.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The catch: two men with the same BMI of 27 can carry very different risk — one holds the weight as muscle, the other as belly fat. BMI alone won't reveal this. That's exactly where waist circumference comes in.
+        </p>
+      </div>
+
+      <!-- BMI limits for athletes -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI limits for athletes and muscular men</h2>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Strength athletes and bodybuilders</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              With high muscle mass, BMI systematically overstates risk. Here, body-fat percentage and fat-free mass index (FFMI) are far more meaningful.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Endurance athletes</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Runners and cyclists often sit at the lower end of the normal range. BMI works better for them because their muscle mass is moderate — yet waist circumference still rounds out the picture.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">"Skinny fat" — lean but fat-rich</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Some men have a normal BMI but little muscle and a lot of belly fat. Here BMI <em>understates</em> risk. A normal BMI is therefore not an all-clear.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your BMI as a man now</h3>
+        <p class="text-stone-300 text-sm mb-5">Instant result with category classification — free and no sign-up required.</p>
+        <router-link
+          to="/en/bmi-calculator-men"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free now &rarr;</router-link>
+      </div>
+
+      <!-- Waist circumference -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Waist circumference as a complement to BMI</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Waist circumference directly measures belly fat — the very thing BMI ignores. Measure in the morning on an empty stomach, standing, roughly at navel height, without sucking in your stomach.
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Waist circumference (men)</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Risk</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 94 cm</td>
+                <td class="px-6 py-3 text-stone-500">Low</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">94 – 102 cm</td>
+                <td class="px-6 py-3 text-stone-500">Increased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&gt; 102 cm</td>
+                <td class="px-6 py-3 text-stone-500">Markedly increased</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          BMI and waist circumference together give a far more reliable picture: a high BMI with a slim waist points to muscle, while a normal BMI with a thick waist points to hidden risk.
+        </p>
+      </div>
+
+      <!-- Worked example -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Worked example: reading a man's BMI</h2>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base text-stone-700 leading-relaxed mb-2"><strong>Mark, 35, 1.82 m, 92 kg:</strong></p>
+          <p class="text-base text-stone-700 leading-relaxed mb-2">BMI = 92 &divide; (1.82 &times; 1.82) = 92 &divide; 3.3124 = <strong>27.8</strong></p>
+          <p class="text-sm text-stone-500 leading-relaxed">That's in the <strong>overweight</strong> band (25.0–29.9). The decider now is waist circumference: at 90 cm his risk is low — the high BMI comes from muscle built through strength training. At 105 cm his risk is markedly higher despite the identical BMI.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Same BMI number, two completely different health situations — which is exactly why BMI should never be read in isolation for men.
+        </p>
+      </div>
+
+      <!-- Disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          <strong>Note:</strong> BMI is a rough indicator and does not replace medical assessment. For high blood pressure, abnormal blood work, or a markedly increased waist circumference, talk to your doctor.
+        </p>
+      </div>
+
+      <!-- Conclusion -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conclusion</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          For men, BMI can mislead in both directions: muscle mass pushes it up, "skinny fat" hides risk below it. Waist circumference makes the decisive factor visible — belly fat.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Calculate your value with our
+          <router-link to="/en/bmi-calculator-men" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI calculator for men</router-link>,
+          read the basics in the
+          <router-link to="/en/blog/calculate-bmi" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">general BMI article</router-link>,
+          and complement the result with your
+          <router-link to="/en/blog/calculate-body-fat" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">body fat percentage</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="bmi-for-men" />
+    </div>
+  </article>
+</template>

--- a/src/pages/blog/en/BmiForWomen.vue
+++ b/src/pages/blog/en/BmiForWomen.vue
@@ -1,0 +1,242 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+
+useHead({
+  title: 'BMI for Women: How Meaningful Is the Body Mass Index? | Health Calculators',
+  description: 'Understand BMI for women: body-fat distribution vs men, hormonal phases, menopause weight shift, the pregnancy caveat and realistic healthy ranges. With a worked example.',
+  path: '/en/blog/bmi-for-women',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'BMI for Women: How Meaningful Is the Body Mass Index?',
+    description: 'Understand BMI for women: body-fat distribution vs men, hormonal phases, menopause weight shift, the pregnancy caveat and realistic healthy ranges. With a worked example.',
+    author: { '@type': 'Organization', name: 'Health Calculators' },
+    publisher: { '@type': 'Organization', name: 'Health Calculators' },
+    datePublished: '2026-06-08',
+    dateModified: '2026-06-08',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://healthcalculator.app/en/blog/bmi-for-women',
+    },
+  },
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link to="/en/blog" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">BMI for Women: How Meaningful Is the Body Mass Index?</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">June 8, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+
+      <!-- Intro -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          <strong>BMI</strong> uses the same formula and the same thresholds for women and men. That makes it convenient — but misleading. A woman's body differs from a man's in body-fat percentage, in where that fat sits, and across hormonal phases.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This article explains how to read <strong>BMI for women</strong> correctly, which life stages shift your weight, and why BMI is a useful starting point but never the full picture.
+        </p>
+      </div>
+
+      <!-- Same formula, different body -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Same formula, different body</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The BMI formula is sex-neutral:
+        </p>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4 text-center">
+          <p class="text-lg font-semibold text-stone-900">BMI = Body weight (kg) &divide; Height (m)&sup2;</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Yet women naturally carry a higher body-fat percentage than men — typically <strong>8 to 10 percentage points more</strong> at the same BMI. A healthy body-fat range for women is roughly 21–33%, for men 8–20%. BMI cannot see this difference: a woman and a man with an identical BMI of 24 have very different body composition.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          There's also <strong>fat distribution</strong>: women tend to store fat on the hips, buttocks and thighs (a gynoid or "pear" shape), men on the belly (an android or "apple" shape). Belly fat is more metabolically active and carries higher health risk — another reason the same BMI doesn't mean the same risk.
+        </p>
+      </div>
+
+      <!-- BMI table -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">BMI table: WHO classification (applies to both sexes)</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The WHO defines the same ranges for women and men:
+        </p>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-4">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Category</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">BMI</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Health risk</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-blue-400 mr-2"></span>Underweight
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&lt; 18.5</td>
+                <td class="px-6 py-3 text-stone-500">Increased (incl. cycle disruption)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-green-600 mr-2"></span>Normal weight
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">18.5 – 24.9</td>
+                <td class="px-6 py-3 text-stone-500">Low</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-yellow-500 mr-2"></span>Overweight
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">25.0 – 29.9</td>
+                <td class="px-6 py-3 text-stone-500">Slightly increased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-orange-500 mr-2"></span>Obesity Class I
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">30.0 – 34.9</td>
+                <td class="px-6 py-3 text-stone-500">Increased</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-400 mr-2"></span>Obesity Class II
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">35.0 – 39.9</td>
+                <td class="px-6 py-3 text-stone-500">High</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-600">
+                  <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-600 mr-2"></span>Obesity Class III
+                </td>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">&ge; 40.0</td>
+                <td class="px-6 py-3 text-stone-500">Very high</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Note: an unusually low BMI (under 18.5) can disrupt the menstrual cycle and even cause periods to stop (amenorrhea). A BMI at the bottom of the normal range is not automatically "healthier".
+        </p>
+      </div>
+
+      <!-- Hormonal phases -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Hormonal phases and weight across the cycle</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          A woman's weight fluctuates across the month — BMI doesn't fluctuate on purpose, but it responds to every reading on the scale.
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Cycle-related water retention</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              In the second half of the cycle (luteal phase) and just before the period, hormonal shifts often lead the body to retain 1–2 kg of water. That weight isn't fat — for a stable BMI reading, always weigh yourself at the same cycle phase, ideally in the morning on an empty stomach.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Hormonal contraception</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Some women report slight weight changes on hormonal contraception, usually from water retention. The effect on BMI is typically small and varies from person to person.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Menopause -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Menopause: when weight and fat distribution shift</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          As estrogen levels fall during menopause, two things happen to the body:
+        </p>
+        <div class="space-y-4">
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">A shift toward belly fat</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              Fat is increasingly stored around the abdomen rather than the hips and thighs — the body moves toward the android pattern. This raises cardiometabolic risk even when BMI stays the same.
+            </p>
+          </div>
+          <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-base font-semibold text-stone-900 mb-2">Falling metabolic rate and muscle loss</h3>
+            <p class="text-sm text-stone-500 leading-relaxed">
+              With age, muscle mass declines (sarcopenia) and the basal metabolic rate drops. With unchanged eating habits, weight often creeps up. Strength training and adequate protein counteract this.
+            </p>
+          </div>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed mt-4">
+          Around menopause especially, waist circumference is more telling than BMI: a waist from about <strong>80 cm</strong> is a warning sign for women, and from <strong>88 cm</strong> a markedly increased risk.
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Calculate your BMI as a woman now</h3>
+        <p class="text-stone-300 text-sm mb-5">Instant result with category classification — free and no sign-up required.</p>
+        <router-link
+          to="/en/bmi-calculator-women"
+          class="inline-block bg-white text-stone-900 font-semibold text-sm px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors duration-150"
+        >Calculate for free now &rarr;</router-link>
+      </div>
+
+      <!-- Pregnancy -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Pregnancy: BMI is not the right tool here</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          During pregnancy, weight gain is expected and healthy — the standard BMI scale doesn't apply. Instead of judging your current BMI, clinicians look at your <strong>pre-pregnancy BMI</strong> and derive the recommended weight gain from the IOM 2009 guidelines.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          If you're pregnant or planning to be, use a
+          <router-link to="/en/blog/pregnancy-bmi-guide" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">pregnancy-BMI approach</router-link>
+          rather than the standard calculator.
+        </p>
+      </div>
+
+      <!-- Worked example -->
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Worked example: reading a woman's BMI</h2>
+        <div class="bg-stone-50 border border-stone-200 rounded-lg p-6 mb-4">
+          <p class="text-base text-stone-700 leading-relaxed mb-2"><strong>Anna, 38, 1.68 m, 65 kg:</strong></p>
+          <p class="text-base text-stone-700 leading-relaxed mb-2">BMI = 65 &divide; (1.68 &times; 1.68) = 65 &divide; 2.8224 = <strong>23.0</strong></p>
+          <p class="text-sm text-stone-500 leading-relaxed">That's <strong>normal weight</strong> (18.5–24.9). Anna's body-fat percentage of, say, 27% is perfectly healthy for a woman her age — the same fat percentage in a man would already be elevated.</p>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          If Anna's weight rises to 72 kg during menopause, her BMI becomes 25.5 (mild overweight). What matters then isn't the number alone but <em>where</em> the extra kilos sit — a waist under 80 cm meaningfully lowers the risk picture.
+        </p>
+      </div>
+
+      <!-- Disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed">
+          <strong>Note:</strong> BMI is a rough indicator and does not replace medical assessment. For cycle disruption, unintended weight changes, or questions about pregnancy and menopause, talk to your doctor.
+        </p>
+      </div>
+
+      <!-- Conclusion -->
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Conclusion</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          BMI is a useful first reference for women too — but it doesn't distinguish by sex, ignores fat distribution, and reacts to cycle- and hormone-driven swings. Complement it with waist circumference and body-fat percentage.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Calculate your value with our
+          <router-link to="/en/bmi-calculator-women" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">BMI calculator for women</router-link>,
+          read the basics in the
+          <router-link to="/en/blog/calculate-bmi" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">general BMI article</router-link>,
+          and complement the result with your
+          <router-link to="/en/blog/calculate-body-fat" class="font-semibold text-stone-900 underline underline-offset-2 hover:text-stone-600 transition-colors">body fat percentage</router-link>.
+        </p>
+      </div>
+
+      <RelatedArticlesEn slug="bmi-for-women" />
+    </div>
+  </article>
+</template>

--- a/src/pages/bmi-frauen.meta.js
+++ b/src/pages/bmi-frauen.meta.js
@@ -1,4 +1,6 @@
 import Component from './BmiFrauenCalculator.vue'
+import BlogDe from './blog/BmiBeiFrauen.vue'
+import BlogEn from './blog/en/BmiForWomen.vue'
 
 export default {
   key: 'bmiFrauen',
@@ -7,4 +9,8 @@ export default {
   group: 'bodyComposition',
   groupOrder: 0,
   order: 7,
+  blog: {
+    de: { slug: 'bmi-bei-frauen', component: BlogDe },
+    en: { slug: 'bmi-for-women', component: BlogEn },
+  },
 }

--- a/src/pages/bmi-maenner.meta.js
+++ b/src/pages/bmi-maenner.meta.js
@@ -1,4 +1,6 @@
 import Component from './BmiMaennerCalculator.vue'
+import BlogDe from './blog/BmiBeiMaennern.vue'
+import BlogEn from './blog/en/BmiForMen.vue'
 
 export default {
   key: 'bmiMaenner',
@@ -7,4 +9,8 @@ export default {
   group: 'bodyComposition',
   groupOrder: 0,
   order: 8,
+  blog: {
+    de: { slug: 'bmi-bei-maennern', component: BlogDe },
+    en: { slug: 'bmi-for-men', component: BlogEn },
+  },
 }


### PR DESCRIPTION
## Problem

`main` is RED. `blog-link-coverage.test.js` (hardened in #280) fails because `bmi-frauen.meta.js` and `bmi-maenner.meta.js` have calculator components but no `blog:` block.

#280 (issue #279) claimed "Add BMI gender-variant blog articles" but its diff was **3 test files only** — count-bumps + a coverage-test hardening, **zero blog content**. So it raised the bar and shipped nothing to clear it → 2 failing tests on main.

## Fix

Adds the 4 missing blogs and wires them in:

- `src/pages/blog/BmiBeiFrauen.vue`, `BmiBeiMaennern.vue` (DE)
- `src/pages/blog/en/BmiForWomen.vue`, `BmiForMen.vue` (EN)
- `bmi-frauen.meta.js` / `bmi-maenner.meta.js`: `blog: { de, en }` blocks
- `articles.js` / `articles-en.js`: 2 article entries each
- `BmiFrauenCalculator.vue` / `BmiMaennerCalculator.vue`: `BlogArticleLink`
- test count-bumps: auto-discovery, blog-article-link, llms-txt, sitemap

## Verification

- `vitest run`: **2649 pass** (broken main: 2 failing — fails on broken, passes on fix)
- `npm run build`: OK, 4 BMI blog pages render DE+EN
- sitemap: 378 URLs, all 4 BMI blogs included

Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)