### PR TITLE
feat(hc-198): FAQPage JSON-LD batch 1 (caffeine, protein, sleep, heartRate, caloriesBurned)

### DIFF
--- a/src/__tests__/faq-ssr.test.js
+++ b/src/__tests__/faq-ssr.test.js
@@ -26,6 +26,11 @@ const SAMPLE_PAGES = [
   'de/zyklusrechner',
   'de/blutzucker-umrechner',
   'de/idealgewicht-rechner',
+  'de/koffein-rechner',
+  'de/protein-rechner',
+  'de/schlafzyklen-rechner',
+  'de/herzfrequenz-zonen',
+  'de/kalorienverbrauch',
 ]
 
 const distExists = existsSync(DIST)

--- a/src/locales/calculators/de/caffeine.json
+++ b/src/locales/calculators/de/caffeine.json
@@ -37,6 +37,32 @@
       "greenTea": "Grüntee (28 mg)",
       "energyDrink": "Energy Drink (80 mg)",
       "cola": "Cola (34 mg / 330 ml)"
-    }
+    },
+    "faq": [
+      {
+        "q": "Wie viel Koffein pro Tag ist für gesunde Erwachsene unbedenklich?",
+        "a": "Die Europäische Behörde für Lebensmittelsicherheit (EFSA) bewertet für gesunde Erwachsene Einzeldosen bis etwa 200 mg sowie eine über den Tag verteilte Gesamtmenge bis 400 mg als unbedenklich. Die individuelle Empfindlichkeit kann abweichen; bei Unsicherheit ärztlichen Rat einholen."
+      },
+      {
+        "q": "Wie lange bleibt Koffein im Körper?",
+        "a": "Koffein hat beim gesunden Erwachsenen eine durchschnittliche Halbwertszeit von etwa 3 bis 5 Stunden. Nach dieser Zeit ist rund die Hälfte abgebaut. Dieser Rechner nutzt den Halbwertszeit-Ansatz, um den geschätzten Koffeinspiegel über den Tag darzustellen."
+      },
+      {
+        "q": "Wie viel Koffein steckt in einer Tasse Kaffee?",
+        "a": "Eine Tasse Filterkaffee (etwa 200 ml) enthält je nach Sorte und Zubereitung typischerweise rund 80 bis 100 mg Koffein, ein Espresso etwa 60 bis 80 mg. Die Werte schwanken stark mit Bohne, Mahlgrad und Brühmethode."
+      },
+      {
+        "q": "Beeinflusst Koffein den Schlaf?",
+        "a": "Ja. Da Koffein nur langsam abgebaut wird, kann Konsum am Nachmittag oder Abend das Einschlafen erschweren. Es wird oft empfohlen, einige Stunden vor dem Schlafengehen auf Koffein zu verzichten."
+      },
+      {
+        "q": "Wie viel Koffein ist in der Schwangerschaft vertretbar?",
+        "a": "Die EFSA nennt für Schwangere eine niedrigere Obergrenze von etwa 200 mg Koffein pro Tag. Schwangere sollten ihren Konsum individuell mit der betreuenden Ärztin oder dem Arzt besprechen."
+      },
+      {
+        "q": "Kann man eine Koffeintoleranz entwickeln?",
+        "a": "Bei regelmäßigem Konsum gewöhnt sich der Körper teilweise an die anregende Wirkung, sodass dieselbe Menge weniger spürbar wirkt. An den von der EFSA genannten Mengen für die gesundheitliche Bewertung ändert das nichts."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/caloriesBurned.json
+++ b/src/locales/calculators/de/caloriesBurned.json
@@ -66,6 +66,32 @@
     "chocolate": "Schokoriegel",
     "weeklyProjection": "Wochenprognose",
     "sessionsPerWeek": "Einheiten / Woche",
-    "kcalPerWeek": "kcal / Woche"
+    "kcalPerWeek": "kcal / Woche",
+    "faq": [
+      {
+        "q": "Wie wird der Kalorienverbrauch berechnet?",
+        "a": "Dieser Rechner nutzt MET-Werte (metabolisches Äquivalent) aus dem Compendium of Physical Activities. Verbrauch = MET × Körpergewicht in kg × Dauer in Stunden. So lässt sich der Energieverbrauch einer Aktivität abschätzen."
+      },
+      {
+        "q": "Was bedeutet MET?",
+        "a": "Ein MET entspricht dem Energieumsatz in Ruhe. Ein Wert von 8 MET bedeutet also etwa den achtfachen Energieverbrauch gegenüber dem Ruhezustand. Die Werte stammen aus dem wissenschaftlichen Compendium of Physical Activities."
+      },
+      {
+        "q": "Wie genau ist die Schätzung?",
+        "a": "Es handelt sich um einen Durchschnittswert. Der tatsächliche Verbrauch hängt von Fitness, Intensität, Technik und Körperzusammensetzung ab und kann abweichen. Die Zahl dient der Orientierung."
+      },
+      {
+        "q": "Wie viel Bewegung pro Woche wird empfohlen?",
+        "a": "Die Weltgesundheitsorganisation (WHO) empfiehlt Erwachsenen mindestens 150 bis 300 Minuten moderate oder 75 bis 150 Minuten intensive körperliche Aktivität pro Woche."
+      },
+      {
+        "q": "Berücksichtigt der Rechner meinen Grundumsatz?",
+        "a": "Nein. Er schätzt nur die zusätzlich durch die Aktivität verbrannten Kalorien. Den täglichen Gesamtumsatz inklusive Grundumsatz ermitteln separate Rechner, etwa auf Basis der DGE-Bezugswerte."
+      },
+      {
+        "q": "Hilft mehr Bewegung beim Abnehmen?",
+        "a": "Bewegung erhöht den Energieverbrauch und unterstützt zusammen mit einer ausgewogenen Ernährung das Gewichtsmanagement. Entscheidend ist die langfristige Energiebilanz."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/heartRate.json
+++ b/src/locales/calculators/de/heartRate.json
@@ -29,6 +29,32 @@
     "fatBurnDesc": "Leichtes Ausdauertraining. Baut aerobe Grundlage auf und verbrennt Fett effizient.",
     "aerobicDesc": "Mittlere Anstrengung. Verbessert Herz-Kreislauf-Fitness und Ausdauer.",
     "anaerobicDesc": "Hohe Anstrengung. Steigert Geschwindigkeit, Kraft und Laktatschwelle.",
-    "vo2maxDesc": "Maximale Anstrengung. Entwickelt Spitzenleistung und Geschwindigkeit."
+    "vo2maxDesc": "Maximale Anstrengung. Entwickelt Spitzenleistung und Geschwindigkeit.",
+    "faq": [
+      {
+        "q": "Wie berechne ich meine maximale Herzfrequenz?",
+        "a": "Eine verbreitete Faustformel lautet 220 minus Lebensalter. Sie liefert einen groben Schätzwert; die tatsächliche maximale Herzfrequenz kann individuell abweichen. Für genaue Werte ist ein ärztlicher Belastungstest sinnvoll."
+      },
+      {
+        "q": "Was ist die Karvonen-Methode?",
+        "a": "Die Karvonen-Formel berechnet Trainingszonen über die Herzfrequenzreserve, also die Differenz zwischen maximaler und Ruheherzfrequenz. Sie ist gut etabliert und individualisiert die Zonen stärker als die reine Prozentmethode."
+      },
+      {
+        "q": "Was bedeuten die Herzfrequenzzonen?",
+        "a": "Die American Heart Association (AHA) beschreibt Zonen von leichter Erholung bis hoher Intensität. Niedrigere Zonen fördern die Grundlagenausdauer, höhere Zonen die Leistungsfähigkeit. Dieser Rechner teilt den Bereich in fünf Zonen."
+      },
+      {
+        "q": "In welcher Zone verbrenne ich am meisten Fett?",
+        "a": "In moderaten Zonen stammt ein größerer Anteil der Energie aus Fett, doch der absolute Kalorienverbrauch ist bei höherer Intensität größer. Für die Gesundheit zählt vor allem die gesamte Bewegung."
+      },
+      {
+        "q": "Wie oft sollte ich trainieren?",
+        "a": "Die AHA empfiehlt Erwachsenen mindestens 150 Minuten moderate oder 75 Minuten intensive Ausdaueraktivität pro Woche. Bei Vorerkrankungen vor Trainingsbeginn ärztlichen Rat einholen."
+      },
+      {
+        "q": "Sind die berechneten Zonen für jeden geeignet?",
+        "a": "Die Werte sind allgemeine Schätzungen für gesunde Erwachsene. Bei Herzerkrankungen, Medikamenten oder Beschwerden sollten die Trainingszonen ärztlich festgelegt werden."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/protein.json
+++ b/src/locales/calculators/de/protein.json
@@ -36,6 +36,32 @@
     "foodSources": "Top-Proteinquellen",
     "food": "Lebensmittel",
     "proteinPer100g": "Protein / 100 g",
-    "goalComparison": "Protein nach Ziel"
+    "goalComparison": "Protein nach Ziel",
+    "faq": [
+      {
+        "q": "Wie viel Protein brauche ich pro Tag?",
+        "a": "Die Deutsche Gesellschaft für Ernährung (DGE) nennt für gesunde Erwachsene einen Richtwert von etwa 0,8 g Protein pro Kilogramm Körpergewicht und Tag. Sportlich aktive Menschen haben einen höheren Bedarf."
+      },
+      {
+        "q": "Wie viel Protein ist für den Muskelaufbau sinnvoll?",
+        "a": "Die International Society of Sports Nutrition (ISSN) gibt für aktive und kraftsportlich trainierende Personen einen Bereich von rund 1,4 bis 2,0 g pro Kilogramm Körpergewicht an. Dieser Rechner berücksichtigt Aktivität und Ziel."
+      },
+      {
+        "q": "Kann man zu viel Protein essen?",
+        "a": "Für gesunde Nieren gilt eine erhöhte Proteinzufuhr allgemein als unproblematisch. Bei einer bestehenden Nierenerkrankung sollte die Menge ärztlich abgestimmt werden. Eine insgesamt ausgewogene Ernährung bleibt wichtig."
+      },
+      {
+        "q": "Decken pflanzliche Quellen den Proteinbedarf?",
+        "a": "Ja. Hülsenfrüchte, Tofu, Tempeh, Nüsse und Getreide liefern reichlich Protein. Da pflanzliche Proteine teils eine geringere Verdaulichkeit haben, können eine etwas höhere Gesamtmenge und die Kombination verschiedener Quellen sinnvoll sein."
+      },
+      {
+        "q": "Wann sollte ich Protein essen?",
+        "a": "Wichtiger als der genaue Zeitpunkt ist laut ISSN die über den Tag verteilte Gesamtmenge. Eine gleichmäßige Verteilung auf mehrere Mahlzeiten kann die Muskelproteinsynthese unterstützen."
+      },
+      {
+        "q": "Brauche ich Protein-Shakes?",
+        "a": "Nein. Der Bedarf lässt sich in der Regel über normale Lebensmittel decken. Shakes sind lediglich eine praktische Ergänzung, wenn die Zufuhr über die Nahrung schwerfällt."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/sleep.json
+++ b/src/locales/calculators/de/sleep.json
@@ -22,6 +22,32 @@
     "recommended": "Empfohlen",
     "cycles": "{n} Zyklen",
     "howItWorks": "So funktioniert's",
-    "howItWorksText": "Ein vollständiger Schlafzyklus dauert ca. 90 Minuten. Das Aufwachen zwischen Zyklen hilft dir, erfrischt aufzustehen. Dieser Rechner berücksichtigt ca. 15 Minuten Einschlafzeit und empfiehlt Zeiten, die auf vollständige Zyklen abgestimmt sind."
+    "howItWorksText": "Ein vollständiger Schlafzyklus dauert ca. 90 Minuten. Das Aufwachen zwischen Zyklen hilft dir, erfrischt aufzustehen. Dieser Rechner berücksichtigt ca. 15 Minuten Einschlafzeit und empfiehlt Zeiten, die auf vollständige Zyklen abgestimmt sind.",
+    "faq": [
+      {
+        "q": "Wie lange dauert ein Schlafzyklus?",
+        "a": "Ein vollständiger Schlafzyklus dauert im Durchschnitt etwa 90 Minuten und durchläuft Leicht-, Tief- und REM-Schlaf. Über die Nacht wiederholen sich vier bis sechs solcher Zyklen. Dieser Rechner geht von 90-Minuten-Zyklen aus."
+      },
+      {
+        "q": "Wie viel Schlaf brauche ich?",
+        "a": "Die National Sleep Foundation (NSF) empfiehlt gesunden Erwachsenen rund 7 bis 9 Stunden Schlaf pro Nacht. Der individuelle Bedarf kann etwas abweichen."
+      },
+      {
+        "q": "Warum wache ich manchmal wie gerädert auf?",
+        "a": "Wer mitten in einer Tiefschlafphase geweckt wird, fühlt sich oft benommen (Schlafträgheit). Ein Aufwachen am Ende eines Zyklus in einer leichteren Schlafphase wird meist als erholsamer empfunden."
+      },
+      {
+        "q": "Warum werden 15 Minuten Einschlafzeit eingerechnet?",
+        "a": "Die meisten Menschen brauchen etwa 10 bis 20 Minuten zum Einschlafen. Der Rechner addiert pauschal rund 15 Minuten, damit die berechneten Zeiten realistischer sind."
+      },
+      {
+        "q": "Was hilft für besseren Schlaf?",
+        "a": "Fachgesellschaften wie die American Academy of Sleep Medicine (AASM) empfehlen regelmäßige Schlafzeiten, ein dunkles, kühles Schlafzimmer sowie den Verzicht auf Koffein und Bildschirme vor dem Zubettgehen. Bei anhaltenden Schlafproblemen ärztlichen Rat suchen."
+      },
+      {
+        "q": "Sind die berechneten Zeiten medizinisch verbindlich?",
+        "a": "Nein. Die Zeiten sind eine Orientierung auf Basis durchschnittlicher Zyklen. Bei anhaltenden Schlafstörungen sollte eine Ärztin oder ein Arzt beziehungsweise ein Schlafmediziner aufgesucht werden."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/caffeine.json
+++ b/src/locales/calculators/en/caffeine.json
@@ -37,6 +37,32 @@
       "greenTea": "Green Tea (28 mg)",
       "energyDrink": "Energy Drink (80 mg)",
       "cola": "Cola (34 mg / 330 ml)"
-    }
+    },
+    "faq": [
+      {
+        "q": "How much caffeine per day is safe for healthy adults?",
+        "a": "The European Food Safety Authority (EFSA) considers single doses up to about 200 mg and a total of up to 400 mg spread across the day to be safe for healthy adults. Individual sensitivity varies; if unsure, ask a physician."
+      },
+      {
+        "q": "How long does caffeine stay in the body?",
+        "a": "In healthy adults caffeine has an average half-life of roughly 3 to 5 hours, meaning about half is cleared in that time. This calculator uses the half-life approach to estimate your caffeine level across the day."
+      },
+      {
+        "q": "How much caffeine is in a cup of coffee?",
+        "a": "A cup of filter coffee (about 200 ml) typically contains around 80 to 100 mg of caffeine, and an espresso about 60 to 80 mg. Values vary widely with the bean, grind and brewing method."
+      },
+      {
+        "q": "Does caffeine affect sleep?",
+        "a": "Yes. Because caffeine clears slowly, consuming it in the afternoon or evening can make falling asleep harder. It is often recommended to avoid caffeine for several hours before bedtime."
+      },
+      {
+        "q": "How much caffeine is acceptable during pregnancy?",
+        "a": "The EFSA sets a lower limit of about 200 mg of caffeine per day for pregnant women. Pregnant women should discuss their individual intake with their doctor or midwife."
+      },
+      {
+        "q": "Can you build up a caffeine tolerance?",
+        "a": "With regular intake the body partly adapts to the stimulating effect, so the same amount feels less noticeable. This does not change the intake amounts EFSA uses for its safety assessment."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/caloriesBurned.json
+++ b/src/locales/calculators/en/caloriesBurned.json
@@ -66,6 +66,32 @@
     "chocolate": "chocolate bars",
     "weeklyProjection": "Weekly Projection",
     "sessionsPerWeek": "sessions / week",
-    "kcalPerWeek": "kcal / week"
+    "kcalPerWeek": "kcal / week",
+    "faq": [
+      {
+        "q": "How is calorie burn calculated?",
+        "a": "This calculator uses MET values (metabolic equivalent) from the Compendium of Physical Activities. Burn = MET × body weight in kg × duration in hours. This estimates the energy expenditure of an activity."
+      },
+      {
+        "q": "What does MET mean?",
+        "a": "One MET equals your energy expenditure at rest. A value of 8 MET therefore means about eight times the energy use compared with resting. The values come from the scientific Compendium of Physical Activities."
+      },
+      {
+        "q": "How accurate is the estimate?",
+        "a": "It is an average value. Actual burn depends on fitness, intensity, technique and body composition and can vary. The figure is meant as guidance."
+      },
+      {
+        "q": "How much activity per week is recommended?",
+        "a": "The World Health Organization (WHO) recommends adults get at least 150 to 300 minutes of moderate or 75 to 150 minutes of vigorous physical activity per week."
+      },
+      {
+        "q": "Does the calculator include my basal metabolic rate?",
+        "a": "No. It estimates only the calories burned additionally through the activity. Separate calculators determine total daily expenditure including basal metabolism, for example based on DGE reference values."
+      },
+      {
+        "q": "Does more activity help with weight loss?",
+        "a": "Activity raises energy expenditure and, together with a balanced diet, supports weight management. The long-term energy balance is decisive."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/heartRate.json
+++ b/src/locales/calculators/en/heartRate.json
@@ -29,6 +29,32 @@
     "fatBurnDesc": "Easy endurance training. Builds aerobic base and burns fat efficiently.",
     "aerobicDesc": "Moderate effort. Improves cardiovascular fitness and endurance.",
     "anaerobicDesc": "Hard effort. Increases speed, power, and lactate threshold.",
-    "vo2maxDesc": "Maximum effort. Develops peak performance and speed."
+    "vo2maxDesc": "Maximum effort. Develops peak performance and speed.",
+    "faq": [
+      {
+        "q": "How do I calculate my maximum heart rate?",
+        "a": "A common rule of thumb is 220 minus your age. It gives a rough estimate; the actual maximum heart rate can vary individually. For precise values an exercise test supervised by a physician is advisable."
+      },
+      {
+        "q": "What is the Karvonen method?",
+        "a": "The Karvonen formula calculates training zones using the heart rate reserve, the difference between maximum and resting heart rate. It is well established and individualizes the zones more than the plain percentage method."
+      },
+      {
+        "q": "What do the heart rate zones mean?",
+        "a": "The American Heart Association (AHA) describes zones from light recovery to high intensity. Lower zones build base endurance, higher zones improve performance. This calculator divides the range into five zones."
+      },
+      {
+        "q": "In which zone do I burn the most fat?",
+        "a": "In moderate zones a larger share of energy comes from fat, but the absolute calorie burn is higher at greater intensity. For health, the total amount of activity matters most."
+      },
+      {
+        "q": "How often should I train?",
+        "a": "The AHA recommends adults get at least 150 minutes of moderate or 75 minutes of vigorous endurance activity per week. With pre-existing conditions, seek medical advice before starting."
+      },
+      {
+        "q": "Are the calculated zones suitable for everyone?",
+        "a": "The values are general estimates for healthy adults. With heart conditions, medication or symptoms, training zones should be set by a physician."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/protein.json
+++ b/src/locales/calculators/en/protein.json
@@ -36,6 +36,32 @@
     "foodSources": "Top Protein Sources",
     "food": "Food",
     "proteinPer100g": "Protein / 100 g",
-    "goalComparison": "Protein by Goal"
+    "goalComparison": "Protein by Goal",
+    "faq": [
+      {
+        "q": "How much protein do I need per day?",
+        "a": "The German Nutrition Society (DGE) gives a reference value of about 0.8 g of protein per kilogram of body weight per day for healthy adults. Physically active people have a higher requirement."
+      },
+      {
+        "q": "How much protein is useful for building muscle?",
+        "a": "The International Society of Sports Nutrition (ISSN) recommends roughly 1.4 to 2.0 g per kilogram of body weight for active and strength-training individuals. This calculator factors in your activity level and goal."
+      },
+      {
+        "q": "Can you eat too much protein?",
+        "a": "For healthy kidneys, a higher protein intake is generally considered unproblematic. With an existing kidney condition the amount should be set with a physician. An overall balanced diet remains important."
+      },
+      {
+        "q": "Can plant-based sources cover protein needs?",
+        "a": "Yes. Legumes, tofu, tempeh, nuts and grains provide plenty of protein. Because plant proteins can be somewhat less digestible, a slightly higher total amount and combining different sources can be useful."
+      },
+      {
+        "q": "When should I eat protein?",
+        "a": "According to the ISSN, the total amount spread across the day matters more than precise timing. Distributing protein evenly across several meals can support muscle protein synthesis."
+      },
+      {
+        "q": "Do I need protein shakes?",
+        "a": "No. Requirements can usually be met through normal food. Shakes are simply a convenient supplement when meeting intake through meals is difficult."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/sleep.json
+++ b/src/locales/calculators/en/sleep.json
@@ -22,6 +22,32 @@
     "recommended": "Recommended",
     "cycles": "{n} cycles",
     "howItWorks": "How it works",
-    "howItWorksText": "A full sleep cycle lasts ~90 minutes. Waking between cycles helps you feel refreshed. This calculator factors in ~15 minutes to fall asleep and recommends times aligned with complete cycles."
+    "howItWorksText": "A full sleep cycle lasts ~90 minutes. Waking between cycles helps you feel refreshed. This calculator factors in ~15 minutes to fall asleep and recommends times aligned with complete cycles.",
+    "faq": [
+      {
+        "q": "How long is a sleep cycle?",
+        "a": "A full sleep cycle lasts about 90 minutes on average and moves through light, deep and REM sleep. Four to six such cycles repeat over the night. This calculator assumes 90-minute cycles."
+      },
+      {
+        "q": "How much sleep do I need?",
+        "a": "The National Sleep Foundation (NSF) recommends roughly 7 to 9 hours of sleep per night for healthy adults. Individual needs can vary somewhat."
+      },
+      {
+        "q": "Why do I sometimes wake up groggy?",
+        "a": "Being woken in the middle of deep sleep often causes grogginess (sleep inertia). Waking at the end of a cycle, during a lighter sleep stage, is usually felt as more refreshing."
+      },
+      {
+        "q": "Why are 15 minutes of falling-asleep time included?",
+        "a": "Most people take about 10 to 20 minutes to fall asleep. The calculator adds roughly 15 minutes so the calculated times are more realistic."
+      },
+      {
+        "q": "What helps for better sleep?",
+        "a": "Professional bodies such as the American Academy of Sleep Medicine (AASM) recommend consistent sleep times, a dark and cool bedroom, and avoiding caffeine and screens before bed. Seek medical advice for persistent sleep problems."
+      },
+      {
+        "q": "Are the calculated times medically binding?",
+        "a": "No. The times are guidance based on average cycles. For persistent sleep disturbances, consult a physician or a sleep specialist."
+      }
+    ]
   }
 }

--- a/src/pages/CaffeineCalculator.vue
+++ b/src/pages/CaffeineCalculator.vue
@@ -6,10 +6,13 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('caffeine.faq') || [])
 
 useHead(() => ({
   title: t('caffeine.meta.title'),
@@ -266,6 +269,8 @@ const drinkKeys = Object.keys(DRINKS)
       </div>
     </div>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <AdSlot class="mt-8" />
   <RelatedCalculators calc-key="caffeine" class="mt-8" />

--- a/src/pages/CaloriesBurnedCalculator.vue
+++ b/src/pages/CaloriesBurnedCalculator.vue
@@ -5,10 +5,13 @@ import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('caloriesBurned.faq') || [])
 
 useHead(() => ({
   title: t('caloriesBurned.meta.title'),
@@ -202,6 +205,8 @@ const sessionOptions = [1, 2, 3, 4, 5, 6, 7]
       </div>
     </div>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <RelatedCalculators calc-key="caloriesBurned" class="mt-8" />
   <BlogArticleLink calculator-key="caloriesBurned" />

--- a/src/pages/HeartRateZones.vue
+++ b/src/pages/HeartRateZones.vue
@@ -6,10 +6,13 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('heartRate.faq') || [])
 
 useHead(() => ({
   title: t('heartRate.meta.title'),
@@ -137,6 +140,8 @@ const zones = computed(() => {
     </div>
   </div>
 
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <AdSlot class="mt-8" />
   <RelatedCalculators calc-key="heartRate" class="mt-8" />

--- a/src/pages/ProteinCalculator.vue
+++ b/src/pages/ProteinCalculator.vue
@@ -6,10 +6,13 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath, locale } = useLocaleRouter()
+
+const faqItems = computed(() => tm('protein.faq') || [])
 
 useHead(() => ({
   title: t('protein.meta.title'),
@@ -286,6 +289,8 @@ const foodSources = computed(() => {
     </div>
   </div>
 
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <AdSlot class="mt-8" />
   <RelatedCalculators calc-key="protein" class="mt-8" />

--- a/src/pages/SleepCycleCalculator.vue
+++ b/src/pages/SleepCycleCalculator.vue
@@ -6,10 +6,13 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+
+const faqItems = computed(() => tm('sleep.faq') || [])
 
 useHead(() => ({
   title: t('sleep.meta.title'),
@@ -135,6 +138,8 @@ const options = computed(() => {
     </p>
   </div>
 
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <AdSlot class="mt-8" />
   <RelatedCalculators calc-key="sleep" class="mt-8" />


### PR DESCRIPTION
## Summary

Rolls out **FAQPage JSON-LD** structured data to the **first batch of 5 calculators**, following the pattern shipped on the first 20 (#198). SEO / AI-citation visibility: makes pages eligible for rich results and gives LLMs sourced, quotable Q&A. **No new routes, no new calculators.**

Each page gets a top-level `faq` array (under its i18n namespace) in **both** DE and EN, plus `CalculatorFAQ.vue` wired in mirroring `BmiCalculator.vue` (`import` + `const faqItems = computed(() => tm('<key>.faq') || [])` + `<CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />`, placed at the end of the result section before the blog/affiliate/ad blocks; `tm` added to `useI18n()`).

## Pre-flight skips

None. All 5 in-scope calculators were checked — **none** already had a `faq` array, so all 5 were implemented.

## Per-calculator question counts (DE + EN, identical counts)

| Calculator | Route (de) | Questions | Authorities cited |
|---|---|---|---|
| caffeine | `koffein-rechner` | 6 | EFSA, (DGE context) |
| protein | `protein-rechner` | 6 | DGE, ISSN |
| sleep | `schlafzyklen-rechner` | 6 | NSF, AASM |
| heartRate | `herzfrequenz-zonen` | 6 | AHA, Karvonen method |
| caloriesBurned | `kalorienverbrauch` | 6 | Compendium of Physical Activities (MET), WHO, DGE |

All answers are **educational / general-information only** — no diagnostic or personal medical advice; borderline questions carry a neutral "ask a physician" framing. Only broadly-established figures used (e.g. EFSA 400 mg/day caffeine, DGE 0.8 g protein/kg/day, ISSN 1.4–2.0 g/kg, ~90 min sleep cycle, NSF 7–9 h, max HR 220−age, WHO 150–300 min/week). DE entries are in German, EN in English.

## Tests — RED → GREEN proof

Extended `src/__tests__/faq-ssr.test.js` `SAMPLE_PAGES` with the 5 DE built routes: `de/koffein-rechner`, `de/protein-rechner`, `de/schlafzyklen-rechner`, `de/herzfrequenz-zonen`, `de/kalorienverbrauch` (slugs verified against router/meta files).

The faq-ssr suite asserts each page emits inline `FAQPage` JSON-LD (`@type` FAQPage, 5–7 `Question`/`Answer` entries, answer text > 20 chars).

- **RED** — stashed the page + locale changes (kept only the test change), rebuilt `dist/`, ran the suite: the 5 new entries **failed** with `no FAQPage JSON-LD found` while the original 22 passed (**5 failed | 22 passed**). Confirms the assertions are non-tautological.
- **GREEN** — restored changes, rebuilt, re-ran: **27 passed (27)**.

> Note: the repo's `vitest.config.js` excludes `faq-ssr.test.js` from the default `vitest run`; it is intended to run via `npm run test:ssr` (build + run). Under the installed vitest v4 that script's positional filter no longer overrides the config `exclude`, so it reports "No test files found" — a **pre-existing** issue (the exclude is committed in `HEAD`, and `vitest.config.js`/`package.json` are out of scope for this task). The faq-ssr assertions were executed directly via an in-repo temp config to produce the RED→GREEN proof above and removed afterward.

## Quality gate (all passed)

- `npm test` (full unit suite): **102 files, 2753 passed**
- `npm run build` (Vite SSG): **success** — `FAQPage` confirmed present in built HTML for all 5 DE pages + EN pages
- faq-ssr assertions: **27 passed** (RED→GREEN as above)
- E2E (Playwright) for the 5 modified calculators (`caffeine`, `protein`, `sleep`, `heart-rate`, `calories-burned`): **52 passed** — no regressions

## Scope / constraints

Diff limited to: 10 locale JSON files (5 keys × de/en), 5 page `.vue` files, and `faq-ssr.test.js`. No changes to `CalculatorFAQ.vue`, `AffiliateBanner.vue`, `AdSlot.vue`, config, router, sitemap, or any of the already-done 20 calculators. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)