### PR TITLE
hc-273-gad7-anxiety: Implement the GAD-7 Anxiety Screening Calculator as describe

### DIFF
--- a/e2e/gad7.spec.js
+++ b/e2e/gad7.spec.js
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test'
+
+const GAD7_KEYS = [
+  'feelingNervous',
+  'cantStopWorrying',
+  'worryingTooMuch',
+  'troubleRelaxing',
+  'restless',
+  'irritable',
+  'afraidSomethingAwful',
+]
+
+async function answerAll(page, value) {
+  for (const q of GAD7_KEYS) {
+    await page.getByTestId(`option-${q}-${value}`).click()
+  }
+}
+
+test.describe('GAD-7 Anxiety Screening (DE)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('de/gad-7-angst-test')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/GAD-7/)
+  })
+
+  test('h1 matches', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('GAD-7')
+  })
+
+  test('back link navigates home', async ({ page }) => {
+    await page.getByRole('link', { name: '← Alle Rechner' }).click()
+    await expect(page).toHaveURL(/\/de\/?$/)
+  })
+
+  test('result hidden before all answers', async ({ page }) => {
+    await expect(page.getByTestId('result-score')).not.toBeVisible()
+    await expect(page.getByTestId('incomplete-hint')).toBeVisible()
+  })
+
+  test('all 0 → score 0, Minimal', async ({ page }) => {
+    await answerAll(page, 0)
+    await expect(page.getByTestId('result-score')).toHaveText('0')
+    await expect(page.getByTestId('result-status')).toHaveText('Minimal')
+    await expect(page.getByTestId('needs-evaluation')).not.toBeVisible()
+  })
+
+  test('all 3 → score 21, Schwer, needs evaluation', async ({ page }) => {
+    await answerAll(page, 3)
+    await expect(page.getByTestId('result-score')).toHaveText('21')
+    await expect(page.getByTestId('result-status')).toHaveText('Schwer')
+    await expect(page.getByTestId('needs-evaluation')).toBeVisible()
+  })
+
+  test('mixed 1+2+0+3+1+2+1 = 10, Moderat, needs evaluation', async ({ page }) => {
+    const vals = { feelingNervous: 1, cantStopWorrying: 2, worryingTooMuch: 0, troubleRelaxing: 3, restless: 1, irritable: 2, afraidSomethingAwful: 1 }
+    for (const [q, v] of Object.entries(vals)) {
+      await page.getByTestId(`option-${q}-${v}`).click()
+    }
+    await expect(page.getByTestId('result-score')).toHaveText('10')
+    await expect(page.getByTestId('result-status')).toHaveText('Moderat')
+    await expect(page.getByTestId('needs-evaluation')).toBeVisible()
+  })
+
+  test('reset clears answers and hides result', async ({ page }) => {
+    await answerAll(page, 1)
+    await expect(page.getByTestId('result-score')).toBeVisible()
+    await page.getByTestId('reset').click()
+    await expect(page.getByTestId('result-score')).not.toBeVisible()
+    await expect(page.getByTestId('incomplete-hint')).toBeVisible()
+  })
+
+  test('disclaimer is shown on page', async ({ page }) => {
+    await expect(page.getByTestId('page-disclaimer')).toBeVisible()
+    await expect(page.getByTestId('page-disclaimer')).toContainText('Screening-Werkzeug')
+  })
+
+  test('severity bands section visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Schweregrade/ })).toBeVisible()
+  })
+
+  test('blog article link is rendered', async ({ page }) => {
+    await expect(page.getByTestId('blog-article-link')).toBeVisible()
+  })
+})
+
+test.describe('GAD-7 Anxiety Screening (EN)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('en/gad-7-anxiety-test')
+  })
+
+  test('page loads with correct title', async ({ page }) => {
+    await expect(page).toHaveTitle(/GAD-7/)
+  })
+
+  test('all 0 → score 0, Minimal, no eval', async ({ page }) => {
+    await answerAll(page, 0)
+    await expect(page.getByTestId('result-score')).toHaveText('0')
+    await expect(page.getByTestId('result-status')).toHaveText('Minimal')
+  })
+
+  test('all 3 → score 21, Severe, needs evaluation', async ({ page }) => {
+    await answerAll(page, 3)
+    await expect(page.getByTestId('result-score')).toHaveText('21')
+    await expect(page.getByTestId('result-status')).toHaveText('Severe')
+    await expect(page.getByTestId('needs-evaluation')).toBeVisible()
+  })
+
+  test('disclaimer is shown on page', async ({ page }) => {
+    await expect(page.getByTestId('page-disclaimer')).toContainText('screening tool')
+  })
+})

--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -34,6 +34,7 @@ const EXPECTED_KEYS = [
   'ankleBrachialIndex',
   'pulsePressure',
   'wilksCoefficient',
+  'gad7',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -129,6 +130,7 @@ const EXPECTED_ROUTE_MAP = {
   ankleBrachialIndex: { de: 'knoechel-arm-index-rechner', en: 'ankle-brachial-index' },
   pulsePressure: { de: 'pulsdruck-rechner', en: 'pulse-pressure' },
   wilksCoefficient: { de: 'wilks-coefficient-rechner', en: 'wilks-coefficient' },
+  gad7: { de: 'gad-7-angst-test', en: 'gad-7-anxiety-test' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -215,6 +217,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'wilks-koeffizient-berechnen',
   'bmi-bei-frauen',
   'bmi-bei-maennern',
+  'gad-7-angst-test-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -301,19 +304,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'wilks-coefficient-guide',
   'bmi-for-women',
   'bmi-for-men',
+  'gad-7-anxiety-test-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 92 calculators', () => {
-    expect(calculatorMetas).toHaveLength(92)
+  it('discovers all 93 calculators', () => {
+    expect(calculatorMetas).toHaveLength(93)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 91 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(92)
+  it('builds calculatorComponents map for all 93 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(93)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -336,15 +340,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 95 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(95)
+  it('discovers all 96 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(96)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 95 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(95)
+  it('discovers all 96 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(96)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -369,10 +373,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 92 calculators with no duplicates', () => {
+  it('groups contain all 93 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(92)
-    expect(new Set(allKeys).size).toBe(92)
+    expect(allKeys).toHaveLength(93)
+    expect(new Set(allKeys).size).toBe(93)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -393,7 +397,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'pulsePressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'wilksCoefficient', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'pulsePressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'wilksCoefficient', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk', 'gad7',
     ])
   })
 
@@ -442,8 +446,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 511 routes', () => {
-    expect(routes).toHaveLength(511)
+  it('generates exactly 516 routes', () => {
+    expect(routes).toHaveLength(516)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/gad7.test.js
+++ b/src/__tests__/gad7.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GAD7_QUESTIONS,
+  calcGad7Score,
+  classifyGad7,
+  needsEvaluation,
+  evaluateGad7,
+} from '../utils/gad7.js'
+
+// GAD-7 — Generalized Anxiety Disorder 7-item scale (Spitzer et al., Arch Intern Med, 2006)
+// 7 questions, each scored 0–3, total 0–21.
+//    0– 4 : Minimal
+//    5– 9 : Mild
+//   10–14 : Moderate
+//   15–21 : Severe
+// needsEvaluation: score >= 10
+
+const FULL = (v) => ({
+  feelingNervous: v,
+  cantStopWorrying: v,
+  worryingTooMuch: v,
+  troubleRelaxing: v,
+  restless: v,
+  irritable: v,
+  afraidSomethingAwful: v,
+})
+
+describe('GAD7_QUESTIONS', () => {
+  it('exposes 7 question keys', () => {
+    expect(GAD7_QUESTIONS).toHaveLength(7)
+  })
+
+  it('uses canonical keys in order', () => {
+    expect(GAD7_QUESTIONS).toEqual([
+      'feelingNervous',
+      'cantStopWorrying',
+      'worryingTooMuch',
+      'troubleRelaxing',
+      'restless',
+      'irritable',
+      'afraidSomethingAwful',
+    ])
+  })
+})
+
+describe('calcGad7Score', () => {
+  it('all zeros → 0', () => {
+    expect(calcGad7Score(FULL(0))).toBe(0)
+  })
+
+  it('all threes → 21', () => {
+    expect(calcGad7Score(FULL(3))).toBe(21)
+  })
+
+  it('mixed answers sum: 1+2+0+3+1+2+1 → 10', () => {
+    expect(calcGad7Score({
+      feelingNervous: 1, cantStopWorrying: 2, worryingTooMuch: 0,
+      troubleRelaxing: 3, restless: 1, irritable: 2, afraidSomethingAwful: 1,
+    })).toBe(10)
+  })
+
+  it('returns null on missing answer', () => {
+    const a = FULL(1)
+    delete a.irritable
+    expect(calcGad7Score(a)).toBe(null)
+  })
+
+  it('returns null on out-of-range value (-1)', () => {
+    expect(calcGad7Score({ ...FULL(1), feelingNervous: -1 })).toBe(null)
+  })
+
+  it('returns null on out-of-range value (4)', () => {
+    expect(calcGad7Score({ ...FULL(1), feelingNervous: 4 })).toBe(null)
+  })
+
+  it('returns null on non-integer (1.5)', () => {
+    expect(calcGad7Score({ ...FULL(1), feelingNervous: 1.5 })).toBe(null)
+  })
+
+  it('returns null on null/undefined input', () => {
+    expect(calcGad7Score(null)).toBe(null)
+    expect(calcGad7Score(undefined)).toBe(null)
+  })
+})
+
+describe('classifyGad7 — verbatim severity bands', () => {
+  it('0 → Minimal', () => { expect(classifyGad7(0)).toBe('Minimal') })
+  it('4 → Minimal (upper boundary)', () => { expect(classifyGad7(4)).toBe('Minimal') })
+  it('5 → Mild (lower boundary)', () => { expect(classifyGad7(5)).toBe('Mild') })
+  it('9 → Mild (upper boundary)', () => { expect(classifyGad7(9)).toBe('Mild') })
+  it('10 → Moderate (lower boundary)', () => { expect(classifyGad7(10)).toBe('Moderate') })
+  it('14 → Moderate (upper boundary)', () => { expect(classifyGad7(14)).toBe('Moderate') })
+  it('15 → Severe (lower boundary)', () => { expect(classifyGad7(15)).toBe('Severe') })
+  it('21 → Severe (maximum)', () => { expect(classifyGad7(21)).toBe('Severe') })
+
+  it('returns null for out-of-range or invalid', () => {
+    expect(classifyGad7(-1)).toBe(null)
+    expect(classifyGad7(22)).toBe(null)
+    expect(classifyGad7(null)).toBe(null)
+    expect(classifyGad7('10')).toBe(null)
+  })
+})
+
+describe('needsEvaluation — cutoff at 10', () => {
+  it('9 → false', () => { expect(needsEvaluation(9)).toBe(false) })
+  it('10 → true (cutoff)', () => { expect(needsEvaluation(10)).toBe(true) })
+  it('14 → true', () => { expect(needsEvaluation(14)).toBe(true) })
+  it('21 → true', () => { expect(needsEvaluation(21)).toBe(true) })
+  it('0 → false', () => { expect(needsEvaluation(0)).toBe(false) })
+  it('non-number → false', () => {
+    expect(needsEvaluation(null)).toBe(false)
+    expect(needsEvaluation('10')).toBe(false)
+  })
+})
+
+describe('evaluateGad7 (one-shot)', () => {
+  it('all 0 → score 0, Minimal, no evaluation', () => {
+    const r = evaluateGad7(FULL(0))
+    expect(r).toEqual({ score: 0, band: 'Minimal', needsEvaluation: false })
+  })
+
+  it('all 3 → score 21, Severe, needsEvaluation', () => {
+    const r = evaluateGad7(FULL(3))
+    expect(r).toEqual({ score: 21, band: 'Severe', needsEvaluation: true })
+  })
+
+  it('mixed answers → score 10, Moderate, needsEvaluation', () => {
+    const r = evaluateGad7({
+      feelingNervous: 1, cantStopWorrying: 2, worryingTooMuch: 0,
+      troubleRelaxing: 3, restless: 1, irritable: 2, afraidSomethingAwful: 1,
+    })
+    expect(r).toEqual({ score: 10, band: 'Moderate', needsEvaluation: true })
+  })
+
+  it('score 9 → Mild, no evaluation (just below cutoff)', () => {
+    const r = evaluateGad7({
+      feelingNervous: 2, cantStopWorrying: 2, worryingTooMuch: 1,
+      troubleRelaxing: 1, restless: 1, irritable: 1, afraidSomethingAwful: 1,
+    })
+    expect(r.score).toBe(9)
+    expect(r.band).toBe('Mild')
+    expect(r.needsEvaluation).toBe(false)
+  })
+
+  it('score 5 → Mild (boundary)', () => {
+    const r = evaluateGad7({
+      feelingNervous: 1, cantStopWorrying: 1, worryingTooMuch: 1,
+      troubleRelaxing: 1, restless: 1, irritable: 0, afraidSomethingAwful: 0,
+    })
+    expect(r.score).toBe(5)
+    expect(r.band).toBe('Mild')
+  })
+
+  it('score 14 → Moderate (upper boundary)', () => {
+    const r = evaluateGad7({
+      feelingNervous: 2, cantStopWorrying: 2, worryingTooMuch: 2,
+      troubleRelaxing: 2, restless: 2, irritable: 2, afraidSomethingAwful: 2,
+    })
+    expect(r.score).toBe(14)
+    expect(r.band).toBe('Moderate')
+    expect(r.needsEvaluation).toBe(true)
+  })
+
+  it('score 15 → Severe (lower boundary)', () => {
+    const r = evaluateGad7({
+      feelingNervous: 3, cantStopWorrying: 3, worryingTooMuch: 2,
+      troubleRelaxing: 2, restless: 2, irritable: 2, afraidSomethingAwful: 1,
+    })
+    expect(r.score).toBe(15)
+    expect(r.band).toBe('Severe')
+  })
+
+  it('returns null on incomplete answers', () => {
+    expect(evaluateGad7({ feelingNervous: 1 })).toBe(null)
+  })
+
+  it('returns null on null input', () => {
+    expect(evaluateGad7(null)).toBe(null)
+  })
+})

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 374 links (92 calcs × 2 locales + 95 blogs × 2 locales)', () => {
+  it('generates 378 links (93 calcs × 2 locales + 96 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(374)
+    expect(links).toHaveLength(378)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -28,6 +28,7 @@ const EXPECTED_KEYS = [
   'ankleBrachialIndex',
   'pulsePressure',
   'wilksCoefficient',
+  'gad7',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -113,6 +114,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'wilks-koeffizient-berechnen',
   'bmi-bei-frauen',
   'bmi-bei-maennern',
+  'gad-7-angst-test-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -198,12 +200,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'wilks-coefficient-guide',
   'bmi-for-women',
   'bmi-for-men',
+  'gad-7-anxiety-test-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 91 calculator meta files', () => {
+  it('discovers all 93 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(92)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(93)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -241,19 +244,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 95 DE blog slugs', () => {
+  it('returns all 96 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(95)
+    expect(de).toHaveLength(96)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 95 EN blog slugs', () => {
+  it('returns all 96 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(95)
+    expect(en).toHaveLength(96)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -321,9 +324,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 184 calcs + 2 blog index + 190 blog articles = 378)', () => {
+  it('generates correct total URL count (2 home + 186 calcs + 2 blog index + 192 blog articles = 382)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(378)
+    expect(urlCount).toBe(382)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -854,6 +854,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'bmiMaenner',
     related: ['calculate-bmi', 'calculate-body-fat', 'calculate-ideal-weight'],
   },
+  {
+    slug: 'gad-7-anxiety-test-calculator',
+    title: 'GAD-7 Anxiety Test: Generalized Anxiety Screening — Score & Bands',
+    description: 'Understand the GAD-7 anxiety screening: 7 questions, score 0–21, severity bands minimal/mild/moderate/severe. Cutoff 10, Spitzer 2006 — screening tool, not a diagnosis.',
+    date: '2026-06-08',
+    readTime: '8 min',
+    calculatorKey: 'gad7',
+    related: ['pms-symptom-calculator-guide', 'menopause-symptom-calculator-guide', 'calculate-sleep-cycles'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -854,6 +854,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'bmiMaenner',
     related: ['bmi-berechnen', 'koerperfett-berechnen', 'idealgewicht-berechnen'],
   },
+  {
+    slug: 'gad-7-angst-test-rechner',
+    title: 'GAD-7 Angst-Test: Generalisierte Angst erkennen — Rechner & Score',
+    description: 'GAD-7 Angst-Screening verstehen: 7 Fragen, Score 0–21, Schweregrade minimal/mild/moderat/schwer. Cutoff 10, Spitzer 2006 — Screening-Werkzeug, keine Diagnose.',
+    date: '2026-06-08',
+    readTime: '8 min',
+    calculatorKey: 'gad7',
+    related: ['pms-symptome-bewerten', 'menopause-symptome-bewerten', 'schlafzyklen-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/gad7.json
+++ b/src/locales/calculators/de/gad7.json
@@ -1,0 +1,91 @@
+{
+  "home": {
+    "calculators": {
+      "gad7": {
+        "name": "GAD-7 Angst-Screening",
+        "description": "Validierter 7-Fragen-Test für generalisierte Angst — Score 0–21 mit Schweregrad."
+      }
+    }
+  },
+  "gad7": {
+    "meta": {
+      "title": "GAD-7 Angst-Test (generalisierte Angststörung) — Online Screening | Health Calculators",
+      "description": "GAD-7 Screening für generalisierte Angststörung online. 7 Fragen, Score 0–21, Schweregrade minimal/mild/moderat/schwer. Kostenlos, anonym, sofort. Screening-Werkzeug — keine Diagnose."
+    },
+    "title": "GAD-7 Angst-Screening",
+    "description": "Wie oft haben dich in den letzten 2 Wochen die folgenden Beschwerden belastet? Wähle pro Frage genau eine Antwort. Dein Gesamtscore (0–21) und der Schweregrad erscheinen automatisch.",
+    "introNote": "Bezugszeitraum: die letzten 2 Wochen. Der GAD-7 ist ein Screening-Werkzeug — keine medizinische Diagnose.",
+    "questions": {
+      "feelingNervous": { "title": "1. Nervosität, Ängstlichkeit oder Anspannung" },
+      "cantStopWorrying": { "title": "2. Nicht in der Lage sein, Sorgen zu stoppen oder zu kontrollieren" },
+      "worryingTooMuch": { "title": "3. Übermäßige Sorgen um verschiedene Dinge" },
+      "troubleRelaxing": { "title": "4. Schwierigkeiten, zu entspannen" },
+      "restless": { "title": "5. So unruhig sein, dass Stillsitzen schwerfällt" },
+      "irritable": { "title": "6. Leicht verärgert oder reizbar sein" },
+      "afraidSomethingAwful": { "title": "7. Gefühl der Angst, als würde etwas Schlimmes passieren" }
+    },
+    "options": [
+      { "value": 0, "label": "Überhaupt nicht" },
+      { "value": 1, "label": "An einzelnen Tagen" },
+      { "value": 2, "label": "An mehr als der Hälfte der Tage" },
+      { "value": 3, "label": "Beinahe jeden Tag" }
+    ],
+    "categories": {
+      "Minimal": "Minimal",
+      "Mild": "Mild",
+      "Moderate": "Moderat",
+      "Severe": "Schwer"
+    },
+    "hints": {
+      "Minimal": "Score 0–4: minimale Angstsymptome. In der Regel keine spezielle Maßnahme nötig — beobachte weiter, wie du dich fühlst.",
+      "Mild": "Score 5–9: leichte Angstsymptome. Selbstfürsorge, Stressmanagement und abwartende Beobachtung sind angemessen. Wiederhole den Test in 2–4 Wochen.",
+      "Moderate": "Score 10–14: moderate Angstsymptome. Bitte hole ärztlichen Rat ein — weitere Abklärung und ggf. ein Behandlungsplan werden empfohlen.",
+      "Severe": "Score 15–21: starke Angstsymptome. Bitte zeitnah ärztliche oder psychotherapeutische Hilfe in Anspruch nehmen. Eine aktive Behandlung wird in der Regel empfohlen."
+    },
+    "reset": "Antworten zurücksetzen",
+    "scoreLabel": "GAD-7-Score",
+    "scoreScale": "von 21",
+    "incompleteHint": "Beantworte alle 7 Fragen, um deinen GAD-7-Score zu sehen.",
+    "scaleTitle": "Schweregrade",
+    "scaleRows": [
+      { "range": "0 – 4", "label": "Minimal", "hint": "Symptome minimal — weiter beobachten" },
+      { "range": "5 – 9", "label": "Mild", "hint": "Symptome leicht — Selbstfürsorge, Test in 2–4 Wochen wiederholen" },
+      { "range": "10 – 14", "label": "Moderat", "hint": "Ärztlichen Rat einholen" },
+      { "range": "15 – 21", "label": "Schwer", "hint": "Zeitnah professionelle Hilfe suchen" }
+    ],
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der GAD-7 wurde 2006 von Spitzer, Kroenke, Williams und Löwe entwickelt und validiert (Arch Intern Med). Sieben Items, je 0 (Überhaupt nicht) bis 3 (Beinahe jeden Tag), ergeben einen Gesamtscore von 0–21. Ein Cutoff von 10 zeigt das beste Verhältnis von Sensitivität (89 %) und Spezifität (82 %) für generalisierte Angststörungen und wird breit als Überweisungs-Schwelle verwendet.",
+    "needsEvaluationLabel": "Dein Wert legt nahe, dass eine weitere Abklärung sinnvoll sein kann",
+    "disclaimer": "Dies ist ein Screening-Werkzeug, keine medizinische Diagnose. Bei einem Wert ab 10 oder bei Beschwerden bitte ärztlichen Rat einholen.",
+    "faq": [
+      {
+        "q": "Was misst der GAD-7?",
+        "a": "Der GAD-7 screent auf eine generalisierte Angststörung, indem er fragt, wie oft du in den letzten 2 Wochen von sieben Kernsymptomen belastet warst. Er wird breit in der Hausarztpraxis und in psychiatrisch-psychotherapeutischen Settings eingesetzt."
+      },
+      {
+        "q": "Was bedeuten die Score-Bereiche?",
+        "a": "0–4 minimal, 5–9 mild, 10–14 moderat, 15–21 schwer ausgeprägte Angstsymptome. Ein Score von 10 oder mehr ist der übliche Cutoff für eine weitere klinische Abklärung."
+      },
+      {
+        "q": "Ist der GAD-7 eine Diagnose?",
+        "a": "Nein. Der GAD-7 ist ein Screening- und Verlaufsinstrument — keine Diagnose. Eine Angststörung wird durch eine ärztliche oder psychotherapeutische Untersuchung, deine Anamnese und klinische Einschätzung bestätigt oder ausgeschlossen."
+      },
+      {
+        "q": "Wie oft sollte ich den GAD-7 machen?",
+        "a": "Sinnvoll ist ein Ausgangswert und dann alle 2–4 Wochen während einer Behandlung oder bei Symptomveränderungen. Trends über mehrere Tests sind aussagekräftiger als ein Einzelwert."
+      },
+      {
+        "q": "Erkennt der GAD-7 auch Panikstörung, soziale Phobie oder PTBS?",
+        "a": "Der GAD-7 ist primär für generalisierte Angst entwickelt, hat aber auch moderate Genauigkeit für Panikstörung, soziale Phobie und PTBS. Bei konkretem Verdacht nutzen Fachpersonen ergänzend andere Werkzeuge (PHQ-9, PCL-5 u. a.)."
+      },
+      {
+        "q": "Was, wenn ich an Selbstverletzung denke?",
+        "a": "Der GAD-7 fragt suizidale Gedanken nicht ab. Wenn du Gedanken hast, dich oder andere zu verletzen, kontaktiere bitte sofort den Notruf oder eine Krisen-Hotline (Deutschland: 0800 1110111 Telefonseelsorge, Notruf 112)."
+      },
+      {
+        "q": "Ist der GAD-7 auch für Jugendliche geeignet?",
+        "a": "Der GAD-7 ist für Erwachsene validiert und wird auch ab ca. 13 Jahren eingesetzt. Für jüngere Kinder gibt es altersgerechtere Werkzeuge."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/gad7.json
+++ b/src/locales/calculators/en/gad7.json
@@ -1,0 +1,91 @@
+{
+  "home": {
+    "calculators": {
+      "gad7": {
+        "name": "GAD-7 Anxiety Screening",
+        "description": "Validated 7-question screening tool for generalized anxiety — score 0–21 with severity band."
+      }
+    }
+  },
+  "gad7": {
+    "meta": {
+      "title": "GAD-7 Anxiety Test (Generalized Anxiety) — Online Screening | Health Calculators",
+      "description": "Take the validated GAD-7 anxiety screening online. 7 questions, score 0–21, severity bands minimal/mild/moderate/severe. Free, anonymous, instant. Screening tool — not a diagnosis."
+    },
+    "title": "GAD-7 Anxiety Screening",
+    "description": "Over the last 2 weeks, how often have you been bothered by the following problems? Pick exactly one answer per question. Your total score (0–21) and severity band will appear automatically.",
+    "introNote": "Reference period: the past 2 weeks. The GAD-7 is a screening tool — not a medical diagnosis.",
+    "questions": {
+      "feelingNervous": { "title": "1. Feeling nervous, anxious, or on edge" },
+      "cantStopWorrying": { "title": "2. Not being able to stop or control worrying" },
+      "worryingTooMuch": { "title": "3. Worrying too much about different things" },
+      "troubleRelaxing": { "title": "4. Trouble relaxing" },
+      "restless": { "title": "5. Being so restless that it is hard to sit still" },
+      "irritable": { "title": "6. Becoming easily annoyed or irritable" },
+      "afraidSomethingAwful": { "title": "7. Feeling afraid as if something awful might happen" }
+    },
+    "options": [
+      { "value": 0, "label": "Not at all" },
+      { "value": 1, "label": "Several days" },
+      { "value": 2, "label": "More than half the days" },
+      { "value": 3, "label": "Nearly every day" }
+    ],
+    "categories": {
+      "Minimal": "Minimal",
+      "Mild": "Mild",
+      "Moderate": "Moderate",
+      "Severe": "Severe"
+    },
+    "hints": {
+      "Minimal": "Score 0–4 suggests minimal anxiety symptoms. No specific action is usually needed — keep monitoring how you feel.",
+      "Mild": "Score 5–9 suggests mild anxiety symptoms. Self-care, stress management and watchful waiting are appropriate. Re-test in 2–4 weeks.",
+      "Moderate": "Score 10–14 suggests moderate anxiety symptoms. Please consult a healthcare professional — further evaluation and a possible treatment plan are recommended.",
+      "Severe": "Score 15–21 suggests severe anxiety symptoms. Please consult a healthcare professional promptly. Active treatment is typically recommended."
+    },
+    "reset": "Reset answers",
+    "scoreLabel": "GAD-7 score",
+    "scoreScale": "of 21",
+    "incompleteHint": "Answer all 7 questions to see your GAD-7 score.",
+    "scaleTitle": "Severity bands",
+    "scaleRows": [
+      { "range": "0 – 4", "label": "Minimal", "hint": "Symptoms minimal — keep monitoring" },
+      { "range": "5 – 9", "label": "Mild", "hint": "Symptoms mild — self-care, re-test in 2–4 weeks" },
+      { "range": "10 – 14", "label": "Moderate", "hint": "Consult a healthcare professional" },
+      { "range": "15 – 21", "label": "Severe", "hint": "Seek professional help promptly" }
+    ],
+    "howItWorks": "How it works",
+    "howItWorksText": "The GAD-7 was developed and validated by Spitzer, Kroenke, Williams and Löwe (Arch Intern Med, 2006). Seven items, each scored 0 (Not at all) to 3 (Nearly every day), sum to 0–21. A cutoff of 10 has the best balance of sensitivity (89 %) and specificity (82 %) for generalized anxiety disorder and is widely used as a referral threshold.",
+    "needsEvaluationLabel": "Your score suggests further evaluation may be helpful",
+    "disclaimer": "This is a screening tool, not a medical diagnosis. If your score is 10 or above, or you have concerns, please consult a healthcare professional.",
+    "faq": [
+      {
+        "q": "What does the GAD-7 measure?",
+        "a": "The GAD-7 screens for generalized anxiety disorder by asking how often you have been bothered by seven core symptoms over the last 2 weeks. It is widely used in primary care and mental-health settings."
+      },
+      {
+        "q": "What do the score bands mean?",
+        "a": "0–4 minimal, 5–9 mild, 10–14 moderate, 15–21 severe anxiety symptoms. A score of 10 or more is the commonly used cutoff that warrants further clinical evaluation."
+      },
+      {
+        "q": "Is the GAD-7 a diagnosis?",
+        "a": "No. The GAD-7 is a screening and severity tool — not a diagnosis. A clinician confirms or rules out an anxiety disorder using a full evaluation, your history and clinical judgement."
+      },
+      {
+        "q": "How often should I take the GAD-7?",
+        "a": "It works well as a baseline and then every 2–4 weeks during treatment or when symptoms change. Trends across multiple tests are more meaningful than a single value."
+      },
+      {
+        "q": "Can the GAD-7 also detect panic disorder, social anxiety or PTSD?",
+        "a": "It performs best for generalized anxiety, but has moderate accuracy for panic disorder, social anxiety disorder and PTSD. A specialist will use additional tools (PHQ-9, PCL-5, etc.) when those are suspected."
+      },
+      {
+        "q": "What if I have thoughts of self-harm?",
+        "a": "The GAD-7 does not screen for suicidal thoughts. If you have thoughts of hurting yourself or others, contact emergency services or a crisis line immediately (in the US: 988; in Germany: 0800 1110111)."
+      },
+      {
+        "q": "Is the GAD-7 suitable for teenagers?",
+        "a": "The GAD-7 is validated for adults and is also used in adolescents from about age 13. For younger children, age-specific tools are preferred."
+      }
+    ]
+  }
+}

--- a/src/pages/Gad7Calculator.vue
+++ b/src/pages/Gad7Calculator.vue
@@ -1,0 +1,203 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { GAD7_QUESTIONS, evaluateGad7 } from '../utils/gad7.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('gad7.faq') || [])
+
+useHead(() => ({
+  title: t('gad7.meta.title'),
+  description: t('gad7.meta.description'),
+  routeKey: 'gad7',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'GAD-7 Anxiety Screening Calculator',
+    url: 'https://healthcalculator.app/en/gad-7-anxiety-test',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const answers = ref({
+  feelingNervous: null,
+  cantStopWorrying: null,
+  worryingTooMuch: null,
+  troubleRelaxing: null,
+  restless: null,
+  irritable: null,
+  afraidSomethingAwful: null,
+})
+
+const result = computed(() => evaluateGad7(answers.value))
+
+const answeredCount = computed(() =>
+  GAD7_QUESTIONS.filter(q => Number.isInteger(answers.value[q])).length,
+)
+
+const progressPct = computed(() => (answeredCount.value / GAD7_QUESTIONS.length) * 100)
+
+const interpretation = computed(() => {
+  if (!result.value) return null
+  const k = result.value.band
+  if (k === 'Minimal') return { key: k, color: 'text-green-600', bg: 'bg-green-600', border: 'border-green-200' }
+  if (k === 'Mild') return { key: k, color: 'text-yellow-600', bg: 'bg-yellow-500', border: 'border-yellow-200' }
+  if (k === 'Moderate') return { key: k, color: 'text-orange-600', bg: 'bg-orange-500', border: 'border-orange-200' }
+  return { key: k, color: 'text-red-600', bg: 'bg-red-500', border: 'border-red-200' }
+})
+
+function reset() {
+  for (const q of GAD7_QUESTIONS) answers.value[q] = null
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('gad7.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('gad7.description') }}</p>
+    </div>
+
+    <!-- Intro / progress -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-6">
+      <p class="text-sm text-stone-600 mb-4">{{ t('gad7.introNote') }}</p>
+      <div class="flex items-center gap-4">
+        <div class="flex-1 h-1.5 bg-stone-100 rounded-full overflow-hidden">
+          <div class="h-full bg-stone-900 transition-all duration-200" :style="{ width: progressPct + '%' }"></div>
+        </div>
+        <span class="text-xs font-semibold text-stone-500 tabular-nums">{{ answeredCount }} / 7</span>
+      </div>
+    </div>
+
+    <!-- Questions -->
+    <div class="space-y-6 mb-6">
+      <div
+        v-for="qKey in GAD7_QUESTIONS"
+        :key="qKey"
+        class="bg-white border border-stone-200 rounded-xl shadow-sm p-6"
+        :data-testid="'question-' + qKey"
+      >
+        <p class="text-base font-semibold text-stone-900 mb-4 leading-snug">
+          {{ t(`gad7.questions.${qKey}.title`) }}
+        </p>
+        <div class="space-y-2">
+          <button
+            v-for="opt in tm('gad7.options')"
+            :key="opt.value"
+            @click="answers[qKey] = opt.value"
+            :data-testid="`option-${qKey}-${opt.value}`"
+            :class="answers[qKey] === opt.value
+              ? 'bg-stone-900 text-white border-stone-900'
+              : 'bg-white text-stone-700 border-stone-200 hover:border-stone-400 hover:bg-stone-50'"
+            class="w-full text-left border rounded-lg px-4 py-3 text-sm font-medium transition-colors duration-150 flex items-center gap-3"
+          >
+            <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold tabular-nums shrink-0"
+              :class="answers[qKey] === opt.value ? 'bg-white text-stone-900' : 'bg-stone-100 text-stone-600'"
+            >{{ opt.value }}</span>
+            <span>{{ opt.label }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Result -->
+    <div v-if="result" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex items-center gap-3 mb-6">
+        <span
+          data-testid="result-status"
+          :class="[interpretation.bg, 'text-white text-sm font-semibold px-3 py-1 rounded-full']"
+        >{{ t('gad7.categories.' + interpretation.key) }}</span>
+        <span
+          v-if="result.needsEvaluation"
+          data-testid="needs-evaluation"
+          class="text-xs font-semibold text-red-700 bg-red-50 border border-red-200 px-2 py-1 rounded"
+        >{{ t('gad7.needsEvaluationLabel') }}</span>
+      </div>
+
+      <div class="mb-6">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('gad7.scoreLabel') }}</div>
+        <div class="flex items-baseline gap-3">
+          <span data-testid="result-score" class="text-6xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ result.score }}</span>
+          <span class="text-base text-stone-400">{{ t('gad7.scoreScale') }}</span>
+        </div>
+      </div>
+
+      <!-- Score scale bar -->
+      <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+        <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-600 via-yellow-500 via-orange-500 to-red-500 rounded-full" style="width: 100%"></div>
+        <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (result.score / 21) * 100 + '%' }"></div>
+      </div>
+
+      <div :class="[interpretation.border, 'border rounded-lg px-4 py-3 bg-stone-50']">
+        <p data-testid="result-hint" class="text-sm text-stone-700 leading-relaxed">{{ t('gad7.hints.' + interpretation.key) }}</p>
+      </div>
+
+      <div class="mt-4 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+        <p data-testid="result-disclaimer" class="text-xs text-amber-900 leading-relaxed">{{ t('gad7.disclaimer') }}</p>
+      </div>
+
+      <div class="mt-6 pt-4 border-t border-stone-100">
+        <button @click="reset" data-testid="reset"
+          class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150">{{ t('gad7.reset') }}</button>
+      </div>
+    </div>
+
+    <div v-else class="bg-stone-50 border border-stone-200 rounded-xl p-6 mb-6">
+      <p data-testid="incomplete-hint" class="text-sm text-stone-500">{{ t('gad7.incompleteHint') }}</p>
+    </div>
+
+    <!-- Score scale -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('gad7.scaleTitle') }}</h2>
+      <div class="space-y-3">
+        <div
+          v-for="(row, i) in tm('gad7.scaleRows')"
+          :key="i"
+          class="flex items-start justify-between border-b border-stone-100 pb-3 last:border-0 last:pb-0"
+        >
+          <div class="flex items-center gap-3">
+            <div :class="[
+              i === 0 ? 'bg-green-600' : i === 1 ? 'bg-yellow-500' : i === 2 ? 'bg-orange-500' : 'bg-red-500',
+              'w-2.5 h-2.5 rounded-full shrink-0 mt-0.5',
+            ]"></div>
+            <div>
+              <span class="text-sm text-stone-900 font-medium">{{ row.label }}</span>
+              <p class="text-xs text-stone-500">{{ row.hint }}</p>
+            </div>
+          </div>
+          <div class="text-sm font-medium text-stone-900 tabular-nums shrink-0 ml-4">{{ row.range }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- How it works -->
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('gad7.howItWorks') }}</h2>
+      <p class="text-sm text-stone-500 leading-relaxed">{{ t('gad7.howItWorksText') }}</p>
+    </div>
+
+    <!-- Disclaimer (prominent, page-level) -->
+    <div data-testid="page-disclaimer" class="bg-amber-50 border border-amber-200 rounded-xl px-6 py-4 mb-6">
+      <p class="text-sm text-amber-900 leading-relaxed font-medium">{{ t('gad7.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="gad7" class="mt-8" />
+    <BlogArticleLink calculator-key="gad7" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/Gad7AngstTestRechner.vue
+++ b/src/pages/blog/Gad7AngstTestRechner.vue
@@ -1,0 +1,245 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'GAD-7 Angst-Test: Generalisierte Angst erkennen — Rechner & Score | Health Calculators',
+  description: 'GAD-7 Angst-Screening verstehen: 7 Fragen, Score 0–21, Schweregrade minimal/mild/moderat/schwer. Cutoff 10, Spitzer 2006, was die Werte für dich bedeuten — mit kostenlosem Online-Rechner.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'GAD-7 Angst-Test: Generalisierte Angst erkennen — Rechner & Score',
+      description: 'Wie ausgeprägt sind deine Angstsymptome? Der GAD-7 ist ein validiertes 7-Fragen-Screening für generalisierte Angststörung. Was die Score-Bänder bedeuten, wann der Cutoff von 10 zählt und was du jetzt tun kannst.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-06-08',
+      dateModified: '2026-06-08',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/gad-7-angst-test-rechner',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was misst der GAD-7?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Der GAD-7 misst die Häufigkeit von sieben Kernsymptomen einer generalisierten Angststörung über die letzten 2 Wochen. Er ist als Screening- und Verlaufsinstrument validiert.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was bedeuten die Score-Bereiche?',
+          acceptedAnswer: { '@type': 'Answer', text: '0–4 minimal, 5–9 mild, 10–14 moderat, 15–21 schwer ausgeprägte Angstsymptome. Ein Score ≥ 10 ist der übliche Cutoff für eine weitere klinische Abklärung.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Ist der GAD-7 eine Diagnose?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Nein. Der GAD-7 ist ein Screening-Werkzeug, keine medizinische Diagnose. Eine Angststörung wird durch eine ärztliche oder psychotherapeutische Untersuchung bestätigt.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was, wenn ich an Selbstverletzung denke?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Der GAD-7 fragt suizidale Gedanken nicht ab. Bei Gedanken an Selbstverletzung sofort den Notruf 112 wählen oder die Telefonseelsorge unter 0800 1110111 (kostenlos, 24/7) kontaktieren.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">GAD-7 Angst-Test: Generalisierte Angst erkennen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">8. Juni 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wie ausgeprägt sind deine <strong>Angstsymptome</strong>? Der <strong>GAD-7</strong> (Generalized Anxiety Disorder 7-item) liefert in sieben Fragen eine validierte Antwort und ist heute das Standard-Werkzeug für das Screening generalisierter Angst in Hausarztpraxen, psychiatrisch-psychotherapeutischen Settings und Studien.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Beitrag erfährst du, wie der GAD-7 funktioniert, was die Score-Bänder bedeuten, ab wann eine weitere Abklärung sinnvoll ist und wie der GAD-7 mit anderen Symptom-Tools zusammenpasst.
+        </p>
+      </div>
+
+      <!-- Prominent disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed font-medium">
+          Dies ist ein Screening-Werkzeug, keine medizinische Diagnose. Bei einem Wert ab 10 oder bei Beschwerden bitte ärztlichen Rat einholen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist der GAD-7?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der GAD-7 wurde 2006 von Spitzer, Kroenke, Williams und Löwe im <em>Archives of Internal Medicine</em> publiziert. Er fragt nach sieben Kernsymptomen generalisierter Angst über die letzten <strong>2 Wochen</strong>. Jedes Item wird mit 0 (Überhaupt nicht) bis 3 (Beinahe jeden Tag) bewertet, der Gesamtscore reicht von 0 bis 21.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei einem Cutoff von 10 hat der GAD-7 eine Sensitivität von 89 % und eine Spezifität von 82 % für die generalisierte Angststörung. Er screent darüber hinaus mit moderater Genauigkeit auch auf Panikstörung, soziale Phobie und PTBS.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die sieben Fragen</h2>
+        <ol class="space-y-3 mb-4 list-decimal list-inside">
+          <li class="text-stone-600 text-base"><strong>Nervosität, Ängstlichkeit oder Anspannung</strong></li>
+          <li class="text-stone-600 text-base"><strong>Nicht in der Lage sein, Sorgen zu stoppen oder zu kontrollieren</strong></li>
+          <li class="text-stone-600 text-base"><strong>Übermäßige Sorgen um verschiedene Dinge</strong></li>
+          <li class="text-stone-600 text-base"><strong>Schwierigkeiten, zu entspannen</strong></li>
+          <li class="text-stone-600 text-base"><strong>So unruhig sein, dass Stillsitzen schwerfällt</strong></li>
+          <li class="text-stone-600 text-base"><strong>Leicht verärgert oder reizbar sein</strong></li>
+          <li class="text-stone-600 text-base"><strong>Gefühl der Angst, als würde etwas Schlimmes passieren</strong></li>
+        </ol>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Antwortoptionen: Überhaupt nicht (0), An einzelnen Tagen (1), An mehr als der Hälfte der Tage (2), Beinahe jeden Tag (3).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Score-Bereiche</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Schweregrad</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bedeutung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0 – 4</td>
+                <td class="px-6 py-3 text-stone-600">Minimal</td>
+                <td class="px-6 py-3 text-stone-600">Minimale Symptome — weiter beobachten</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5 – 9</td>
+                <td class="px-6 py-3 text-stone-600">Mild</td>
+                <td class="px-6 py-3 text-stone-600">Selbstfürsorge, Stressmanagement, Wiederholung in 2–4 Wochen</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">10 – 14</td>
+                <td class="px-6 py-3 text-stone-600">Moderat</td>
+                <td class="px-6 py-3 text-stone-600">Ärztlichen Rat einholen, weitere Abklärung</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">15 – 21</td>
+                <td class="px-6 py-3 text-stone-600">Schwer</td>
+                <td class="px-6 py-3 text-stone-600">Zeitnah professionelle Hilfe — aktive Behandlung empfohlen</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der <strong>Cutoff von 10</strong> ist die etablierte Schwelle für eine weitere klinische Abklärung. Eine <strong>Score-Veränderung um ≥ 5 Punkte</strong> gilt als klinisch bedeutsam — wichtig zur Verlaufsbeurteilung unter Therapie.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was der GAD-7 nicht ersetzt</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der GAD-7 erkennt <strong>Symptomhäufigkeit</strong>, aber nicht die Ursache. Schilddrüsenüberfunktion, Koffein, Medikamente, Schlafmangel und körperliche Erkrankungen können ein angst-ähnliches Bild erzeugen. Ein erhöhter Score sollte deshalb immer ärztlich eingeordnet werden.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Suizidale Gedanken und Selbstverletzung fragt der GAD-7 <strong>nicht</strong> ab. Bei akuten Krisen ist sofortige Hilfe wichtig — Notruf 112 oder Telefonseelsorge 0800 1110111 (kostenlos, 24/7).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was du jetzt tun kannst</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score &lt; 5:</strong> Symptome minimal. Weiter beobachten und Belastungen reduzieren.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score 5–9:</strong> Selbstfürsorge — Schlaf, Bewegung, Atemübungen, Reduktion von Koffein/Alkohol. Re-Test in 2–4 Wochen.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score ≥ 10:</strong> Termin beim Hausarzt oder Psychotherapeuten. Kognitive Verhaltenstherapie ist gut belegt; medikamentöse Optionen (SSRI) gibt es ebenfalls.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Akute Krise:</strong> Telefonseelsorge 0800 1110111 oder Notruf 112.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen & Rechner</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>PMS-Symptome</strong> — Angstsymptome treten zyklusabhängig auf. Eine PMS-Selbstauskunft hilft, prämenstruelle Belastung von generalisierter Angst zu trennen. Zum <router-link :to="localeBlogPath('pms-symptome-bewerten')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">PMS-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Menopause-Symptome</strong> — in den Wechseljahren häufen sich Angst und innere Unruhe. Eine Symptomerfassung zeigt, ob die hormonelle Phase eine Rolle spielt. Zum <router-link :to="localeBlogPath('menopause-symptome-bewerten')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Menopause-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Schlafzyklen</strong> — Schlafmangel ist einer der stärksten Verstärker von Angstsymptomen. Schon eine Woche ausreichender Schlaf senkt häufig den GAD-7-Score. Zum <router-link :to="localeBlogPath('schlafzyklen-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Schlafzyklen-Artikel</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deinen GAD-7-Score berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Sieben Fragen, anonym, sofort. Direkte Einordnung deiner Angstsymptome der letzten 2 Wochen.</p>
+        <router-link
+          :to="localePath('gad7')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum GAD-7 Angst-Screening &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Wie oft sollte ich den GAD-7 machen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Sinnvoll ist ein Ausgangswert und dann alle 2–4 Wochen während einer Behandlung oder bei Symptomveränderungen. Die Trend-Entwicklung über mehrere Tests ist aussagekräftiger als ein Einzelwert.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Mein Score liegt über 15 — ist das ein Notfall?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Ein hoher Score ist kein akuter Notfall, aber ein klares Signal für ausgeprägte Symptome. Vereinbare zeitnah einen Termin bei Hausarzt oder Psychotherapie. Bei akuten Suizidgedanken oder Selbstverletzungs-Impulsen unabhängig vom Score sofort Notruf 112 oder Telefonseelsorge 0800 1110111.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Funktioniert der GAD-7 auch bei Jugendlichen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Der GAD-7 ist primär für Erwachsene validiert und wird auch ab etwa 13 Jahren eingesetzt. Für jüngere Kinder gibt es altersgerechtere Werkzeuge.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Erkennt der GAD-7 auch Panikstörung oder Depression?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Der GAD-7 ist auf generalisierte Angst optimiert, hat aber moderate Genauigkeit für Panikstörung, soziale Phobie und PTBS. Für Depression nutzt man ergänzend den PHQ-9. In der Praxis werden GAD-7 und PHQ-9 häufig gemeinsam eingesetzt.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles slug="gad-7-angst-test-rechner" />
+  </article>
+</template>

--- a/src/pages/blog/en/Gad7AnxietyTestCalculator.vue
+++ b/src/pages/blog/en/Gad7AnxietyTestCalculator.vue
@@ -1,0 +1,245 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'GAD-7 Anxiety Test: Generalized Anxiety Screening — Score & Bands | Health Calculators',
+  description: 'Understand the GAD-7 anxiety screening: 7 questions, score 0–21, severity bands minimal/mild/moderate/severe. Cutoff 10, Spitzer 2006, what the score means — with free online calculator.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'GAD-7 Anxiety Test: Generalized Anxiety Screening — Score & Bands',
+      description: 'How troubled are you by anxiety symptoms? The GAD-7 is a validated 7-question screening for generalized anxiety disorder. What the bands mean, when the cutoff of 10 matters and what to do next.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-06-08',
+      dateModified: '2026-06-08',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/gad-7-anxiety-test-calculator',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What does the GAD-7 measure?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The GAD-7 measures the frequency of seven core symptoms of generalized anxiety disorder over the past 2 weeks. It is validated as a screening and severity tool.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What do the score bands mean?',
+          acceptedAnswer: { '@type': 'Answer', text: '0–4 minimal, 5–9 mild, 10–14 moderate, 15–21 severe anxiety symptoms. A score ≥ 10 is the commonly used cutoff for further clinical evaluation.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Is the GAD-7 a diagnosis?',
+          acceptedAnswer: { '@type': 'Answer', text: 'No. The GAD-7 is a screening tool, not a medical diagnosis. An anxiety disorder is confirmed through clinical evaluation with a healthcare professional.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What if I have thoughts of self-harm?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The GAD-7 does not screen for suicidal thoughts. If you have thoughts of hurting yourself or others, contact emergency services or a crisis line immediately (US: 988; UK: 116 123; Germany: 0800 1110111).' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">GAD-7 Anxiety Test: Generalized Anxiety Screening</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">June 8, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">8 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          How troubled are you by <strong>anxiety symptoms</strong>? The <strong>GAD-7</strong> (Generalized Anxiety Disorder 7-item) provides a validated answer in seven questions and is today's standard tool for screening generalized anxiety in primary care, mental-health settings and research.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how the GAD-7 works, what the severity bands mean, when further evaluation is needed, and how the GAD-7 connects to other symptom tools.
+        </p>
+      </div>
+
+      <!-- Prominent disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed font-medium">
+          This is a screening tool, not a medical diagnosis. If your score is 10 or above, or you have concerns, please consult a healthcare professional.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is the GAD-7?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The GAD-7 was developed and validated in 2006 by Spitzer, Kroenke, Williams and Löwe in the <em>Archives of Internal Medicine</em>. It asks about seven core symptoms of generalized anxiety over the past <strong>2 weeks</strong>. Each item is scored 0 (Not at all) to 3 (Nearly every day), with a total range of 0–21.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          At a cutoff of 10, the GAD-7 has a sensitivity of 89 % and specificity of 82 % for generalized anxiety disorder. It also screens with moderate accuracy for panic disorder, social anxiety disorder and PTSD.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The seven questions</h2>
+        <ol class="space-y-3 mb-4 list-decimal list-inside">
+          <li class="text-stone-600 text-base"><strong>Feeling nervous, anxious or on edge</strong></li>
+          <li class="text-stone-600 text-base"><strong>Not being able to stop or control worrying</strong></li>
+          <li class="text-stone-600 text-base"><strong>Worrying too much about different things</strong></li>
+          <li class="text-stone-600 text-base"><strong>Trouble relaxing</strong></li>
+          <li class="text-stone-600 text-base"><strong>Being so restless that it is hard to sit still</strong></li>
+          <li class="text-stone-600 text-base"><strong>Becoming easily annoyed or irritable</strong></li>
+          <li class="text-stone-600 text-base"><strong>Feeling afraid as if something awful might happen</strong></li>
+        </ol>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Response options: Not at all (0), Several days (1), More than half the days (2), Nearly every day (3).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Severity bands</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Severity</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Meaning</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0 – 4</td>
+                <td class="px-6 py-3 text-stone-600">Minimal</td>
+                <td class="px-6 py-3 text-stone-600">Minimal symptoms — keep monitoring</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5 – 9</td>
+                <td class="px-6 py-3 text-stone-600">Mild</td>
+                <td class="px-6 py-3 text-stone-600">Self-care, stress management, re-test in 2–4 weeks</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">10 – 14</td>
+                <td class="px-6 py-3 text-stone-600">Moderate</td>
+                <td class="px-6 py-3 text-stone-600">Consult a healthcare professional, further evaluation</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">15 – 21</td>
+                <td class="px-6 py-3 text-stone-600">Severe</td>
+                <td class="px-6 py-3 text-stone-600">Seek professional help promptly — active treatment recommended</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A <strong>cutoff of 10</strong> is the established threshold for further clinical evaluation. A change of <strong>≥ 5 points</strong> on follow-up is considered clinically meaningful and useful for tracking response to treatment.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What the GAD-7 does not replace</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The GAD-7 captures <strong>symptom frequency</strong>, not cause. Thyroid overactivity, caffeine, certain medications, sleep deprivation and other medical conditions can mimic an anxiety picture. An elevated score should therefore always be put in context by a clinician.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The GAD-7 does <strong>not</strong> screen for suicidal thoughts or self-harm. If you are in acute crisis, contact emergency services immediately — US: 988 (Suicide & Crisis Lifeline); UK: 116 123 (Samaritans); Germany: 0800 1110111 (Telefonseelsorge).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What to do next</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score &lt; 5:</strong> Symptoms minimal. Keep monitoring and reduce stressors.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score 5–9:</strong> Self-care — sleep, exercise, breathing techniques, less caffeine/alcohol. Re-test in 2–4 weeks.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score ≥ 10:</strong> Make an appointment with your GP or a mental-health professional. Cognitive behavioural therapy is well evidenced; SSRIs are also an option.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Acute crisis:</strong> Call your local emergency line or a crisis hotline (US: 988; UK: 116 123).</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics & calculators</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>PMS symptoms</strong> — anxiety symptoms can be cycle-driven. A PMS self-assessment helps separate premenstrual distress from generalized anxiety. Read the <router-link :to="localeBlogPath('pms-symptom-calculator-guide')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">PMS guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Menopause symptoms</strong> — anxiety and inner restlessness frequently increase during menopause. A symptom assessment shows whether the hormonal phase plays a role. Read the <router-link :to="localeBlogPath('menopause-symptom-calculator-guide')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">menopause guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Sleep cycles</strong> — sleep loss is one of the strongest amplifiers of anxiety. Even a week of adequate sleep often lowers the GAD-7 score. Read the <router-link :to="localeBlogPath('calculate-sleep-cycles')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">sleep cycle guide</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Take the GAD-7 now</h3>
+        <p class="text-stone-300 text-sm mb-5">Seven questions, anonymous, instant. Get an immediate interpretation of your anxiety symptoms over the past 2 weeks.</p>
+        <router-link
+          :to="localePath('gad7')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Go to the GAD-7 anxiety screening &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequently asked questions</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">How often should I take the GAD-7?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              A baseline first, then every 2–4 weeks during treatment or whenever symptoms change. Trends across multiple tests are more meaningful than any single value.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">My score is above 15 — is that an emergency?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              A high score is not an acute emergency, but it is a clear signal of significant symptoms. Make an appointment with a GP or therapist promptly. If you have acute thoughts of self-harm or suicide regardless of score, contact emergency services or a crisis line immediately (US: 988; UK: 116 123; Germany: 112 / 0800 1110111).
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Is the GAD-7 suitable for teenagers?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              The GAD-7 is primarily validated for adults and is also used from about age 13. For younger children, age-specific instruments are preferred.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Does the GAD-7 also detect panic disorder or depression?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              The GAD-7 is optimized for generalized anxiety but has moderate accuracy for panic disorder, social anxiety and PTSD. For depression, the PHQ-9 complements it — in practice, the two are often used together.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticlesEn slug="gad-7-anxiety-test-calculator" />
+  </article>
+</template>

--- a/src/pages/gad7.meta.js
+++ b/src/pages/gad7.meta.js
@@ -1,0 +1,16 @@
+import Component from './Gad7Calculator.vue'
+import BlogDe from './blog/Gad7AngstTestRechner.vue'
+import BlogEn from './blog/en/Gad7AnxietyTestCalculator.vue'
+
+export default {
+  key: 'gad7',
+  component: Component,
+  slugs: { de: 'gad-7-angst-test', en: 'gad-7-anxiety-test' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 120,
+  blog: {
+    de: { slug: 'gad-7-angst-test-rechner', component: BlogDe },
+    en: { slug: 'gad-7-anxiety-test-calculator', component: BlogEn },
+  },
+}

--- a/src/utils/gad7.js
+++ b/src/utils/gad7.js
@@ -1,0 +1,65 @@
+// GAD-7 — Generalized Anxiety Disorder 7-item scale (Spitzer RL et al., Arch Intern Med, 2006).
+//
+// Seven questions about the past 2 weeks, each scored 0–3, total 0–21:
+//   1. Feeling nervous, anxious or on edge
+//   2. Not being able to stop or control worrying
+//   3. Worrying too much about different things
+//   4. Trouble relaxing
+//   5. Being so restless that it's hard to sit still
+//   6. Becoming easily annoyed or irritable
+//   7. Feeling afraid as if something awful might happen
+//
+// Severity band (Spitzer 2006):
+//    0– 4 : Minimal
+//    5– 9 : Mild
+//   10–14 : Moderate
+//   15–21 : Severe
+//
+// Cutoff: a score ≥ 10 warrants further clinical evaluation.
+
+export const GAD7_QUESTIONS = [
+  'feelingNervous',
+  'cantStopWorrying',
+  'worryingTooMuch',
+  'troubleRelaxing',
+  'restless',
+  'irritable',
+  'afraidSomethingAwful',
+]
+
+function isValidAnswer(v) {
+  return Number.isInteger(v) && v >= 0 && v <= 3
+}
+
+export function calcGad7Score(answers) {
+  if (!answers || typeof answers !== 'object') return null
+  let total = 0
+  for (const q of GAD7_QUESTIONS) {
+    if (!isValidAnswer(answers[q])) return null
+    total += answers[q]
+  }
+  return total
+}
+
+export function classifyGad7(total) {
+  if (typeof total !== 'number' || !Number.isFinite(total)) return null
+  if (total < 0 || total > 21) return null
+  if (total <= 4) return 'Minimal'
+  if (total <= 9) return 'Mild'
+  if (total <= 14) return 'Moderate'
+  return 'Severe'
+}
+
+export function needsEvaluation(total) {
+  return typeof total === 'number' && Number.isFinite(total) && total >= 10
+}
+
+export function evaluateGad7(answers) {
+  const score = calcGad7Score(answers)
+  if (score === null) return null
+  return {
+    score,
+    band: classifyGad7(score),
+    needsEvaluation: needsEvaluation(score),
+  }
+}


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-273-gad7-anxiety
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-273-gad7-anxiety-20260608-233022`
**Cost:** $6.790425750000002

Closes jenslaufer/health-calculators#273

### Prompt
> Implement the GAD-7 Anxiety Screening Calculator as described in issue #273.

Follow the EXACT same pattern as existing self-report screening calculators in the repo
(`AsthmaControlCalculator.vue`, `CopdAssessmentCalculator.vue`, `PainScaleCalculator.vue`).
Use the auto-discovery pattern — no shared file modifications (except the 3 documented exceptions below).

Requirements:
- Vue 3 + Tailwind CSS calculator component with 7 questions × 4 response options (0–3)
- Live total score (0–21) + severity band + `needsEvaluation` flag (≥10)
- Clear/Reset button
- Prominent disclaimer: screening tool, NOT a diagnosis
- Blog articles: DE + EN (SEO optimized, FAQPage structured data)
- Internal links to pmsSymptom, menopauseSymptom, sleepCycle (verify routes in articles*.js)
- Unit tests with verbatim score+band assertions from issue
- E2E test
- SSG pre-rendering must work

## Verbatim NICHT-VERHANDELBAR (do NOT improvise)

Bands (verbatim):
  0–4   → 'Minimal'
  5–9   → 'Mild'
  10–14 → 'Moderate'
  15–21 → 'Severe'

Cutoff: needsEvaluation(score) === score >= 10

Question text (verbatim, EN + DE — full list in issue #273 NICHT VERHANDELBAR block).
Response labels (verbatim):
  EN: Not at all | Several days | More than half the days | Nearly every day
  DE: Überhaupt nicht | An einzelnen Tagen | An mehr als der Hälfte der Tage | Beinahe jeden Tag

## Internal linking (REQUIRED)
- Blog → own calculator (DE + EN routes) + 2–3 related calculators (pmsSymptom, menopauseSymptom, sleepCycle)
- Calculator page → this blog (DE + EN)
- Verify every target route exists in `src/data/articles.js` + `articles-en.js`


## RETRY-AWARE no-diff guard (READ FIRST)
Before `git push`, run `git status`. If no new files staged → DO NOT push.


## PARTIAL-COMMIT GUARD (MANDATORY)
Before `git push`, run:
  git diff --name-only main..HEAD | sort

Output MUST contain ALL of these paths (substitute <DeBlogPascal> + <EnBlogPascal>):
  e2e/gad7.spec.js
  src/__tests__/auto-discovery.test.js
  src/__tests__/gad7.test.js
  src/__tests__/llms-txt.test.js
  src/__tests__/sitemap.test.js
  src/data/articles-en.js
  src/data/articles.js
  src/locales/calculators/de/gad7.json
  src/locales/calculators/en/gad7.json
  src/pages/Gad7Calculator.vue
  src/pages/blog/<DeBlogPascal>.vue
  src/pages/blog/en/<EnBlogPascal>.vue
  src/pages/gad7.meta.js
  src/utils/gad7.js

If ANY path is missing → DO NOT push. Counter check: `git diff --name-only main..HEAD | wc -l` MUST be >= 14.

## EN BLOG COMPONENT IMPORT (MANDATORY)
In `src/pages/blog/en/<EnBlogPascal>.vue`, the related-articles component MUST be
`RelatedArticlesEn` (from `../../../components/RelatedArticlesEn.vue`),
NOT `RelatedArticles` (which is the German component using DE article slugs).
Pre-push check: `grep -E "^import RelatedArticles[^E]" src/pages/blog/en/<file>.vue`
MUST return ZERO lines. DE blog page keeps `RelatedArticles` unchanged.
Reference for correct import: `src/pages/blog/en/CholesterolRatio.vue`.

Reference: study `src/pages/AsthmaControlCalculator.vue` + `src/pages/asthmaControl.meta.js` + `src/locales/calculators/{de,en}/asthmaControl.json` + `src/__tests__/asthmaControl.test.js` + `e2e/asthmaControl.spec.js`.

## TDD-red-first ordering (MANDATORY)
1. Red unit test (8+ cases from issue: all-zero, all-three, 5, 9, 10, 14, 15 boundaries, needsEvaluation flag).
2. Green logic (`src/utils/gad7.js`).
3. View + locale JSON + meta anchor `src/pages/gad7.meta.js`
   (key: 'gad7',
    slugs: { de: 'gad-7-angst-test', en: 'gad-7-anxiety-test' },
    blog: { de: 'gad-7-angst-test-rechner', en: 'gad-7-anxiety-test-calculator' }).
4. E2E test (fill all 7 questions via radio/button, verify score + band).
5. Blog articles + articles.js + articles-en.js registration.
6. Final verification: `npm test` + `npm run test:e2e` + `npm run build`.

## Locale-Path + Meta-Anchor (CRITICAL)
HC auto-discovers via `src/discovery.js` scanning `src/pages/*.meta.js`. Without the meta file there is NO ROUTE.
Create:
- `src/pages/gad7.meta.js` (mirror `src/pages/asthmaControl.meta.js`)
- `src/locales/calculators/de/gad7.json` + `src/locales/calculators/en/gad7.json`
  (flat top-level keys; mirror asthmaControl.json shape, but with 7 questions + 4 response labels)

## HC blog-count + calculator-count assertion bump (MANDATORY before push)
Open `src/__tests__/auto-discovery.test.js`. Read current N first via:
  grep -E "toHaveLength\([0-9]+\)" src/__tests__/auto-discovery.test.js
Then bump:
- `calculatorMetas` and `calculatorComponents` length: N → N+1
- `blogComponentsDe` and `blogComponentsEn` length: M → M+1
- Append new DE slug to `EXPECTED_BLOG_SLUGS_DE` and EN slug to `EXPECTED_BLOG_SLUGS_EN`
Without this, `npm test` red-fails.
EXCEPTION to "do not modify existing files": this single test file MAY be modified for these bumps only.

## Register blog in articles*.js (MANDATORY — main RED otherwise)
Add new entry to BOTH `src/data/articles.js` (DE) AND `src/data/articles-en.js` (EN) mirroring existing entry shape:
```js
{
  slug: '<your-de-blog-slug>',
  title: '<DE blog title>',
  description: '<DE meta description, ~155 chars>',
  date: '<today YYYY-MM-DD>',
  readTime: '<N> min',
  calculatorKey: 'gad7',
  related: ['pmsSymptom', 'menopauseSymptom', 'sleepCycle'],
},
```
Same shape for `articles-en.js`. EXCEPTION to "do not modify existing files": these two files MAY be appended for this single new entry only.

## E2E Selector rules (Playwright strict-mode)
- NEVER `text=Substring`. USE `getByRole`, `getByTestId`, `getByText(..., { exact: true })`.

## YMYL disclaimer (REQUIRED — non-negotiable)
Calculator page + Result panel + Blog MUST display:
  EN: "This is a screening tool, not a medical diagnosis. If your score is 10 or above, or you have concerns, please consult a healthcare professional."
  DE: "Dies ist ein Screening-Werkzeug, keine medizinische Diagnose. Bei einem Wert ab 10 oder bei Beschwerden bitte ärztlichen Rat einholen."
No diagnostic language anywhere. No "you have anxiety" — only "your score suggests …".

CRITICAL CONSTRAINTS:
- DO NOT modify or delete ANY existing calculator files (EXCEPT the test + articles files listed above)
- Only ADD new files following the auto-discovery pattern