### PR TITLE
fix(hc-272): use RelatedArticlesEn on all EN blog pages (39 files, repo-wide)

### DIFF
--- a/src/__tests__/related-articles-en-import.test.js
+++ b/src/__tests__/related-articles-en-import.test.js
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const EN_BLOG_DIR = path.resolve(__dirname, '../pages/blog/en')
+
+// Recursively collect every *.vue file under src/pages/blog/en/.
+function collectVueFiles(dir) {
+  const out = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...collectVueFiles(full))
+    else if (entry.isFile() && entry.name.endsWith('.vue')) out.push(full)
+  }
+  return out
+}
+
+// The German component. RelatedArticlesEn legitimately contains "RelatedArticles"
+// as a substring, so we match only the precise DE tokens:
+//   - the DE import path: components/RelatedArticles.vue
+//   - the DE component tag: <RelatedArticles NOT followed by "En"
+const DE_IMPORT_PATH = /components\/RelatedArticles\.vue/
+const DE_COMPONENT_TAG = /<RelatedArticles(?!En)/
+
+describe('EN blog pages must use the English RelatedArticlesEn component', () => {
+  const files = collectVueFiles(EN_BLOG_DIR)
+
+  it('finds EN blog pages to check', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it('no EN blog page imports or uses the German RelatedArticles component', () => {
+    const offenders = files
+      .filter((file) => {
+        const src = fs.readFileSync(file, 'utf8')
+        return DE_IMPORT_PATH.test(src) || DE_COMPONENT_TAG.test(src)
+      })
+      .map((file) => path.relative(EN_BLOG_DIR, file))
+
+    expect(
+      offenders,
+      `These EN blog pages still reference the German RelatedArticles component ` +
+        `instead of RelatedArticlesEn:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+})

--- a/src/pages/blog/en/AnemiaRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/AnemiaRiskCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -172,7 +172,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="anemia-risk-calculator-guide" />
+      <RelatedArticlesEn slug="anemia-risk-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/ApgarScoreCalculatorGuide.vue
+++ b/src/pages/blog/en/ApgarScoreCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -149,7 +149,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="apgar-score-calculator-guide" />
+      <RelatedArticlesEn slug="apgar-score-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/AsthmaControlTestGuide.vue
+++ b/src/pages/blog/en/AsthmaControlTestGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -213,6 +213,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/BabyFeedingAmountCalculator.vue
+++ b/src/pages/blog/en/BabyFeedingAmountCalculator.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -97,7 +97,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="baby-feeding-amount-calculator" />
+      <RelatedArticlesEn slug="baby-feeding-amount-calculator" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/BabyMilestoneTracker.vue
+++ b/src/pages/blog/en/BabyMilestoneTracker.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -211,6 +211,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/BloodAlcoholEstimatorGuide.vue
+++ b/src/pages/blog/en/BloodAlcoholEstimatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -245,7 +245,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="blood-alcohol-estimator-guide" />
+      <RelatedArticlesEn slug="blood-alcohol-estimator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/BodySurfaceAreaCalculator.vue
+++ b/src/pages/blog/en/BodySurfaceAreaCalculator.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -188,6 +188,6 @@ useHead({
 
     </div>
 
-    <RelatedArticles slug="body-surface-area-calculator" />
+    <RelatedArticlesEn slug="body-surface-area-calculator" />
   </article>
 </template>

--- a/src/pages/blog/en/BreastCancerRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/BreastCancerRiskCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -205,7 +205,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="breast-cancer-risk-calculator-guide" />
+      <RelatedArticlesEn slug="breast-cancer-risk-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/CardiovascularRiskCalculator.vue
+++ b/src/pages/blog/en/CardiovascularRiskCalculator.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -206,7 +206,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="cardiovascular-risk-framingham" />
+      <RelatedArticlesEn slug="cardiovascular-risk-framingham" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/ChildCalorieNeedsGuide.vue
+++ b/src/pages/blog/en/ChildCalorieNeedsGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -234,6 +234,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/ChildDosageCalculator.vue
+++ b/src/pages/blog/en/ChildDosageCalculator.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -246,6 +246,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/ChildGrowthPercentileBlog.vue
+++ b/src/pages/blog/en/ChildGrowthPercentileBlog.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -256,6 +256,6 @@ useHead({
 
     </div>
 
-    <RelatedArticles slug="child-growth-percentile-chart" />
+    <RelatedArticlesEn slug="child-growth-percentile-chart" />
   </article>
 </template>

--- a/src/pages/blog/en/CopdAssessmentGuide.vue
+++ b/src/pages/blog/en/CopdAssessmentGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -283,6 +283,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/CreatinineClearanceCalculatorGuide.vue
+++ b/src/pages/blog/en/CreatinineClearanceCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -227,6 +227,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/DehydrationRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/DehydrationRiskCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -166,7 +166,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="dehydration-risk-calculator-guide" />
+      <RelatedArticlesEn slug="dehydration-risk-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/DiabetesRiskScore.vue
+++ b/src/pages/blog/en/DiabetesRiskScore.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -252,6 +252,6 @@ useHead({
 
     </div>
 
-    <RelatedArticles slug="diabetes-risk-score" />
+    <RelatedArticlesEn slug="diabetes-risk-score" />
   </article>
 </template>

--- a/src/pages/blog/en/ErectileDysfunctionIief5.vue
+++ b/src/pages/blog/en/ErectileDysfunctionIief5.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -181,7 +181,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="erectile-dysfunction-iief-5" />
+      <RelatedArticlesEn slug="erectile-dysfunction-iief-5" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/FfmiCalculatorGuide.vue
+++ b/src/pages/blog/en/FfmiCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -150,7 +150,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="ffmi-calculator-guide" />
+      <RelatedArticlesEn slug="ffmi-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/GfrCalculatorKidneyFunction.vue
+++ b/src/pages/blog/en/GfrCalculatorKidneyFunction.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -209,7 +209,7 @@ useHead({
         </ul>
       </div>
 
-      <RelatedArticles />
+      <RelatedArticlesEn />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/HeadCircumferenceBabyGuide.vue
+++ b/src/pages/blog/en/HeadCircumferenceBabyGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -213,6 +213,6 @@ useHead({
 
     </div>
 
-    <RelatedArticles slug="head-circumference-baby-guide" />
+    <RelatedArticlesEn slug="head-circumference-baby-guide" />
   </article>
 </template>

--- a/src/pages/blog/en/HeartFailureRiskCalculator.vue
+++ b/src/pages/blog/en/HeartFailureRiskCalculator.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -189,7 +189,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="heart-failure-risk-calculator" />
+      <RelatedArticlesEn slug="heart-failure-risk-calculator" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/HepatitisRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/HepatitisRiskCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -177,7 +177,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="hepatitis-risk-calculator-guide" />
+      <RelatedArticlesEn slug="hepatitis-risk-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/HomaIrInsulinResistanceGuide.vue
+++ b/src/pages/blog/en/HomaIrInsulinResistanceGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -222,6 +222,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles slug="homa-ir-insulin-resistance-guide" />
+    <RelatedArticlesEn slug="homa-ir-insulin-resistance-guide" />
   </article>
 </template>

--- a/src/pages/blog/en/IronDeficiencyCalculatorGuide.vue
+++ b/src/pages/blog/en/IronDeficiencyCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -167,7 +167,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="iron-deficiency-calculator-guide" />
+      <RelatedArticlesEn slug="iron-deficiency-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/MalePatternBaldnessNorwood.vue
+++ b/src/pages/blog/en/MalePatternBaldnessNorwood.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -175,7 +175,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="male-pattern-baldness-norwood" />
+      <RelatedArticlesEn slug="male-pattern-baldness-norwood" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/MeanArterialPressureGuide.vue
+++ b/src/pages/blog/en/MeanArterialPressureGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -208,6 +208,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles slug="mean-arterial-pressure-guide" />
+    <RelatedArticlesEn slug="mean-arterial-pressure-guide" />
   </article>
 </template>

--- a/src/pages/blog/en/MenopauseSymptomCalculatorGuide.vue
+++ b/src/pages/blog/en/MenopauseSymptomCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -198,7 +198,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="menopause-symptom-calculator-guide" />
+      <RelatedArticlesEn slug="menopause-symptom-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/NewbornJaundiceCalculatorGuide.vue
+++ b/src/pages/blog/en/NewbornJaundiceCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -233,6 +233,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/OsteoporosisRiskCalculatorGuide.vue
+++ b/src/pages/blog/en/OsteoporosisRiskCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -165,7 +165,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="osteoporosis-risk-calculator-guide" />
+      <RelatedArticlesEn slug="osteoporosis-risk-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/PainScaleCalculatorGuide.vue
+++ b/src/pages/blog/en/PainScaleCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -241,6 +241,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/PcosSymptomChecker.vue
+++ b/src/pages/blog/en/PcosSymptomChecker.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -191,7 +191,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="pcos-symptom-checker" />
+      <RelatedArticlesEn slug="pcos-symptom-checker" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/PediatricBloodPressureGuide.vue
+++ b/src/pages/blog/en/PediatricBloodPressureGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -231,6 +231,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/PediatricBmiGuide.vue
+++ b/src/pages/blog/en/PediatricBmiGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -223,6 +223,6 @@ useHead({
 
     </div>
 
-    <RelatedArticles slug="pediatric-bmi-guide" />
+    <RelatedArticlesEn slug="pediatric-bmi-guide" />
   </article>
 </template>

--- a/src/pages/blog/en/PmsSymptomCalculatorGuide.vue
+++ b/src/pages/blog/en/PmsSymptomCalculatorGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -199,7 +199,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="pms-symptom-calculator-guide" />
+      <RelatedArticlesEn slug="pms-symptom-calculator-guide" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/PregnancyCalorieNeedsGuide.vue
+++ b/src/pages/blog/en/PregnancyCalorieNeedsGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -257,6 +257,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/SmokingCostCalculatorBlog.vue
+++ b/src/pages/blog/en/SmokingCostCalculatorBlog.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath } = useLocaleRouter()
@@ -252,6 +252,6 @@ useHead({
 
     </div>
 
-    <RelatedArticles slug="smoking-cost-calculator" />
+    <RelatedArticlesEn slug="smoking-cost-calculator" />
   </article>
 </template>

--- a/src/pages/blog/en/StepsToCaloriesGuide.vue
+++ b/src/pages/blog/en/StepsToCaloriesGuide.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -241,6 +241,6 @@ useHead({
       </div>
     </div>
 
-    <RelatedArticles />
+    <RelatedArticlesEn />
   </article>
 </template>

--- a/src/pages/blog/en/StrokeRiskCalculatorChaDsVasc.vue
+++ b/src/pages/blog/en/StrokeRiskCalculatorChaDsVasc.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -199,7 +199,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="stroke-risk-calculator-cha2ds2-vasc" />
+      <RelatedArticlesEn slug="stroke-risk-calculator-cha2ds2-vasc" />
     </div>
   </article>
 </template>

--- a/src/pages/blog/en/TestosteroneLevelCalculator.vue
+++ b/src/pages/blog/en/TestosteroneLevelCalculator.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useHead } from '../../../composables/useHead.js'
-import RelatedArticles from '../../../components/RelatedArticles.vue'
+import RelatedArticlesEn from '../../../components/RelatedArticlesEn.vue'
 import { useLocaleRouter } from '../../../composables/useLocaleRouter.js'
 
 const { localePath, localeBlogPath } = useLocaleRouter()
@@ -187,7 +187,7 @@ useHead({
         </p>
       </div>
 
-      <RelatedArticles slug="testosterone-level-calculator" />
+      <RelatedArticlesEn slug="testosterone-level-calculator" />
     </div>
   </article>
 </template>


### PR DESCRIPTION
## Summary
Fixes the `RelatedArticlesEn` component-import drift on English blog pages. Issue #272 named **one** file as the "only outlier" — that premise was **false**. A deterministic grep found **39** files under `src/pages/blog/en/` importing the German `RelatedArticles.vue` instead of the English `RelatedArticlesEn.vue`. This PR fixes **all 39** and adds a guard so the drift cannot return. **It supersedes the single-file scope of #272.**

## Why it was a bug
- `components/RelatedArticles.vue` hard-codes the German heading "Verwandte Artikel" and pulls DE articles via `getRelatedArticles` (`data/articles.js`).
- `components/RelatedArticlesEn.vue` is the English counterpart: heading "Related Articles", pulls EN articles via `getEnRelatedArticles` (`data/articles-en.js`).
- Same required `slug` String prop → pure drop-in swap.
- On EN pages the German component currently renders nothing (no DE slug matches), but it is a latent defect: any slug collision would surface a German heading on an English page.

## Changes
- Swapped the import and component tag in all 39 flagged `src/pages/blog/en/*.vue` files (both `slug="..."` and bare `<RelatedArticles />` forms). Slug values and surrounding markup untouched.
- Added `src/__tests__/related-articles-en-import.test.js` (vitest, node env): recursively scans every `*.vue` under `src/pages/blog/en/` and fails listing offenders if any references the DE import path `components/RelatedArticles.vue` or the bare `<RelatedArticles` tag (RelatedArticlesEn allowed). **Written first; confirmed RED on 39 files before the fix, GREEN after.**

## Out of scope (untouched)
DE blog pages, the components themselves, and the data files.

## Quality gate
- `npm ci` ✓
- `npm run build` ✓
- `npm test` ✓ — 2753 tests, 102 files green, incl. the new guard
- Completeness guard: `grep -rl "components/RelatedArticles\.vue" src/pages/blog/en/` → empty ✓
- Sanity diff vs main: 39 EN pages + the new test file ✓
- E2E: relevant Playwright specs run; the 14 failures (DE calculator blog banners, BlogHome 15-article count, body-fat blog links) are **pre-existing** — reproduced identically on a clean `origin/main` baseline and untouched by this change.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)