### PR TITLE
fix(hc-284): hide AffiliateBanner while URL is placeholder

### DIFF
--- a/e2e/english-affiliates.spec.js
+++ b/e2e/english-affiliates.spec.js
@@ -1,38 +1,58 @@
 import { test, expect } from '@playwright/test'
+import { adConfig, routeContextMap } from '../src/ads/config.js'
 
-const enCalculators = [
-  { slug: 'bmi-calculator', program: 'Hims' },
-  { slug: 'body-fat-calculator', program: 'Hims' },
-  { slug: 'calorie-deficit-calculator', program: 'Hims' },
-  { slug: 'tdee-calculator', program: 'Hims' },
-  { slug: 'macro-calculator', program: 'Noom' },
-  { slug: 'bmr-calculator', program: 'Noom' },
-  { slug: 'protein-calculator', program: 'Thorne' },
-  { slug: 'water-intake-calculator', program: 'Ritual' },
-  { slug: 'heart-rate-zones', program: 'AG1' },
-  { slug: 'ideal-weight-calculator', program: 'AG1' },
-  { slug: 'sleep-cycle-calculator', program: 'AG1' },
-  { slug: 'blood-pressure-calculator', program: 'AG1' },
-  { slug: 'pregnancy-calculator', program: 'AG1' },
-  { slug: 'ovulation-calculator', program: 'AG1' },
-  { slug: 'intermittent-fasting-calculator', program: 'AG1' },
-  { slug: 'waist-hip-ratio-calculator', program: 'AG1' },
-  { slug: 'calories-burned', program: 'AG1' },
-]
+const LIVE_URL = /^https?:\/\//
 
-for (const { slug, program } of enCalculators) {
-  test(`EN ${slug} shows affiliate banner`, async ({ page }) => {
-    await page.goto(`en/${slug}`)
-    const banner = page.getByTestId('affiliate-banner')
-    await expect(banner).toBeVisible()
-    await expect(banner.getByText('Ad', { exact: true })).toBeVisible()
-    await expect(banner.locator('a')).toHaveAttribute('rel', 'noopener sponsored')
-  })
+function resolveUrl(lang, slug) {
+  const contextMap = routeContextMap[lang] || routeContextMap.de
+  const ctx = contextMap[slug] || 'default'
+  const localeConfig = adConfig[lang] || adConfig.de
+  const config = localeConfig[ctx] || localeConfig.default
+  return config.affiliate.url
 }
 
-test('DE calculator shows German affiliate (not English programs)', async ({ page }) => {
-  await page.goto('de/bmi-rechner')
-  const banner = page.getByTestId('affiliate-banner')
-  await expect(banner).toBeVisible()
-  await expect(banner.getByText('Anzeige', { exact: true })).toBeVisible()
-})
+const enSlugs = [
+  'bmi-calculator',
+  'body-fat-calculator',
+  'calorie-deficit-calculator',
+  'tdee-calculator',
+  'macro-calculator',
+  'bmr-calculator',
+  'protein-calculator',
+  'water-intake-calculator',
+  'heart-rate-zones',
+  'ideal-weight-calculator',
+  'sleep-cycle-calculator',
+  'blood-pressure-calculator',
+  'pregnancy-calculator',
+  'ovulation-calculator',
+  'intermittent-fasting-calculator',
+  'waist-hip-ratio-calculator',
+  'calories-burned',
+]
+
+const cases = [
+  ...enSlugs.map((slug) => ({ lang: 'en', slug, path: `en/${slug}`, label: 'Ad' })),
+  { lang: 'de', slug: 'bmi-rechner', path: 'de/bmi-rechner', label: 'Anzeige' },
+]
+
+for (const { lang, slug, path, label } of cases) {
+  const url = resolveUrl(lang, slug)
+  const live = LIVE_URL.test(url)
+
+  test(`${lang.toUpperCase()} ${slug} — banner ${live ? 'visible with live URL' : 'hidden while URL is placeholder'}`, async ({ page }) => {
+    await page.goto(path)
+    const banner = page.getByTestId('affiliate-banner')
+
+    if (!live) {
+      await expect(banner).toHaveCount(0)
+      return
+    }
+
+    await expect(banner).toBeVisible()
+    await expect(banner.getByText(label, { exact: true })).toBeVisible()
+    const cta = banner.locator('a')
+    await expect(cta).toHaveAttribute('rel', 'noopener sponsored')
+    await expect(cta).toHaveAttribute('href', url)
+  })
+}

--- a/src/__tests__/affiliateBanner.test.js
+++ b/src/__tests__/affiliateBanner.test.js
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+
+function makeI18n(locale = 'en') {
+  return createI18n({ legacy: false, locale, messages: { de: {}, en: {} } })
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+  })
+}
+
+async function mountAt(path, locale) {
+  const router = makeRouter()
+  router.push(path)
+  await router.isReady()
+  return mount(AffiliateBanner, {
+    global: { plugins: [makeI18n(locale), router] },
+  })
+}
+
+describe('AffiliateBanner placeholder guard', () => {
+  it('does NOT render when the resolved EN affiliate url is the placeholder "#"', async () => {
+    const wrapper = await mountAt('/en/bmi-calculator', 'en')
+    expect(wrapper.find('[data-testid="affiliate-banner"]').exists()).toBe(false)
+  })
+
+  it('does NOT render when the resolved DE affiliate url is the placeholder "#"', async () => {
+    const wrapper = await mountAt('/de/bmi-rechner', 'de')
+    expect(wrapper.find('[data-testid="affiliate-banner"]').exists()).toBe(false)
+  })
+
+  it('does NOT render for an unmapped slug (default url is also "#")', async () => {
+    const wrapper = await mountAt('/en/some-unmapped-slug', 'en')
+    expect(wrapper.find('[data-testid="affiliate-banner"]').exists()).toBe(false)
+  })
+})

--- a/src/components/AffiliateBanner.vue
+++ b/src/components/AffiliateBanner.vue
@@ -17,10 +17,12 @@ const affiliate = computed(() => {
   const config = localeConfig[ctx] || localeConfig.default
   return config.affiliate
 })
+
+const hasLiveUrl = computed(() => /^https?:\/\//.test(affiliate.value.url))
 </script>
 
 <template>
-  <div class="mt-6 bg-stone-50 border border-stone-200 rounded-xl p-6" data-testid="affiliate-banner">
+  <div v-if="hasLiveUrl" class="mt-6 bg-stone-50 border border-stone-200 rounded-xl p-6" data-testid="affiliate-banner">
     <p class="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-2">
       {{ locale === 'de' ? 'Anzeige' : 'Ad' }}
     </p>


### PR DESCRIPTION
## Summary
- AffiliateBanner now hides itself when the resolved affiliate URL is still the placeholder `#`, removing the dead `rel="sponsored"` CTA from ~90 calculator pages on YMYL health content.
- `src/ads/config.js` stays untouched — once a real tracking link replaces `#`, the banner reappears on the mapped pages with zero code change.
- E2E spec rewritten to be config-driven: asserts hidden when URL is placeholder, visible with `rel="noopener sponsored"` + real href when URL is live. Self-adjusts as registrations land.

## Test plan
- [x] New `src/__tests__/affiliateBanner.test.js` (TDD: failed first, then passed)
- [x] `npm test` — 2692 passed
- [x] `npm run build` — green
- [x] `npx playwright test e2e/english-affiliates.spec.js` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)