### PR TITLE
GH-288: Add x-default hreflang annotation for SEO language fallback

### DIFF
--- a/src/__tests__/useHead.test.js
+++ b/src/__tests__/useHead.test.js
@@ -49,7 +49,28 @@ describe('useHead', () => {
       { rel: 'canonical', href: 'https://healthcalculator.app/de/bmi-rechner/' },
       { rel: 'alternate', hreflang: 'de', href: 'https://healthcalculator.app/de/bmi-rechner/' },
       { rel: 'alternate', hreflang: 'en', href: 'https://healthcalculator.app/en/bmi-calculator/' },
+      { rel: 'alternate', hreflang: 'x-default', href: 'https://healthcalculator.app/de/bmi-rechner/' },
     ]))
+  })
+
+  it('x-default hreflang points to German version even when viewing English', () => {
+    mockLocale.value = 'en'
+    mockRoute.path = '/en/bmi-calculator'
+    useHead(() => ({
+      title: 'BMI Calculator',
+      description: 'Calculate your BMI',
+      routeKey: 'bmi',
+    }))
+
+    expect(useUnhead).toHaveBeenCalledTimes(1)
+    const head = useUnhead.mock.calls[0][0].value
+
+    const xDefaultLink = head.link.find(l => l.hreflang === 'x-default')
+    expect(xDefaultLink).toEqual({
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: 'https://healthcalculator.app/de/bmi-rechner/',
+    })
   })
 
   it('accepts a plain object instead of a function', () => {

--- a/src/composables/useHead.js
+++ b/src/composables/useHead.js
@@ -41,17 +41,20 @@ export function useHead(getConfig) {
     const currentLocale = locale.value
     const otherLocale = currentLocale === 'de' ? 'en' : 'de'
 
-    let currentPath, otherPath
+    let currentPath, otherPath, defaultPath
     if (configRouteKey === 'blogArticle') {
       const slug = route.meta.slug
       currentPath = `/${currentLocale}/blog/${slug}/`
       otherPath = `/${otherLocale}/blog/${slug}/`
+      defaultPath = `/de/blog/${slug}/`
     } else if (configRouteKey && routeMap[configRouteKey]) {
       currentPath = ensureSlash(resolveLocalePath(configRouteKey, currentLocale))
       otherPath = ensureSlash(resolveLocalePath(configRouteKey, otherLocale))
+      defaultPath = ensureSlash(resolveLocalePath(configRouteKey, 'de'))
     } else {
       currentPath = ensureSlash(route.path)
       otherPath = ensureSlash(route.path)
+      defaultPath = ensureSlash(route.path.replace(/\/en\//, '/de/'))
     }
 
     const url = `${BASE_URL}${currentPath}`
@@ -76,6 +79,7 @@ export function useHead(getConfig) {
         { rel: 'canonical', href: url },
         { rel: 'alternate', hreflang: currentLocale, href: `${BASE_URL}${currentPath}` },
         { rel: 'alternate', hreflang: otherLocale, href: `${BASE_URL}${otherPath}` },
+        { rel: 'alternate', hreflang: 'x-default', href: `${BASE_URL}${defaultPath}` },
       ],
     }
 


### PR DESCRIPTION
> ⚠️ **Acceptance check could not confirm** — the worker validated tests + quality gate but its self-check returned `unknown` on the acceptance criteria. Review the diff before merging.

---

### Summary
Adds a missing `x-default` hreflang link annotation to SEO headers. This specifies the default language version (German) for search engines to serve when a visitor's language settings don't match available translations. Without `x-default`, Google must guess which version to show.

### Why
Live SEO audits revealed the site emits only `de` and `en` hreflang tags but no `x-default` fallback. Per Google's recommendations, an explicit default improves search behavior for users without matching language preferences.

### Notes
The implementation computes `defaultPath` separately for three route contexts:
- **Blog articles**: Uses the `de/blog/{slug}/` pattern
- **Mapped routes**: Resolves the route key for German locale via `resolveLocalePath`  
- **Other routes**: Replaces `/en/` with `/de/` in the current path

Tests verify the x-default link correctly points to German regardless of the currently viewed locale. All changes remain within `useHead.js` and its test file.

---
_Estimated human time: ~45 min_

Closes #288
