### PR TITLE
PHQ-9 Depression Screening calculator + DE/EN blog (closes #286)

### DIFF
--- a/src/__tests__/auto-discovery.test.js
+++ b/src/__tests__/auto-discovery.test.js
@@ -35,6 +35,7 @@ const EXPECTED_KEYS = [
   'pulsePressure',
   'wilksCoefficient',
   'gad7',
+  'phq9',
 ]
 
 const EXPECTED_BLOG_ONLY_KEYS = ['vitaminDDeficiency', 'diabetesPrevention', 'menopauseNatural']
@@ -131,6 +132,7 @@ const EXPECTED_ROUTE_MAP = {
   pulsePressure: { de: 'pulsdruck-rechner', en: 'pulse-pressure' },
   wilksCoefficient: { de: 'wilks-coefficient-rechner', en: 'wilks-coefficient' },
   gad7: { de: 'gad-7-angst-test', en: 'gad-7-anxiety-test' },
+  phq9: { de: 'phq-9-depressionstest', en: 'phq-9-depression-test' },
 }
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -218,6 +220,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'bmi-bei-frauen',
   'bmi-bei-maennern',
   'gad-7-angst-test-rechner',
+  'phq-9-depressionstest-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -305,19 +308,20 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'bmi-for-women',
   'bmi-for-men',
   'gad-7-anxiety-test-calculator',
+  'phq-9-depression-test-calculator',
 ]
 
 describe('calculator discovery', () => {
-  it('discovers all 93 calculators', () => {
-    expect(calculatorMetas).toHaveLength(93)
+  it('discovers all 94 calculators', () => {
+    expect(calculatorMetas).toHaveLength(94)
     const keys = calculatorMetas.map(m => m.key)
     for (const key of EXPECTED_KEYS) {
       expect(keys).toContain(key)
     }
   })
 
-  it('builds calculatorComponents map for all 93 keys', () => {
-    expect(Object.keys(calculatorComponents)).toHaveLength(93)
+  it('builds calculatorComponents map for all 94 keys', () => {
+    expect(Object.keys(calculatorComponents)).toHaveLength(94)
     for (const key of EXPECTED_KEYS) {
       expect(calculatorComponents[key]).toBeDefined()
     }
@@ -340,15 +344,15 @@ describe('calculator discovery', () => {
 })
 
 describe('blog component discovery', () => {
-  it('discovers all 96 German blog components', () => {
-    expect(Object.keys(blogComponentsDe)).toHaveLength(96)
+  it('discovers all 97 German blog components', () => {
+    expect(Object.keys(blogComponentsDe)).toHaveLength(97)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(blogComponentsDe[slug]).toBeDefined()
     }
   })
 
-  it('discovers all 96 English blog components', () => {
-    expect(Object.keys(blogComponentsEn)).toHaveLength(96)
+  it('discovers all 97 English blog components', () => {
+    expect(Object.keys(blogComponentsEn)).toHaveLength(97)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(blogComponentsEn[slug]).toBeDefined()
     }
@@ -373,10 +377,10 @@ describe('calculator groups', () => {
     expect(calculatorGroups[3].key).toBe('pregnancy')
   })
 
-  it('groups contain all 93 calculators with no duplicates', () => {
+  it('groups contain all 94 calculators with no duplicates', () => {
     const allKeys = calculatorGroups.flatMap(g => g.calculators)
-    expect(allKeys).toHaveLength(93)
-    expect(new Set(allKeys).size).toBe(93)
+    expect(allKeys).toHaveLength(94)
+    expect(new Set(allKeys).size).toBe(94)
     for (const key of EXPECTED_KEYS) {
       expect(allKeys).toContain(key)
     }
@@ -397,7 +401,7 @@ describe('calculator groups', () => {
 
   it('fitnessRecovery group has correct calculators in order', () => {
     expect(calculatorGroups[2].calculators).toEqual([
-      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'pulsePressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'wilksCoefficient', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk', 'gad7',
+      'heartRate', 'sleep', 'bloodPressure', 'meanArterialPressure', 'pulsePressure', 'vo2Max', 'oneRepMax', 'runningPace', 'bac', 'hba1c', 'homaIr', 'bloodSugar', 'gfr', 'smokingCost', 'childGrowth', 'headCircumference', 'pediatricBmi', 'lifeExpectancy', 'diabetesRisk', 'biologicalAge', 'vitaminD', 'alcoholUnits', 'bodyTemperature', 'anionGap', 'sodiumCorrection', 'childDosage', 'cholesterolRatio', 'ldlFriedewald', 'ankleBrachialIndex', 'wilksCoefficient', 'prostateRisk', 'testosteroneLevel', 'erectileDysfunction', 'malePattern', 'cardiovascularRisk', 'strokeRisk', 'bloodAlcoholEstimator', 'dehydrationRisk', 'heartFailureRisk', 'thyroidFunction', 'anemiaRisk', 'osteoporosisRisk', 'hepatitisRisk', 'correctedCalcium', 'asthmaControl', 'copdAssessment', 'creatinineClearance', 'painScale', 'pediatricBloodPressure', 'schritteKalorienRechner', 'ironDeficiency', 'breastCancerRisk', 'gad7', 'phq9',
     ])
   })
 
@@ -446,8 +450,8 @@ describe('i18n completeness', () => {
 })
 
 describe('SSG routes', () => {
-  it('generates exactly 516 routes', () => {
-    expect(routes).toHaveLength(516)
+  it('generates exactly 521 routes', () => {
+    expect(routes).toHaveLength(521)
   })
 
   it('has locale routes for all calculators in both languages', () => {

--- a/src/__tests__/llms-txt.test.js
+++ b/src/__tests__/llms-txt.test.js
@@ -65,9 +65,9 @@ describe('generateLlmsTxt', () => {
     }
   })
 
-  it('generates 378 links (93 calcs × 2 locales + 96 blogs × 2 locales)', () => {
+  it('generates 382 links (94 calcs × 2 locales + 97 blogs × 2 locales)', () => {
     const links = txt.split('\n').filter(l => l.startsWith('- ['))
-    expect(links).toHaveLength(378)
+    expect(links).toHaveLength(382)
   })
 
   it('blog titles do not contain "| Health Calculators" suffix', () => {

--- a/src/__tests__/phq9.test.js
+++ b/src/__tests__/phq9.test.js
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PHQ9_QUESTIONS,
+  calcPhq9Score,
+  classifyPhq9,
+  needsEvaluation,
+  item9Flag,
+  evaluatePhq9,
+} from '../utils/phq9.js'
+
+// PHQ-9 — Patient Health Questionnaire 9-item depression scale (Kroenke, Spitzer & Williams, J Gen Intern Med, 2001)
+// 9 questions, each scored 0–3, total 0–27.
+//    0– 4 : Minimal
+//    5– 9 : Mild
+//   10–14 : Moderate
+//   15–19 : ModeratelySevere
+//   20–27 : Severe
+// needsEvaluation: score >= 10
+// item9Flag: item 9 (self-harm) answer >= 1 — independent of the total score
+
+// Build an answers object from an array of 9 values in canonical item order.
+const fromArray = (vals) =>
+  Object.fromEntries(PHQ9_QUESTIONS.map((q, i) => [q, vals[i]]))
+
+const FULL = (v) => fromArray(Array(9).fill(v))
+
+describe('PHQ9_QUESTIONS', () => {
+  it('exposes 9 question keys', () => {
+    expect(PHQ9_QUESTIONS).toHaveLength(9)
+  })
+
+  it('uses canonical keys in item order (1..9)', () => {
+    expect(PHQ9_QUESTIONS).toEqual([
+      'littleInterest',
+      'feelingDown',
+      'sleepTrouble',
+      'tiredLowEnergy',
+      'appetiteProblems',
+      'feelingBadAboutSelf',
+      'troubleConcentrating',
+      'movingSlowlyOrRestless',
+      'selfHarmThoughts',
+    ])
+  })
+})
+
+describe('calcPhq9Score', () => {
+  it('all zeros → 0', () => {
+    expect(calcPhq9Score(FULL(0))).toBe(0)
+  })
+
+  it('all threes → 27', () => {
+    expect(calcPhq9Score(FULL(3))).toBe(27)
+  })
+
+  it('mixed answers [2,2,2,1,1,1,1,0,0] → 10', () => {
+    expect(calcPhq9Score(fromArray([2, 2, 2, 1, 1, 1, 1, 0, 0]))).toBe(10)
+  })
+
+  it('returns null on missing answer', () => {
+    const a = FULL(1)
+    delete a.troubleConcentrating
+    expect(calcPhq9Score(a)).toBe(null)
+  })
+
+  it('returns null on out-of-range value (-1)', () => {
+    expect(calcPhq9Score({ ...FULL(1), littleInterest: -1 })).toBe(null)
+  })
+
+  it('returns null on out-of-range value (4)', () => {
+    expect(calcPhq9Score({ ...FULL(1), littleInterest: 4 })).toBe(null)
+  })
+
+  it('returns null on non-integer (1.5)', () => {
+    expect(calcPhq9Score({ ...FULL(1), littleInterest: 1.5 })).toBe(null)
+  })
+
+  it('returns null on null/undefined input', () => {
+    expect(calcPhq9Score(null)).toBe(null)
+    expect(calcPhq9Score(undefined)).toBe(null)
+  })
+})
+
+describe('classifyPhq9 — verbatim 5-band severity scale', () => {
+  it('0 → Minimal', () => { expect(classifyPhq9(0)).toBe('Minimal') })
+  it('4 → Minimal (upper boundary)', () => { expect(classifyPhq9(4)).toBe('Minimal') })
+  it('5 → Mild (lower boundary)', () => { expect(classifyPhq9(5)).toBe('Mild') })
+  it('9 → Mild (upper boundary)', () => { expect(classifyPhq9(9)).toBe('Mild') })
+  it('10 → Moderate (lower boundary)', () => { expect(classifyPhq9(10)).toBe('Moderate') })
+  it('14 → Moderate (upper boundary)', () => { expect(classifyPhq9(14)).toBe('Moderate') })
+  it('15 → ModeratelySevere (lower boundary)', () => { expect(classifyPhq9(15)).toBe('ModeratelySevere') })
+  it('19 → ModeratelySevere (upper boundary)', () => { expect(classifyPhq9(19)).toBe('ModeratelySevere') })
+  it('20 → Severe (lower boundary)', () => { expect(classifyPhq9(20)).toBe('Severe') })
+  it('27 → Severe (maximum)', () => { expect(classifyPhq9(27)).toBe('Severe') })
+
+  it('returns null for out-of-range or invalid', () => {
+    expect(classifyPhq9(-1)).toBe(null)
+    expect(classifyPhq9(28)).toBe(null)
+    expect(classifyPhq9(null)).toBe(null)
+    expect(classifyPhq9('10')).toBe(null)
+  })
+})
+
+describe('needsEvaluation — cutoff at 10', () => {
+  it('9 → false', () => { expect(needsEvaluation(9)).toBe(false) })
+  it('10 → true (cutoff)', () => { expect(needsEvaluation(10)).toBe(true) })
+  it('19 → true', () => { expect(needsEvaluation(19)).toBe(true) })
+  it('27 → true', () => { expect(needsEvaluation(27)).toBe(true) })
+  it('0 → false', () => { expect(needsEvaluation(0)).toBe(false) })
+  it('non-number → false', () => {
+    expect(needsEvaluation(null)).toBe(false)
+    expect(needsEvaluation('10')).toBe(false)
+  })
+})
+
+describe('item9Flag — self-harm safety flag, independent of total', () => {
+  it('item 9 = 0 → false', () => {
+    expect(item9Flag(FULL(0))).toBe(false)
+  })
+  it('item 9 = 1 → true', () => {
+    expect(item9Flag(fromArray([0, 0, 0, 0, 0, 0, 0, 0, 1]))).toBe(true)
+  })
+  it('item 9 = 2 with otherwise-zero answers → true (low total, flag still fires)', () => {
+    expect(item9Flag(fromArray([0, 0, 0, 0, 0, 0, 0, 0, 2]))).toBe(true)
+  })
+  it('item 9 = 3 → true', () => {
+    expect(item9Flag(fromArray([0, 0, 0, 0, 0, 0, 0, 0, 3]))).toBe(true)
+  })
+  it('all 1 → true (item 9 = 1)', () => {
+    expect(item9Flag(FULL(1))).toBe(true)
+  })
+  it('invalid/missing item 9 → false', () => {
+    expect(item9Flag({})).toBe(false)
+    expect(item9Flag(null)).toBe(false)
+  })
+})
+
+describe('evaluatePhq9 — six worked examples from issue #286', () => {
+  it('all 0 → score 0, Minimal, no evaluation, no item-9 flag', () => {
+    expect(evaluatePhq9(FULL(0))).toEqual({
+      score: 0, band: 'Minimal', needsEvaluation: false, item9Flag: false,
+    })
+  })
+
+  it('all 1 → score 9, Mild, no evaluation, item-9 flag TRUE', () => {
+    expect(evaluatePhq9(FULL(1))).toEqual({
+      score: 9, band: 'Mild', needsEvaluation: false, item9Flag: true,
+    })
+  })
+
+  it('all 3 → score 27, Severe, needsEvaluation, item-9 flag', () => {
+    expect(evaluatePhq9(FULL(3))).toEqual({
+      score: 27, band: 'Severe', needsEvaluation: true, item9Flag: true,
+    })
+  })
+
+  it('[2,2,2,1,1,1,1,0,0] → score 10, Moderate, needsEvaluation, no item-9 flag', () => {
+    expect(evaluatePhq9(fromArray([2, 2, 2, 1, 1, 1, 1, 0, 0]))).toEqual({
+      score: 10, band: 'Moderate', needsEvaluation: true, item9Flag: false,
+    })
+  })
+
+  it('[3,3,3,2,2,2,2,2,0] → score 19, ModeratelySevere, needsEvaluation, no item-9 flag', () => {
+    expect(evaluatePhq9(fromArray([3, 3, 3, 2, 2, 2, 2, 2, 0]))).toEqual({
+      score: 19, band: 'ModeratelySevere', needsEvaluation: true, item9Flag: false,
+    })
+  })
+
+  it('[0,0,0,0,0,0,0,0,2] → score 2, Minimal, no evaluation, item-9 flag TRUE (critical case)', () => {
+    expect(evaluatePhq9(fromArray([0, 0, 0, 0, 0, 0, 0, 0, 2]))).toEqual({
+      score: 2, band: 'Minimal', needsEvaluation: false, item9Flag: true,
+    })
+  })
+
+  it('returns null on incomplete answers', () => {
+    expect(evaluatePhq9({ littleInterest: 1 })).toBe(null)
+  })
+
+  it('returns null on null input', () => {
+    expect(evaluatePhq9(null)).toBe(null)
+  })
+})

--- a/src/__tests__/sitemap.test.js
+++ b/src/__tests__/sitemap.test.js
@@ -29,6 +29,7 @@ const EXPECTED_KEYS = [
   'pulsePressure',
   'wilksCoefficient',
   'gad7',
+  'phq9',
 ]
 
 const EXPECTED_BLOG_SLUGS_DE = [
@@ -115,6 +116,7 @@ const EXPECTED_BLOG_SLUGS_DE = [
   'bmi-bei-frauen',
   'bmi-bei-maennern',
   'gad-7-angst-test-rechner',
+  'phq-9-depressionstest-rechner',
 ]
 
 const EXPECTED_BLOG_SLUGS_EN = [
@@ -201,12 +203,13 @@ const EXPECTED_BLOG_SLUGS_EN = [
   'bmi-for-women',
   'bmi-for-men',
   'gad-7-anxiety-test-calculator',
+  'phq-9-depression-test-calculator',
 ]
 
 describe('discoverMetas', () => {
-  it('discovers all 93 calculator meta files', () => {
+  it('discovers all 94 calculator meta files', () => {
     const metas = discoverMetas(META_DIR)
-    expect(metas.filter(m => !m.blogOnly)).toHaveLength(93)
+    expect(metas.filter(m => !m.blogOnly)).toHaveLength(94)
   })
 
   it('discovers all expected calculator keys', () => {
@@ -244,19 +247,19 @@ describe('discoverMetas', () => {
 })
 
 describe('discoverBlogSlugs', () => {
-  it('returns all 96 DE blog slugs', () => {
+  it('returns all 97 DE blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { de } = discoverBlogSlugs(metas)
-    expect(de).toHaveLength(96)
+    expect(de).toHaveLength(97)
     for (const slug of EXPECTED_BLOG_SLUGS_DE) {
       expect(de, `missing de blog slug: ${slug}`).toContain(slug)
     }
   })
 
-  it('returns all 96 EN blog slugs', () => {
+  it('returns all 97 EN blog slugs', () => {
     const metas = discoverMetas(META_DIR)
     const { en } = discoverBlogSlugs(metas)
-    expect(en).toHaveLength(96)
+    expect(en).toHaveLength(97)
     for (const slug of EXPECTED_BLOG_SLUGS_EN) {
       expect(en, `missing en blog slug: ${slug}`).toContain(slug)
     }
@@ -324,9 +327,9 @@ describe('generateSitemap', () => {
     expect(xml).toContain(`hreflang="en" href="${BASE_URL}/en/"`)
   })
 
-  it('generates correct total URL count (2 home + 186 calcs + 2 blog index + 192 blog articles = 382)', () => {
+  it('generates correct total URL count (2 home + 188 calcs + 2 blog index + 194 blog articles = 386)', () => {
     const urlCount = (xml.match(/<url>/g) || []).length
-    expect(urlCount).toBe(382)
+    expect(urlCount).toBe(386)
   })
 
   it('every <loc> URL ends with a trailing slash', () => {

--- a/src/data/articles-en.js
+++ b/src/data/articles-en.js
@@ -863,6 +863,15 @@ slug: 'calculate-vo2max',
     calculatorKey: 'gad7',
     related: ['pms-symptom-calculator-guide', 'menopause-symptom-calculator-guide', 'calculate-sleep-cycles'],
   },
+  {
+    slug: 'phq-9-depression-test-calculator',
+    title: 'PHQ-9 Depression Test: Screening for Depression — Score & Bands',
+    description: 'Understand the PHQ-9 depression screening: 9 questions, score 0–27, five severity bands from minimal to severe. Cutoff 10, item 9 on self-harm, Kroenke 2001 — screening tool, not a diagnosis.',
+    date: '2026-06-16',
+    readTime: '9 min',
+    calculatorKey: 'phq9',
+    related: ['gad-7-anxiety-test-calculator', 'calculate-sleep-cycles', 'biological-age-calculator'],
+  },
 ]
 
 export function getEnArticleBySlug(slug) {

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -863,6 +863,15 @@ slug: 'vo2max-berechnen',
     calculatorKey: 'gad7',
     related: ['pms-symptome-bewerten', 'menopause-symptome-bewerten', 'schlafzyklen-berechnen'],
   },
+  {
+    slug: 'phq-9-depressionstest-rechner',
+    title: 'PHQ-9 Depressionstest: Depression erkennen — Rechner & Score',
+    description: 'PHQ-9 Depressions-Screening verstehen: 9 Fragen, Score 0–27, fünf Schweregrade von minimal bis schwer. Cutoff 10, Item 9 zur Selbstgefährdung, Kroenke 2001 — Screening-Werkzeug, keine Diagnose.',
+    date: '2026-06-16',
+    readTime: '9 min',
+    calculatorKey: 'phq9',
+    related: ['gad-7-angst-test-rechner', 'schlafzyklen-berechnen', 'biologisches-alter-berechnen'],
+  },
 ]
 
 export function getArticleBySlug(slug) {

--- a/src/locales/calculators/de/phq9.json
+++ b/src/locales/calculators/de/phq9.json
@@ -1,0 +1,105 @@
+{
+  "home": {
+    "calculators": {
+      "phq9": {
+        "name": "PHQ-9 Depressions-Screening",
+        "description": "Validierter 9-Fragen-Test für Depression — Score 0–27 mit Schweregrad und Selbstgefährdungs-Hinweis."
+      }
+    }
+  },
+  "phq9": {
+    "meta": {
+      "title": "PHQ-9 Depressionstest (Gesundheitsfragebogen für Patienten) — Online Screening | Health Calculators",
+      "description": "PHQ-9 Depressions-Screening online. 9 Fragen, Score 0–27, Schweregrade minimal bis schwer. Kostenlos, anonym, sofort. Screening-Werkzeug — keine Diagnose."
+    },
+    "title": "PHQ-9 Depressions-Screening",
+    "description": "Wie oft haben dich in den letzten 2 Wochen die folgenden Beschwerden belastet? Wähle pro Frage genau eine Antwort. Dein Gesamtscore (0–27) und der Schweregrad erscheinen automatisch.",
+    "introNote": "Bezugszeitraum: die letzten 2 Wochen. Der PHQ-9 ist ein Screening-Werkzeug — keine medizinische Diagnose.",
+    "questions": {
+      "littleInterest": { "title": "1. Wenig Interesse oder Freude an Ihren Tätigkeiten" },
+      "feelingDown": { "title": "2. Niedergeschlagenheit, Schwermut oder Hoffnungslosigkeit" },
+      "sleepTrouble": { "title": "3. Schwierigkeiten ein- oder durchzuschlafen oder vermehrter Schlaf" },
+      "tiredLowEnergy": { "title": "4. Müdigkeit oder Gefühl, keine Energie zu haben" },
+      "appetiteProblems": { "title": "5. Verminderter Appetit oder übermäßiges Bedürfnis zu essen" },
+      "feelingBadAboutSelf": { "title": "6. Schlechte Meinung von sich selbst; Gefühl, ein Versager zu sein oder die Familie enttäuscht zu haben" },
+      "troubleConcentrating": { "title": "7. Schwierigkeiten, sich auf etwas zu konzentrieren, z. B. beim Zeitunglesen oder Fernsehen" },
+      "movingSlowlyOrRestless": { "title": "8. Verlangsamte Bewegungen/Sprache, die auch anderen auffallen würde — oder im Gegenteil ungewohnte Unruhe/Zappeligkeit" },
+      "selfHarmThoughts": { "title": "9. Gedanken, dass Sie lieber tot wären oder sich Leid zufügen möchten" }
+    },
+    "options": [
+      { "value": 0, "label": "Überhaupt nicht" },
+      { "value": 1, "label": "An einzelnen Tagen" },
+      { "value": 2, "label": "An mehr als der Hälfte der Tage" },
+      { "value": 3, "label": "Beinahe jeden Tag" }
+    ],
+    "categories": {
+      "Minimal": "Minimal",
+      "Mild": "Mild",
+      "Moderate": "Moderat",
+      "ModeratelySevere": "Mittelschwer",
+      "Severe": "Schwer"
+    },
+    "hints": {
+      "Minimal": "Score 0–4: minimale depressive Symptome. In der Regel keine spezielle Maßnahme nötig — beobachte weiter, wie du dich fühlst.",
+      "Mild": "Score 5–9: leichte depressive Symptome. Selbstfürsorge, abwartende Beobachtung und Unterstützung sind angemessen. Wiederhole den Test in 2–4 Wochen.",
+      "Moderate": "Score 10–14: moderate depressive Symptome. Bitte hole ärztlichen Rat ein — weitere Abklärung und ein Behandlungsplan werden empfohlen.",
+      "ModeratelySevere": "Score 15–19: mittelschwere depressive Symptome. Bitte zeitnah ärztliche oder psychotherapeutische Hilfe in Anspruch nehmen. Eine aktive Behandlung wird in der Regel empfohlen.",
+      "Severe": "Score 20–27: schwere depressive Symptome. Bitte zeitnah professionelle Hilfe suchen. Eine aktive Behandlung wird dringend empfohlen."
+    },
+    "crisis": {
+      "label": "Sofortige Hilfe",
+      "title": "Du hast Gedanken an Selbstgefährdung angegeben — bitte hole dir jetzt Hilfe",
+      "text": "Wenn du Gedanken hast, dass du lieber tot wärst oder dir Leid zufügen möchtest, hast du jetzt Unterstützung verdient. Bitte kontaktiere sofort professionelle Hilfe — du musst das nicht allein durchstehen. Telefonseelsorge: 0800 111 0 111 oder 0800 111 0 222 (kostenlos, rund um die Uhr). In akuten Notfällen wähle den Notruf 112."
+    },
+    "reset": "Antworten zurücksetzen",
+    "scoreLabel": "PHQ-9-Score",
+    "scoreScale": "von 27",
+    "incompleteHint": "Beantworte alle 9 Fragen, um deinen PHQ-9-Score zu sehen.",
+    "scaleTitle": "Schweregrade",
+    "scaleRows": [
+      { "range": "0 – 4", "label": "Minimal", "hint": "Symptome minimal — weiter beobachten" },
+      { "range": "5 – 9", "label": "Mild", "hint": "Symptome leicht — Selbstfürsorge, Test in 2–4 Wochen wiederholen" },
+      { "range": "10 – 14", "label": "Moderat", "hint": "Ärztlichen Rat einholen" },
+      { "range": "15 – 19", "label": "Mittelschwer", "hint": "Zeitnah professionelle Hilfe suchen" },
+      { "range": "20 – 27", "label": "Schwer", "hint": "Aktive Behandlung dringend empfohlen" }
+    ],
+    "howItWorks": "So funktioniert's",
+    "howItWorksText": "Der PHQ-9 wurde 2001 von Kroenke, Spitzer und Williams entwickelt und validiert (J Gen Intern Med). Neun Items, je 0 (Überhaupt nicht) bis 3 (Beinahe jeden Tag), ergeben einen Gesamtscore von 0–27. Ein Cutoff von 10 zeigt das beste Verhältnis von Sensitivität (88 %) und Spezifität (88 %) für eine Major Depression und wird breit als Überweisungs-Schwelle verwendet. Item 9 fragt direkt nach Gedanken an Selbstgefährdung — jede positive Antwort erfordert sofortige Aufmerksamkeit, unabhängig vom Gesamtscore.",
+    "needsEvaluationLabel": "Dein Wert legt nahe, dass eine weitere Abklärung sinnvoll sein kann",
+    "disclaimer": "Dies ist ein Screening-Werkzeug, keine medizinische Diagnose. Bei einem Wert ab 10, wenn du die Frage zu Selbstgefährdung mit mehr als „Überhaupt nicht“ beantwortet hast, oder bei Beschwerden bitte ärztlichen Rat einholen.",
+    "section": {
+      "blogLink": {
+        "label": "Zum Ratgeber",
+        "title": "PHQ-9 Depressionstest: Was dein Score bedeutet",
+        "url": "/blog/phq-9-depressionstest-rechner",
+        "readingTime": "9 min Lesezeit"
+      }
+    },
+    "faq": [
+      {
+        "q": "Was misst der PHQ-9?",
+        "a": "Der PHQ-9 screent auf eine Depression, indem er fragt, wie oft du in den letzten 2 Wochen von neun Kernsymptomen belastet warst. Er ist eines der am häufigsten genutzten Depressions-Instrumente in der Hausarztpraxis und in psychiatrisch-psychotherapeutischen Settings."
+      },
+      {
+        "q": "Was bedeuten die Score-Bereiche?",
+        "a": "0–4 minimal, 5–9 mild, 10–14 moderat, 15–19 mittelschwer, 20–27 schwer ausgeprägte depressive Symptome. Ein Score von 10 oder mehr ist der übliche Cutoff für eine weitere klinische Abklärung."
+      },
+      {
+        "q": "Ist der PHQ-9 eine Diagnose?",
+        "a": "Nein. Der PHQ-9 ist ein Screening- und Verlaufsinstrument — keine Diagnose. Eine Depression wird durch eine ärztliche oder psychotherapeutische Untersuchung, deine Anamnese und klinische Einschätzung bestätigt oder ausgeschlossen."
+      },
+      {
+        "q": "Was bedeutet Frage 9 zur Selbstgefährdung?",
+        "a": "Item 9 fragt nach Gedanken, dass du lieber tot wärst oder dir Leid zufügen möchtest. Jede Antwort außer „Überhaupt nicht“ bedeutet, dass du dir sofort Hilfe holen solltest — kontaktiere unabhängig vom Gesamtscore sofort die Telefonseelsorge (0800 111 0 111 / 0800 111 0 222, kostenlos, 24/7) oder in akuten Notfällen den Notruf 112."
+      },
+      {
+        "q": "Wie oft sollte ich den PHQ-9 machen?",
+        "a": "Sinnvoll ist ein Ausgangswert und dann alle 2–4 Wochen während einer Behandlung oder bei Symptomveränderungen. Trends über mehrere Tests sind aussagekräftiger als ein Einzelwert."
+      },
+      {
+        "q": "Sollte ich den PHQ-9 zusammen mit dem GAD-7 machen?",
+        "a": "Oft ja. Depression und Angst treten häufig gemeinsam auf, daher setzen Fachpersonen den PHQ-9 für Depression und den GAD-7 für Angst regelmäßig nebeneinander ein, um ein vollständigeres Bild zu erhalten."
+      }
+    ]
+  }
+}

--- a/src/locales/calculators/en/phq9.json
+++ b/src/locales/calculators/en/phq9.json
@@ -1,0 +1,105 @@
+{
+  "home": {
+    "calculators": {
+      "phq9": {
+        "name": "PHQ-9 Depression Screening",
+        "description": "Validated 9-question screening tool for depression — score 0–27 with severity band and self-harm safety check."
+      }
+    }
+  },
+  "phq9": {
+    "meta": {
+      "title": "PHQ-9 Depression Test (Patient Health Questionnaire) — Online Screening | Health Calculators",
+      "description": "Take the validated PHQ-9 depression screening online. 9 questions, score 0–27, severity bands minimal to severe. Free, anonymous, instant. Screening tool — not a diagnosis."
+    },
+    "title": "PHQ-9 Depression Screening",
+    "description": "Over the last 2 weeks, how often have you been bothered by the following problems? Pick exactly one answer per question. Your total score (0–27) and severity band will appear automatically.",
+    "introNote": "Reference period: the past 2 weeks. The PHQ-9 is a screening tool — not a medical diagnosis.",
+    "questions": {
+      "littleInterest": { "title": "1. Little interest or pleasure in doing things" },
+      "feelingDown": { "title": "2. Feeling down, depressed, or hopeless" },
+      "sleepTrouble": { "title": "3. Trouble falling or staying asleep, or sleeping too much" },
+      "tiredLowEnergy": { "title": "4. Feeling tired or having little energy" },
+      "appetiteProblems": { "title": "5. Poor appetite or overeating" },
+      "feelingBadAboutSelf": { "title": "6. Feeling bad about yourself — or that you are a failure or have let yourself or your family down" },
+      "troubleConcentrating": { "title": "7. Trouble concentrating on things, such as reading the newspaper or watching television" },
+      "movingSlowlyOrRestless": { "title": "8. Moving or speaking so slowly that other people could have noticed? Or the opposite — being so fidgety or restless that you have been moving around a lot more than usual" },
+      "selfHarmThoughts": { "title": "9. Thoughts that you would be better off dead, or of hurting yourself in some way" }
+    },
+    "options": [
+      { "value": 0, "label": "Not at all" },
+      { "value": 1, "label": "Several days" },
+      { "value": 2, "label": "More than half the days" },
+      { "value": 3, "label": "Nearly every day" }
+    ],
+    "categories": {
+      "Minimal": "Minimal",
+      "Mild": "Mild",
+      "Moderate": "Moderate",
+      "ModeratelySevere": "Moderately severe",
+      "Severe": "Severe"
+    },
+    "hints": {
+      "Minimal": "Score 0–4 suggests minimal depression symptoms. No specific action is usually needed — keep monitoring how you feel.",
+      "Mild": "Score 5–9 suggests mild depression symptoms. Self-care, watchful waiting and support are appropriate. Re-test in 2–4 weeks.",
+      "Moderate": "Score 10–14 suggests moderate depression symptoms. Please consult a healthcare professional — further evaluation and a treatment plan are recommended.",
+      "ModeratelySevere": "Score 15–19 suggests moderately severe depression symptoms. Please consult a healthcare professional promptly. Active treatment is typically recommended.",
+      "Severe": "Score 20–27 suggests severe depression symptoms. Please seek professional help promptly. Active treatment is strongly recommended."
+    },
+    "crisis": {
+      "label": "Immediate support",
+      "title": "You indicated thoughts of self-harm — please reach out now",
+      "text": "If you are having thoughts of being better off dead or of hurting yourself, you deserve support right now. Please contact your local emergency services or a crisis line immediately — you do not have to face this alone. In the US call or text 988 (Suicide & Crisis Lifeline); in the UK call 116 123 (Samaritans); elsewhere contact your local emergency number or a crisis hotline."
+    },
+    "reset": "Reset answers",
+    "scoreLabel": "PHQ-9 score",
+    "scoreScale": "of 27",
+    "incompleteHint": "Answer all 9 questions to see your PHQ-9 score.",
+    "scaleTitle": "Severity bands",
+    "scaleRows": [
+      { "range": "0 – 4", "label": "Minimal", "hint": "Symptoms minimal — keep monitoring" },
+      { "range": "5 – 9", "label": "Mild", "hint": "Symptoms mild — self-care, re-test in 2–4 weeks" },
+      { "range": "10 – 14", "label": "Moderate", "hint": "Consult a healthcare professional" },
+      { "range": "15 – 19", "label": "Moderately severe", "hint": "Seek professional help promptly" },
+      { "range": "20 – 27", "label": "Severe", "hint": "Active treatment strongly recommended" }
+    ],
+    "howItWorks": "How it works",
+    "howItWorksText": "The PHQ-9 was developed and validated by Kroenke, Spitzer and Williams (J Gen Intern Med, 2001). Nine items, each scored 0 (Not at all) to 3 (Nearly every day), sum to 0–27. A cutoff of 10 has the best balance of sensitivity (88 %) and specificity (88 %) for major depression and is widely used as a referral threshold. Item 9 asks directly about thoughts of self-harm — any positive answer warrants immediate attention, regardless of the total score.",
+    "needsEvaluationLabel": "Your score suggests further evaluation may be helpful",
+    "disclaimer": "This is a screening tool, not a medical diagnosis. If your score is 10 or above, you answered the self-harm question with anything other than “Not at all”, or you have concerns, please consult a healthcare professional.",
+    "section": {
+      "blogLink": {
+        "label": "Read the guide",
+        "title": "PHQ-9 Depression Test: What Your Score Means",
+        "url": "/blog/en/phq-9-depression-test-calculator",
+        "readingTime": "9 min read"
+      }
+    },
+    "faq": [
+      {
+        "q": "What does the PHQ-9 measure?",
+        "a": "The PHQ-9 screens for depression by asking how often you have been bothered by nine core symptoms over the last 2 weeks. It is one of the most widely used depression tools in primary care and mental-health settings."
+      },
+      {
+        "q": "What do the score bands mean?",
+        "a": "0–4 minimal, 5–9 mild, 10–14 moderate, 15–19 moderately severe, 20–27 severe depression symptoms. A score of 10 or more is the commonly used cutoff that warrants further clinical evaluation."
+      },
+      {
+        "q": "Is the PHQ-9 a diagnosis?",
+        "a": "No. The PHQ-9 is a screening and severity tool — not a diagnosis. A clinician confirms or rules out depression using a full evaluation, your history and clinical judgement."
+      },
+      {
+        "q": "What does question 9 about self-harm mean?",
+        "a": "Item 9 asks about thoughts that you would be better off dead or of hurting yourself. Any answer other than “Not at all” means you should seek help immediately — contact your local emergency services or a crisis line right now, regardless of your total score."
+      },
+      {
+        "q": "How often should I take the PHQ-9?",
+        "a": "It works well as a baseline and then every 2–4 weeks during treatment or when symptoms change. Trends across multiple tests are more meaningful than a single value."
+      },
+      {
+        "q": "Should I take the PHQ-9 together with the GAD-7?",
+        "a": "Often, yes. Depression and anxiety frequently occur together, so clinicians regularly use the PHQ-9 for depression and the GAD-7 for anxiety side by side to get a fuller picture."
+      }
+    ]
+  }
+}

--- a/src/pages/Phq9Calculator.vue
+++ b/src/pages/Phq9Calculator.vue
@@ -1,0 +1,220 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '../composables/useHead.js'
+import BlogArticleLink from '../components/BlogArticleLink.vue'
+import RelatedCalculators from '../components/RelatedCalculators.vue'
+import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
+import AdSlot from '../components/AdSlot.vue'
+import { useLocaleRouter } from '../composables/useLocaleRouter.js'
+import { PHQ9_QUESTIONS, evaluatePhq9 } from '../utils/phq9.js'
+
+const { t, tm } = useI18n()
+const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('phq9.faq') || [])
+
+useHead(() => ({
+  title: t('phq9.meta.title'),
+  description: t('phq9.meta.description'),
+  routeKey: 'phq9',
+  jsonLd: {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'PHQ-9 Depression Screening Calculator',
+    url: 'https://healthcalculator.app/en/phq-9-depression-test',
+    applicationCategory: 'HealthApplication',
+    operatingSystem: 'Any',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  },
+}))
+
+const answers = ref({
+  littleInterest: null,
+  feelingDown: null,
+  sleepTrouble: null,
+  tiredLowEnergy: null,
+  appetiteProblems: null,
+  feelingBadAboutSelf: null,
+  troubleConcentrating: null,
+  movingSlowlyOrRestless: null,
+  selfHarmThoughts: null,
+})
+
+const result = computed(() => evaluatePhq9(answers.value))
+
+const answeredCount = computed(() =>
+  PHQ9_QUESTIONS.filter(q => Number.isInteger(answers.value[q])).length,
+)
+
+const progressPct = computed(() => (answeredCount.value / PHQ9_QUESTIONS.length) * 100)
+
+const interpretation = computed(() => {
+  if (!result.value) return null
+  const k = result.value.band
+  if (k === 'Minimal') return { key: k, color: 'text-green-600', bg: 'bg-green-600', border: 'border-green-200' }
+  if (k === 'Mild') return { key: k, color: 'text-yellow-600', bg: 'bg-yellow-500', border: 'border-yellow-200' }
+  if (k === 'Moderate') return { key: k, color: 'text-orange-600', bg: 'bg-orange-500', border: 'border-orange-200' }
+  if (k === 'ModeratelySevere') return { key: k, color: 'text-red-600', bg: 'bg-red-500', border: 'border-red-200' }
+  return { key: k, color: 'text-red-700', bg: 'bg-red-600', border: 'border-red-300' }
+})
+
+function reset() {
+  for (const q of PHQ9_QUESTIONS) answers.value[q] = null
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-10">
+      <router-link :to="localePath('home')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; {{ t('common.backToAll') }}</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-2">{{ t('phq9.title') }}</h1>
+      <p class="text-base text-stone-500 font-normal">{{ t('phq9.description') }}</p>
+    </div>
+
+    <!-- Intro / progress -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-6 mb-6">
+      <p class="text-sm text-stone-600 mb-4">{{ t('phq9.introNote') }}</p>
+      <div class="flex items-center gap-4">
+        <div class="flex-1 h-1.5 bg-stone-100 rounded-full overflow-hidden">
+          <div class="h-full bg-stone-900 transition-all duration-200" :style="{ width: progressPct + '%' }"></div>
+        </div>
+        <span class="text-xs font-semibold text-stone-500 tabular-nums">{{ answeredCount }} / 9</span>
+      </div>
+    </div>
+
+    <!-- Questions -->
+    <div class="space-y-6 mb-6">
+      <div
+        v-for="qKey in PHQ9_QUESTIONS"
+        :key="qKey"
+        class="bg-white border border-stone-200 rounded-xl shadow-sm p-6"
+        :data-testid="'question-' + qKey"
+      >
+        <p class="text-base font-semibold text-stone-900 mb-4 leading-snug">
+          {{ t(`phq9.questions.${qKey}.title`) }}
+        </p>
+        <div class="space-y-2">
+          <button
+            v-for="opt in tm('phq9.options')"
+            :key="opt.value"
+            @click="answers[qKey] = opt.value"
+            :data-testid="`option-${qKey}-${opt.value}`"
+            :class="answers[qKey] === opt.value
+              ? 'bg-stone-900 text-white border-stone-900'
+              : 'bg-white text-stone-700 border-stone-200 hover:border-stone-400 hover:bg-stone-50'"
+            class="w-full text-left border rounded-lg px-4 py-3 text-sm font-medium transition-colors duration-150 flex items-center gap-3"
+          >
+            <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold tabular-nums shrink-0"
+              :class="answers[qKey] === opt.value ? 'bg-white text-stone-900' : 'bg-stone-100 text-stone-600'"
+            >{{ opt.value }}</span>
+            <span>{{ opt.label }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <AffiliateBanner class="my-6" />
+
+    <!-- Crisis note — fires whenever item 9 is positive, INDEPENDENT of the total score -->
+    <div
+      v-if="result && result.item9Flag"
+      data-testid="crisis-note"
+      class="bg-red-50 border-2 border-red-300 rounded-xl p-6 mb-6"
+    >
+      <div class="flex items-center gap-3 mb-2">
+        <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-600 text-white text-sm font-bold shrink-0">!</span>
+        <span class="text-xs font-bold uppercase tracking-widest text-red-700">{{ t('phq9.crisis.label') }}</span>
+      </div>
+      <p class="text-base font-bold text-red-900 mb-2 leading-snug">{{ t('phq9.crisis.title') }}</p>
+      <p data-testid="crisis-text" class="text-sm text-red-900 leading-relaxed">{{ t('phq9.crisis.text') }}</p>
+    </div>
+
+    <!-- Result -->
+    <div v-if="result" class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <div class="flex items-center gap-3 mb-6">
+        <span
+          data-testid="result-status"
+          :class="[interpretation.bg, 'text-white text-sm font-semibold px-3 py-1 rounded-full']"
+        >{{ t('phq9.categories.' + interpretation.key) }}</span>
+        <span
+          v-if="result.needsEvaluation"
+          data-testid="needs-evaluation"
+          class="text-xs font-semibold text-red-700 bg-red-50 border border-red-200 px-2 py-1 rounded"
+        >{{ t('phq9.needsEvaluationLabel') }}</span>
+      </div>
+
+      <div class="mb-6">
+        <div class="text-xs font-semibold text-stone-500 uppercase tracking-widest mb-2">{{ t('phq9.scoreLabel') }}</div>
+        <div class="flex items-baseline gap-3">
+          <span data-testid="result-score" class="text-6xl font-bold text-stone-900 tabular-nums tracking-tight leading-none">{{ result.score }}</span>
+          <span class="text-base text-stone-400">{{ t('phq9.scoreScale') }}</span>
+        </div>
+      </div>
+
+      <!-- Score scale bar -->
+      <div class="relative h-3 bg-stone-200 rounded-full overflow-hidden mb-6">
+        <div class="absolute inset-y-0 left-0 bg-gradient-to-r from-green-600 via-yellow-500 via-orange-500 to-red-600 rounded-full" style="width: 100%"></div>
+        <div class="absolute top-0 h-full w-0.5 bg-stone-900" :style="{ left: (result.score / 27) * 100 + '%' }"></div>
+      </div>
+
+      <div :class="[interpretation.border, 'border rounded-lg px-4 py-3 bg-stone-50']">
+        <p data-testid="result-hint" class="text-sm text-stone-700 leading-relaxed">{{ t('phq9.hints.' + interpretation.key) }}</p>
+      </div>
+
+      <div class="mt-4 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+        <p data-testid="result-disclaimer" class="text-xs text-amber-900 leading-relaxed">{{ t('phq9.disclaimer') }}</p>
+      </div>
+
+      <div class="mt-6 pt-4 border-t border-stone-100">
+        <button @click="reset" data-testid="reset"
+          class="text-sm font-medium text-stone-500 hover:text-stone-800 transition-colors duration-150">{{ t('phq9.reset') }}</button>
+      </div>
+    </div>
+
+    <div v-else class="bg-stone-50 border border-stone-200 rounded-xl p-6 mb-6">
+      <p data-testid="incomplete-hint" class="text-sm text-stone-500">{{ t('phq9.incompleteHint') }}</p>
+    </div>
+
+    <!-- Score scale -->
+    <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-6">
+      <h2 class="text-lg font-semibold text-stone-900 mb-4">{{ t('phq9.scaleTitle') }}</h2>
+      <div class="space-y-3">
+        <div
+          v-for="(row, i) in tm('phq9.scaleRows')"
+          :key="i"
+          class="flex items-start justify-between border-b border-stone-100 pb-3 last:border-0 last:pb-0"
+        >
+          <div class="flex items-center gap-3">
+            <div :class="[
+              i === 0 ? 'bg-green-600' : i === 1 ? 'bg-yellow-500' : i === 2 ? 'bg-orange-500' : i === 3 ? 'bg-red-500' : 'bg-red-600',
+              'w-2.5 h-2.5 rounded-full shrink-0 mt-0.5',
+            ]"></div>
+            <div>
+              <span class="text-sm text-stone-900 font-medium">{{ row.label }}</span>
+              <p class="text-xs text-stone-500">{{ row.hint }}</p>
+            </div>
+          </div>
+          <div class="text-sm font-medium text-stone-900 tabular-nums shrink-0 ml-4">{{ row.range }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- How it works -->
+    <div class="bg-white rounded-xl shadow-sm border border-stone-200 p-8 mb-6">
+      <h2 class="text-base font-semibold text-stone-900 mb-3">{{ t('phq9.howItWorks') }}</h2>
+      <p class="text-sm text-stone-500 leading-relaxed">{{ t('phq9.howItWorksText') }}</p>
+    </div>
+
+    <!-- Disclaimer (prominent, page-level) -->
+    <div data-testid="page-disclaimer" class="bg-amber-50 border border-amber-200 rounded-xl px-6 py-4 mb-6">
+      <p class="text-sm text-amber-900 leading-relaxed font-medium">{{ t('phq9.disclaimer') }}</p>
+    </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
+    <RelatedCalculators calc-key="phq9" class="mt-8" />
+    <BlogArticleLink calculator-key="phq9" />
+    <AdSlot class="mt-8" />
+  </div>
+</template>

--- a/src/pages/blog/Phq9DepressionsTestRechner.vue
+++ b/src/pages/blog/Phq9DepressionsTestRechner.vue
@@ -1,0 +1,265 @@
+<script setup>
+import { useHead } from '../../composables/useHead.js'
+import RelatedArticles from '../../components/RelatedArticles.vue'
+import { useLocaleRouter } from '../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'PHQ-9 Depressionstest: Depression erkennen — Rechner & Score | Health Calculators',
+  description: 'PHQ-9 Depressions-Screening verstehen: 9 Fragen, Score 0–27, fünf Schweregrade von minimal bis schwer. Cutoff 10, Item 9 zur Selbstgefährdung, Kroenke 2001 — mit kostenlosem Online-Rechner.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'PHQ-9 Depressionstest: Depression erkennen — Rechner & Score',
+      description: 'Wie ausgeprägt sind deine depressiven Symptome? Der PHQ-9 ist ein validiertes 9-Fragen-Screening für Depression. Was die fünf Schweregrade bedeuten, warum Item 9 zur Selbstgefährdung unabhängig vom Score zählt und was du jetzt tun kannst.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-06-16',
+      dateModified: '2026-06-16',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/de/blog/phq-9-depressionstest-rechner',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'Was misst der PHQ-9?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Der PHQ-9 misst die Häufigkeit von neun Kernsymptomen einer Depression über die letzten 2 Wochen. Er ist als Screening- und Verlaufsinstrument validiert.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was bedeuten die Score-Bereiche?',
+          acceptedAnswer: { '@type': 'Answer', text: '0–4 minimal, 5–9 mild, 10–14 moderat, 15–19 mittelschwer, 20–27 schwer ausgeprägte depressive Symptome. Ein Score ≥ 10 ist der übliche Cutoff für eine weitere klinische Abklärung.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Was bedeutet Frage 9 zur Selbstgefährdung?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Item 9 fragt nach Gedanken, lieber tot zu sein oder sich Leid zuzufügen. Jede Antwort außer „Überhaupt nicht“ erfordert unabhängig vom Gesamtscore sofortige Hilfe — Telefonseelsorge 0800 111 0 111 oder Notruf 112.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Ist der PHQ-9 eine Diagnose?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Nein. Der PHQ-9 ist ein Screening-Werkzeug, keine medizinische Diagnose. Eine Depression wird durch eine ärztliche oder psychotherapeutische Untersuchung bestätigt.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">PHQ-9 Depressionstest: Depression erkennen</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">16. Juni 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min Lesezeit</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Wie ausgeprägt sind deine <strong>depressiven Symptome</strong>? Der <strong>PHQ-9</strong> (Patient Health Questionnaire, 9 Items) liefert in neun Fragen eine validierte Antwort und ist heute das am häufigsten genutzte Werkzeug für das Screening von Depression in Hausarztpraxen, psychiatrisch-psychotherapeutischen Settings und Studien weltweit.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          In diesem Beitrag erfährst du, wie der PHQ-9 funktioniert, was die fünf Schweregrade bedeuten, warum die neunte Frage zur Selbstgefährdung eine Sonderrolle einnimmt und was du nach deinem Ergebnis tun kannst.
+        </p>
+      </div>
+
+      <!-- Prominent disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed font-medium">
+          Dies ist ein Screening-Werkzeug, keine medizinische Diagnose. Bei einem Wert ab 10 oder bei Beschwerden bitte ärztlichen Rat einholen. Bei Gedanken an Selbstgefährdung sofort Hilfe holen: Telefonseelsorge 0800 111 0 111 / 0800 111 0 222 (kostenlos, 24/7) oder Notruf 112.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was ist der PHQ-9?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der PHQ-9 wurde 2001 von Kroenke, Spitzer und Williams im <em>Journal of General Internal Medicine</em> publiziert. Er bildet die neun Kernsymptome einer Major Depression aus dem Diagnosemanual DSM direkt ab und fragt, wie häufig sie dich über die letzten <strong>2 Wochen</strong> belastet haben. Jedes Item wird mit 0 (Überhaupt nicht) bis 3 (Beinahe jeden Tag) bewertet, der Gesamtscore reicht von 0 bis 27.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Bei einem Cutoff von 10 hat der PHQ-9 eine Sensitivität und Spezifität von jeweils rund 88 % für eine Major Depression. Im deutschsprachigen Raum ist er als Teil des <em>Gesundheitsfragebogens für Patienten</em> (PHQ-D) weit verbreitet. Er ist gemeinfrei und kostenlos einsetzbar — einer der Gründe für seine globale Verbreitung.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die neun Fragen</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          „Wie oft fühlten Sie sich im Verlauf der letzten 2 Wochen durch die folgenden Beschwerden beeinträchtigt?“
+        </p>
+        <ol class="space-y-3 mb-4 list-decimal list-inside">
+          <li class="text-stone-600 text-base"><strong>Wenig Interesse oder Freude an Ihren Tätigkeiten</strong></li>
+          <li class="text-stone-600 text-base"><strong>Niedergeschlagenheit, Schwermut oder Hoffnungslosigkeit</strong></li>
+          <li class="text-stone-600 text-base"><strong>Schwierigkeiten ein- oder durchzuschlafen oder vermehrter Schlaf</strong></li>
+          <li class="text-stone-600 text-base"><strong>Müdigkeit oder Gefühl, keine Energie zu haben</strong></li>
+          <li class="text-stone-600 text-base"><strong>Verminderter Appetit oder übermäßiges Bedürfnis zu essen</strong></li>
+          <li class="text-stone-600 text-base"><strong>Schlechte Meinung von sich selbst; Gefühl, ein Versager zu sein</strong></li>
+          <li class="text-stone-600 text-base"><strong>Schwierigkeiten, sich zu konzentrieren</strong></li>
+          <li class="text-stone-600 text-base"><strong>Verlangsamung oder im Gegenteil ungewohnte Unruhe</strong></li>
+          <li class="text-stone-600 text-base"><strong>Gedanken, lieber tot zu sein oder sich Leid zuzufügen</strong></li>
+        </ol>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Antwortoptionen: Überhaupt nicht (0), An einzelnen Tagen (1), An mehr als der Hälfte der Tage (2), Beinahe jeden Tag (3).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Score-Bereiche</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Schweregrad</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Bedeutung</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0 – 4</td>
+                <td class="px-6 py-3 text-stone-600">Minimal</td>
+                <td class="px-6 py-3 text-stone-600">Minimale Symptome — weiter beobachten</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5 – 9</td>
+                <td class="px-6 py-3 text-stone-600">Mild</td>
+                <td class="px-6 py-3 text-stone-600">Selbstfürsorge, Unterstützung, Wiederholung in 2–4 Wochen</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">10 – 14</td>
+                <td class="px-6 py-3 text-stone-600">Moderat</td>
+                <td class="px-6 py-3 text-stone-600">Ärztlichen Rat einholen, weitere Abklärung</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">15 – 19</td>
+                <td class="px-6 py-3 text-stone-600">Mittelschwer</td>
+                <td class="px-6 py-3 text-stone-600">Zeitnah professionelle Hilfe — aktive Behandlung empfohlen</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">20 – 27</td>
+                <td class="px-6 py-3 text-stone-600">Schwer</td>
+                <td class="px-6 py-3 text-stone-600">Zeitnah professionelle Hilfe — Behandlung dringend empfohlen</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Der <strong>Cutoff von 10</strong> ist die etablierte Schwelle für eine weitere klinische Abklärung. Eine <strong>Score-Veränderung um ≥ 5 Punkte</strong> gilt als klinisch bedeutsam — wichtig zur Verlaufsbeurteilung unter Therapie.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Die Sonderrolle von Frage 9</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Anders als alle anderen Items steht die <strong>neunte Frage zur Selbstgefährdung</strong> für sich. Sie fragt nach Gedanken, lieber tot zu sein oder sich Leid zuzufügen. Wer hier mehr als „Überhaupt nicht“ ankreuzt, sollte <strong>unabhängig vom Gesamtscore</strong> sofort Unterstützung suchen — selbst dann, wenn die übrigen acht Fragen niedrig ausfallen und der Gesamtwert im minimalen Bereich liegt.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Genau deshalb zeigt der Rechner bei einer positiven Antwort auf Item 9 einen eigenen, deutlich hervorgehobenen Hinweis an. Ein niedriger Gesamtscore mit positivem Item 9 ist der kritische Fall, der leicht übersehen wird. Suizidale Gedanken sind ein medizinischer Notfall — bitte zögere nicht, Hilfe zu holen.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was der PHQ-9 nicht ersetzt</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Der PHQ-9 erkennt <strong>Symptomhäufigkeit</strong>, aber nicht die Ursache. Schilddrüsenunterfunktion, Eisenmangel, chronischer Schlafmangel, Medikamente und körperliche Erkrankungen können ein depressionsähnliches Bild erzeugen. Ein erhöhter Score sollte deshalb immer ärztlich eingeordnet werden.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Auch trennt der PHQ-9 nicht zwischen Depression und Angst — beide treten häufig gemeinsam auf. In der Praxis werden PHQ-9 und <router-link :to="localePath('gad7')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">GAD-7</router-link> deshalb oft gemeinsam eingesetzt.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Was du jetzt tun kannst</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score &lt; 5:</strong> Symptome minimal. Weiter beobachten und Belastungen reduzieren.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score 5–9:</strong> Selbstfürsorge — Schlaf, Bewegung, soziale Kontakte, Tagesstruktur. Re-Test in 2–4 Wochen.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score ≥ 10:</strong> Termin beim Hausarzt oder Psychotherapeuten. Psychotherapie ist gut belegt; medikamentöse Optionen (z. B. SSRI) gibt es ebenfalls.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Gedanken an Selbstgefährdung — unabhängig vom Score:</strong> Telefonseelsorge 0800 111 0 111 / 0800 111 0 222 (kostenlos, 24/7) oder Notruf 112.</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Verwandte Themen & Rechner</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>GAD-7 Angst-Screening</strong> — Depression und Angst treten häufig gemeinsam auf. Der GAD-7 ergänzt den PHQ-9 für ein vollständigeres Bild. Zum <router-link :to="localeBlogPath('gad-7-angst-test-rechner')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">GAD-7-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Schlafzyklen</strong> — Schlafstörungen sind ein Kernsymptom der Depression (Frage 3). Geregelter Schlaf wirkt sich häufig direkt auf den PHQ-9-Score aus. Zum <router-link :to="localeBlogPath('schlafzyklen-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Schlafzyklen-Artikel</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Biologisches Alter</strong> — anhaltende depressive Symptome und chronischer Stress beschleunigen die Alterung. Ein Blick auf das biologische Alter ordnet Lebensstil-Faktoren ein. Zum <router-link :to="localeBlogPath('biologisches-alter-berechnen')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">Artikel über biologisches Alter</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Jetzt deinen PHQ-9-Score berechnen</h3>
+        <p class="text-stone-300 text-sm mb-5">Neun Fragen, anonym, sofort. Direkte Einordnung deiner depressiven Symptome der letzten 2 Wochen.</p>
+        <router-link
+          :to="localePath('phq9')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Zum PHQ-9 Depressions-Screening &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Häufige Fragen</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Wie oft sollte ich den PHQ-9 machen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Sinnvoll ist ein Ausgangswert und dann alle 2–4 Wochen während einer Behandlung oder bei Symptomveränderungen. Die Trend-Entwicklung über mehrere Tests ist aussagekräftiger als ein Einzelwert.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Ich habe Frage 9 angekreuzt — was nun?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Jede Antwort außer „Überhaupt nicht“ auf Frage 9 ist ein ernstes Signal, unabhängig vom Gesamtscore. Bitte hole dir sofort Hilfe: Telefonseelsorge 0800 111 0 111 oder 0800 111 0 222 (kostenlos, rund um die Uhr), in akuten Notfällen den Notruf 112. Du musst das nicht allein durchstehen.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Funktioniert der PHQ-9 auch bei Jugendlichen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Der PHQ-9 ist für Erwachsene validiert. Für Jugendliche gibt es die angepasste Variante PHQ-A. Für jüngere Kinder sind altersgerechtere Werkzeuge vorzuziehen.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Erkennt der PHQ-9 auch Angststörungen?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Nein, der PHQ-9 ist auf Depression optimiert. Für Angst nutzt man ergänzend den GAD-7. In der Praxis werden beide häufig gemeinsam eingesetzt, da Depression und Angst oft zusammen auftreten.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticles slug="phq-9-depressionstest-rechner" />
+  </article>
+</template>

--- a/src/pages/blog/en/Phq9DepressionTestCalculator.vue
+++ b/src/pages/blog/en/Phq9DepressionTestCalculator.vue
@@ -1,0 +1,265 @@
+<script setup>
+import { useHead } from '../../../composables/useHead.js'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
+import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
+
+const { localePath, localeBlogPath } = useLocaleRouter()
+
+useHead({
+  title: 'PHQ-9 Depression Test: Screening for Depression — Score & Bands | Health Calculators',
+  description: 'Understand the PHQ-9 depression screening: 9 questions, score 0–27, five severity bands from minimal to severe. Cutoff 10, item 9 on self-harm, Kroenke 2001 — with free online calculator.',
+  routeKey: 'blogArticle',
+  jsonLd: [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: 'PHQ-9 Depression Test: Screening for Depression — Score & Bands',
+      description: 'How troubled are you by depression symptoms? The PHQ-9 is a validated 9-question screening for depression. What the five severity bands mean, why item 9 on self-harm matters regardless of the total score, and what to do next.',
+      author: { '@type': 'Organization', name: 'Health Calculators' },
+      publisher: { '@type': 'Organization', name: 'Health Calculators' },
+      datePublished: '2026-06-16',
+      dateModified: '2026-06-16',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://healthcalculator.app/en/blog/phq-9-depression-test-calculator',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What does the PHQ-9 measure?',
+          acceptedAnswer: { '@type': 'Answer', text: 'The PHQ-9 measures the frequency of nine core symptoms of depression over the past 2 weeks. It is validated as a screening and severity tool.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What do the score bands mean?',
+          acceptedAnswer: { '@type': 'Answer', text: '0–4 minimal, 5–9 mild, 10–14 moderate, 15–19 moderately severe, 20–27 severe depression symptoms. A score ≥ 10 is the commonly used cutoff for further clinical evaluation.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'What does question 9 about self-harm mean?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Item 9 asks about thoughts of being better off dead or of hurting yourself. Any answer other than “Not at all” means you should seek help immediately, regardless of your total score — contact your local emergency services or a crisis line right now.' },
+        },
+        {
+          '@type': 'Question',
+          name: 'Is the PHQ-9 a diagnosis?',
+          acceptedAnswer: { '@type': 'Answer', text: 'No. The PHQ-9 is a screening tool, not a medical diagnosis. Depression is confirmed through clinical evaluation with a healthcare professional.' },
+        },
+      ],
+    },
+  ],
+})
+</script>
+
+<template>
+  <article>
+    <div class="mb-10">
+      <router-link :to="localePath('blog')" class="text-sm text-stone-400 hover:text-stone-800 transition-colors mb-4 inline-block">&larr; Blog</router-link>
+      <h1 class="text-4xl font-bold tracking-tight text-stone-900 mb-3">PHQ-9 Depression Test: Screening for Depression</h1>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-stone-400 tabular-nums">June 16, 2026</span>
+        <span class="text-sm text-stone-300">&middot;</span>
+        <span class="text-sm text-stone-400">9 min read</span>
+      </div>
+    </div>
+
+    <div class="prose prose-stone max-w-none">
+      <div class="bg-white border border-stone-200 rounded-xl shadow-sm p-8 mb-8">
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          How troubled are you by <strong>depression symptoms</strong>? The <strong>PHQ-9</strong> (Patient Health Questionnaire, 9 items) provides a validated answer in nine questions and is today the most widely used tool for screening depression in primary care, mental-health settings and research worldwide.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          This guide explains how the PHQ-9 works, what the five severity bands mean, why the ninth question on self-harm plays a special role, and what to do after you see your result.
+        </p>
+      </div>
+
+      <!-- Prominent disclaimer -->
+      <div class="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-8">
+        <p class="text-sm text-amber-900 leading-relaxed font-medium">
+          This is a screening tool, not a medical diagnosis. If your score is 10 or above, or you have concerns, please consult a healthcare professional. If you have thoughts of self-harm, get help now — contact your local emergency services or a crisis line immediately (US: call or text 988; UK: 116 123).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What is the PHQ-9?</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The PHQ-9 was developed and validated in 2001 by Kroenke, Spitzer and Williams in the <em>Journal of General Internal Medicine</em>. It maps the nine core symptoms of major depression from the DSM diagnostic manual directly into questions and asks how often they have bothered you over the past <strong>2 weeks</strong>. Each item is scored 0 (Not at all) to 3 (Nearly every day), with a total range of 0–27.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          At a cutoff of 10, the PHQ-9 has a sensitivity and specificity of roughly 88 % each for major depression. It is in the public domain and free to use — one reason for its global adoption.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The nine questions</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          “Over the last 2 weeks, how often have you been bothered by any of the following problems?”
+        </p>
+        <ol class="space-y-3 mb-4 list-decimal list-inside">
+          <li class="text-stone-600 text-base"><strong>Little interest or pleasure in doing things</strong></li>
+          <li class="text-stone-600 text-base"><strong>Feeling down, depressed, or hopeless</strong></li>
+          <li class="text-stone-600 text-base"><strong>Trouble falling or staying asleep, or sleeping too much</strong></li>
+          <li class="text-stone-600 text-base"><strong>Feeling tired or having little energy</strong></li>
+          <li class="text-stone-600 text-base"><strong>Poor appetite or overeating</strong></li>
+          <li class="text-stone-600 text-base"><strong>Feeling bad about yourself — or that you are a failure</strong></li>
+          <li class="text-stone-600 text-base"><strong>Trouble concentrating on things</strong></li>
+          <li class="text-stone-600 text-base"><strong>Moving or speaking slowly — or the opposite, being fidgety or restless</strong></li>
+          <li class="text-stone-600 text-base"><strong>Thoughts that you would be better off dead, or of hurting yourself</strong></li>
+        </ol>
+        <p class="text-base text-stone-600 leading-relaxed">
+          Response options: Not at all (0), Several days (1), More than half the days (2), Nearly every day (3).
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Severity bands</h2>
+        <div class="bg-white border border-stone-200 rounded-xl shadow-sm overflow-hidden mb-6">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-stone-50 border-b border-stone-200">
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Score</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Severity</th>
+                <th class="text-left px-6 py-3 font-semibold text-stone-700">Meaning</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-stone-100">
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">0 – 4</td>
+                <td class="px-6 py-3 text-stone-600">Minimal</td>
+                <td class="px-6 py-3 text-stone-600">Minimal symptoms — keep monitoring</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">5 – 9</td>
+                <td class="px-6 py-3 text-stone-600">Mild</td>
+                <td class="px-6 py-3 text-stone-600">Self-care, support, re-test in 2–4 weeks</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">10 – 14</td>
+                <td class="px-6 py-3 text-stone-600">Moderate</td>
+                <td class="px-6 py-3 text-stone-600">Consult a healthcare professional, further evaluation</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">15 – 19</td>
+                <td class="px-6 py-3 text-stone-600">Moderately severe</td>
+                <td class="px-6 py-3 text-stone-600">Seek professional help promptly — active treatment recommended</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-3 text-stone-900 font-medium tabular-nums">20 – 27</td>
+                <td class="px-6 py-3 text-stone-600">Severe</td>
+                <td class="px-6 py-3 text-stone-600">Seek professional help promptly — treatment strongly recommended</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-base text-stone-600 leading-relaxed">
+          A <strong>cutoff of 10</strong> is the established threshold for further clinical evaluation. A change of <strong>≥ 5 points</strong> on follow-up is considered clinically meaningful and useful for tracking response to treatment.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">The special role of question 9</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          Unlike every other item, the <strong>ninth question on self-harm</strong> stands on its own. It asks about thoughts of being better off dead or of hurting yourself. Anyone who selects more than “Not at all” here should seek support immediately — <strong>regardless of the total score</strong>, even if the other eight questions are low and the total sits in the minimal range.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          That is exactly why the calculator shows a separate, prominently highlighted note whenever item 9 is positive. A low total with a positive item 9 is the critical case that is easily missed. Suicidal thoughts are a medical emergency — please do not hesitate to reach out for help.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What the PHQ-9 does not replace</h2>
+        <p class="text-base text-stone-600 leading-relaxed mb-4">
+          The PHQ-9 captures <strong>symptom frequency</strong>, not cause. Hypothyroidism, iron deficiency, chronic sleep loss, certain medications and other medical conditions can mimic a depression picture. An elevated score should therefore always be put in context by a clinician.
+        </p>
+        <p class="text-base text-stone-600 leading-relaxed">
+          The PHQ-9 also does not separate depression from anxiety — the two frequently occur together. In practice, the PHQ-9 and the <router-link :to="localePath('gad7')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">GAD-7</router-link> are therefore often used together.
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">What to do next</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score &lt; 5:</strong> Symptoms minimal. Keep monitoring and reduce stressors.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score 5–9:</strong> Self-care — sleep, exercise, social contact, daily structure. Re-test in 2–4 weeks.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Score ≥ 10:</strong> Make an appointment with your GP or a mental-health professional. Psychotherapy is well evidenced; medication (e.g. SSRIs) is also an option.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Thoughts of self-harm — regardless of score:</strong> contact your local emergency services or a crisis line immediately (US: call or text 988; UK: 116 123 Samaritans).</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Related topics & calculators</h2>
+        <ul class="space-y-3">
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>GAD-7 anxiety screening</strong> — depression and anxiety frequently occur together. The GAD-7 complements the PHQ-9 for a fuller picture. Read the <router-link :to="localeBlogPath('gad-7-anxiety-test-calculator')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">GAD-7 guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Sleep cycles</strong> — sleep problems are a core symptom of depression (question 3). Regular sleep often directly affects the PHQ-9 score. Read the <router-link :to="localeBlogPath('calculate-sleep-cycles')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">sleep cycle guide</router-link>.</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="w-1.5 h-1.5 rounded-full bg-stone-400 mt-2 shrink-0"></span>
+            <span class="text-stone-600 text-base"><strong>Biological age</strong> — persistent depression and chronic stress accelerate ageing. A look at biological age puts lifestyle factors in context. Read the <router-link :to="localeBlogPath('biological-age-calculator')" class="text-stone-700 underline underline-offset-2 hover:text-stone-900">biological age guide</router-link>.</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-stone-900 rounded-xl p-8 mb-8 text-center">
+        <h3 class="text-xl font-bold text-white mb-2">Take the PHQ-9 now</h3>
+        <p class="text-stone-300 text-sm mb-5">Nine questions, anonymous, instant. Get an immediate interpretation of your depression symptoms over the past 2 weeks.</p>
+        <router-link
+          :to="localePath('phq9')"
+          class="inline-block bg-white text-stone-900 font-semibold px-6 py-3 rounded-lg hover:bg-stone-100 transition-colors"
+        >Go to the PHQ-9 depression screening &rarr;</router-link>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="text-2xl font-bold text-stone-900 mb-4">Frequently asked questions</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">How often should I take the PHQ-9?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              A baseline first, then every 2–4 weeks during treatment or whenever symptoms change. Trends across multiple tests are more meaningful than any single value.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">I answered question 9 — what now?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              Any answer other than “Not at all” on question 9 is a serious signal, regardless of your total score. Please get help immediately — in the US call or text 988 (Suicide & Crisis Lifeline); in the UK call 116 123 (Samaritans); elsewhere contact your local emergency number. You do not have to face this alone.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Is the PHQ-9 suitable for teenagers?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              The PHQ-9 is validated for adults. For adolescents there is an adapted version, the PHQ-A. For younger children, age-specific instruments are preferred.
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-stone-900 mb-2">Does the PHQ-9 also detect anxiety disorders?</h3>
+            <p class="text-base text-stone-600 leading-relaxed">
+              No, the PHQ-9 is optimized for depression. For anxiety, the GAD-7 complements it. In practice the two are often used together, as depression and anxiety frequently co-occur.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <RelatedArticlesEn slug="phq-9-depression-test-calculator" />
+  </article>
+</template>

--- a/src/pages/phq9.meta.js
+++ b/src/pages/phq9.meta.js
@@ -1,0 +1,16 @@
+import Component from './Phq9Calculator.vue'
+import BlogDe from './blog/Phq9DepressionsTestRechner.vue'
+import BlogEn from './blog/en/Phq9DepressionTestCalculator.vue'
+
+export default {
+  key: 'phq9',
+  component: Component,
+  slugs: { de: 'phq-9-depressionstest', en: 'phq-9-depression-test' },
+  group: 'fitnessRecovery',
+  groupOrder: 2,
+  order: 125,
+  blog: {
+    de: { slug: 'phq-9-depressionstest-rechner', component: BlogDe },
+    en: { slug: 'phq-9-depression-test-calculator', component: BlogEn },
+  },
+}

--- a/src/utils/phq9.js
+++ b/src/utils/phq9.js
@@ -1,0 +1,83 @@
+// PHQ-9 — Patient Health Questionnaire 9-item depression scale (Kroenke, Spitzer & Williams, J Gen Intern Med, 2001).
+//
+// Nine questions about the past 2 weeks, each scored 0–3, total 0–27:
+//   1. Little interest or pleasure in doing things
+//   2. Feeling down, depressed, or hopeless
+//   3. Trouble falling or staying asleep, or sleeping too much
+//   4. Feeling tired or having little energy
+//   5. Poor appetite or overeating
+//   6. Feeling bad about yourself — or that you are a failure
+//   7. Trouble concentrating on things
+//   8. Moving or speaking so slowly that others could notice — or the opposite, restlessness
+//   9. Thoughts that you would be better off dead, or of hurting yourself
+//
+// Severity bands (Kroenke 2001):
+//    0– 4 : Minimal
+//    5– 9 : Mild
+//   10–14 : Moderate
+//   15–19 : ModeratelySevere
+//   20–27 : Severe
+//
+// Cutoff: a score ≥ 10 warrants further clinical evaluation.
+// Item-9 safety flag: any answer ≥ 1 on item 9 (self-harm) fires a crisis note,
+// INDEPENDENT of the total score — a low total with a positive item 9 is the critical case.
+
+export const PHQ9_QUESTIONS = [
+  'littleInterest',
+  'feelingDown',
+  'sleepTrouble',
+  'tiredLowEnergy',
+  'appetiteProblems',
+  'feelingBadAboutSelf',
+  'troubleConcentrating',
+  'movingSlowlyOrRestless',
+  'selfHarmThoughts',
+]
+
+// Item 9 — the self-harm item that drives the safety flag.
+const ITEM_9 = 'selfHarmThoughts'
+
+function isValidAnswer(v) {
+  return Number.isInteger(v) && v >= 0 && v <= 3
+}
+
+export function calcPhq9Score(answers) {
+  if (!answers || typeof answers !== 'object') return null
+  let total = 0
+  for (const q of PHQ9_QUESTIONS) {
+    if (!isValidAnswer(answers[q])) return null
+    total += answers[q]
+  }
+  return total
+}
+
+export function classifyPhq9(total) {
+  if (typeof total !== 'number' || !Number.isFinite(total)) return null
+  if (total < 0 || total > 27) return null
+  if (total <= 4) return 'Minimal'
+  if (total <= 9) return 'Mild'
+  if (total <= 14) return 'Moderate'
+  if (total <= 19) return 'ModeratelySevere'
+  return 'Severe'
+}
+
+export function needsEvaluation(total) {
+  return typeof total === 'number' && Number.isFinite(total) && total >= 10
+}
+
+// Fires whenever item 9 (self-harm) is answered ≥ 1 — independent of the total score.
+export function item9Flag(answers) {
+  if (!answers || typeof answers !== 'object') return false
+  return Number.isInteger(answers[ITEM_9]) && answers[ITEM_9] >= 1
+}
+
+export function evaluatePhq9(answers) {
+  const score = calcPhq9Score(answers)
+  if (score === null) return null
+  return {
+    score,
+    band: classifyPhq9(score),
+    needsEvaluation: needsEvaluation(score),
+    item9Flag: item9Flag(answers),
+  }
+}


### PR DESCRIPTION
## Summary
Adds the **PHQ-9 depression screening** calculator as the depression sibling of GAD-7, built by mirroring the GAD-7 calculator end-to-end per issue #286.

- **9 items** (Kroenke, Spitzer & Williams 2001), each 0–3, total 0–27
- **5-band severity scale**: Minimal / Mild / Moderate / ModeratelySevere / Severe
- **Item-9 safety flag**: a prominent crisis note fires whenever item 9 (self-harm) is answered ≥ 1, **independent of the total score** — incl. the critical low-total case `[0,0,0,0,0,0,0,0,2]`
- DE crisis resources (Telefonseelsorge 0800 111 0 111 / 0800 111 0 222, Notruf 112) and EN equivalents live in the locale JSON, not hardcoded
- Paired DE/EN blog articles (≥ 1200 words each), wired into `articles.js` / `articles-en.js`, cross-linking GAD-7, sleep cycles and biological age

## Tests
- `npm test` green (2739 passed) — incl. new `phq9.test.js` asserting all six worked examples from #286 and `blog-link-coverage.test.js` for phq9
- `npm run build` green — sitemap 386 URLs, llms.txt 382 links; `phq-9-depressionstest` and `phq-9-depression-test` present in dist

## Count bumps (live values)
- calculators 93 → 94 (auto-discovery, sitemap)
- blog components 96 → 97 (DE + EN)
- sitemap URLs 382 → 386 (+4: calc DE+EN + blog DE+EN)
- SSG routes 516 → 521 (+5: the +4 above plus the old `/blog/<de-slug>` redirect)
- llms.txt links 378 → 382

## Deviation from the issue's 12-file guard
The issue's partial-commit guard lists 12 files but omits **`src/__tests__/llms-txt.test.js`**, which carries the same calc/blog count assertion and is updated identically. The GAD-7 sibling PR (commit a3136bc) also touched this file, confirming it belongs in the change set. Total: 13 files, all PHQ-9-scoped.

Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)