### PR TITLE
hc-288-xdefault-agenttask: Implement issue #288: add an hreflang `x-default` annotation

### DIFF
--- a/src/__tests__/useHead.test.js
+++ b/src/__tests__/useHead.test.js
@@ -49,7 +49,43 @@ describe('useHead', () => {
       { rel: 'canonical', href: 'https://healthcalculator.app/de/bmi-rechner/' },
       { rel: 'alternate', hreflang: 'de', href: 'https://healthcalculator.app/de/bmi-rechner/' },
       { rel: 'alternate', hreflang: 'en', href: 'https://healthcalculator.app/en/bmi-calculator/' },
+      { rel: 'alternate', hreflang: 'x-default', href: 'https://healthcalculator.app/de/bmi-rechner/' },
     ]))
+  })
+
+  it('emits an x-default hreflang pointing to the de URL on a de page', () => {
+    mockLocale.value = 'de'
+    useHead(() => ({
+      title: 'BMI Rechner',
+      description: 'Berechne deinen BMI',
+      routeKey: 'bmi',
+    }))
+
+    const head = useUnhead.mock.calls[0][0].value
+    const xDefault = head.link.find(l => l.hreflang === 'x-default')
+    expect(xDefault, 'x-default hreflang missing').toBeDefined()
+    expect(xDefault.rel).toBe('alternate')
+    expect(xDefault.href).toMatch(/^https:\/\/healthcalculator\.app\/de\//)
+    expect(xDefault.href, 'x-default URL missing trailing slash').toMatch(/\/$/)
+    expect(xDefault.href).toBe('https://healthcalculator.app/de/bmi-rechner/')
+  })
+
+  it('keeps x-default pointing to the de URL on an en page', () => {
+    mockLocale.value = 'en'
+    mockRoute.path = '/en/bmi-calculator'
+    useHead(() => ({
+      title: 'BMI Calculator',
+      description: 'Calculate your BMI',
+      routeKey: 'bmi',
+    }))
+
+    const head = useUnhead.mock.calls[0][0].value
+    const xDefault = head.link.find(l => l.hreflang === 'x-default')
+    expect(xDefault, 'x-default hreflang missing').toBeDefined()
+    expect(xDefault.rel).toBe('alternate')
+    expect(xDefault.href).toMatch(/^https:\/\/healthcalculator\.app\/de\//)
+    expect(xDefault.href, 'x-default URL missing trailing slash').toMatch(/\/$/)
+    expect(xDefault.href).toBe('https://healthcalculator.app/de/bmi-rechner/')
   })
 
   it('accepts a plain object instead of a function', () => {

--- a/src/composables/useHead.js
+++ b/src/composables/useHead.js
@@ -76,6 +76,7 @@ export function useHead(getConfig) {
         { rel: 'canonical', href: url },
         { rel: 'alternate', hreflang: currentLocale, href: `${BASE_URL}${currentPath}` },
         { rel: 'alternate', hreflang: otherLocale, href: `${BASE_URL}${otherPath}` },
+        { rel: 'alternate', hreflang: 'x-default', href: `${BASE_URL}${currentLocale === 'de' ? currentPath : otherPath}` },
       ],
     }
 


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-288-xdefault-agenttask
**Agent:** claude
**Model:** claude-opus-4-8
**Branch:** `agent/hc-288-xdefault-agenttask-20260617-104522`
**Cost:** $0.861464

Closes jenslaufer/health-calculators#288

### Prompt
> Implement issue #288: add an hreflang `x-default` annotation. Read issue #288 first — its Fix + Tests blocks are authoritative.

## Root cause
The hreflang link tags in `src/composables/useHead.js` emit only `de` and `en`, no `x-default`. Without x-default Google guesses the fallback language version. Verified: `grep -rn "x-default" src/` is empty.

## Fix (single file)
In `src/composables/useHead.js`, in the `link:` array, directly after the two existing `{ rel: 'alternate', hreflang: ... }` lines, add an x-default line that points to the GERMAN version of the page (de is primary; `/` redirects to `/de/`). The de URL is `currentPath` when the current locale is `de`, otherwise `otherPath`:

    { rel: 'alternate', hreflang: 'x-default', href: `${BASE_URL}${currentLocale === 'de' ? currentPath : otherPath}` },

This covers calculator pages, blog articles and home — all run through `useHead`.

## Test (TDD — must FAIL on old tree, PASS on new)
Extend `src/__tests__/useHead.test.js`: assert the rendered `link` array contains an entry with `hreflang: 'x-default'` whose `href` is the de URL — it must start with `https://healthcalculator.app/de/` and end with a trailing slash. Add a case that proves it: on an EN page the x-default still points to the de URL.

## Final-QG before push (abort-on-fail — do NOT push on a red step)
- `npm test` green (incl. the new assertions).
- `npm run build` green (vite-ssg).

## Constraints
- Touch ONLY `src/composables/useHead.js` and its test file.
- DO NOT modify or delete any other files, calculators, blog articles, or existing test assertions (only ADD new ones).
- PARTIAL-COMMIT GUARD: all touched files in one commit; `git status` clean before push.