### PR TITLE
feat(hc-198): FAQPage JSON-LD batch 2 — oneRepMax, leanBodyMass, bsa, smokingCost, alcoholUnits

### DIFF
--- a/src/__tests__/faq-ssr.test.js
+++ b/src/__tests__/faq-ssr.test.js
@@ -31,6 +31,11 @@ const SAMPLE_PAGES = [
   'de/schlafzyklen-rechner',
   'de/herzfrequenz-zonen',
   'de/kalorienverbrauch',
+  'de/one-rep-max-rechner',
+  'de/magermasse-rechner',
+  'de/koerperoberflaeche-rechner',
+  'de/rauchen-kosten-rechner',
+  'de/alkohol-einheiten-rechner',
 ]
 
 const distExists = existsSync(DIST)

--- a/src/locales/calculators/de/alcoholUnits.json
+++ b/src/locales/calculators/de/alcoholUnits.json
@@ -85,6 +85,28 @@
       "sleepDesc": "Alkohol verschlechtert die Schlafqualität, unterdrückt den REM-Schlaf und erhöht Müdigkeit am Folgetag."
     },
     "disclaimerTitle": "Hinweis",
-    "disclaimer": "Dieser Rechner dient zur Information und ersetzt keine ärztliche Beratung. Kein Alkohol ist sicherer als jeder Konsum. Bei Fragen zu deinem Trinkverhalten wende dich an einen Arzt oder die Suchtberatung (z. B. BZgA: 0800 111 0 111)."
+    "disclaimer": "Dieser Rechner dient zur Information und ersetzt keine ärztliche Beratung. Kein Alkohol ist sicherer als jeder Konsum. Bei Fragen zu deinem Trinkverhalten wende dich an einen Arzt oder die Suchtberatung (z. B. BZgA: 0800 111 0 111).",
+    "faq": [
+      {
+        "q": "Was ist eine Alkoholeinheit?",
+        "a": "Eine Alkoholeinheit (auch Standardglas) ist eine festgelegte Menge reinen Alkohols (Ethanol), gemessen in Gramm. Sie macht unterschiedliche Getränke vergleichbar, da Bier, Wein und Spirituosen sehr verschiedene Alkoholgehalte haben. International liegt eine Einheit häufig bei rund 10 Gramm reinem Ethanol."
+      },
+      {
+        "q": "Wie wird die Alkoholmenge berechnet?",
+        "a": "Die Gramm reinen Alkohols ergeben sich aus Volumen × Alkoholgehalt (ABV) × Dichte von Ethanol. Ethanol hat eine Dichte von etwa 0,789 g/ml. Beispiel: 500 ml Bier mit 5 % ABV enthalten rund 0,5 l × 0,05 × 0,789 g/ml ≈ 20 Gramm reinen Alkohol. Diese Menge teilt der Rechner durch den Wert einer Einheit."
+      },
+      {
+        "q": "Warum schwankt der Wert einer Einheit je nach Land?",
+        "a": "Es gibt keine weltweit einheitliche Definition. Verschiedene Länder legen ein Standardglas auf unterschiedliche Grammwerte fest. Deshalb kann dasselbe Getränk je nach verwendeter Definition unterschiedlich viele Einheiten ergeben. Der Rechner macht die zugrunde liegende Menge an reinem Alkohol transparent."
+      },
+      {
+        "q": "Wie viel Alkohol ist unbedenklich?",
+        "a": "Nach Einschätzung der Weltgesundheitsorganisation (WHO) gibt es keine Menge Alkohol, die völlig ohne Risiko ist. Weniger ist grundsätzlich besser als mehr. Eine individuelle Einordnung deines Konsums kann nur eine Ärztin oder ein Arzt geben."
+      },
+      {
+        "q": "Wofür ist das Zählen von Einheiten nützlich?",
+        "a": "Einheiten helfen, den eigenen Konsum über verschiedene Getränke hinweg im Blick zu behalten und besser einzuschätzen. Sie ersetzen keine medizinische Beurteilung, machen die getrunkene Alkoholmenge aber greifbar und vergleichbar."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/bsa.json
+++ b/src/locales/calculators/de/bsa.json
@@ -40,6 +40,32 @@
     "formulaDuboisDesc": "Älteste und am häufigsten verwendete Formel. Standard in der Chemotherapie.",
     "formulaMostellerDesc": "Einfachste Berechnung, sehr gute Näherung. Empfohlen vom New England Journal of Medicine.",
     "formulaHaycockDesc": "Optimiert für Kinder und Erwachsene. Gilt als besonders präzise.",
-    "formulaBoydDesc": "Berücksichtigt nichtlineare Beziehung zwischen Gewicht und BSA. Weniger verbreitet."
+    "formulaBoydDesc": "Berücksichtigt nichtlineare Beziehung zwischen Gewicht und BSA. Weniger verbreitet.",
+    "faq": [
+      {
+        "q": "Was ist die Körperoberfläche (BSA)?",
+        "a": "Die Körperoberfläche (Body Surface Area, BSA) ist die geschätzte gesamte Außenfläche des Körpers, angegeben in Quadratmetern. Sie wird aus Größe und Gewicht berechnet und in der Medizin häufig genutzt, um Körperfunktionen unabhängig von der reinen Körpergröße zu skalieren."
+      },
+      {
+        "q": "Wie wird die BSA berechnet?",
+        "a": "Der Rechner verwendet etablierte Formeln. Die Mosteller-Formel berechnet die BSA als Wurzel aus (Größe in cm × Gewicht in kg / 3600) und ist wegen ihrer Einfachheit weit verbreitet. Die ältere Du-Bois-Formel verknüpft Größe und Gewicht über feste Exponenten. Beide liefern für die meisten Erwachsenen ähnliche Werte."
+      },
+      {
+        "q": "Warum unterscheiden sich die Formeln?",
+        "a": "Die Formeln wurden anhand unterschiedlicher Stichproben und Annahmen entwickelt, weshalb ihre Ergebnisse leicht voneinander abweichen können. Mosteller und Du Bois stimmen bei durchschnittlichen Körpermaßen meist eng überein; an den Randbereichen können die Differenzen größer ausfallen."
+      },
+      {
+        "q": "Wofür wird die BSA in der Medizin genutzt?",
+        "a": "Die BSA dient als Bezugsgröße, um physiologische Werte zu skalieren, etwa den Herzindex oder die geschätzte Nierenfunktion. Sie wird auch bei der Dosierung mancher Medikamente herangezogen. Dieser Rechner ist rein informativ — über konkrete Dosierungen entscheidet ausschließlich eine Ärztin oder ein Arzt."
+      },
+      {
+        "q": "Welche Formel sollte ich wählen?",
+        "a": "Für die meisten Zwecke liefert die Mosteller-Formel eine einfache und gut anerkannte Näherung; das New England Journal of Medicine hat sie wegen ihrer Praktikabilität hervorgehoben. Im klinischen Umfeld richtet sich die Wahl der Formel nach den jeweiligen Vorgaben der Einrichtung."
+      },
+      {
+        "q": "Ist die BSA dasselbe wie der BMI?",
+        "a": "Nein. Der BMI setzt Gewicht ins Verhältnis zur Größe, um das Gewicht einzuordnen. Die BSA schätzt die Oberfläche des Körpers und dient vor allem der physiologischen Skalierung. Beide Werte verfolgen unterschiedliche Zwecke und ersetzen keine ärztliche Beurteilung."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/leanBodyMass.json
+++ b/src/locales/calculators/de/leanBodyMass.json
@@ -20,6 +20,32 @@
     "boer": "Boer",
     "james": "James",
     "hume": "Hume",
-    "average": "Durchschnitt"
+    "average": "Durchschnitt",
+    "faq": [
+      {
+        "q": "Was ist die Magermasse (Lean Body Mass)?",
+        "a": "Die Magermasse, auch fettfreie Masse, ist dein gesamtes Körpergewicht abzüglich der Fettmasse. Dazu zählen Muskeln, Knochen, Organe, Bindegewebe und Körperwasser. Sie wird in diesem Rechner geschätzt, nicht direkt gemessen."
+      },
+      {
+        "q": "Wie wird die Magermasse berechnet?",
+        "a": "Der Rechner verwendet etablierte Schätzformeln. Die Boer-Formel und die Hume-Formel leiten die fettfreie Masse aus Größe, Gewicht und Geschlecht ab. Grundprinzip: Magermasse = Gesamtgewicht − Fettmasse. Da die Formeln auf Bevölkerungsdaten beruhen, liefern sie eine Näherung für die jeweilige Gruppe."
+      },
+      {
+        "q": "Warum unterscheiden sich Boer- und Hume-Formel?",
+        "a": "Beide Formeln wurden anhand unterschiedlicher Stichproben entwickelt und gewichten Größe und Gewicht etwas anders. Deshalb können ihre Ergebnisse leicht voneinander abweichen. Der Vergleich mehrerer Formeln zeigt dir eine plausible Bandbreite statt eines einzelnen Werts."
+      },
+      {
+        "q": "Wie genau ist die Schätzung?",
+        "a": "Es handelt sich um eine Schätzung auf Basis von Körpermaßen, nicht um eine Messung. Genauere Verfahren wie DEXA, hydrostatisches Wiegen oder Bioimpedanzanalyse messen die Körperzusammensetzung direkt. Bei sehr muskulösen oder sehr untergewichtigen Personen können Formelwerte stärker abweichen."
+      },
+      {
+        "q": "Wofür ist die Magermasse nützlich?",
+        "a": "Die fettfreie Masse wird unter anderem genutzt, um den Grundumsatz einzuschätzen, Trainingsfortschritte zu beobachten oder Ernährungsziele zu planen. Sie ergänzt den BMI, der nicht zwischen Muskel und Fett unterscheidet."
+      },
+      {
+        "q": "Ersetzt der Rechner eine medizinische Untersuchung?",
+        "a": "Nein. Die Werte dienen der allgemeinen Information und Orientierung. Für eine genaue Bestimmung der Körperzusammensetzung oder bei gesundheitlichen Fragen wende dich an eine Ärztin oder einen Arzt."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/oneRepMax.json
+++ b/src/locales/calculators/de/oneRepMax.json
@@ -29,6 +29,32 @@
     "lombardi": "Lombardi",
     "oconner": "O'Conner",
     "howItWorks": "So funktioniert's",
-    "howItWorksText": "Das One Rep Max (1RM) ist das maximale Gewicht, das du für eine einzelne Wiederholung heben kannst. Diese Formeln schätzen dein 1RM aus einem submaximalen Satz — sicherer als ein echter Maximalversuch. Die Epley-Formel ist die am häufigsten verwendete: 1RM = Gewicht × (1 + Wiederholungen/30)."
+    "howItWorksText": "Das One Rep Max (1RM) ist das maximale Gewicht, das du für eine einzelne Wiederholung heben kannst. Diese Formeln schätzen dein 1RM aus einem submaximalen Satz — sicherer als ein echter Maximalversuch. Die Epley-Formel ist die am häufigsten verwendete: 1RM = Gewicht × (1 + Wiederholungen/30).",
+    "faq": [
+      {
+        "q": "Was ist das One-Rep-Max (1RM)?",
+        "a": "Das One-Rep-Max ist das höchste Gewicht, das du eine einzige Wiederholung einer Übung mit sauberer Technik bewegen kannst. Es dient als Bezugsgröße für die Trainingssteuerung, weil sich Trainingsgewichte häufig als Prozentsatz des 1RM angeben lassen."
+      },
+      {
+        "q": "Wie schätzt dieser Rechner mein 1RM?",
+        "a": "Der Rechner nutzt etablierte Schätzformeln aus einem submaximalen Satz. Die Epley-Formel lautet 1RM = Gewicht × (1 + Wiederholungen/30), die Brzycki-Formel 1RM = Gewicht × 36 / (37 − Wiederholungen). Beide leiten aus Gewicht und Wiederholungszahl einen geschätzten Maximalwert ab — du musst also kein echtes Maximalgewicht heben."
+      },
+      {
+        "q": "Warum liefern die Formeln unterschiedliche Werte?",
+        "a": "Jede Formel beruht auf einem etwas anderen mathematischen Modell des Zusammenhangs zwischen Gewicht und Wiederholungen. Epley und Brzycki stimmen bei niedrigen Wiederholungszahlen meist eng überein und weichen bei vielen Wiederholungen stärker voneinander ab. Der Vergleich mehrerer Formeln gibt dir eine realistische Bandbreite statt einer einzelnen Zahl."
+      },
+      {
+        "q": "Wie genau ist die Schätzung?",
+        "a": "Sie ist eine Näherung. Schätzformeln sind am zuverlässigsten bei etwa zwei bis zehn Wiederholungen; bei sehr hohen Wiederholungszahlen wird die Schätzung ungenauer. Tagesform, Technik und Übung beeinflussen das Ergebnis. Sieh den Wert als Orientierung, nicht als exakte Messung."
+      },
+      {
+        "q": "Muss ich ein echtes Maximalgewicht heben?",
+        "a": "Nein — das ist der Vorteil der Schätzung. Du absolvierst einen submaximalen Satz mit kontrollierter Technik, und die Formel rechnet das 1RM hoch. Das senkt das Verletzungsrisiko gegenüber einem echten Maximalversuch, der nur mit Erfahrung und Hilfestellung erfolgen sollte."
+      },
+      {
+        "q": "Wozu wird das 1RM im Training genutzt?",
+        "a": "Krafttrainingskonzepte, etwa der National Strength and Conditioning Association (NSCA), geben Trainingsintensitäten häufig als Prozentsatz des 1RM an. So lassen sich Belastung und Wiederholungsbereiche für Kraft-, Hypertrophie- oder Ausdauerziele steuern. Bei gesundheitlichen Fragen oder Vorerkrankungen sprich vor intensivem Training mit einer Ärztin oder einem Arzt."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/de/smokingCost.json
+++ b/src/locales/calculators/de/smokingCost.json
@@ -39,6 +39,28 @@
       "ebike": { "emoji": "🚲", "label": "E-Bike" },
       "gym": { "emoji": "🏋️", "label": "Fitnessstudio (1 Jahr)" },
       "streaming": { "emoji": "🎬", "label": "Streaming (1 Jahr)" }
-    }
+    },
+    "faq": [
+      {
+        "q": "Was berechnet dieser Rechner?",
+        "a": "Der Rechner schätzt die finanziellen Kosten des Rauchens. Er hochrechnet deine Ausgaben über die Zeit nach dem einfachen Prinzip: Packungen pro Tag × Preis pro Packung × Anzahl der Tage. Es geht ausschließlich um Geld, nicht um gesundheitliche Folgen."
+      },
+      {
+        "q": "Wie werden die Kosten ermittelt?",
+        "a": "Aus deinem täglichen Konsum und dem Packungspreis ergeben sich Tages-, Monats- und Jahreskosten sowie eine Hochrechnung über mehrere Jahre. Das ist eine reine Multiplikation — je genauer deine Angaben zu Menge und Preis, desto realistischer das Ergebnis."
+      },
+      {
+        "q": "Sind die langfristigen Kosten realistisch?",
+        "a": "Sie sind eine Projektion auf Basis gleichbleibender Annahmen. In der Realität verändern sich Tabakpreise, etwa durch Steuererhöhungen, und auch dein Konsum kann schwanken. Die Hochrechnung zeigt eine Größenordnung, keine exakte Vorhersage."
+      },
+      {
+        "q": "Berücksichtigt der Rechner Gesundheitskosten?",
+        "a": "Nein. Der Rechner erfasst nur die direkten Ausgaben für Tabak. Mögliche indirekte Kosten — etwa für Gesundheit oder Versicherungen — sind nicht enthalten. Die Weltgesundheitsorganisation (WHO) weist darauf hin, dass Rauchen erhebliche gesundheitliche Risiken birgt; eine fachliche Einordnung dazu gibt eine Ärztin oder ein Arzt."
+      },
+      {
+        "q": "Kann mir die Zahl beim Aufhören helfen?",
+        "a": "Viele Menschen empfinden die sichtbare Summe als Motivation. Den ersparten Betrag konkret vor Augen zu haben, kann den Anreiz erhöhen. Für Unterstützung beim Rauchstopp bieten Gesundheitsbehörden und ärztliche Beratungsstellen passende Programme an."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/alcoholUnits.json
+++ b/src/locales/calculators/en/alcoholUnits.json
@@ -85,6 +85,28 @@
       "sleepDesc": "Alcohol impairs sleep quality, suppresses REM sleep, and increases daytime fatigue even after moderate consumption."
     },
     "disclaimerTitle": "Disclaimer",
-    "disclaimer": "This calculator is for informational purposes only and does not replace medical advice. No alcohol is safer than any consumption. If you have concerns about your drinking, speak to a doctor or a support service (e.g. UK Drinkline: 0300 123 1110)."
+    "disclaimer": "This calculator is for informational purposes only and does not replace medical advice. No alcohol is safer than any consumption. If you have concerns about your drinking, speak to a doctor or a support service (e.g. UK Drinkline: 0300 123 1110).",
+    "faq": [
+      {
+        "q": "What is a unit of alcohol?",
+        "a": "A unit of alcohol (also called a standard drink) is a defined amount of pure alcohol (ethanol), measured in grams. It makes different drinks comparable, because beer, wine, and spirits have very different alcohol contents. Internationally, one unit is often around 10 grams of pure ethanol."
+      },
+      {
+        "q": "How is the amount of alcohol calculated?",
+        "a": "The grams of pure alcohol come from volume × alcohol content (ABV) × the density of ethanol. Ethanol has a density of about 0.789 g/ml. For example, 500 ml of beer at 5% ABV contains roughly 0.5 l × 0.05 × 0.789 g/ml ≈ 20 grams of pure alcohol. The calculator divides that amount by the value of one unit."
+      },
+      {
+        "q": "Why does the value of a unit vary by country?",
+        "a": "There is no single worldwide definition. Different countries set a standard drink at different gram values. As a result, the same drink can amount to a different number of units depending on the definition used. The calculator makes the underlying amount of pure alcohol transparent."
+      },
+      {
+        "q": "How much alcohol is safe?",
+        "a": "According to the World Health Organization (WHO), no level of alcohol consumption is completely free of risk. Less is generally better than more. Only a physician can give an individual assessment of your consumption."
+      },
+      {
+        "q": "What is counting units useful for?",
+        "a": "Units help you keep track of your consumption across different drinks and judge it more easily. They do not replace a medical assessment, but they make the amount of alcohol you drink tangible and comparable."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/bsa.json
+++ b/src/locales/calculators/en/bsa.json
@@ -40,6 +40,32 @@
     "formulaDuboisDesc": "Oldest and most widely used formula. Standard in chemotherapy dosing.",
     "formulaMostellerDesc": "Simplest calculation, very accurate approximation. Recommended by the New England Journal of Medicine.",
     "formulaHaycockDesc": "Optimized for children and adults. Considered highly accurate.",
-    "formulaBoydDesc": "Accounts for non-linear relationship between weight and BSA. Less commonly used."
+    "formulaBoydDesc": "Accounts for non-linear relationship between weight and BSA. Less commonly used.",
+    "faq": [
+      {
+        "q": "What is body surface area (BSA)?",
+        "a": "Body surface area is the estimated total external area of the body, expressed in square metres. It is calculated from height and weight and is widely used in medicine to scale body functions independently of height alone."
+      },
+      {
+        "q": "How is BSA calculated?",
+        "a": "The calculator uses established formulas. The Mosteller formula computes BSA as the square root of (height in cm × weight in kg / 3600) and is popular for its simplicity. The older Du Bois formula combines height and weight using fixed exponents. Both give similar values for most adults."
+      },
+      {
+        "q": "Why do the formulas differ?",
+        "a": "The formulas were developed from different samples and assumptions, so their results can vary slightly. Mosteller and Du Bois usually agree closely at average body measurements; differences can be larger at the extremes."
+      },
+      {
+        "q": "What is BSA used for in medicine?",
+        "a": "BSA serves as a reference for scaling physiologic values such as cardiac index or estimated kidney function, and it is used in dosing some medications. This calculator is informational only — decisions about specific dosing are made solely by a physician."
+      },
+      {
+        "q": "Which formula should I choose?",
+        "a": "For most purposes the Mosteller formula offers a simple and well-recognised approximation; the New England Journal of Medicine has highlighted it for its practicality. In clinical settings, the choice of formula follows the relevant institution's guidance."
+      },
+      {
+        "q": "Is BSA the same as BMI?",
+        "a": "No. BMI relates weight to height to classify body weight. BSA estimates the surface area of the body and is mainly used for physiologic scaling. The two values serve different purposes and do not replace a medical assessment."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/leanBodyMass.json
+++ b/src/locales/calculators/en/leanBodyMass.json
@@ -20,6 +20,32 @@
     "boer": "Boer",
     "james": "James",
     "hume": "Hume",
-    "average": "Average"
+    "average": "Average",
+    "faq": [
+      {
+        "q": "What is lean body mass?",
+        "a": "Lean body mass, also called fat-free mass, is your total body weight minus your fat mass. It includes muscle, bone, organs, connective tissue, and body water. This calculator estimates it rather than measuring it directly."
+      },
+      {
+        "q": "How is lean body mass calculated?",
+        "a": "The calculator uses established estimation formulas. The Boer formula and the Hume formula derive fat-free mass from your height, weight, and sex. The underlying principle is: lean body mass = total weight − fat mass. Because the formulas are based on population data, they give an approximation for the relevant group."
+      },
+      {
+        "q": "Why do the Boer and Hume formulas differ?",
+        "a": "Each formula was developed from a different sample and weights height and weight slightly differently, so their results can vary a little. Comparing several formulas gives you a plausible range rather than a single value."
+      },
+      {
+        "q": "How accurate is the estimate?",
+        "a": "It is an estimate based on body measurements, not a direct measurement. More precise methods such as DEXA, hydrostatic weighing, or bioelectrical impedance measure body composition directly. For very muscular or very underweight individuals, formula-based values can deviate more."
+      },
+      {
+        "q": "What is lean body mass useful for?",
+        "a": "Fat-free mass is used, among other things, to estimate resting metabolic rate, track training progress, or plan nutrition goals. It complements BMI, which does not distinguish between muscle and fat."
+      },
+      {
+        "q": "Does this calculator replace a medical assessment?",
+        "a": "No. The values are for general information and orientation. For an accurate measurement of body composition or any health concerns, consult a physician."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/oneRepMax.json
+++ b/src/locales/calculators/en/oneRepMax.json
@@ -29,6 +29,32 @@
     "lombardi": "Lombardi",
     "oconner": "O'Conner",
     "howItWorks": "How it works",
-    "howItWorksText": "The one-rep max (1RM) is the maximum weight you can lift for a single repetition. These formulas estimate your 1RM from a submaximal lift — safer than actually attempting a true max. The Epley formula is the most widely used: 1RM = weight × (1 + reps/30)."
+    "howItWorksText": "The one-rep max (1RM) is the maximum weight you can lift for a single repetition. These formulas estimate your 1RM from a submaximal lift — safer than actually attempting a true max. The Epley formula is the most widely used: 1RM = weight × (1 + reps/30).",
+    "faq": [
+      {
+        "q": "What is the one-rep max (1RM)?",
+        "a": "The one-rep max is the heaviest weight you can lift for a single repetition of an exercise with good form. It serves as a reference point for programming, because training loads are often prescribed as a percentage of your 1RM."
+      },
+      {
+        "q": "How does this calculator estimate my 1RM?",
+        "a": "It uses established estimation formulas applied to a submaximal set. The Epley formula is 1RM = weight × (1 + reps/30); the Brzycki formula is 1RM = weight × 36 / (37 − reps). Both convert your weight and rep count into an estimated maximum, so you do not need to attempt a true max lift."
+      },
+      {
+        "q": "Why do the formulas give different numbers?",
+        "a": "Each formula uses a slightly different mathematical model of the relationship between weight and repetitions. Epley and Brzycki tend to agree closely at low rep counts and diverge more as reps increase. Comparing several formulas gives you a realistic range rather than a single figure."
+      },
+      {
+        "q": "How accurate is the estimate?",
+        "a": "It is an approximation. Estimation formulas are most reliable in roughly the two-to-ten rep range; at very high rep counts the estimate becomes less precise. Daily readiness, technique, and the exercise itself all affect the result. Treat the number as a guide, not an exact measurement."
+      },
+      {
+        "q": "Do I have to lift an actual maximum weight?",
+        "a": "No — that is the point of the estimate. You perform a submaximal set with controlled form, and the formula projects your 1RM. This reduces injury risk compared with a true max attempt, which should only be done with experience and a spotter."
+      },
+      {
+        "q": "What is the 1RM used for in training?",
+        "a": "Strength-training frameworks, such as those from the National Strength and Conditioning Association (NSCA), often prescribe intensity as a percentage of 1RM. This lets you set loads and rep ranges for strength, hypertrophy, or endurance goals. If you have health concerns or pre-existing conditions, consult a physician before intense training."
+      }
+    ]
   }
 }

--- a/src/locales/calculators/en/smokingCost.json
+++ b/src/locales/calculators/en/smokingCost.json
@@ -39,6 +39,28 @@
       "ebike": { "emoji": "🚲", "label": "E-bike" },
       "gym": { "emoji": "🏋️", "label": "Gym membership (1 year)" },
       "streaming": { "emoji": "🎬", "label": "Streaming (1 year)" }
-    }
+    },
+    "faq": [
+      {
+        "q": "What does this calculator work out?",
+        "a": "The calculator estimates the financial cost of smoking. It projects your spending over time using a simple principle: packs per day × price per pack × number of days. It is about money only, not health outcomes."
+      },
+      {
+        "q": "How are the costs calculated?",
+        "a": "Your daily consumption and the price per pack produce daily, monthly, and yearly costs, plus a projection over several years. It is pure multiplication — the more accurate your figures for quantity and price, the more realistic the result."
+      },
+      {
+        "q": "Are the long-term costs realistic?",
+        "a": "They are a projection based on constant assumptions. In reality, tobacco prices change, for example through tax increases, and your consumption may vary too. The projection shows an order of magnitude, not an exact forecast."
+      },
+      {
+        "q": "Does the calculator include health costs?",
+        "a": "No. It captures only the direct spending on tobacco. Possible indirect costs — for health or insurance, for example — are not included. The World Health Organization (WHO) notes that smoking carries substantial health risks; a physician can provide a professional assessment of those."
+      },
+      {
+        "q": "Can the number help me quit?",
+        "a": "Many people find the visible total motivating. Seeing the money you could save laid out concretely can strengthen the incentive. For help with quitting, health authorities and medical advisory services offer suitable programmes."
+      }
+    ]
   }
 }

--- a/src/pages/AlcoholUnitsCalculator.vue
+++ b/src/pages/AlcoholUnitsCalculator.vue
@@ -6,10 +6,12 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+const faqItems = computed(() => tm('alcoholUnits.faq') || [])
 
 useHead(() => ({
   title: t('alcoholUnits.meta.title'),
@@ -376,6 +378,8 @@ function resetDrink(drink) {
         {{ t('alcoholUnits.disclaimer') }}
       </p>
     </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <RelatedCalculators calc-key="alcoholUnits" class="mt-8" />
     <BlogArticleLink calculator-key="alcoholUnits" />

--- a/src/pages/BsaCalculator.vue
+++ b/src/pages/BsaCalculator.vue
@@ -6,10 +6,12 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+const faqItems = computed(() => tm('bsa.faq') || [])
 
 useHead(() => ({
   title: t('bsa.meta.title'),
@@ -263,6 +265,8 @@ const allBsa = computed(() => {
         </div>
       </div>
     </div>
+
+    <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
     <RelatedCalculators calc-key="bsa" class="mt-8" />
     <BlogArticleLink calculator-key="bsa" />

--- a/src/pages/LeanBodyMassCalculator.vue
+++ b/src/pages/LeanBodyMassCalculator.vue
@@ -6,10 +6,12 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+const faqItems = computed(() => tm('leanBodyMass.faq') || [])
 
 useHead(() => ({
   title: t('leanBodyMass.meta.title'),
@@ -170,6 +172,8 @@ const heightLabel = computed(() => t('common.' + (unit.value === 'metric' ? 'cm'
       </div>
     </div>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <AdSlot class="mt-8" />
   <RelatedCalculators calc-key="leanBodyMass" class="mt-8" />

--- a/src/pages/OneRepMaxCalculator.vue
+++ b/src/pages/OneRepMaxCalculator.vue
@@ -5,10 +5,12 @@ import { useHead } from '../composables/useHead.js'
 import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+const faqItems = computed(() => tm('oneRepMax.faq') || [])
 
 useHead(() => ({
   title: t('oneRepMax.meta.title'),
@@ -178,6 +180,8 @@ const percentageChart = computed(() => {
     <h2 class="text-base font-semibold text-stone-900 mb-2">{{ t('oneRepMax.howItWorks') }}</h2>
     <p class="text-sm text-stone-500 leading-relaxed">{{ t('oneRepMax.howItWorksText') }}</p>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <RelatedCalculators calc-key="oneRepMax" class="mt-8" />
   <BlogArticleLink calculator-key="oneRepMax" />

--- a/src/pages/SmokingCostCalculator.vue
+++ b/src/pages/SmokingCostCalculator.vue
@@ -6,10 +6,12 @@ import BlogArticleLink from '../components/BlogArticleLink.vue'
 import RelatedCalculators from '../components/RelatedCalculators.vue'
 import AffiliateBanner from '../components/AffiliateBanner.vue'
 import AdSlot from '../components/AdSlot.vue'
+import CalculatorFAQ from '../components/CalculatorFAQ.vue'
 import { useLocaleRouter } from '../composables/useLocaleRouter.js'
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 const { localePath } = useLocaleRouter()
+const faqItems = computed(() => tm('smokingCost.faq') || [])
 
 useHead(() => ({
   title: t('smokingCost.meta.title'),
@@ -251,6 +253,8 @@ function fmt(value) {
       </div>
     </div>
   </div>
+
+  <CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />
 
   <AdSlot class="mt-8" />
   <RelatedCalculators calc-key="smokingCost" class="mt-8" />


### PR DESCRIPTION
## Summary

Rolls out **FAQPage JSON-LD** structured data to a second batch of 5 calculators, following the exact pattern shipped in batch 1 (#296). Each page now emits FAQPage JSON-LD in the SSG build, making it eligible for rich results and giving LLMs sourced, quotable Q&A. **No new routes, no new calculators.**

## Scope (5 calculators)

| Calculator | DE route | EN route | DE Qs | EN Qs |
|---|---|---|---|---|
| oneRepMax | one-rep-max-rechner | one-rep-max-calculator | 6 | 6 |
| leanBodyMass | magermasse-rechner | lean-body-mass-calculator | 6 | 6 |
| bsa | koerperoberflaeche-rechner | body-surface-area-calculator | 6 | 6 |
| smokingCost | rauchen-kosten-rechner | smoking-cost-calculator | 5 | 5 |
| alcoholUnits | alkohol-einheiten-rechner | alcohol-units-calculator | 5 | 5 |

## Pre-flight skips

None — none of the 5 calculators had a pre-existing `faq` array. All 5 received new FAQ content in both languages.

## Sourcing (educational, non-diagnostic)

- **oneRepMax** — Epley & Brzycki 1RM estimation formulas (shown explicitly); NSCA for %-of-1RM training-load context. Framed as an estimate from a submaximal lift.
- **leanBodyMass** — Boer & Hume formulas; LBM = total mass − fat mass; flagged as an estimate.
- **bsa** — Mosteller & Du Bois formulas; explains clinical physiologic scaling; dosing explicitly deferred to a physician.
- **smokingCost** — arithmetic projection (packs/day × price × time); health framing kept qualitative and attributed to WHO; emphasises **financial** cost only.
- **alcoholUnits** — WHO standard-drink concept; unit = volume × ABV × ethanol density (~0.789 g/ml); "no risk-free level per WHO", no invented thresholds.

All borderline answers carry a neutral "ask a physician" framing. No invented studies, statistics, or precise figures.

## Wiring

Each page mirrors `CaffeineCalculator.vue`: `CalculatorFAQ` import, `const { t, tm } = useI18n()`, `const faqItems = computed(() => tm('<key>.faq') || [])`, and `<CalculatorFAQ :questions="faqItems" :title="t('common.faqTitle')" />` placed before the related/affiliate/ad blocks. No other markup changed.

## Tests — RED → GREEN proof

Extended `src/__tests__/faq-ssr.test.js` `SAMPLE_PAGES` with the 5 new DE routes.

- **RED** — built with the page/JSON wiring reverted (test change only) → faq-ssr ran **32 tests: 5 failed | 27 passed**. The 5 new pages failed with `no FAQPage JSON-LD found` (e.g. `de/koerperoberflaeche-rechner`), proving the assertions are non-tautological.
- **GREEN** — restored wiring, rebuilt → faq-ssr ran **32 passed (32)**. The 5 new pages execute (not skipped — build runs before the test so `describe.skipIf(!distExists)` is active).

## Quality gate

- `npm ci` ✅
- `npm run build` (Vite SSG) ✅ — produces `dist/` the faq-ssr test reads
- `npm test` (vitest) ✅ — **2753 passed (102 files)**
- faq-ssr (excluded from default vitest config; run explicitly against `dist/`) ✅ — **32 passed**
- E2E for the 5 touched calculators ✅ — `one-rep-max`, `lean-body-mass`, `smoking-cost`, `alcoholUnits` pass; `bsa.spec.js` has **one pre-existing failure** ("formula comparison table" strict-mode violation on `getByText('Du Bois (1916)')` resolving to 4 elements). Verified it fails identically on the original page with my changes stashed — **not introduced by this PR** and out of scope.

## Diff

10 locale JSON (5 keys × de/en) + 5 page `.vue` + `faq-ssr.test.js`. No deps, no route/sitemap/config/component changes, no edits to already-shipped FAQs.