### PR TITLE
hc-290-redirect-normalizer: SEO-Fix: eliminate internal-link 301 redirects that GSC repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite-ssg build && node scripts/generate-sitemap.js && node scripts/generate-llms-txt.js",
+    "build": "vite-ssg build && node scripts/normalize-internal-links.js && node scripts/generate-sitemap.js && node scripts/generate-llms-txt.js",
     "preview": "vite preview",
     "test": "vitest run",
     "test:ssr": "npm run build && vitest run src/__tests__/faq-ssr.test.js"

--- a/scripts/normalize-internal-links.js
+++ b/scripts/normalize-internal-links.js
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DIST_DIR = join(__dirname, '../dist')
+
+// Internal links pointing at /de or /en (optionally with a path), no #fragment or ?query.
+const LINK_RE = /href="(\/(?:de|en)(?:\/[^"#?]*)?)"/g
+// Paths ending in a file extension are real files, not routes — leave them alone.
+const FILE_EXT_RE = /\.(xml|png|svg|jpe?g|webp|json|webmanifest|pdf|css|js|gif|avif|ico|txt)$/i
+
+/**
+ * Rewrite slash-less internal /de|/en links to trailing-slash form.
+ * Idempotent: already-slashed links, file-extension paths, fragments,
+ * queries, and external links are left untouched.
+ */
+export function normalizeInternalLinks(html) {
+  return html.replace(LINK_RE, (match, url) => {
+    if (url.endsWith('/')) return match
+    if (FILE_EXT_RE.test(url)) return match
+    return `href="${url}/"`
+  })
+}
+
+function walkHtml(dir) {
+  const files = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) files.push(...walkHtml(full))
+    else if (entry.name.endsWith('.html')) files.push(full)
+  }
+  return files
+}
+
+if (process.argv[1]?.endsWith('normalize-internal-links.js')) {
+  const files = walkHtml(DIST_DIR)
+  let changed = 0
+  for (const file of files) {
+    const src = readFileSync(file, 'utf-8')
+    const out = normalizeInternalLinks(src)
+    if (out !== src) {
+      writeFileSync(file, out)
+      changed++
+    }
+  }
+  console.log(`Normalized internal links: ${changed}/${files.length} files updated`)
+}

--- a/src/__tests__/normalize-internal-links.test.js
+++ b/src/__tests__/normalize-internal-links.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeInternalLinks } from '../../scripts/normalize-internal-links.js'
+
+describe('normalizeInternalLinks', () => {
+  it('appends a trailing slash to slash-less /de and /en links', () => {
+    expect(normalizeInternalLinks('<a href="/de">')).toBe('<a href="/de/">')
+    expect(normalizeInternalLinks('<a href="/en">')).toBe('<a href="/en/">')
+    expect(normalizeInternalLinks('<a href="/de/blog/foo">')).toBe('<a href="/de/blog/foo/">')
+    expect(normalizeInternalLinks('<a href="/en/bmi">')).toBe('<a href="/en/bmi/">')
+  })
+
+  it('is idempotent — already-slashed links stay untouched', () => {
+    const html = '<a href="/de/"><a href="/en/blog/foo/">'
+    expect(normalizeInternalLinks(html)).toBe(html)
+    expect(normalizeInternalLinks(normalizeInternalLinks('<a href="/de/bmi">')))
+      .toBe('<a href="/de/bmi/">')
+  })
+
+  it('skips file-extension paths', () => {
+    const html = [
+      '<a href="/de/sitemap.xml">',
+      '<a href="/en/image.png">',
+      '<a href="/de/doc.pdf">',
+      '<a href="/en/app.webmanifest">',
+      '<a href="/de/icon.svg">',
+    ].join('')
+    expect(normalizeInternalLinks(html)).toBe(html)
+  })
+
+  it('skips links with a fragment or query', () => {
+    const html = '<a href="/de/blog#section"><a href="/en/bmi?ref=1">'
+    expect(normalizeInternalLinks(html)).toBe(html)
+  })
+
+  it('leaves external and non-/de|/en links untouched', () => {
+    const html = [
+      '<a href="https://example.com/de">',
+      '<a href="/fr/page">',
+      '<a href="/about">',
+      '<a href="mailto:x@y.com">',
+    ].join('')
+    expect(normalizeInternalLinks(html)).toBe(html)
+  })
+
+  it('normalizes multiple links in one document', () => {
+    const html = '<a href="/de/a"> text <a href="/en/b/"> more <a href="/de/c">'
+    expect(normalizeInternalLinks(html))
+      .toBe('<a href="/de/a/"> text <a href="/en/b/"> more <a href="/de/c/">')
+  })
+})


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-290-redirect-normalizer
**Agent:** claude
**Model:** claude-opus-4-8
**Branch:** `agent/gh-290-normalizer-20260617-062522`
**Cost:** $1.7765665000000004

Closes jenslaufer/health-calculators#290

### Prompt
> SEO-Fix: eliminate internal-link 301 redirects that GSC reports as "Page with redirect". See issue #290.

ROOT CAUSE: HC navigation already renders internal links WITH trailing-slash, but ~33 hardcoded `<a href="/de|en/...">` links in blog-article files are still slash-LESS (live 301 proof). Canonical/sitemap/GitHub-Pages use trailing-slash → those links 301 every crawl → GSC "Page with redirect".

NOTE: hreflang x-default is already handled separately in PR #289 — NOT part of this task. Do not touch x-default.

KEY INSIGHT: Playwright runs against `npx vite` (source) — NOT against dist/. So leave ALL source untouched (blog articles, nav, routes) and post-process only the built dist/ HTML. This fixes Googlebot AND keeps E2E green.

## New script `scripts/normalize-internal-links.js`
After `vite-ssg build`, walk all `dist/**/*.html` and rewrite internal `<a href="/de/...">` / `/en/...` without trailing slash to `/.../`:
- Match `/de`, `/en`, `/de/<path>`, `/en/<path>`; append `/` if missing.
- SKIP: already trailing-slash; file-extension paths (.xml .png .svg .jpg .jpeg .webp .json .webmanifest .pdf .css .js .gif .avif .ico .txt); links with `#` fragment or `?` query; external links.
- IDEMPOTENT (existing correct nav links stay untouched).
- Walk dist/ using the SAME fs method already used in `scripts/generate-sitemap.js` — do not assume a new dependency exists; mirror its approach.
- Export the core function (`html string -> normalized html string`) so it is unit-testable.
- Hook into the `build` script in package.json AFTER `vite-ssg build` and BEFORE generate-sitemap:
  `vite-ssg build && node scripts/normalize-internal-links.js && node scripts/generate-sitemap.js && node scripts/generate-llms-txt.js`

## Test (TDD — must FAIL on old code, PASS on new)
- New normalizer unit test in `src/__tests__/`: import the exported function; assert slash-less→slash, idempotent, skips file-extension/`#`/`?`/external/already-slash, and leaves non-`/de|/en` links untouched.

## Final QG before push (abort-on-fail — if any step is red, DO NOT push)
- `npm test` green (incl. new test).
- `npm run build` green (vite-ssg + normalizer step).
- Acceptance grep MUST be EMPTY:
  grep -rhoP 'href="/(de|en)(/[^"#?]*)?"' dist --include='*.html' | grep -P '[^/"]"$' | grep -vP '\.(xml|txt|ico|png|svg|jpg|jpeg|webp|json|webmanifest|pdf|css|js|gif|avif)"$' | sort -u
- `npx playwright test` green (source unchanged → MUST stay green).

## Constraints
- DO NOT change nav, routes, blog articles, or existing tests (add new test only). Purely additive: one new build script.
- NO slug/sitemap changes. Do not touch x-default (PR #289 owns it).
- PARTIAL-COMMIT GUARD: one clean commit; `git status` clean before push.
- DO NOT DELETE unrelated files.