### PR TITLE
hc-293-noindex-guard: Add a build-time guard that fails the build if `noindex` lea

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite-ssg build && node scripts/normalize-internal-links.js && node scripts/generate-sitemap.js && node scripts/generate-llms-txt.js",
+    "build": "vite-ssg build && node scripts/normalize-internal-links.js && node scripts/generate-sitemap.js && node scripts/generate-llms-txt.js && node scripts/verify-noindex.js",
     "preview": "vite preview",
     "test": "vitest run",
     "test:ssr": "npm run build && vitest run src/__tests__/faq-ssr.test.js"

--- a/scripts/verify-noindex.js
+++ b/scripts/verify-noindex.js
@@ -1,0 +1,69 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, dirname, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DIST_DIR = join(__dirname, '../dist')
+
+const ROBOTS_META_RE = /<meta\b[^>]*\bname\s*=\s*["']robots["'][^>]*>/gi
+const NOT_FOUND_TITLE_RE = /<title[^>]*>[^<]*Page not found[^<]*<\/title>/i
+
+function hasNoindex(html) {
+  const matches = html.match(ROBOTS_META_RE)
+  if (!matches) return false
+  return matches.some(tag => /content\s*=\s*["'][^"']*noindex/i.test(tag))
+}
+
+function isNotFoundPage(relPath, html) {
+  const normalized = relPath.split(sep).join('/')
+  if (normalized === '404.html') return true
+  return NOT_FOUND_TITLE_RE.test(html)
+}
+
+function walkHtml(dir) {
+  const files = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) files.push(...walkHtml(full))
+    else if (entry.name.endsWith('.html')) files.push(full)
+  }
+  return files
+}
+
+export function scanDistForNoindex(distDir) {
+  const files = walkHtml(distDir)
+  const offenders = []
+  let notFoundHasNoindex = false
+  let notFoundFound = false
+
+  for (const file of files) {
+    const rel = relative(distDir, file)
+    const html = readFileSync(file, 'utf-8')
+    const isNotFound = isNotFoundPage(rel, html)
+    const noindex = hasNoindex(html)
+
+    if (isNotFound) {
+      notFoundFound = true
+      if (noindex) notFoundHasNoindex = true
+    } else if (noindex) {
+      offenders.push(file)
+    }
+  }
+
+  const ok = offenders.length === 0 && notFoundFound && notFoundHasNoindex
+  return { offenders, notFoundHasNoindex, notFoundFound, totalPages: files.length, ok }
+}
+
+if (process.argv[1]?.endsWith('verify-noindex.js')) {
+  const result = scanDistForNoindex(DIST_DIR)
+  if (result.offenders.length > 0) {
+    console.error(`verify-noindex: FAIL — ${result.offenders.length} non-404 page(s) carry noindex:`)
+    for (const f of result.offenders) console.error(`  ${f}`)
+    process.exit(1)
+  }
+  if (!result.notFoundFound || !result.notFoundHasNoindex) {
+    console.error('verify-noindex: FAIL — 404 page is missing its noindex meta')
+    process.exit(1)
+  }
+  console.log(`verify-noindex: ${result.totalPages} pages OK, 404 noindex present`)
+}

--- a/src/__tests__/verify-noindex.test.js
+++ b/src/__tests__/verify-noindex.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { scanDistForNoindex } from '../../scripts/verify-noindex.js'
+
+const realPage = (title = 'BMI Calculator') => `<!doctype html>
+<html><head><title>${title}</title>
+<meta name="robots" content="index, follow" />
+</head><body>ok</body></html>`
+
+const notFoundPage = () => `<!doctype html>
+<html><head><title>Page not found — Health Calculators</title>
+<meta name="robots" content="noindex" />
+</head><body>404</body></html>`
+
+const noindexRealPage = () => `<!doctype html>
+<html><head><title>Some Calculator</title>
+<meta name="robots" content="noindex, follow" />
+</head><body>oops</body></html>`
+
+let dir
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'verify-noindex-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const write = (rel, html) => {
+  const full = join(dir, rel)
+  mkdirSync(join(full, '..'), { recursive: true })
+  writeFileSync(full, html)
+}
+
+describe('scanDistForNoindex', () => {
+  it('passes on a clean tree: real pages indexable, 404 noindex present', () => {
+    write('index.html', realPage('Home'))
+    write('de/bmi/index.html', realPage('BMI'))
+    write('en/bmi/index.html', realPage('BMI EN'))
+    write('404.html', notFoundPage())
+
+    const r = scanDistForNoindex(dir)
+    expect(r.offenders).toEqual([])
+    expect(r.notFoundHasNoindex).toBe(true)
+    expect(r.ok).toBe(true)
+    expect(r.totalPages).toBeGreaterThanOrEqual(4)
+  })
+
+  it('flags a real (non-404) page that carries noindex', () => {
+    write('index.html', realPage('Home'))
+    write('de/bmi/index.html', noindexRealPage())
+    write('404.html', notFoundPage())
+
+    const r = scanDistForNoindex(dir)
+    expect(r.ok).toBe(false)
+    expect(r.offenders.some(p => p.endsWith('de/bmi/index.html'))).toBe(true)
+  })
+
+  it('fails when the 404 page is missing its noindex', () => {
+    write('index.html', realPage('Home'))
+    write('404.html', realPage('Page not found — Health Calculators'))
+
+    const r = scanDistForNoindex(dir)
+    expect(r.notFoundHasNoindex).toBe(false)
+    expect(r.ok).toBe(false)
+  })
+
+  it('treats pages whose title contains "Page not found" as the 404 catch-all', () => {
+    write('index.html', realPage('Home'))
+    write('404.html', notFoundPage())
+    // SPA-style catch-all rendered at a non-/404 path
+    write('de/missing/index.html', notFoundPage())
+
+    const r = scanDistForNoindex(dir)
+    expect(r.offenders).toEqual([])
+    expect(r.ok).toBe(true)
+  })
+
+  it('matches noindex case-insensitively and tolerates attribute order', () => {
+    write('index.html', realPage('Home'))
+    write('404.html', notFoundPage())
+    write('de/x/index.html', `<html><head><title>X</title>
+<META CONTENT="NoIndex, follow" NAME="robots"></head><body></body></html>`)
+
+    const r = scanDistForNoindex(dir)
+    expect(r.ok).toBe(false)
+    expect(r.offenders.some(p => p.endsWith('de/x/index.html'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Automated Agent Task

**Task:** hc-293-noindex-guard
**Agent:** claude
**Model:** claude-opus-4-7
**Branch:** `agent/hc-293-noindex-guard-20260618-111001`
**Cost:** $1.1601679999999999

Closes jenslaufer/health-calculators#293

### Prompt
> Add a build-time guard that fails the build if `noindex` leaks onto a real
prerendered page. Context: GSC showed a ~3-week total impression collapse
(May 1–17) consistent with real routes falling through to the `noindex`
NotFound catch-all. There is currently NO test guarding this; a single bad
routing/auto-discovery merge could silently de-index the whole site again.

## Scope (infrastructure + test only — do NOT touch any source Vue or route files)

1. New `scripts/verify-noindex.js`, mirroring the existing post-build script
   pattern in `scripts/normalize-internal-links.js` (ESM, runnable via
   `node scripts/verify-noindex.js`, scans the built `dist/` tree):
   - Recursively read every `dist/**/*.html`.
   - A page is "the 404 page" if its path is `dist/404.html` OR its HTML
     contains the NotFound marker (the page title "Page not found" — verify
     the exact string in `dist/404.html` after a build before hardcoding it).
   - FAIL (exit code 1) if any NON-404 page contains a robots meta with
     `noindex` (match `<meta name="robots" ... content="...noindex...">`,
     case-insensitive, tolerant of attribute order/whitespace).
   - FAIL if `dist/404.html` does NOT contain `noindex` (the guard must also
     confirm the legitimate noindex is still present, so the test can't be
     satisfied by simply stripping all noindex).
   - On failure, print the list of offending file paths, then exit 1.
   - On success, print a one-line summary (e.g. "verify-noindex: N pages OK,
     404 noindex present") and exit 0.
   - Use the same "run-as-main" guard idiom as normalize-internal-links.js
     (`if (process.argv[1]?.endsWith('verify-noindex.js'))`) and EXPORT the
     core scan function so the unit test can import it without a real build.

2. Append `node scripts/verify-noindex.js` to the `build` script in
   package.json, AFTER the existing post-build scripts
   (`vite-ssg build && normalize-internal-links && generate-sitemap &&
   generate-llms-txt && verify-noindex`). Do not reorder the existing steps.

3. TDD unit test `src/__tests__/verify-noindex.test.js` (vitest) for the
   exported scan function, driven by in-memory/temp fixtures (do NOT require a
   real build):
   - PASSES on a clean fixture set: real pages with `index, follow` + a
     404 page with `noindex`.
   - FAILS (the function reports an offender) when a real (non-404) page
     carries `noindex` — this assertion MUST fail against a no-op
     implementation and pass against the real one (no tautology).
   - FAILS when the 404 page is missing its `noindex`.
   Write the test FIRST, confirm it fails without the implementation, then
   implement until green.

## Quality gate (run before pushing; abort and report if any step fails)
- `npm ci`
- `npm run test` (vitest) — all green, including the new test.
- `npm run build` — must complete; the new verify-noindex step must PASS on
   the current clean tree (this is the real end-to-end proof the guard works
   against live output). Confirm the build still emits the same sitemap URL
   count as before your change (no URL added/removed).
- As a negative check, temporarily inject `<meta name="robots" content="noindex">`
   into one built calculator page and re-run `node scripts/verify-noindex.js`
   to confirm it exits non-zero; then revert the injection. (Do not commit the
   injection.)

## Constraints
- 94 calculators unchanged; sitemap URL count unchanged.
- Additive only: new script + new test + one line in package.json build chain.
- DO NOT DELETE or modify any unrelated files, source Vue components, routes,
  or other scripts. Keep it to 1–2 commits.